### PR TITLE
Fix vscode extension build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
   tests:
     uses: janosh/workflows/.github/workflows/deno-test.yml@main
     with:
-      test-cmd: deno task vitest
+      test-cmd: deno task vitest && cd extensions/vscode && deno task test
       e2e-install-cmd: npx playwright install chromium
       e2e-test-cmd: npx playwright test
       deno-version: 2.3.7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
   tests:
     uses: janosh/workflows/.github/workflows/deno-test.yml@main
     with:
-      test-cmd: deno task vitest && cd extensions/vscode && deno task test
+      test-cmd: deno task vitest && cd extensions/vscode && deno install && deno task test
       e2e-install-cmd: npx playwright install chromium
       e2e-test-cmd: npx playwright test
       deno-version: 2.3.7

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -6,25 +6,6 @@
   "publisher": "janosh",
   "icon": "icon.png",
   "repository": "https://github.com/janosh/matterviz",
-  "bugs": "https://github.com/janosh/matterviz/issues",
-  "license": "MIT",
-  "keywords": [
-    "chemistry",
-    "materials",
-    "visualization",
-    "structure",
-    "trajectory",
-    "3d",
-    "molecular dynamics",
-    "crystallography"
-  ],
-  "categories": [
-    "Data Science",
-    "Machine Learning",
-    "Visualization",
-    "Notebooks",
-    "Education"
-  ],
   "engines": { "vscode": "^1.96.0" },
   "main": "./dist/extension.cjs",
   "contributes": {
@@ -67,18 +48,16 @@
     }
   },
   "scripts": {
-    "build": "rm -rf dist && tsc && cp -r ../../src/lib/theme dist/src/lib/ && mv dist/extensions/vscode/src/extension.js dist/extension.cjs && sed -i.bak 's|../../../src/lib/theme/index|./src/lib/theme/index|g' dist/extension.cjs && rm -f dist/extension.cjs.bak && vite build",
-    "dev": "tsc --watch & vite build --watch",
-    "test": "vitest run",
+    "build": "rm -rf dist && vite build --config vite.webview.config.mjs && mkdir -p dist/src && cp -r ../../src/lib dist/src/lib/ && vite build",
     "package": "pnpm build && vsce package"
   },
   "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^5.1.0",
-    "@types/node": "^24.0.10",
+    "@sveltejs/vite-plugin-svelte": "^6.1.0",
+    "@types/node": "^24.0.14",
     "@types/vscode": "^1.96.0",
-    "svelte": "^5.34.8",
+    "svelte": "^5.36.6",
     "typescript": "^5.8.3",
-    "vite": "^7.0.0",
+    "vite": "^7.0.5",
     "vitest": "^3.2.4"
   }
 }

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -6,6 +6,13 @@
   "publisher": "janosh",
   "icon": "icon.png",
   "repository": "https://github.com/janosh/matterviz",
+  "categories": [
+    "Data Science",
+    "Machine Learning",
+    "Visualization",
+    "Notebooks",
+    "Education"
+  ],
   "engines": { "vscode": "^1.96.0" },
   "main": "./dist/extension.cjs",
   "contributes": {
@@ -48,7 +55,8 @@
     }
   },
   "scripts": {
-    "build": "rm -rf dist && vite build --config vite.webview.config.mjs && mkdir -p dist/src && cp -r ../../src/lib dist/src/lib/ && vite build",
+    "build": "rm -rf dist && vite build --config vite.webview.config.ts && mkdir -p dist/src && cp -r ../../src/lib dist/src/lib/ && vite build",
+    "test": "vitest run",
     "package": "pnpm build && vsce package"
   },
   "devDependencies": {

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -56,8 +56,8 @@
   },
   "scripts": {
     "build": "rm -rf dist && vite build --config vite.webview.config.ts && mkdir -p dist/src && cp -r ../../src/lib dist/src/lib/ && vite build",
-    "test": "vitest run",
-    "package": "pnpm build && vsce package"
+    "package": "pnpm build && vsce package",
+    "test": "vitest"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^6.1.0",

--- a/extensions/vscode/tests/webview.test.ts
+++ b/extensions/vscode/tests/webview.test.ts
@@ -139,9 +139,5 @@ describe(`Webview Integration - ASE Binary Trajectory Support`, () => {
     expect(
       new TextDecoder().decode(result_array.slice(8, 24)).replace(/\0/g, ``),
     ).toBe(`ASE-Trajectory`)
-
-    console.log(
-      `✅ ASE trajectory file regression test passed - binary conversion works correctly`,
-    )
   })
 })

--- a/extensions/vscode/tsconfig.json
+++ b/extensions/vscode/tsconfig.json
@@ -5,7 +5,17 @@
     "outDir": "./dist",
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "moduleResolution": "node",
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "allowJs": true,
+    "baseUrl": ".",
+    "paths": {
+      "$lib": ["../../src/lib"],
+      "$lib/*": ["../../src/lib/*"],
+      "$site": ["../../src/site"],
+      "$site/*": ["../../src/site/*"]
+    }
   },
   "include": ["src/**/*"]
 }

--- a/extensions/vscode/vite.config.mjs
+++ b/extensions/vscode/vite.config.mjs
@@ -8,8 +8,16 @@ import { defineConfig } from 'vite'
 
 const __dirname = fileURLToPath(new URL(`.`, import.meta.url))
 
-export default defineConfig({
-  plugins: [svelte()],
+export default defineConfig(({ mode }) => ({
+  plugins: [
+    mode === `test`
+      ? { // just ignore svelte files in test mode
+        name: `svelte-mock`,
+        resolveId: (id) => id.endsWith(`.svelte`) ? id : null,
+        load: (id) => id.endsWith(`.svelte`) ? `export default {}` : null,
+      }
+      : svelte(),
+  ],
   build: {
     outDir: `dist`,
     rollupOptions: {
@@ -23,4 +31,4 @@ export default defineConfig({
       $lib: resolve(__dirname, `../../src/lib`),
     },
   },
-})
+}))

--- a/extensions/vscode/vite.webview.config.mjs
+++ b/extensions/vscode/vite.webview.config.mjs
@@ -1,0 +1,26 @@
+import { svelte } from '@sveltejs/vite-plugin-svelte'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vite'
+
+const __dirname = fileURLToPath(new URL(`.`, import.meta.url))
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: resolve(__dirname, `src/extension.ts`),
+      formats: ['cjs'],
+      fileName: () => 'extension.cjs',
+    },
+    rollupOptions: {
+      external: ['vscode', 'fs', 'path'],
+    },
+    minify: false,
+  },
+  resolve: {
+    alias: {
+      $lib: resolve(__dirname, `../../src/lib`),
+    },
+  },
+  plugins: [svelte()],
+})

--- a/extensions/vscode/vite.webview.config.ts
+++ b/extensions/vscode/vite.webview.config.ts
@@ -9,11 +9,11 @@ export default defineConfig({
   build: {
     lib: {
       entry: resolve(__dirname, `src/extension.ts`),
-      formats: ['cjs'],
-      fileName: () => 'extension.cjs',
+      formats: [`cjs`],
+      fileName: () => `extension.cjs`,
     },
     rollupOptions: {
-      external: ['vscode', 'fs', 'path'],
+      external: [`vscode`, `fs`, `path`],
     },
     minify: false,
   },

--- a/extensions/vscode/webview/src/main.ts
+++ b/extensions/vscode/webview/src/main.ts
@@ -70,7 +70,6 @@ const get_vscode_api = (): WebviewApi | null => {
       return vscode_api
     } catch (error) {
       console.warn(`Failed to acquire VSCode API:`, error)
-      return null
     }
   }
 
@@ -79,8 +78,6 @@ const get_vscode_api = (): WebviewApi | null => {
 
 // Handle file change events from extension
 const handle_file_change = async (message: FileChangeMessage): Promise<void> => {
-  console.log(`File change message:`, message)
-
   if (message.command === `fileDeleted`) {
     // File was deleted - show error message
     const container = document.getElementById(`matterviz-app`)
@@ -97,12 +94,8 @@ const handle_file_change = async (message: FileChangeMessage): Promise<void> => 
 
   if (message.command === `fileUpdated` && message.data) {
     try {
-      // Apply updated theme
-      if (message.theme) {
-        apply_theme(message.theme as ThemeName)
-      }
+      if (message.theme) apply_theme(message.theme as ThemeName)
 
-      // Parse updated file content
       const { content, filename, isCompressed } = message.data
       const result = await parse_file_content(content, filename, isCompressed)
 
@@ -113,18 +106,18 @@ const handle_file_change = async (message: FileChangeMessage): Promise<void> => 
         current_app = create_display(container, result, result.filename) as MatterVizApp
       }
 
-      const api = get_vscode_api()
-      if (api) {
-        api.postMessage({
+      const vscode = get_vscode_api()
+      if (vscode) {
+        vscode.postMessage({
           command: `info`,
           text: `File reloaded successfully`,
         })
       }
     } catch (error) {
       console.error(`Failed to reload file:`, error)
-      const api = get_vscode_api()
-      if (api) {
-        api.postMessage({
+      const vscode = get_vscode_api()
+      if (vscode) {
+        vscode.postMessage({
           command: `error`,
           text: `Failed to reload file: ${error}`,
         })
@@ -147,7 +140,6 @@ export function base64_to_array_buffer(base64: string): ArrayBuffer {
 const apply_theme = (theme: ThemeName): void => {
   const root = document.documentElement
 
-  // Set the data-theme attribute
   root.setAttribute(`data-theme`, theme)
 
   // Apply MatterViz theme if available
@@ -164,14 +156,6 @@ const apply_theme = (theme: ThemeName): void => {
       }
     }
   }
-
-  // Set color-scheme CSS property for better browser integration
-  root.style.setProperty(
-    `color-scheme`,
-    theme === `light` || theme === `white` ? `light` : `dark`,
-  )
-
-  // VSCode-specific variables are now included in the centralized theme system
 }
 
 // Parse file content and determine if it's a structure or trajectory
@@ -296,8 +280,8 @@ const create_display = (
     : `Structure rendered: ${filename} (${result.data.sites.length} sites)`
 
   // Get VSCode API if available
-  const api = get_vscode_api()
-  api?.postMessage({ command: `info`, text: message })
+  const vscode = get_vscode_api()
+  vscode?.postMessage({ command: `info`, text: message })
 
   return {
     destroy: () => {
@@ -330,27 +314,17 @@ const initialize_app = async (): Promise<MatterVizApp> => {
     current_app = app
 
     // Set up file change monitoring
-    const api = get_vscode_api()
-    if (api) {
-      console.log(`[MatterViz Webview] Setting up file change listener`)
+    const vscode = get_vscode_api()
+    if (vscode) {
       // Listen for file change messages from extension
       globalThis.addEventListener(`message`, (event) => {
         const message = event.data as FileChangeMessage
-        console.log(`[MatterViz Webview] Received message:`, message)
-        if (
-          message.command === `fileUpdated` || message.command === `fileDeleted`
-        ) {
-          console.log(
-            `[MatterViz Webview] Handling file change:`,
-            message.command,
-          )
+        if (message.command === `fileUpdated` || message.command === `fileDeleted`) {
           handle_file_change(message)
         }
       })
     } else {
-      console.log(
-        `[MatterViz Webview] VSCode API not available - file watching disabled`,
-      )
+      console.warn(`VSCode API not available - file watching disabled`)
     }
 
     return app
@@ -358,8 +332,8 @@ const initialize_app = async (): Promise<MatterVizApp> => {
     const err = error instanceof Error ? error : new Error(String(error))
     create_error_display(container, err, filename)
     // Get VSCode API if available
-    const api = get_vscode_api()
-    api?.postMessage({
+    const vscode = get_vscode_api()
+    vscode?.postMessage({
       command: `error`,
       text: `Failed to render file: ${err.message}`,
     })

--- a/extensions/vscode/webview/src/main.ts
+++ b/extensions/vscode/webview/src/main.ts
@@ -2,7 +2,7 @@
 import '$lib/app.css'
 import { parse_structure_file } from '$lib/io/parse'
 import Structure from '$lib/structure/Structure.svelte'
-import type { ThemeName } from '$lib/theme/index'
+import { is_valid_theme_name, type ThemeName } from '$lib/theme/index'
 import { is_trajectory_file, parse_trajectory_data } from '$lib/trajectory/parse'
 import Trajectory from '$lib/trajectory/Trajectory.svelte'
 import { mount } from 'svelte'
@@ -94,7 +94,7 @@ const handle_file_change = async (message: FileChangeMessage): Promise<void> => 
 
   if (message.command === `fileUpdated` && message.data) {
     try {
-      if (message.theme) apply_theme(message.theme as ThemeName)
+      if (message.theme && is_valid_theme_name(message.theme)) apply_theme(message.theme)
 
       const { content, filename, isCompressed } = message.data
       const result = await parse_file_content(content, filename, isCompressed)

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,7 +2,7 @@ import type { PlaywrightTestConfig } from '@playwright/test'
 
 export default {
   webServer: {
-    command: `deno task dev --port 3005`,
+    command: `vite dev --port 3005`,
     port: 3005,
     reuseExistingServer: true,
   },

--- a/src/app.html
+++ b/src/app.html
@@ -49,9 +49,9 @@
       const resolved = mode === 'auto' ? system : mode
 
       // Apply theme CSS variables
-      const root = document.documentElement
       const theme = window.MATTERVIZ_THEMES[resolved]
       const css_map = window.MATTERVIZ_CSS_MAP
+      const root = document.documentElement
 
       for (const key in theme) {
         if (css_map[key]) root.style.setProperty(css_map[key], theme[key])
@@ -59,7 +59,6 @@
 
       // Set theme attribute and store resolved theme
       root.setAttribute('data-theme', resolved)
-      window.__MATTERVIZ_THEME__ = { mode, resolved, system }
     </script>
     %sveltekit.head%
   </head>

--- a/src/lib/ContextMenu.svelte
+++ b/src/lib/ContextMenu.svelte
@@ -103,7 +103,7 @@
   .context-menu {
     background: var(--surface-bg);
     border: 1px solid var(--border-color);
-    border-radius: 8px;
+    border-radius: var(--border-radius, 4px);
     box-shadow: 0 8px 16px -4px rgba(0, 0, 0, 0.3), 0 4px 8px -2px rgba(0, 0, 0, 0.1);
     backdrop-filter: blur(4px);
     min-width: var(--context-menu-min-width, 160px);

--- a/src/lib/ContextMenu.svelte
+++ b/src/lib/ContextMenu.svelte
@@ -122,7 +122,7 @@
     color: var(--text-color-muted);
     text-transform: uppercase;
     letter-spacing: 0.5px;
-    background: var(--surface-hover-bg);
+    background: var(--surface-bg-hover);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -145,7 +145,7 @@
     border-radius: 0;
   }
   button:hover:not(.disabled) {
-    background: var(--surface-hover-bg);
+    background: var(--surface-bg-hover);
   }
   button.selected {
     background: var(--accent-color);

--- a/src/lib/DraggablePanel.svelte
+++ b/src/lib/DraggablePanel.svelte
@@ -251,7 +251,7 @@
   }
   .draggable-panel {
     position: absolute; /* Use absolute so panel scrolls with page content */
-    background: var(--panel-bg, rgba(15, 23, 42, 0.95));
+    background: var(--panel-bg);
     border: 1px solid var(--panel-border, rgba(255, 255, 255, 0.15));
     border-radius: 6px;
     padding: var(--panel-padding, 1ex);
@@ -321,10 +321,6 @@
     margin: 0 0 0 5pt;
     border: 1px solid rgba(255, 255, 255, 0.05);
     box-sizing: border-box;
-  }
-  .draggable-panel :global(.section-heading) {
-    margin: 8pt 0 2pt;
-    font-size: 0.9em;
   }
   .draggable-panel :global(.panel-row) {
     display: flex;

--- a/src/lib/DraggablePanel.svelte
+++ b/src/lib/DraggablePanel.svelte
@@ -2,7 +2,7 @@
   import { Icon } from '$lib'
   import type { IconName } from '$lib/icons'
   import type { Snippet } from 'svelte'
-  import { draggable } from 'svelte-multiselect/attachments'
+  import { draggable, tooltip } from 'svelte-multiselect/attachments'
   import type { HTMLAttributes } from 'svelte/elements'
 
   interface Props {
@@ -28,7 +28,6 @@
     has_been_dragged?: boolean
     currently_dragging?: boolean
   }
-
   let {
     show = $bindable(false),
     show_panel = true,
@@ -96,10 +95,6 @@
     show_control_buttons = true
     currently_dragging = true
     on_drag_start()
-  }
-
-  function handle_drag_end() {
-    currently_dragging = false
   }
 
   // Position calculation
@@ -180,9 +175,9 @@
     onclick={(event) => handle_button_click(event, custom_toggle || toggle_panel)}
     aria-expanded={show}
     aria-controls="draggable-panel"
-    title={toggle_props.title ?? (show ? `Close panel` : `Open panel`)}
     {...toggle_props}
     class="panel-toggle {toggle_props.class ?? ``}"
+    {@attach tooltip({ content: toggle_props.title ?? (show ? `Close panel` : `Open panel`) })}
   >
     <Icon icon={show ? open_icon : closed_icon} style={icon_style} />
   </button>
@@ -191,7 +186,7 @@
     {@attach draggable({
       handle_selector: `.drag-handle`,
       on_drag_start: handle_drag_start,
-      on_drag_end: handle_drag_end,
+      on_drag_end: () => (currently_dragging = false),
     })}
     bind:this={panel_div}
     role="dialog"
@@ -252,7 +247,7 @@
   .draggable-panel {
     position: absolute; /* Use absolute so panel scrolls with page content */
     background: var(--panel-bg);
-    border: 1px solid var(--panel-border, rgba(255, 255, 255, 0.15));
+    border: var(--panel-border, 1px solid rgba(255, 255, 255, 0.15));
     border-radius: 6px;
     padding: var(--panel-padding, 1ex);
     box-sizing: border-box;

--- a/src/lib/Spinner.svelte
+++ b/src/lib/Spinner.svelte
@@ -22,7 +22,7 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    background: var(--spinner-bg, rgba(255, 255, 255, 0.9));
+    background: var(--spinner-bg);
     color: var(--spinner-text-color, #333);
     backdrop-filter: blur(4px);
     z-index: var(--spinner-z-index, 10);

--- a/src/lib/app.css
+++ b/src/lib/app.css
@@ -2,7 +2,7 @@
   --theme-transition-duration: 0.3s;
   --text-color: #eee;
   --page-bg: #090019;
-  --max-text-width: 40em;
+  --max-text-width: 50em;
 
   --github-corner-color: var(--page-bg);
   --github-corner-bg: var(--text-color);
@@ -37,7 +37,7 @@ main {
   margin: auto;
   margin-bottom: 3em;
   width: 100%;
-  max-width: 50em;
+  max-width: var(--max-text-width);
   container-type: inline-size;
 }
 a {

--- a/src/lib/element/BohrAtom.svelte
+++ b/src/lib/element/BohrAtom.svelte
@@ -125,7 +125,6 @@
   svg {
     overflow: visible;
     width: 100%;
-    background-color: var(--surface-bg);
     border-radius: var(--border-radius);
   }
   g.shell {

--- a/src/lib/periodic-table/PeriodicTable.svelte
+++ b/src/lib/periodic-table/PeriodicTable.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { Category, ChemicalElement, XyObj } from '$lib'
   import { elem_symbols, ElementPhoto, type ElementSymbol, ElementTile } from '$lib'
-  import { is_color } from '$lib/colors'
+  import { default_category_colors, is_color } from '$lib/colors'
   import element_data from '$lib/element/data'
   import * as d3_sc from 'd3-scale-chromatic'
   import type { ComponentProps, Snippet } from 'svelte'
@@ -211,7 +211,10 @@
       ) {
         // Use missing color for zero/missing values or when no heatmap data
         if (missing_color === `element-category` && element) {
-          return `var(--${element.category.replaceAll(` `, `-`)}-bg-color)`
+          const category_key = element.category.replaceAll(` `, `-`)
+          return `var(--${category_key}-bg-color, ${
+            default_category_colors[category_key] || `#cccccc`
+          })`
         }
         return missing_color
       }
@@ -345,19 +348,6 @@
   .periodic-table-container {
     /* needed for gap: 0.3cqw; to work */
     container-type: inline-size;
-
-    /* Default category colors - can be overridden by user */
-    --diatomic-nonmetal-bg-color: #ff8c00;
-    --noble-gas-bg-color: darkorchid;
-    --alkali-metal-bg-color: darkgreen;
-    --alkaline-earth-metal-bg-color: darkslateblue;
-    --metalloid-bg-color: darkgoldenrod;
-    --polyatomic-nonmetal-bg-color: brown;
-    --transition-metal-bg-color: #571e6c;
-    --post-transition-metal-bg-color: #938d4a;
-    --lanthanide-bg-color: #58748e;
-    --actinide-bg-color: cornflowerblue;
-    --experimental-bg-color: gray;
   }
   div.periodic-table {
     display: grid;

--- a/src/lib/plot/Histogram.svelte
+++ b/src/lib/plot/Histogram.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { DraggablePanel } from '$lib'
   import type { DataSeries } from '$lib/plot'
   import { HistogramControls, PlotLegend } from '$lib/plot'
   import { bin, extent, max } from 'd3-array'
@@ -43,6 +44,7 @@
     plot_controls?: Snippet<[]>
     // Callback for handling series visibility changes
     on_series_toggle?: (series_idx: number) => void
+    controls_toggle_props?: ComponentProps<typeof DraggablePanel>[`toggle_props`]
     [key: string]: unknown
   }
   let {
@@ -72,6 +74,7 @@
     plot_controls,
     // Callback for handling series visibility changes
     on_series_toggle = () => {},
+    controls_toggle_props,
     ...rest
   }: Props = $props()
 
@@ -372,10 +375,7 @@
   <!-- Control Panel -->
   {#if show_controls}
     <HistogramControls
-      toggle_props={{
-        style:
-          `position: absolute; top: var(--ctrl-btn-top, 1ex); right: var(--ctrl-btn-right, 1ex); background-color: transparent;`,
-      }}
+      toggle_props={controls_toggle_props}
       bind:show_controls
       bind:controls_open
       bind:bins

--- a/src/lib/plot/Histogram.svelte
+++ b/src/lib/plot/Histogram.svelte
@@ -372,6 +372,10 @@
   <!-- Control Panel -->
   {#if show_controls}
     <HistogramControls
+      toggle_props={{
+        style:
+          `position: absolute; top: var(--ctrl-btn-top, 1ex); right: var(--ctrl-btn-right, 1ex); background-color: transparent;`,
+      }}
       bind:show_controls
       bind:controls_open
       bind:bins

--- a/src/lib/plot/HistogramControls.svelte
+++ b/src/lib/plot/HistogramControls.svelte
@@ -34,8 +34,8 @@
     y_format?: string
     // Selected property for single mode
     selected_property?: string
-    controls_toggle_props?: ComponentProps<typeof DraggablePanel>[`toggle_props`]
-    controls_panel_props?: ComponentProps<typeof DraggablePanel>[`panel_props`]
+    toggle_props?: ComponentProps<typeof DraggablePanel>[`toggle_props`]
+    panel_props?: ComponentProps<typeof DraggablePanel>[`panel_props`]
   }
   let {
     show_controls = $bindable(false),
@@ -56,8 +56,8 @@
     x_format = $bindable(`.2~s`),
     y_format = $bindable(`d`),
     selected_property = $bindable(``),
-    controls_toggle_props,
-    controls_panel_props,
+    toggle_props,
+    panel_props,
   }: Props = $props()
 
   // Local variables for format inputs to prevent invalid values from reaching props
@@ -130,13 +130,17 @@
     toggle_props={{
       class: `histogram-controls-toggle`,
       title: `${controls_open ? `Close` : `Open`} histogram controls`,
-      ...controls_toggle_props,
+      style:
+        `position: absolute; top: var(--ctrl-btn-top, 1ex); right: var(--ctrl-btn-right, 1ex); background-color: transparent; ${
+          toggle_props?.style ?? ``
+        }`,
+      ...toggle_props,
     }}
     panel_props={{
       class: `histogram-controls-panel`,
       style:
         `--panel-width: 16em; max-height: 450px; overflow-y: auto; padding-right: 4px;`,
-      ...controls_panel_props,
+      ...panel_props,
     }}
   >
     {#if plot_controls}

--- a/src/lib/plot/HistogramControls.svelte
+++ b/src/lib/plot/HistogramControls.svelte
@@ -3,7 +3,7 @@
   import type { DataSeries } from '$lib/plot'
   import { format } from 'd3-format'
   import { timeFormat } from 'd3-time-format'
-  import type { Snippet } from 'svelte'
+  import type { ComponentProps, Snippet } from 'svelte'
   import type { TicksOption } from './scales'
 
   interface Props {
@@ -34,6 +34,8 @@
     y_format?: string
     // Selected property for single mode
     selected_property?: string
+    toggle_props?: ComponentProps<typeof DraggablePanel>[`toggle_props`]
+    panel_props?: ComponentProps<typeof DraggablePanel>[`panel_props`]
   }
 
   let {
@@ -55,6 +57,8 @@
     x_format = $bindable(`.2~s`),
     y_format = $bindable(`d`),
     selected_property = $bindable(``),
+    toggle_props,
+    panel_props,
   }: Props = $props()
 
   // Local variables for format inputs to prevent invalid values from reaching props
@@ -124,199 +128,194 @@
     open_icon="Cross"
     icon_style="transform: scale(1.2);"
     offset={{ x: -35, y: 10 }}
-    toggle_props={{
-      class: `histogram-controls-toggle`,
-      style: `position: absolute; top: 10px; right: 10px;`,
-    }}
+    toggle_props={{ class: `histogram-controls-toggle`, ...toggle_props }}
     panel_props={{
       class: `histogram-controls-panel`,
       style:
         `--panel-width: 16em; max-height: 450px; overflow-y: auto; padding-right: 4px;`,
+      ...panel_props,
     }}
   >
     {#if plot_controls}
       {@render plot_controls()}
     {:else}
-      <div class="histogram-controls-content">
-        <!-- Histogram-specific Controls -->
-        <h4 class="section-heading">Histogram</h4>
-        <div class="controls-group">
+      <h4 style="margin-top: 0">Histogram Controls</h4>
+      <div class="controls-group">
+        <div class="panel-row">
+          <label for="bins-input">Bins:</label>
+          <input
+            id="bins-input"
+            type="range"
+            min="5"
+            max="100"
+            step="5"
+            bind:value={bins}
+          />
+          <input
+            type="number"
+            min="5"
+            max="100"
+            step="5"
+            bind:value={bins}
+            class="number-input"
+          />
+        </div>
+        {#if has_multiple_series}
           <div class="panel-row">
-            <label for="bins-input">Bins:</label>
-            <input
-              id="bins-input"
-              type="range"
-              min="5"
-              max="100"
-              step="5"
-              bind:value={bins}
-            />
-            <input
-              type="number"
-              min="5"
-              max="100"
-              step="5"
-              bind:value={bins}
-              class="number-input"
-            />
+            <label for="mode-select">Mode:</label>
+            <select bind:value={mode} id="mode-select">
+              <option value="single">Single</option>
+              <option value="overlay">Overlay</option>
+            </select>
           </div>
-          {#if has_multiple_series}
+          {#if mode === `single`}
             <div class="panel-row">
-              <label for="mode-select">Mode:</label>
-              <select bind:value={mode} id="mode-select">
-                <option value="single">Single</option>
-                <option value="overlay">Overlay</option>
+              <label for="property-select">Property:</label>
+              <select bind:value={selected_property} id="property-select">
+                <option value="">All</option>
+                {#each series_options as option (option)} 
+                  <option value={option}>{option}</option>
+                {/each}
               </select>
             </div>
-            {#if mode === `single`}
-              <div class="panel-row">
-                <label for="property-select">Property:</label>
-                <select bind:value={selected_property} id="property-select">
-                  <option value="">All</option>
-                  {#each series_options as option (option)} 
-                    <option value={option}>{option}</option>
-                  {/each}
-                </select>
-              </div>
-            {/if}
           {/if}
-          <label class="checkbox-label">
-            <input type="checkbox" bind:checked={show_legend} />
-            Show legend
-          </label>
-        </div>
+        {/if}
+        <label class="checkbox-label">
+          <input type="checkbox" bind:checked={show_legend} />
+          Show legend
+        </label>
+      </div>
 
-        <!-- Bar Style Controls -->
-        <h4 class="section-heading">Bar Style</h4>
-        <div class="controls-group">
-          <div class="panel-row">
-            <label for="bar-opacity-range">Opacity:</label>
-            <input
-              id="bar-opacity-range"
-              type="range"
-              min="0"
-              max="1"
-              step="0.05"
-              bind:value={bar_opacity}
-            />
-            <input
-              type="number"
-              min="0"
-              max="1"
-              step="0.05"
-              bind:value={bar_opacity}
-              class="number-input"
-            />
-          </div>
-          <div class="panel-row">
-            <label for="bar-stroke-width-range">Stroke Width:</label>
-            <input
-              id="bar-stroke-width-range"
-              type="range"
-              min="0"
-              max="5"
-              step="0.1"
-              bind:value={bar_stroke_width}
-            />
-            <input
-              type="number"
-              min="0"
-              max="5"
-              step="0.1"
-              bind:value={bar_stroke_width}
-              class="number-input"
-            />
-          </div>
+      <!-- Bar Style Controls -->
+      <h4>Bar Style</h4>
+      <div class="controls-group">
+        <div class="panel-row">
+          <label for="bar-opacity-range">Opacity:</label>
+          <input
+            id="bar-opacity-range"
+            type="range"
+            min="0"
+            max="1"
+            step="0.05"
+            bind:value={bar_opacity}
+          />
+          <input
+            type="number"
+            min="0"
+            max="1"
+            step="0.05"
+            bind:value={bar_opacity}
+            class="number-input"
+          />
         </div>
-
-        <!-- Display Controls -->
-        <h4 class="section-heading">Display</h4>
-        <div class="controls-group">
-          <label class="checkbox-label">
-            <input type="checkbox" bind:checked={x_grid as boolean} />
-            X-axis grid
-          </label>
-          <label class="checkbox-label">
-            <input type="checkbox" bind:checked={y_grid as boolean} />
-            Y-axis grid
-          </label>
+        <div class="panel-row">
+          <label for="bar-stroke-width-range">Stroke Width:</label>
+          <input
+            id="bar-stroke-width-range"
+            type="range"
+            min="0"
+            max="5"
+            step="0.1"
+            bind:value={bar_stroke_width}
+          />
+          <input
+            type="number"
+            min="0"
+            max="5"
+            step="0.1"
+            bind:value={bar_stroke_width}
+            class="number-input"
+          />
         </div>
+      </div>
 
-        <!-- Scale Type Controls -->
-        <h4 class="section-heading">Scale Type</h4>
-        <div class="controls-group">
-          <div class="panel-row">
-            <label for="x-scale-select">X-axis:</label>
-            <select bind:value={x_scale_type} id="x-scale-select">
-              <option value="linear">Linear</option>
-              <option value="log">Log</option>
-            </select>
-          </div>
-          <div class="panel-row">
-            <label for="y-scale-select">Y-axis:</label>
-            <select bind:value={y_scale_type} id="y-scale-select">
-              <option value="linear">Linear</option>
-              <option value="log">Log</option>
-            </select>
-          </div>
+      <!-- Display Controls -->
+      <h4>Display</h4>
+      <div class="controls-group">
+        <label class="checkbox-label">
+          <input type="checkbox" bind:checked={x_grid as boolean} />
+          X-axis grid
+        </label>
+        <label class="checkbox-label">
+          <input type="checkbox" bind:checked={y_grid as boolean} />
+          Y-axis grid
+        </label>
+      </div>
+
+      <!-- Scale Type Controls -->
+      <h4>Scale Type</h4>
+      <div class="controls-group">
+        <div class="panel-row">
+          <label for="x-scale-select">X-axis:</label>
+          <select bind:value={x_scale_type} id="x-scale-select">
+            <option value="linear">Linear</option>
+            <option value="log">Log</option>
+          </select>
         </div>
-
-        <!-- Tick Controls -->
-        <h4 class="section-heading">Ticks</h4>
-        <div class="controls-group">
-          <div class="panel-row">
-            <label for="x-ticks-input">X-axis:</label>
-            <input
-              id="x-ticks-input"
-              type="number"
-              min="2"
-              max="20"
-              step="1"
-              value={typeof x_ticks === `number` ? x_ticks : 8}
-              oninput={(event) => handle_ticks_input(event, `x`)}
-              class="number-input"
-            />
-          </div>
-          <div class="panel-row">
-            <label for="y-ticks-input">Y-axis:</label>
-            <input
-              id="y-ticks-input"
-              type="number"
-              min="2"
-              max="20"
-              step="1"
-              value={typeof y_ticks === `number` ? y_ticks : 6}
-              oninput={(event) => handle_ticks_input(event, `y`)}
-              class="number-input"
-            />
-          </div>
+        <div class="panel-row">
+          <label for="y-scale-select">Y-axis:</label>
+          <select bind:value={y_scale_type} id="y-scale-select">
+            <option value="linear">Linear</option>
+            <option value="log">Log</option>
+          </select>
         </div>
+      </div>
 
-        <!-- Format Controls -->
-        <h4 class="section-heading">Tick Format</h4>
-        <div class="controls-group">
-          <div class="panel-row">
-            <label for="x-format">X-axis:</label>
-            <input
-              id="x-format"
-              type="text"
-              bind:value={x_format_input}
-              placeholder=".2~s / .0% / %Y-%m-%d"
-              class="format-input"
-              oninput={(event) => handle_format_input(event, `x`)}
-            />
-          </div>
-          <div class="panel-row">
-            <label for="y-format">Y-axis:</label>
-            <input
-              id="y-format"
-              type="text"
-              bind:value={y_format_input}
-              placeholder="d / .1e / .0%"
-              class="format-input"
-              oninput={(event) => handle_format_input(event, `y`)}
-            />
-          </div>
+      <!-- Tick Controls -->
+      <h4>Ticks</h4>
+      <div class="controls-group">
+        <div class="panel-row">
+          <label for="x-ticks-input">X-axis:</label>
+          <input
+            id="x-ticks-input"
+            type="number"
+            min="2"
+            max="20"
+            step="1"
+            value={typeof x_ticks === `number` ? x_ticks : 8}
+            oninput={(event) => handle_ticks_input(event, `x`)}
+            class="number-input"
+          />
+        </div>
+        <div class="panel-row">
+          <label for="y-ticks-input">Y-axis:</label>
+          <input
+            id="y-ticks-input"
+            type="number"
+            min="2"
+            max="20"
+            step="1"
+            value={typeof y_ticks === `number` ? y_ticks : 6}
+            oninput={(event) => handle_ticks_input(event, `y`)}
+            class="number-input"
+          />
+        </div>
+      </div>
+
+      <!-- Format Controls -->
+      <h4>Tick Format</h4>
+      <div class="controls-group">
+        <div class="panel-row">
+          <label for="x-format">X-axis:</label>
+          <input
+            id="x-format"
+            type="text"
+            bind:value={x_format_input}
+            placeholder=".2~s / .0% / %Y-%m-%d"
+            class="format-input"
+            oninput={(event) => handle_format_input(event, `x`)}
+          />
+        </div>
+        <div class="panel-row">
+          <label for="y-format">Y-axis:</label>
+          <input
+            id="y-format"
+            type="text"
+            bind:value={y_format_input}
+            placeholder="d / .1e / .0%"
+            class="format-input"
+            oninput={(event) => handle_format_input(event, `y`)}
+          />
         </div>
       </div>
     {/if}
@@ -324,24 +323,14 @@
 {/if}
 
 <style>
-  .section-heading {
-    margin: 0 0 8px 0;
+  h4 {
+    margin: 8pt 0 2pt;
     font-size: 0.9em;
-    color: var(--text-color-muted, #ccc);
-    font-weight: 600;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-    padding-bottom: 4px;
-  }
-  .histogram-controls-content {
-    max-height: 450px;
-    overflow-y: auto;
-    padding-right: 4px;
   }
   .controls-group {
     display: flex;
     flex-direction: column;
-    gap: 6px;
-    margin-bottom: 16px;
+    gap: 6pt;
   }
   .checkbox-label {
     display: flex;

--- a/src/lib/plot/HistogramControls.svelte
+++ b/src/lib/plot/HistogramControls.svelte
@@ -34,10 +34,9 @@
     y_format?: string
     // Selected property for single mode
     selected_property?: string
-    toggle_props?: ComponentProps<typeof DraggablePanel>[`toggle_props`]
-    panel_props?: ComponentProps<typeof DraggablePanel>[`panel_props`]
+    controls_toggle_props?: ComponentProps<typeof DraggablePanel>[`toggle_props`]
+    controls_panel_props?: ComponentProps<typeof DraggablePanel>[`panel_props`]
   }
-
   let {
     show_controls = $bindable(false),
     controls_open = $bindable(false),
@@ -57,8 +56,8 @@
     x_format = $bindable(`.2~s`),
     y_format = $bindable(`d`),
     selected_property = $bindable(``),
-    toggle_props,
-    panel_props,
+    controls_toggle_props,
+    controls_panel_props,
   }: Props = $props()
 
   // Local variables for format inputs to prevent invalid values from reaching props
@@ -128,12 +127,16 @@
     open_icon="Cross"
     icon_style="transform: scale(1.2);"
     offset={{ x: -35, y: 10 }}
-    toggle_props={{ class: `histogram-controls-toggle`, ...toggle_props }}
+    toggle_props={{
+      class: `histogram-controls-toggle`,
+      title: `${controls_open ? `Close` : `Open`} histogram controls`,
+      ...controls_toggle_props,
+    }}
     panel_props={{
       class: `histogram-controls-panel`,
       style:
         `--panel-width: 16em; max-height: 450px; overflow-y: auto; padding-right: 4px;`,
-      ...panel_props,
+      ...controls_panel_props,
     }}
   >
     {#if plot_controls}

--- a/src/lib/plot/ScatterPlot.svelte
+++ b/src/lib/plot/ScatterPlot.svelte
@@ -1889,7 +1889,8 @@
     {#if show_controls}
       <ScatterPlotControls
         toggle_props={{
-          style: `position: absolute; top: 0; right: 0; background-color: transparent;`,
+          style:
+            `position: absolute; top: var(--ctrl-btn-top, 1ex); right: var(--ctrl-btn-right, 1ex); background-color: transparent;`,
         }}
         bind:this={controls_component}
         bind:show_controls

--- a/src/lib/plot/ScatterPlot.svelte
+++ b/src/lib/plot/ScatterPlot.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { cells_3x3, corner_cells, Line, symbol_names } from '$lib'
+  import { cells_3x3, corner_cells, DraggablePanel, Line, symbol_names } from '$lib'
   import type { D3ColorSchemeName, D3InterpolateName } from '$lib/colors'
   import { luminance } from '$lib/colors'
   import * as math from '$lib/math'
@@ -135,6 +135,7 @@
     show_lines?: boolean
     selected_series_idx?: number
     color_axis_labels?: boolean | { y1?: string | null; y2?: string | null } // Y-axis label colors: true (auto), false (none), or explicit colors
+    controls_toggle_props?: ComponentProps<typeof DraggablePanel>[`toggle_props`]
     [key: string]: unknown
   }
   let {
@@ -208,6 +209,7 @@
     show_lines = $bindable(true),
     selected_series_idx = $bindable(0),
     color_axis_labels = true,
+    controls_toggle_props,
     ...rest
   }: Props = $props()
 
@@ -1888,10 +1890,7 @@
     <!-- Control Panel positioned in top-right corner -->
     {#if show_controls}
       <ScatterPlotControls
-        toggle_props={{
-          style:
-            `position: absolute; top: var(--ctrl-btn-top, 1ex); right: var(--ctrl-btn-right, 1ex); background-color: transparent;`,
-        }}
+        toggle_props={controls_toggle_props}
         bind:this={controls_component}
         bind:show_controls
         bind:controls_open
@@ -1996,7 +1995,7 @@
     height: 100%;
     min-height: var(--scatter-min-height, 100px);
     container-type: inline-size;
-    z-index: var(--scatter-z-index, 1);
+    z-index: var(--scatter-z-index);
   }
   svg {
     width: 100%;

--- a/src/lib/plot/ScatterPlotControls.svelte
+++ b/src/lib/plot/ScatterPlotControls.svelte
@@ -223,311 +223,297 @@
     panel_props={{
       class: `scatter-controls-panel`,
       style:
-        `--panel-width: 16em; max-height: 400px; overflow-y: auto; padding-right: 4px;`,
+        `--panel-width: 16em; max-height: 450px; overflow-y: auto; padding-right: 4px;`,
       ...panel_props,
     }}
   >
     {#if plot_controls}
       {@render plot_controls()}
     {:else}
-      <div class="plot-controls-content">
-        <!-- Display Controls -->
-        <h4 class="section-heading" style="margin-top: 0">Display</h4>
-        <div class="controls-group">
+      <h4 style="margin-top: 0">Scatter Plot Controls</h4>
+      <div class="controls-group">
+        <label class="checkbox-label">
+          <input type="checkbox" bind:checked={show_zero_lines} /> Show zero lines
+        </label>
+        <label class="checkbox-label">
+          <input type="checkbox" bind:checked={show_points} /> Show points
+        </label>
+        <label class="checkbox-label">
+          <input type="checkbox" bind:checked={show_lines} /> Show lines
+        </label>
+        <label class="checkbox-label">
+          <input type="checkbox" bind:checked={x_grid as boolean} /> X-axis grid
+        </label>
+        <label class="checkbox-label">
+          <input type="checkbox" bind:checked={y_grid as boolean} /> Y-axis grid
+        </label>
+        {#if has_y2_points}
           <label class="checkbox-label">
-            <input type="checkbox" bind:checked={show_zero_lines} /> Show zero lines
+            <input type="checkbox" bind:checked={y2_grid as boolean} /> Y2-axis grid
           </label>
-          <label class="checkbox-label">
-            <input type="checkbox" bind:checked={show_points} /> Show points
-          </label>
-          <label class="checkbox-label">
-            <input type="checkbox" bind:checked={show_lines} /> Show lines
-          </label>
-          <label class="checkbox-label">
-            <input type="checkbox" bind:checked={x_grid as boolean} /> X-axis grid
-          </label>
-          <label class="checkbox-label">
-            <input type="checkbox" bind:checked={y_grid as boolean} /> Y-axis grid
-          </label>
-          {#if has_y2_points}
-            <label class="checkbox-label">
-              <input type="checkbox" bind:checked={y2_grid as boolean} /> Y2-axis grid
-            </label>
-          {/if}
-        </div>
-
-        <!-- Range Controls -->
-        <h4 class="section-heading">Axis Range</h4>
-        <div class="controls-group">
-          <div class="range-row">
-            <label for="x-range-min">X-axis:</label>
-            <input {...input_props(`x`, `min`, x_range)} />
-            <span class="range-separator">to</span>
-            <input {...input_props(`x`, `max`, x_range)} />
-          </div>
-          <div class="range-row">
-            <label for="y-range-min">Y-axis:</label>
-            <input {...input_props(`y`, `min`, y_range)} />
-            <span class="range-separator">to</span>
-            <input {...input_props(`y`, `max`, y_range)} />
-          </div>
-          {#if has_y2_points}
-            <div class="range-row">
-              <label for="y2-range-min">Y2-axis:</label>
-              <input {...input_props(`y2`, `min`, y2_range)} />
-              <span class="range-separator">to</span>
-              <input {...input_props(`y2`, `max`, y2_range)} />
-            </div>
-          {/if}
-        </div>
-
-        <!-- Format Controls -->
-        <h4 class="section-heading">Tick Format</h4>
-        <div class="controls-group">
-          <div class="panel-row">
-            <label for="x-format">X-axis:</label>
-            <input
-              id="x-format"
-              type="text"
-              bind:value={x_format_input}
-              placeholder=".2f / .0% / %Y-%m-%d"
-              class="format-input"
-              oninput={format_input_handler(`x`)}
-            />
-          </div>
-          <div class="panel-row">
-            <label for="y-format">Y-axis:</label>
-            <input
-              id="y-format"
-              type="text"
-              bind:value={y_format_input}
-              placeholder=".2f / .1e / .0%"
-              class="format-input"
-              oninput={format_input_handler(`y`)}
-            />
-          </div>
-          {#if has_y2_points}
-            <div class="panel-row">
-              <label for="y2-format">Y2-axis:</label>
-              <input
-                id="y2-format"
-                type="text"
-                bind:value={y2_format_input}
-                placeholder=".2f / .1e / .0%"
-                class="format-input"
-                oninput={format_input_handler(`y2`)}
-              />
-            </div>
-          {/if}
-        </div>
-
-        <!-- Series Selection (for multi-series style controls) -->
-        {#if has_multiple_series}
-          <div class="controls-group">
-            <div class="panel-row">
-              <label for="series-select">Series</label>
-              <select bind:value={selected_series_idx} id="series-select">
-                {#each series.filter(Boolean) as
-                  series_data,
-                  idx
-                  (series_data.label ?? idx)
-                }
-                  <option value={idx}>
-                    {series_data.label ?? `Series ${idx + 1}`}
-                  </option>
-                {/each}
-              </select>
-            </div>
-          </div>
         {/if}
+      </div>
 
-        <!-- Point Style Controls -->
-        {#if show_points}
-          <h4 class="section-heading">Point Style</h4>
-          <div class="controls-group">
-            <div class="panel-row">
-              <label for="point-size-range">Size:</label>
-              <input
-                id="point-size-range"
-                type="range"
-                min="1"
-                max="20"
-                step="0.5"
-                bind:value={point_size}
-              />
-              <input
-                type="number"
-                min="1"
-                max="20"
-                step="0.5"
-                bind:value={point_size}
-                class="number-input"
-              />
-            </div>
-            <div class="panel-row">
-              <label for="point-color">Color:</label>
-              <input
-                id="point-color"
-                type="color"
-                bind:value={point_color}
-                class="color-input"
-              />
-              <input
-                type="range"
-                min="0"
-                max="1"
-                step="0.05"
-                bind:value={point_opacity}
-                class="opacity-slider"
-                title="Color opacity"
-              />
-              <input
-                type="number"
-                min="0"
-                max="1"
-                step="0.05"
-                bind:value={point_opacity}
-                class="number-input opacity-number"
-              />
-            </div>
-            <div class="panel-row">
-              <label for="point-stroke-width-range">Stroke Width:</label>
-              <input
-                id="point-stroke-width-range"
-                type="range"
-                min="0"
-                max="5"
-                step="0.1"
-                bind:value={point_stroke_width}
-              />
-              <input
-                type="number"
-                min="0"
-                max="5"
-                step="0.1"
-                bind:value={point_stroke_width}
-                class="number-input"
-              />
-            </div>
-            <div class="panel-row">
-              <label for="point-stroke-color">Stroke Color:</label>
-              <input
-                id="point-stroke-color"
-                type="color"
-                bind:value={point_stroke_color}
-              />
-              <input
-                type="range"
-                min="0"
-                max="1"
-                step="0.05"
-                bind:value={point_stroke_opacity}
-                class="opacity-slider"
-                title="Stroke opacity"
-              />
-              <input
-                type="number"
-                min="0"
-                max="1"
-                step="0.05"
-                bind:value={point_stroke_opacity}
-                class="number-input opacity-number"
-              />
-            </div>
-          </div>
-        {/if}
-
-        <!-- Line Style Controls -->
-        {#if show_lines}
-          <h4 class="section-heading">Line Style</h4>
-          <div class="controls-group">
-            <div class="panel-row">
-              <label for="line-width-range">Line Width:</label>
-              <input
-                id="line-width-range"
-                type="range"
-                min="0.5"
-                max="10"
-                step="0.5"
-                bind:value={line_width}
-              />
-              <input
-                type="number"
-                min="0.5"
-                max="10"
-                step="0.5"
-                bind:value={line_width}
-                class="number-input"
-              />
-            </div>
-            <div class="panel-row">
-              <label for="line-color">Line Color:</label>
-              <input
-                id="line-color"
-                type="color"
-                bind:value={line_color}
-              />
-              <input
-                type="range"
-                min="0"
-                max="1"
-                step="0.05"
-                bind:value={line_opacity}
-                class="opacity-slider"
-                title="Line opacity"
-              />
-              <input
-                type="number"
-                min="0"
-                max="1"
-                step="0.05"
-                bind:value={line_opacity}
-                class="number-input opacity-number"
-              />
-            </div>
-            <div class="panel-row">
-              <label for="line-style-select">Line Style:</label>
-              <select
-                id="line-style-select"
-                value={line_dash ?? `solid`}
-                onchange={(event) => {
-                  line_dash = event.currentTarget.value === `solid`
-                    ? undefined
-                    : event.currentTarget.value
-                }}
-              >
-                <option value="solid">Solid</option>
-                <option value="4,4">Dashed</option>
-                <option value="2,2">Dotted</option>
-                <option value="8,4,2,4">Dash-dot</option>
-              </select>
-            </div>
+      <!-- Range Controls -->
+      <h4>Axis Range</h4>
+      <div class="controls-group">
+        <div class="range-row">
+          <label for="x-range-min">X-axis:</label>
+          <input {...input_props(`x`, `min`, x_range)} />
+          <span class="range-separator">to</span>
+          <input {...input_props(`x`, `max`, x_range)} />
+        </div>
+        <div class="range-row">
+          <label for="y-range-min">Y-axis:</label>
+          <input {...input_props(`y`, `min`, y_range)} />
+          <span class="range-separator">to</span>
+          <input {...input_props(`y`, `max`, y_range)} />
+        </div>
+        {#if has_y2_points}
+          <div class="range-row">
+            <label for="y2-range-min">Y2-axis:</label>
+            <input {...input_props(`y2`, `min`, y2_range)} />
+            <span class="range-separator">to</span>
+            <input {...input_props(`y2`, `max`, y2_range)} />
           </div>
         {/if}
       </div>
+
+      <!-- Format Controls -->
+      <h4>Tick Format</h4>
+      <div class="controls-group">
+        <div class="panel-row">
+          <label for="x-format">X-axis:</label>
+          <input
+            id="x-format"
+            type="text"
+            bind:value={x_format_input}
+            placeholder=".2f / .0% / %Y-%m-%d"
+            class="format-input"
+            oninput={format_input_handler(`x`)}
+          />
+        </div>
+        <div class="panel-row">
+          <label for="y-format">Y-axis:</label>
+          <input
+            id="y-format"
+            type="text"
+            bind:value={y_format_input}
+            placeholder=".2f / .1e / .0%"
+            class="format-input"
+            oninput={format_input_handler(`y`)}
+          />
+        </div>
+        {#if has_y2_points}
+          <div class="panel-row">
+            <label for="y2-format">Y2-axis:</label>
+            <input
+              id="y2-format"
+              type="text"
+              bind:value={y2_format_input}
+              placeholder=".2f / .1e / .0%"
+              class="format-input"
+              oninput={format_input_handler(`y2`)}
+            />
+          </div>
+        {/if}
+      </div>
+
+      <!-- Series Selection (for multi-series style controls) -->
+      {#if has_multiple_series}
+        <div class="controls-group">
+          <div class="panel-row">
+            <label for="series-select">Series</label>
+            <select bind:value={selected_series_idx} id="series-select">
+              {#each series.filter(Boolean) as
+                series_data,
+                idx
+                (series_data.label ?? idx)
+              }
+                <option value={idx}>
+                  {series_data.label ?? `Series ${idx + 1}`}
+                </option>
+              {/each}
+            </select>
+          </div>
+        </div>
+      {/if}
+
+      <!-- Point Style Controls -->
+      {#if show_points}
+        <h4>Point Style</h4>
+        <div class="controls-group">
+          <div class="panel-row">
+            <label for="point-size-range">Size:</label>
+            <input
+              id="point-size-range"
+              type="range"
+              min="1"
+              max="20"
+              step="0.5"
+              bind:value={point_size}
+            />
+            <input
+              type="number"
+              min="1"
+              max="20"
+              step="0.5"
+              bind:value={point_size}
+              class="number-input"
+            />
+          </div>
+          <div class="panel-row">
+            <label for="point-color">Color:</label>
+            <input
+              id="point-color"
+              type="color"
+              bind:value={point_color}
+              class="color-input"
+            />
+            <input
+              type="range"
+              min="0"
+              max="1"
+              step="0.05"
+              bind:value={point_opacity}
+              class="opacity-slider"
+              title="Color opacity"
+            />
+            <input
+              type="number"
+              min="0"
+              max="1"
+              step="0.05"
+              bind:value={point_opacity}
+              class="number-input opacity-number"
+            />
+          </div>
+          <div class="panel-row">
+            <label for="point-stroke-width-range">Stroke Width:</label>
+            <input
+              id="point-stroke-width-range"
+              type="range"
+              min="0"
+              max="5"
+              step="0.1"
+              bind:value={point_stroke_width}
+            />
+            <input
+              type="number"
+              min="0"
+              max="5"
+              step="0.1"
+              bind:value={point_stroke_width}
+              class="number-input"
+            />
+          </div>
+          <div class="panel-row">
+            <label for="point-stroke-color">Stroke Color:</label>
+            <input
+              id="point-stroke-color"
+              type="color"
+              bind:value={point_stroke_color}
+            />
+            <input
+              type="range"
+              min="0"
+              max="1"
+              step="0.05"
+              bind:value={point_stroke_opacity}
+              class="opacity-slider"
+              title="Stroke opacity"
+            />
+            <input
+              type="number"
+              min="0"
+              max="1"
+              step="0.05"
+              bind:value={point_stroke_opacity}
+              class="number-input opacity-number"
+            />
+          </div>
+        </div>
+      {/if}
+
+      <!-- Line Style Controls -->
+      {#if show_lines}
+        <h4>Line Style</h4>
+        <div class="controls-group">
+          <div class="panel-row">
+            <label for="line-width-range">Line Width:</label>
+            <input
+              id="line-width-range"
+              type="range"
+              min="0.5"
+              max="10"
+              step="0.5"
+              bind:value={line_width}
+            />
+            <input
+              type="number"
+              min="0.5"
+              max="10"
+              step="0.5"
+              bind:value={line_width}
+              class="number-input"
+            />
+          </div>
+          <div class="panel-row">
+            <label for="line-color">Line Color:</label>
+            <input
+              id="line-color"
+              type="color"
+              bind:value={line_color}
+            />
+            <input
+              type="range"
+              min="0"
+              max="1"
+              step="0.05"
+              bind:value={line_opacity}
+              class="opacity-slider"
+              title="Line opacity"
+            />
+            <input
+              type="number"
+              min="0"
+              max="1"
+              step="0.05"
+              bind:value={line_opacity}
+              class="number-input opacity-number"
+            />
+          </div>
+          <div class="panel-row">
+            <label for="line-style-select">Line Style:</label>
+            <select
+              id="line-style-select"
+              value={line_dash ?? `solid`}
+              onchange={(event) => {
+                line_dash = event.currentTarget.value === `solid`
+                  ? undefined
+                  : event.currentTarget.value
+              }}
+            >
+              <option value="solid">Solid</option>
+              <option value="4,4">Dashed</option>
+              <option value="2,2">Dotted</option>
+              <option value="8,4,2,4">Dash-dot</option>
+            </select>
+          </div>
+        </div>
+      {/if}
     {/if}
   </DraggablePanel>
 {/if}
 
 <style>
-  .section-heading {
-    margin: 0 0 8px 0;
+  h4 {
+    margin: 8pt 0 2pt;
     font-size: 0.9em;
-    color: var(--text-color-muted, #ccc);
-    font-weight: 600;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-    padding-bottom: 4px;
-  }
-  .plot-controls-content {
-    max-height: 400px;
-    overflow-y: auto;
-    padding-right: 4px;
   }
   .controls-group {
     display: flex;
     flex-direction: column;
-    gap: 6px;
-    margin-bottom: 16px;
   }
   .checkbox-label {
     display: flex;

--- a/src/lib/plot/ScatterPlotControls.svelte
+++ b/src/lib/plot/ScatterPlotControls.svelte
@@ -47,8 +47,8 @@
     show_points?: boolean
     show_lines?: boolean
     selected_series_idx?: number
-    toggle_props?: ComponentProps<typeof DraggablePanel>[`toggle_props`]
-    panel_props?: ComponentProps<typeof DraggablePanel>[`panel_props`]
+    controls_toggle_props?: ComponentProps<typeof DraggablePanel>[`toggle_props`]
+    controls_panel_props?: ComponentProps<typeof DraggablePanel>[`panel_props`]
   }
   let {
     show_controls = $bindable(false),
@@ -87,8 +87,8 @@
     show_points = $bindable(true),
     show_lines = $bindable(true),
     selected_series_idx = $bindable(0),
-    toggle_props = {},
-    panel_props = {},
+    controls_toggle_props = {},
+    controls_panel_props = {},
   }: Props = $props()
 
   // Derived state
@@ -219,12 +219,16 @@
     closed_icon="Settings"
     open_icon="Cross"
     icon_style="transform: scale(1.2);"
-    toggle_props={{ class: `scatter-controls-toggle`, ...toggle_props }}
+    toggle_props={{
+      class: `scatter-controls-toggle`,
+      title: `${controls_open ? `Close` : `Open`} scatter plot controls`,
+      ...controls_toggle_props,
+    }}
     panel_props={{
       class: `scatter-controls-panel`,
       style:
         `--panel-width: 16em; max-height: 450px; overflow-y: auto; padding-right: 4px;`,
-      ...panel_props,
+      ...controls_panel_props,
     }}
   >
     {#if plot_controls}

--- a/src/lib/plot/ScatterPlotControls.svelte
+++ b/src/lib/plot/ScatterPlotControls.svelte
@@ -47,8 +47,8 @@
     show_points?: boolean
     show_lines?: boolean
     selected_series_idx?: number
-    controls_toggle_props?: ComponentProps<typeof DraggablePanel>[`toggle_props`]
-    controls_panel_props?: ComponentProps<typeof DraggablePanel>[`panel_props`]
+    toggle_props?: ComponentProps<typeof DraggablePanel>[`toggle_props`]
+    panel_props?: ComponentProps<typeof DraggablePanel>[`panel_props`]
   }
   let {
     show_controls = $bindable(false),
@@ -87,8 +87,8 @@
     show_points = $bindable(true),
     show_lines = $bindable(true),
     selected_series_idx = $bindable(0),
-    controls_toggle_props = {},
-    controls_panel_props = {},
+    toggle_props = {},
+    panel_props = {},
   }: Props = $props()
 
   // Derived state
@@ -222,13 +222,17 @@
     toggle_props={{
       class: `scatter-controls-toggle`,
       title: `${controls_open ? `Close` : `Open`} scatter plot controls`,
-      ...controls_toggle_props,
+      style:
+        `position: absolute; top: var(--ctrl-btn-top, 1ex); right: var(--ctrl-btn-right, 1ex); background-color: transparent; ${
+          toggle_props?.style ?? ``
+        }`,
+      ...toggle_props,
     }}
     panel_props={{
       class: `scatter-controls-panel`,
       style:
         `--panel-width: 16em; max-height: 450px; overflow-y: auto; padding-right: 4px;`,
-      ...controls_panel_props,
+      ...panel_props,
     }}
   >
     {#if plot_controls}

--- a/src/lib/plot/index.ts
+++ b/src/lib/plot/index.ts
@@ -2,9 +2,17 @@ import type { SimulationNodeDatum } from 'd3-force'
 import type { SymbolType } from 'd3-shape'
 import * as d3_symbols from 'd3-shape'
 import type { ComponentProps } from 'svelte'
-import { type TweenedOptions } from 'svelte/motion'
 import type ColorBar from './ColorBar.svelte'
 import PlotLegend from './PlotLegend.svelte'
+
+// TODO restore: import { type TweenedOptions } from 'svelte/motion'
+// pending https://github.com/sveltejs/svelte/issues/16151
+interface TweenedOptions<T> {
+  delay?: number
+  duration?: number | ((from: T, to: T) => number)
+  easing?: (t: number) => number
+  interpolate?: (a: T, b: T) => (t: number) => T
+}
 
 export { default as ColorBar } from './ColorBar.svelte'
 export { default as ColorScaleSelect } from './ColorScaleSelect.svelte'

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -451,7 +451,8 @@
     width: 100vw !important;
   }
   .structure.dragover {
-    background: var(--struct-dragover-bg);
+    background: var(--struct-dragover-bg, var(--dragover-bg));
+    border: var(--struct-dragover-border, var(--dragover-border));
   }
   div.bottom-left {
     position: absolute;
@@ -464,8 +465,8 @@
     position: absolute;
     display: flex;
     justify-content: end;
-    top: var(--struct-buttons-top, 1ex);
-    right: var(--struct-buttons-right, 1ex);
+    top: var(--struct-buttons-top, var(--ctrl-btn-top, 1ex));
+    right: var(--struct-buttons-right, var(--ctrl-btn-right, 1ex));
     gap: var(--struct-buttons-gap, 3pt);
     /* buttons need higher z-index than StructureLegend to make info/controls panels occlude legend */
     z-index: var(--struct-buttons-z-index, 2);

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -11,6 +11,7 @@
   import { colors } from '$lib/state.svelte'
   import { Canvas } from '@threlte/core'
   import type { ComponentProps, Snippet } from 'svelte'
+  import { tooltip } from 'svelte-multiselect'
   import type { Camera, Scene } from 'three'
   import { WebGLRenderer } from 'three'
   import {
@@ -302,7 +303,7 @@
 
 <svelte:document
   onfullscreenchange={() => {
-    fullscreen = !!document.fullscreenElement
+    fullscreen = Boolean(document.fullscreenElement)
   }}
 />
 
@@ -349,7 +350,7 @@
           <button
             onclick={toggle_fullscreen}
             class="fullscreen-toggle"
-            title="{fullscreen ? `Exit` : `Enter`} fullscreen"
+            {@attach tooltip({ content: `${fullscreen ? `Exit` : `Enter`} fullscreen` })}
           >
             {#if typeof fullscreen_toggle === `function`}
               {@render fullscreen_toggle()}
@@ -367,6 +368,7 @@
             {structure}
             bind:panel_open={info_panel_open}
             custom_toggle={toggle_info}
+            {@attach tooltip({ content: `Structure info panel` })}
           />
         {/if}
 

--- a/src/lib/structure/StructureControls.svelte
+++ b/src/lib/structure/StructureControls.svelte
@@ -46,8 +46,8 @@
     copy_xyz_btn_text?: string
     scene?: Scene
     camera?: Camera
-    panel_props?: ComponentProps<typeof DraggablePanel>[`panel_props`]
-    toggle_props?: ComponentProps<typeof DraggablePanel>[`toggle_props`]
+    controls_panel_props?: ComponentProps<typeof DraggablePanel>[`panel_props`]
+    controls_toggle_props?: ComponentProps<typeof DraggablePanel>[`toggle_props`]
     [key: string]: unknown
   }
   let {
@@ -87,8 +87,8 @@
     copy_xyz_btn_text = `📋 XYZ`,
     scene = undefined,
     camera = undefined,
-    panel_props = $bindable({}),
-    toggle_props = $bindable({}),
+    controls_panel_props = $bindable({}),
+    controls_toggle_props = $bindable({}),
     ...rest
   }: Props = $props()
 
@@ -163,8 +163,12 @@
 
 <DraggablePanel
   bind:show={controls_open}
-  panel_props={{ class: `controls-panel`, ...panel_props }}
-  toggle_props={{ class: `structure-controls-toggle`, title: `Open controls`, ...toggle_props }}
+  panel_props={{ class: `controls-panel`, ...controls_panel_props }}
+  toggle_props={{
+    class: `structure-controls-toggle`,
+    title: `${controls_open ? `Close` : `Open`} structure controls`,
+    ...controls_toggle_props,
+  }}
   icon_style="transform: scale(1.2);"
   {...rest}
 >

--- a/src/lib/structure/StructureControls.svelte
+++ b/src/lib/structure/StructureControls.svelte
@@ -46,6 +46,8 @@
     copy_xyz_btn_text?: string
     scene?: Scene
     camera?: Camera
+    panel_props?: ComponentProps<typeof DraggablePanel>[`panel_props`]
+    toggle_props?: ComponentProps<typeof DraggablePanel>[`toggle_props`]
     [key: string]: unknown
   }
   let {
@@ -85,6 +87,8 @@
     copy_xyz_btn_text = `📋 XYZ`,
     scene = undefined,
     camera = undefined,
+    panel_props = $bindable({}),
+    toggle_props = $bindable({}),
     ...rest
   }: Props = $props()
 
@@ -159,13 +163,16 @@
 
 <DraggablePanel
   bind:show={controls_open}
-  panel_props={{ class: `controls-panel` }}
-  toggle_props={{ class: `structure-controls-toggle`, title: `Open controls` }}
+  panel_props={{ class: `controls-panel`, ...panel_props }}
+  toggle_props={{ class: `structure-controls-toggle`, title: `Open controls`, ...toggle_props }}
   icon_style="transform: scale(1.2);"
   {...rest}
 >
+  <h4 style="margin-top: 0">Structure Controls</h4>
   <!-- Visibility Controls -->
-  <div style="display: flex; align-items: center; gap: 4pt; flex-wrap: wrap">
+  <div
+    style="display: flex; align-items: center; gap: 4pt; flex-wrap: wrap; max-width: 90%"
+  >
     Show <label>
       <input
         type="checkbox"
@@ -206,7 +213,7 @@
   <hr />
 
   <!-- Atom Controls -->
-  <h4 class="section-heading">Atoms</h4>
+  <h4>Atoms</h4>
   <label class="slider-control">
     Radius <small>(Å)</small>
     <input
@@ -265,7 +272,7 @@
 
   <!-- Force Vector Controls -->
   {#if has_forces && scene_props.show_force_vectors}
-    <h4 class="section-heading">Force Vectors</h4>
+    <h4>Force Vectors</h4>
     <label class="slider-control">
       Scale
       <input
@@ -292,7 +299,7 @@
   {/if}
 
   <!-- Cell Controls -->
-  <h4 class="section-heading">Cell</h4>
+  <h4>Cell</h4>
   <label>
     <input
       type="checkbox"
@@ -348,7 +355,7 @@
   <hr />
 
   <!-- Background Controls -->
-  <h4 class="section-heading">Background</h4>
+  <h4>Background</h4>
   <div class="panel-row">
     <label class="compact">
       Color
@@ -382,7 +389,7 @@
 
   {#if show_full_controls}
     <!-- Camera Controls -->
-    <h4 class="section-heading">Camera</h4>
+    <h4>Camera</h4>
     <label>
       Auto rotate speed
       <input
@@ -462,7 +469,7 @@
     <hr />
 
     <!-- Lighting Controls -->
-    <h4 class="section-heading">Lighting</h4>
+    <h4>Lighting</h4>
     <label>
       <span title="Intensity of the directional light" {@attach tooltip()}>
         Directional light
@@ -540,7 +547,7 @@
 
   <!-- Export Controls -->
   <hr />
-  <h4 class="section-heading">Export</h4>
+  <h4>Export</h4>
   <span
     style="display: flex; gap: 4pt; margin: 3pt 0 0; align-items: center; flex-wrap: wrap"
   >
@@ -600,10 +607,9 @@
 </DraggablePanel>
 
 <style>
-  .section-heading {
+  h4 {
     margin: 8pt 0 2pt;
     font-size: 0.9em;
-    color: var(--text-muted, #ccc);
   }
   .panel-row {
     display: flex;

--- a/src/lib/structure/StructureControls.svelte
+++ b/src/lib/structure/StructureControls.svelte
@@ -46,8 +46,8 @@
     copy_xyz_btn_text?: string
     scene?: Scene
     camera?: Camera
-    controls_panel_props?: ComponentProps<typeof DraggablePanel>[`panel_props`]
-    controls_toggle_props?: ComponentProps<typeof DraggablePanel>[`toggle_props`]
+    panel_props?: ComponentProps<typeof DraggablePanel>[`panel_props`]
+    toggle_props?: ComponentProps<typeof DraggablePanel>[`toggle_props`]
     [key: string]: unknown
   }
   let {
@@ -87,8 +87,8 @@
     copy_xyz_btn_text = `📋 XYZ`,
     scene = undefined,
     camera = undefined,
-    controls_panel_props = $bindable({}),
-    controls_toggle_props = $bindable({}),
+    panel_props = $bindable({}),
+    toggle_props = $bindable({}),
     ...rest
   }: Props = $props()
 
@@ -163,11 +163,11 @@
 
 <DraggablePanel
   bind:show={controls_open}
-  panel_props={{ class: `controls-panel`, ...controls_panel_props }}
+  panel_props={{ class: `controls-panel`, ...panel_props }}
   toggle_props={{
     class: `structure-controls-toggle`,
     title: `${controls_open ? `Close` : `Open`} structure controls`,
-    ...controls_toggle_props,
+    ...toggle_props,
   }}
   icon_style="transform: scale(1.2);"
   {...rest}

--- a/src/lib/structure/StructureInfoPanel.svelte
+++ b/src/lib/structure/StructureInfoPanel.svelte
@@ -265,7 +265,11 @@
 <DraggablePanel
   bind:show={panel_open}
   max_width="24em"
-  toggle_props={{ class: `structure-info-toggle`, title: `Toggle structure info`, ...toggle_props }}
+  toggle_props={{
+    class: `structure-info-toggle`,
+    title: `${panel_open ? `Close` : `Open`} structure info`,
+    ...toggle_props,
+  }}
   open_icon="Cross"
   closed_icon="Info"
   icon_style="transform: scale(1.1);"
@@ -437,7 +441,7 @@
   }
   section div.toggle-item:hover {
     background: var(--panel-btn-hover-bg, rgba(255, 255, 255, 0.1));
-    border-color: var(--panel-border, rgba(255, 255, 255, 0.3));
+    border: var(--panel-border, 1px solid rgba(255, 255, 255, 0.3));
   }
   section div.toggle-item span:first-child {
     font-size: 0.9em;

--- a/src/lib/theme/ThemeControl.svelte
+++ b/src/lib/theme/ThemeControl.svelte
@@ -8,11 +8,8 @@
     onchange?: (mode: ThemeMode) => void // Callback when theme changes
     [key: string]: unknown
   }
-  let {
-    theme_mode = $bindable(theme_state.mode),
-    onchange = () => {},
-    ...rest
-  }: Props = $props()
+  let { theme_mode = $bindable(theme_state.mode), onchange = () => {}, ...rest }:
+    Props = $props()
 
   // Sync and save when theme changes
   $effect(() => {
@@ -26,7 +23,7 @@
   })
 </script>
 
-<select bind:value={theme_mode} class="theme-control" {...rest}>
+<select bind:value={theme_mode} {...rest} class="theme-control {rest.class ?? ``}">
   {#each THEME_OPTIONS as option (option.value)}
     <option value={option.value}>{option.icon} {option.label}</option>
   {/each}
@@ -38,8 +35,8 @@
     bottom: 1em;
     left: 1em;
     z-index: var(--theme-control-z-index, 1);
-    background: var(--theme-control-bg);
-    border: 1px solid var(--theme-control-border);
+    background: var(--btn-bg);
+    border: var(--panel-border);
     color: var(--text-color);
     border-radius: 5pt;
     padding: 4pt 6pt;
@@ -48,8 +45,8 @@
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   }
   .theme-control:hover {
-    background: var(--theme-control-hover-bg);
-    border-color: var(--theme-control-hover-border);
+    background: var(--btn-hover-bg);
+    border: var(--panel-border);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   }
   .theme-control:focus {

--- a/src/lib/theme/ThemeControl.svelte
+++ b/src/lib/theme/ThemeControl.svelte
@@ -37,7 +37,7 @@
     position: fixed;
     bottom: 1em;
     left: 1em;
-    z-index: 100;
+    z-index: var(--theme-control-z-index, 1);
     background: var(--theme-control-bg);
     border: 1px solid var(--theme-control-border);
     color: var(--text-color);

--- a/src/lib/theme/index.ts
+++ b/src/lib/theme/index.ts
@@ -1,11 +1,9 @@
 // Theme System for MatterViz
 
-export * from './themes'
-
 const is_browser = typeof window !== `undefined`
 const storage_key = `matterviz-theme`
 
-// Core theme constants - single source of truth
+// Core theme constants
 export const COLOR_THEMES = {
   light: `light`,
   dark: `dark`,
@@ -15,7 +13,6 @@ export const COLOR_THEMES = {
 
 export const AUTO_THEME = `auto` as const
 
-// whether a theme is light or dark
 export type ThemeType = `light` | `dark`
 export const THEME_TYPE: Record<ThemeName, ThemeType> = {
   [COLOR_THEMES.light]: `light`,
@@ -24,7 +21,6 @@ export const THEME_TYPE: Record<ThemeName, ThemeType> = {
   [COLOR_THEMES.black]: `dark`,
 } as const
 
-// Types
 export type ThemeName = keyof typeof COLOR_THEMES
 export type ThemeMode = ThemeName | typeof AUTO_THEME
 
@@ -65,7 +61,7 @@ declare global {
 export const get_theme_preference = (): ThemeMode => {
   if (!is_browser) return AUTO_THEME
   try {
-    const saved = localStorage.getItem(storage_key)
+    const saved = localStorage[storage_key]
     return is_valid_theme_mode(saved || ``) ? saved as ThemeMode : AUTO_THEME
   } catch {
     return AUTO_THEME
@@ -73,9 +69,8 @@ export const get_theme_preference = (): ThemeMode => {
 }
 
 export const save_theme_preference = (mode: ThemeMode): void => {
-  if (!is_browser) return
   try {
-    localStorage.setItem(storage_key, mode)
+    localStorage[storage_key] = mode
   } catch {
     // Silently fail if localStorage is unavailable
   }
@@ -103,21 +98,7 @@ export const apply_theme_to_dom = (mode: ThemeMode): void => {
     }
   })
 
-  root.style.setProperty(`color-scheme`, THEME_TYPE[resolved])
   root.setAttribute(`data-theme`, resolved)
-}
-
-// Initialize theme system
-export const init_theme = (): void => {
-  if (!is_browser) return
-
-  const mode = get_theme_preference()
-  apply_theme_to_dom(mode)
-
-  matchMedia(`(prefers-color-scheme: dark)`).addEventListener(
-    `change`,
-    () => get_theme_preference() === AUTO_THEME && apply_theme_to_dom(AUTO_THEME),
-  )
 }
 
 // Theme getters

--- a/src/lib/theme/themes.js
+++ b/src/lib/theme/themes.js
@@ -1,6 +1,8 @@
-// Theme System - Single Source of Truth
-// Base colors used across themes
-const colors = {
+// MatterViz color themes.
+// Note: This file needs to be symlinked into static/ to be importable by app.html before initial page render to prevent flashing colors before client-side JS kicks in. It also needs to be in src/lib so it gets packaged and shipped to NPM for use by the anywidgets in pymatviz.
+// Can't use exports in this file as would then require type="module" in app.html to import which would defer until after HTML is ready (module files are always deferred).
+
+const colors = { // Base colors used across themes
   // Text colors
   txt_light: `#374151`, // Dark gray
   txt_dark: `#eee`, // Light gray
@@ -12,12 +14,6 @@ const colors = {
   bg_dark: `#090019`, // Very dark blue
   bg_white: `#ffffff`, // Pure white
   bg_black: `#000000`, // Pure black
-
-  // Surfaces (cards, panels, etc.)
-  surf_light: `#ffffff`, // White cards on light bg
-  surf_dark: `#2a2a2a`, // Dark cards on dark bg
-  surf_white: `#fafafa`, // Off-white cards on white bg
-  surf_black: `#0f0f0f`, // Very dark cards on black bg
 
   // Borders
   border_light: `#d1d5db`, // Gray border
@@ -90,10 +86,10 @@ const themes = {
     black: colors.txt_black,
   },
   'surface-bg': {
-    light: colors.surf_light,
-    dark: colors.surf_dark,
-    white: colors.surf_white,
-    black: colors.surf_black,
+    light: `rgb(237, 238, 239)`,
+    dark: `rgb(33, 36, 43)`,
+    white: `rgb(250, 250, 250)`,
+    black: `rgb(19, 19, 19)`,
   },
   'border-color': {
     light: colors.border_light,
@@ -112,8 +108,8 @@ const themes = {
   'surface-hover-bg': {
     light: `#e5e7eb`,
     dark: `#3a3a3a`,
-    white: `#fafafa`,
-    black: `#1a1a1a`,
+    white: `#f3f3f3`,
+    black: `#1f1f1f`,
   },
   'accent-hover-color': {
     light: `#3730a3`,
@@ -155,6 +151,24 @@ const themes = {
     white: `#dc2626`,
     black: `#f87171`,
   },
+  'error-button-bg': {
+    light: `#dc2626`,
+    dark: `#7f1d1d`,
+    white: `#b91c1c`,
+    black: `#991b1b`,
+  },
+  'error-button-hover-bg': {
+    light: `#b91c1c`,
+    dark: `#991b1b`,
+    white: `#991b1b`,
+    black: `#7f1d1d`,
+  },
+  'error-border': {
+    light: `1px solid #fca5a5`,
+    dark: `1px solid #dc2626`,
+    white: `1px solid #fecaca`,
+    black: `1px solid #991b1b`,
+  },
   'text-color-muted': {
     light: `#6b7280`,
     dark: `#9ca3af`,
@@ -165,6 +179,7 @@ const themes = {
   // Interactive elements (buttons, etc.)
   'btn-bg': btn_bg(0.2, 0.12),
   'btn-hover-bg': btn_bg(0.3, 0.25),
+  'btn-disabled-bg': btn_bg(0.1, 0.05),
 
   // Tooltips
   'tooltip-bg': tooltip_bg(`243, 244, 246`, `0, 40, 60`),
@@ -172,103 +187,20 @@ const themes = {
 
   // Structure-specific
   'struct-bg': {
-    light: `rgba(0, 0, 0, 0.02)`,
+    light: `rgba(0, 0, 0, 0.04)`,
     dark: `rgba(255, 255, 255, 0.07)`,
-    white: `rgba(0, 0, 0, 0.01)`,
+    white: `rgba(0, 0, 0, 0.02)`,
     black: `rgba(255, 255, 255, 0.1)`,
-  },
-  'struct-dragover-bg': {
-    light: `rgba(0, 0, 0, 0.15)`,
-    dark: `rgba(0, 0, 0, 0.7)`,
-    white: `rgba(0, 0, 0, 0.05)`,
-    black: `rgba(0, 0, 0, 0.8)`,
   },
 
   // Panel backgrounds (DraggablePanel, etc.)
   'panel-bg': {
-    light: `rgba(229, 231, 235, 0.95)`,
-    dark: `rgba(15, 23, 42, 0.95)`,
-    white: `rgba(248, 250, 252, 0.98)`,
-    black: `rgba(26, 26, 26, 0.98)`,
+    light: `rgb(229, 231, 235)`,
+    dark: `rgb(28 29 33)`,
+    white: `rgb(248, 250, 252)`,
+    black: `rgb(26, 26, 26)`,
   },
   'panel-border': border_alpha(0.15),
-
-  // Traj-specific
-  'traj-surface': {
-    light: `rgba(241, 243, 245, 0.95)`,
-    dark: `rgba(45, 55, 72, 0.95)`,
-    white: `rgba(255, 255, 255, 0.98)`,
-    black: `rgba(15, 15, 15, 0.98)`,
-  },
-  'traj-border-color': {
-    light: colors.border_light,
-    dark: `#4a5568`,
-    white: colors.border_white,
-    black: colors.border_black,
-  },
-  'traj-accent': {
-    light: colors.acc_light,
-    dark: `#63b3ed`,
-    white: colors.acc_white,
-    black: colors.acc_black,
-  },
-
-  // Trajectory component variables (used directly)
-  'traj-text-color': {
-    light: colors.txt_light,
-    dark: `#e2e8f0`,
-    white: colors.txt_white,
-    black: `#f1f5f9`,
-  },
-  'traj-heading-color': {
-    light: colors.txt_light,
-    dark: `#e2e8f0`,
-    white: colors.txt_white,
-    black: `#f1f5f9`,
-  },
-  'traj-error-color': {
-    light: colors.error_text_light,
-    dark: colors.error_text_dark,
-    white: colors.error_text_white,
-    black: colors.error_text_black,
-  },
-  'traj-error-border': {
-    light: colors.error_border_light,
-    dark: colors.error_border_dark,
-    white: colors.error_border_white,
-    black: colors.error_border_black,
-  },
-  'traj-error-button-bg': {
-    light: colors.error_btn_light,
-    dark: colors.error_btn_dark,
-    white: colors.error_btn_white,
-    black: colors.error_btn_black,
-  },
-  'traj-error-button-hover-bg': {
-    light: colors.error_btn_hover_light,
-    dark: colors.error_btn_hover_dark,
-    white: colors.error_btn_hover_white,
-    black: colors.error_btn_hover_black,
-  },
-  'traj-border': border_alpha(0.15),
-  'traj-dropzone-border': {
-    light: `#9ca3af`,
-    dark: `#4a5568`,
-    white: `#e5e7eb`,
-    black: `#374151`,
-  },
-  'traj-dragover-border': {
-    light: colors.acc_light,
-    dark: `#007acc`,
-    white: colors.acc_white,
-    black: `#0ea5e9`,
-  },
-  'traj-dragover-bg': {
-    light: `rgba(79, 70, 229, 0.1)`,
-    dark: `rgba(0, 122, 204, 0.1)`,
-    white: `rgba(37, 99, 235, 0.05)`,
-    black: `rgba(14, 165, 233, 0.05)`,
-  },
 
   // Dropzone states
   'dropzone-border': {
@@ -284,10 +216,10 @@ const themes = {
     black: `rgba(15, 15, 15, 0.7)`,
   },
   'dragover-border': {
-    light: colors.acc_light,
-    dark: `#007acc`,
-    white: colors.acc_white,
-    black: `#0ea5e9`,
+    light: `1px solid ${colors.acc_light}`,
+    dark: `1px solid #007acc`,
+    white: `1px solid ${colors.acc_white}`,
+    black: `1px solid #0ea5e9`,
   },
   'dragover-bg': {
     light: `rgba(79, 70, 229, 0.1)`,
@@ -394,20 +326,6 @@ const themes = {
     white: colors.txt_white,
     black: colors.txt_black,
   },
-
-  // VSCode-specific
-  'vscode-editor-background': {
-    light: colors.bg_white,
-    dark: `#1e1e1e`,
-    white: colors.bg_white,
-    black: colors.bg_black,
-  },
-  'vscode-editor-foreground': {
-    light: `#333333`,
-    dark: `#d4d4d4`,
-    white: colors.txt_white,
-    black: colors.txt_black,
-  },
 }
 
 // Generate flattened themes and export
@@ -427,5 +345,3 @@ globalThis.MATTERVIZ_THEMES = { light, dark, white, black }
 globalThis.MATTERVIZ_CSS_MAP = Object.fromEntries(
   Object.keys(themes).map((key) => [key, `--${key}`]),
 )
-globalThis.MATTERVIZ_THEME_SOURCE = themes
-globalThis.MATTERVIZ_SSR_PROPS = Object.keys(themes)

--- a/src/lib/theme/themes.js
+++ b/src/lib/theme/themes.js
@@ -64,13 +64,6 @@ const tooltip_bg = (light_bg, dark_bg, light_op = 0.95, dark_op = 0.95) => ({
   black: `rgba(20, 20, 20, 0.98)`,
 })
 
-const border_alpha = (alpha = 0.2) => ({
-  light: `rgba(0, 0, 0, ${alpha})`,
-  dark: `rgba(255, 255, 255, ${alpha})`,
-  white: `rgba(0, 0, 0, ${alpha / 2})`,
-  black: `rgba(255, 255, 255, ${alpha / 2})`,
-})
-
 const themes = {
   // Core colors
   'page-bg': {
@@ -177,13 +170,18 @@ const themes = {
   },
 
   // Interactive elements (buttons, etc.)
-  'btn-bg': btn_bg(0.2, 0.12),
-  'btn-hover-bg': btn_bg(0.3, 0.25),
+  'btn-bg': btn_bg(0.1, 0.12),
+  'btn-hover-bg': btn_bg(0.2, 0.25),
   'btn-disabled-bg': btn_bg(0.1, 0.05),
 
   // Tooltips
   'tooltip-bg': tooltip_bg(`243, 244, 246`, `0, 40, 60`),
-  'tooltip-border': border_alpha(0.15),
+  'tooltip-border': {
+    light: `1px solid rgba(0, 0, 0, 0.15)`,
+    dark: `1px solid rgba(255, 255, 255, 0.15)`,
+    white: `1px solid rgba(0, 0, 0, 0.075)`,
+    black: `1px solid rgba(255, 255, 255, 0.075)`,
+  },
 
   // Structure-specific
   'struct-bg': {
@@ -200,14 +198,19 @@ const themes = {
     white: `rgb(248, 250, 252)`,
     black: `rgb(26, 26, 26)`,
   },
-  'panel-border': border_alpha(0.15),
+  'panel-border': {
+    light: `1px solid rgba(0, 0, 0, 0.15)`,
+    dark: `1px solid rgba(255, 255, 255, 0.15)`,
+    white: `1px solid rgba(0, 0, 0, 0.075)`,
+    black: `1px solid rgba(255, 255, 255, 0.075)`,
+  },
 
   // Dropzone states
   'dropzone-border': {
-    light: `#9ca3af`,
-    dark: `#4a5568`,
-    white: `#e5e7eb`,
-    black: `#374151`,
+    light: `1px solid #9ca3af`,
+    dark: `1px solid #4a5568`,
+    white: `1px solid #e5e7eb`,
+    black: `1px solid #374151`,
   },
   'dropzone-bg': {
     light: `rgba(0, 0, 0, 0.02)`,
@@ -226,21 +229,6 @@ const themes = {
     dark: `rgba(0, 122, 204, 0.1)`,
     white: `rgba(37, 99, 235, 0.05)`,
     black: `rgba(14, 165, 233, 0.05)`,
-  },
-
-  // Theme control
-  'theme-control-bg': {
-    light: `rgba(241, 243, 245, 0.9)`,
-    dark: `rgba(15, 23, 42, 0.9)`,
-    white: `rgba(255, 255, 255, 0.95)`,
-    black: `rgba(0, 0, 0, 0.95)`,
-  },
-  'theme-control-border': border_alpha(0.25),
-  'theme-control-hover-bg': {
-    light: `rgba(241, 243, 245, 0.95)`,
-    dark: `rgba(15, 23, 42, 0.95)`,
-    white: `rgba(255, 255, 255, 0.98)`,
-    black: `rgba(15, 15, 15, 0.98)`,
   },
 
   // Navigation links

--- a/src/lib/theme/themes.js
+++ b/src/lib/theme/themes.js
@@ -98,7 +98,7 @@ const themes = {
   },
 
   // Hover states
-  'surface-hover-bg': {
+  'surface-bg-hover': {
     light: `#e5e7eb`,
     dark: `#3a3a3a`,
     white: `#f3f3f3`,

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -494,7 +494,7 @@
 <div
   class:dragover
   class:active={is_playing || panels_open.structure_info || panels_open.structure_controls ||
-  panels_open.plot_info || panels_open.plot_controls}
+  panels_open.plot_controls}
   bind:this={wrapper}
   bind:clientWidth={viewport.width}
   bind:clientHeight={viewport.height}

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -923,7 +923,8 @@
     align-items: center;
     gap: 1rem;
     padding: 0.5rem;
-    background: var(--surface-hover-bg);
+    z-index: var(--traj-controls-z-index, 1);
+    background: var(--surface-bg-hover);
     backdrop-filter: blur(4px);
     position: relative;
     border-radius: var(--border-radius) var(--border-radius) 0 0;
@@ -1138,9 +1139,6 @@
   .view-mode-option:first-child {
     border-top-left-radius: 3px;
     border-top-right-radius: 3px;
-  }
-  .view-mode-option:hover {
-    background: var(--surface-bg-hover);
   }
   .view-mode-option.selected {
     color: var(--accent-color);

--- a/src/lib/trajectory/TrajectoryError.svelte
+++ b/src/lib/trajectory/TrajectoryError.svelte
@@ -31,9 +31,9 @@
     place-content: center;
     place-items: center;
     text-align: center;
-    color: var(--traj-error-color);
+    color: var(--error-color);
     border-radius: var(--traj-border-radius);
-    border: 1px solid var(--traj-error-border);
+    border: var(--error-border);
     box-sizing: border-box;
     flex: 1;
   }
@@ -46,7 +46,7 @@
   }
   .error-message button {
     margin-top: 1rem;
-    background: var(--traj-error-button-bg);
+    background: var(--error-button-bg);
     color: white;
     border: none;
     border-radius: 4px;
@@ -55,7 +55,7 @@
     transition: background-color 0.2s;
   }
   .error-message button:hover {
-    background: var(--traj-error-button-hover-bg);
+    background: var(--error-button-hover-bg);
   }
   /* Styles for unsupported format messages */
   .error-message :global(.unsupported-format) {
@@ -67,7 +67,7 @@
     overflow-x: hidden;
   }
   .error-message :global(.unsupported-format h4) {
-    color: var(--traj-error-color);
+    color: var(--error-color);
     margin: 0 0 1rem 0;
     font-size: 1.1rem;
     display: flex;
@@ -75,13 +75,11 @@
     gap: 0.5rem;
   }
   .error-message :global(.unsupported-format h5) {
-    color: var(--traj-text-color);
     margin: 0.75rem 0 0.25rem 0;
     font-size: 0.9rem;
     font-weight: 600;
   }
   .error-message :global(.unsupported-format p) {
-    color: var(--traj-text-color);
     margin: 0.25rem 0;
     text-align: left;
     font-size: 0.85rem;
@@ -92,7 +90,6 @@
     padding-left: 1.5rem;
   }
   .error-message :global(.unsupported-format li) {
-    color: var(--traj-text-color);
     margin: 0.25rem 0;
   }
   .error-message :global(.unsupported-format .code-options) {
@@ -105,14 +102,12 @@
     margin: 0;
   }
   .error-message :global(.unsupported-format .code-options strong) {
-    color: var(--traj-code-title-color);
     display: block;
     margin-bottom: 0.25rem;
     font-size: 0.85rem;
     font-weight: 600;
   }
   .error-message :global(.unsupported-format pre) {
-    background: var(--traj-pre-bg);
     padding: 0.5rem;
     margin: 0;
     overflow-x: auto;
@@ -123,7 +118,6 @@
     overflow-y: auto;
   }
   .error-message :global(.unsupported-format p code) {
-    background: var(--traj-inline-code-bg);
     padding: 0.2em 0.4em;
     border-radius: 3px;
     font-family: 'SFMono-Regular', 'Consolas', 'Liberation Mono', 'Menlo', monospace;

--- a/src/lib/trajectory/TrajectoryError.svelte
+++ b/src/lib/trajectory/TrajectoryError.svelte
@@ -32,7 +32,7 @@
     place-items: center;
     text-align: center;
     color: var(--error-color);
-    border-radius: var(--traj-border-radius);
+    border-radius: var(--border-radius);
     border: var(--error-border);
     box-sizing: border-box;
     flex: 1;

--- a/src/lib/trajectory/TrajectoryInfoPanel.svelte
+++ b/src/lib/trajectory/TrajectoryInfoPanel.svelte
@@ -4,6 +4,7 @@
   import { theme_state } from '$lib/state.svelte'
   import { type AnyStructure, electro_neg_formula } from '$lib/structure'
   import { tooltip as create_tooltip } from 'svelte-multiselect/attachments'
+  import { SvelteSet } from 'svelte/reactivity'
   import type { Trajectory } from './index'
 
   interface Props {
@@ -27,15 +28,14 @@
     ...rest
   }: Props = $props()
 
-  let copied_items = $state<Set<string>>(new Set())
+  let copied_items = new SvelteSet<string>()
 
   async function copy_item(label: string, value: string, key: string) {
     try {
       await navigator.clipboard.writeText(`${label}: ${value}`)
-      copied_items = new Set(copied_items).add(key)
+      copied_items.add(key)
       setTimeout(() => {
         copied_items.delete(key)
-        copied_items = new Set(copied_items)
       }, 1000)
     } catch (error) {
       console.error(`Failed to copy to clipboard:`, error)
@@ -93,7 +93,7 @@
     const current_frame = trajectory.frames[current_step_idx]
     if (!current_frame?.structure?.sites) return []
 
-    const sections: (InfoItem | null | false | ``)[][] = []
+    const sections: InfoItem[][] = []
 
     // File info section
     const file_items = [
@@ -183,7 +183,7 @@
         return range &&
           safe_item(key.charAt(0).toUpperCase() + key.slice(1), range, key)
       }),
-    ].filter(Boolean)
+    ].filter(is_info_item)
 
     if (traj_items.length > 0) sections.push(traj_items)
 
@@ -201,7 +201,7 @@
           `energy-current`,
         ),
         energy_range && safe_item(`Energy Range`, energy_range, `energy-range`),
-      ].filter(Boolean)
+      ].filter(is_info_item)
 
       if (energy_items.length > 0) sections.push(energy_items)
     }
@@ -220,7 +220,7 @@
           `force-current`,
         ),
         force_range && safe_item(`Force Range`, force_range, `force-range`),
-      ].filter(Boolean)
+      ].filter(is_info_item)
 
       if (force_items.length > 0) sections.push(force_items)
     }
@@ -236,13 +236,13 @@
         const vol_change =
           ((Math.max(...volumes) - Math.min(...volumes)) / Math.min(...volumes)) * 100
         if (Math.abs(vol_change) > 0.1 && is_valid_number(vol_change)) {
-          sections.push(
-            [safe_item(
-              `Volume Change`,
-              `${format_num(vol_change, `.2~f`)}%`,
-              `vol-change`,
-            )].filter(Boolean),
-          )
+          const vol_items = [safe_item(
+            `Volume Change`,
+            `${format_num(vol_change, `.2~f`)}%`,
+            `vol-change`,
+          )].filter(is_info_item)
+
+          if (vol_items.length > 0) sections.push(vol_items)
         }
       }
     }

--- a/src/lib/trajectory/TrajectoryInfoPanel.svelte
+++ b/src/lib/trajectory/TrajectoryInfoPanel.svelte
@@ -3,6 +3,7 @@
   import { format_num } from '$lib/labels'
   import { theme_state } from '$lib/state.svelte'
   import { type AnyStructure, electro_neg_formula } from '$lib/structure'
+  import type { ComponentProps } from 'svelte'
   import { tooltip as create_tooltip } from 'svelte-multiselect/attachments'
   import { SvelteSet } from 'svelte/reactivity'
   import type { Trajectory } from './index'
@@ -15,6 +16,8 @@
     file_size?: number | null
     file_object?: File | null
     panel_open?: boolean
+    toggle_props?: ComponentProps<typeof DraggablePanel>[`toggle_props`]
+    panel_props?: ComponentProps<typeof DraggablePanel>[`panel_props`]
     [key: string]: unknown
   }
   let {
@@ -25,6 +28,8 @@
     file_size,
     file_object,
     panel_open = $bindable(false),
+    toggle_props,
+    panel_props,
     ...rest
   }: Props = $props()
 
@@ -254,7 +259,11 @@
 <DraggablePanel
   bind:show={panel_open}
   max_width="24em"
-  toggle_props={{ class: `trajectory-info-toggle`, title: `Toggle trajectory info` }}
+  toggle_props={{
+    class: `trajectory-info-toggle`,
+    title: `${panel_open ? `Close` : `Open`} trajectory info`,
+    ...toggle_props,
+  }}
   open_icon="Cross"
   closed_icon="Info"
   icon_style="transform: scale(1.3);"
@@ -263,6 +272,7 @@
     style: `box-shadow: 0 5px 10px rgba(0, 0, 0, ${
       theme_state.type === `dark` ? `0.5` : `0.1`
     }); max-height: 80vh;`,
+    ...panel_props,
   }}
   {...rest}
 >

--- a/src/routes/(demos)/composition/+page.svelte
+++ b/src/routes/(demos)/composition/+page.svelte
@@ -102,7 +102,7 @@
     gap: 1pt;
     padding: 4pt 9pt;
     background: var(--card-bg, rgba(255, 255, 255, 0.05));
-    border-radius: 8px;
+    border-radius: var(--border-radius, 4px);
     border: 1px solid var(--card-border, rgba(255, 255, 255, 0.1));
   }
   .composition-card h4 {

--- a/src/routes/(demos)/trajectory/+page.svelte
+++ b/src/routes/(demos)/trajectory/+page.svelte
@@ -30,7 +30,6 @@
 {#each trajectory_files_paths as file (file)}
   <TrajectoryViewer
     data_url={file}
-    spinner_props={{ style: `background: transparent; color: white` }}
     class="full-bleed"
     style="margin-top: 5em"
   />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -32,7 +32,7 @@
 <div class="structure-viewers">
   {#each [`Li4Fe3Mn1(PO4)4.cif`, `mp-756175.json`] as file_url (file_url)}
     <div style="flex: 1">
-      <h3>{file_url.split(`.`)[0]}</h3>
+      <h3 style="margin: 0 0 1ex">{file_url.split(`.`)[0]}</h3>
       <Structure
         data_url="/structures/{file_url}"
         scene_props={{ auto_rotate: 0.5 }}
@@ -91,11 +91,11 @@
   }
   .structure-viewers {
     display: flex;
+    flex-wrap: wrap;
     gap: 2em;
     max-width: 1400px;
-    margin: 2em auto;
+    margin-inline: auto;
     text-align: center;
-    flex-wrap: wrap;
     min-width: 300px;
   }
 </style>

--- a/src/routes/acknowledgements/+page.md
+++ b/src/routes/acknowledgements/+page.md
@@ -27,7 +27,7 @@ Note that the last two cells are empty because there were only 8 items in the li
 Big thanks to the element image providers listed below. Each image caption links back to the source website. See [`fetch-elem-images.ts`](https://github.com/janosh/matterviz/blob/-/src/fetch-elem-images.ts) for details.
 
 <ul class="elem-img">
-    {#each Object.entries(img_sources) as [key, href]}
+    {#each Object.entries(img_sources) as [key, href] (key)}
       {@const [number, name] = key.split(`-`)}
       <li>
         <a {href}>{number} {name}</a>

--- a/src/site/PeriodicTableControls.svelte
+++ b/src/site/PeriodicTableControls.svelte
@@ -222,7 +222,7 @@
 
 <div class="controls-grid">
   <section class="category-colors">
-    <h3>
+    <h3 style="grid-column: span 2">
       Element Category Colors
       {#if category_colors_modified}
         <button class="section-reset" onclick={reset_category_colors}>reset</button>
@@ -472,17 +472,17 @@
 <style>
   .controls-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-    gap: 1.5em;
-    margin: 1em auto;
+    grid-template-columns:
+      var(--ptable-ctrl-columns, repeat(auto-fit, minmax(320px, 1fr)));
+    gap: var(--ptable-ctrl-gap, 1.5em);
+    margin: var(--ptable-ctrl-margin, 2em auto);
     padding: 0 1em;
     max-width: 1200px;
   }
   section {
-    background: rgba(255, 255, 255, 0.02);
+    background: var(--code-bg);
     border-radius: 6px;
-    padding: 0.75em;
-    border: 1px solid rgba(255, 255, 255, 0.05);
+    padding: 6pt 2ex;
   }
   section h3 {
     display: flex;
@@ -491,22 +491,11 @@
     margin: 0 0 0.8em 0;
     border-bottom: 1px solid rgba(255, 255, 255, 0.2);
     padding-bottom: 0.3em;
-    font-size: 1.1em;
-    color: var(--text-color);
+    max-height: max-content;
   }
   button.section-reset {
     background: rgba(255, 255, 255, 0.1);
-    color: var(--text-color);
     border: 1px solid rgba(255, 255, 255, 0.2);
-    border-radius: 3px;
-    padding: 2px 8px;
-    font-size: 0.75em;
-    opacity: 0.8;
-    transition: opacity 0.2s;
-  }
-  button.section-reset:hover {
-    opacity: 1;
-    background: rgba(255, 255, 255, 0.2);
   }
   section > label {
     display: flex;
@@ -536,10 +525,10 @@
     border-radius: 3px;
   }
   section > label input[type='color'] {
-    width: 40px;
-    height: 30px;
+    width: 50px;
+    height: 20px;
     border-radius: 3px;
-    border: 1px solid rgba(255, 255, 255, 0.2);
+    border: 1px solid var(--border-color);
   }
   section > label select {
     flex: 1;
@@ -549,7 +538,6 @@
   }
   section > label button {
     background: rgba(255, 255, 255, 0.1);
-    color: var(--text-color);
     border: 1px solid rgba(255, 255, 255, 0.2);
     border-radius: 3px;
     padding: 3px 6px;
@@ -559,45 +547,29 @@
   }
   section > label button:hover {
     opacity: 1;
-    background: rgba(255, 255, 255, 0.2);
   }
   .category-colors {
     display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   }
   .category-colors label {
+    margin: 0;
     display: flex;
     align-items: center;
-    gap: 0.4em;
-    padding: 0.3em 0.4em;
-    border-radius: 3px;
-    font-size: 0.8em;
+    gap: 6pt;
+    flex-wrap: nowrap;
     text-transform: capitalize;
     transition: background-color 0.2s;
   }
-  .category-colors label:hover {
-    background-color: rgba(255, 255, 255, 0.1);
+  .category-colors label span {
+    flex: 1;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
   }
   .category-colors input[type='color'] {
-    width: 20px;
-    height: 20px;
+    width: 25px;
+    height: 25px;
     border-radius: 50%;
-    border: 1px solid rgba(255, 255, 255, 0.2);
-  }
-  .category-colors span {
-    flex: 1;
-  }
-  .category-colors button {
-    background: rgba(255, 255, 255, 0.1);
-    color: var(--text-color);
-    border: 1px solid rgba(255, 255, 255, 0.2);
-    border-radius: 3px;
-    padding: 2px 6px;
-    font-size: 0.75em;
-    opacity: 0.7;
-    transition: opacity 0.2s;
-  }
-  .category-colors button:hover {
-    opacity: 1;
-    background: rgba(255, 255, 255, 0.2);
   }
 </style>

--- a/tests/playwright/structure-info-panel.test.ts
+++ b/tests/playwright/structure-info-panel.test.ts
@@ -27,8 +27,9 @@ test.describe(`StructureInfoPanel`, () => {
     await page.locator(`button[title*="structure info"]`).click()
     await expect(page.locator(`.structure-info-panel`)).toBeVisible()
 
+    const panel_heading = page.locator(`.structure-info-panel h4`).first()
     // Check main sections are present
-    await expect(page.locator(`.section-heading`).first()).toHaveText(`Structure Info`)
+    await expect(panel_heading).toHaveText(`Structure Info`)
     await expect(page.locator(`text=Cell`).first()).toBeVisible()
     await expect(page.locator(`text=Usage Tips`)).toBeVisible()
 
@@ -93,7 +94,7 @@ test.describe(`StructureInfoPanel`, () => {
     await page.locator(`button[title*="structure info"]`).click()
 
     // Get initial position
-    const panel = page.locator(`.info-panel-content`)
+    const panel = page.locator(`div.draggable-panel:has-text("Structure Info")`)
     const initial_box = await panel.boundingBox()
     expect(initial_box).toBeTruthy()
     if (!initial_box) return

--- a/tests/vitest/periodic-table/PeriodicTable.test.svelte.ts
+++ b/tests/vitest/periodic-table/PeriodicTable.test.svelte.ts
@@ -117,9 +117,8 @@ describe(`PeriodicTable`, () => {
       await tick()
       // Check that a background color has been applied (exact color may vary based on color scale)
       const bg_color = doc_query(`div.element-tile`).style.backgroundColor
-      expect(bg_color).toBeTruthy()
       expect(bg_color).not.toBe(`transparent`)
-      expect(bg_color).not.toBe(``)
+      // expect(bg_color).not.toBe(``) // can't test for non-empty string since CSS custom properties don't resolve in happy-dom
     }
   })
 
@@ -202,7 +201,7 @@ describe(`PeriodicTable`, () => {
 
   test.each(
     [
-      [`element-category`, `var(--diatomic-nonmetal-bg-color)`],
+      [`element-category`, ``], // should be var(--diatomic-nonmetal-bg-color) but CSS custom properties don't resolve in happy-dom
       [`#ff0000`, `#ff0000`],
       [`#666666`, `#666666`],
     ] as const,

--- a/tests/vitest/structure/StructureInfoPanel.test.ts
+++ b/tests/vitest/structure/StructureInfoPanel.test.ts
@@ -52,7 +52,7 @@ test.each([
 
     if (atom_count <= atom_count_thresholds[1]) {
       // Sites section should exist
-      const sites_section = document.querySelector(`h4.section-heading`)
+      const sites_section = document.querySelector(`.structure-info-panel h4`)
       expect(sites_section).not.toBeNull()
 
       if (atom_count >= atom_count_thresholds[0]) {
@@ -89,9 +89,11 @@ test(`structure with > 500 atoms should not create sites section`, () => {
   })
 
   // Check that no sites section exists
-  const sites_headings = Array.from(document.querySelectorAll(`h4.section-heading`))
-  const sites_section = sites_headings.find((h) =>
-    (h as HTMLElement).textContent?.includes(`Sites`)
+  const sites_headings = Array.from(
+    document.querySelectorAll<HTMLHeadingElement>(`.structure-info-panel h4`),
+  )
+  const sites_section = sites_headings.find((heading) =>
+    heading.textContent?.includes(`Sites`)
   )
   expect(sites_section).toBeUndefined()
 

--- a/tests/vitest/theme/index.test.ts
+++ b/tests/vitest/theme/index.test.ts
@@ -183,17 +183,6 @@ describe(`Theme System`, () => {
       },
     )
 
-    test.each(Object.keys(COLOR_THEMES))(
-      `apply_theme_to_dom("%s") sets color-scheme correctly`,
-      (theme) => {
-        apply_theme_to_dom(theme as ThemeName)
-        const expected_scheme = THEME_TYPE[theme as ThemeName]
-        expect(document.documentElement.style.getPropertyValue(`color-scheme`)).toBe(
-          expected_scheme,
-        )
-      },
-    )
-
     test.each([[true, `dark`], [false, `light`]])(
       `apply_theme_to_dom("auto") with system preference %s resolves to "%s"`,
       (dark_preference, expected_theme) => {
@@ -207,9 +196,6 @@ describe(`Theme System`, () => {
 
         apply_theme_to_dom(`auto`)
         expect(document.documentElement.getAttribute(`data-theme`)).toBe(expected_theme)
-        expect(document.documentElement.style.getPropertyValue(`color-scheme`)).toBe(
-          expected_theme,
-        )
       },
     )
 
@@ -230,9 +216,6 @@ describe(`Theme System`, () => {
       globalThis.MATTERVIZ_CSS_MAP = {}
 
       expect(() => apply_theme_to_dom(`light`)).not.toThrow()
-      expect(document.documentElement.style.getPropertyValue(`color-scheme`)).toBe(
-        `light`,
-      )
     })
 
     test(`apply_theme_to_dom handles missing global data gracefully`, () => {
@@ -242,9 +225,6 @@ describe(`Theme System`, () => {
       globalThis.MATTERVIZ_CSS_MAP = undefined
 
       expect(() => apply_theme_to_dom(`light`)).not.toThrow()
-      expect(document.documentElement.style.getPropertyValue(`color-scheme`)).toBe(
-        `light`,
-      )
     })
   })
 
@@ -275,9 +255,6 @@ describe(`Theme System`, () => {
 
       const root = document.documentElement
       expect(root.getAttribute(`data-theme`)).toBe(theme)
-      expect(root.style.getPropertyValue(`color-scheme`)).toBe(
-        THEME_TYPE[theme as ThemeName],
-      )
       const expected = globalThis.MATTERVIZ_THEMES[theme as ThemeName] as {
         surface_bg: string
         text_color: string
@@ -304,28 +281,24 @@ describe(`Theme System`, () => {
         apply_theme_to_dom(`auto`)
 
         expect(document.documentElement.getAttribute(`data-theme`)).toBe(expected_theme)
-        expect(document.documentElement.style.getPropertyValue(`color-scheme`)).toBe(
-          expected_theme,
-        )
       },
     )
   })
 
   describe(`Theme data integrity`, () => {
     test(`all theme keys have complete variant coverage`, () => {
-      const theme_source = globalThis.MATTERVIZ_THEME_SOURCE as
-        | Record<string, Record<string, string>>
-        | undefined
-      if (!theme_source) return
-
-      const theme_keys = Object.keys(theme_source)
-      const variants = Object.keys(COLOR_THEMES)
+      const theme_names = Object.keys(globalThis.MATTERVIZ_THEMES)
+      const first_theme = globalThis.MATTERVIZ_THEMES[theme_names[0] as ThemeName]
+      const expected_keys = Object.keys(first_theme)
       const missing_variants: string[] = []
 
-      for (const variant of variants) {
-        for (const key of theme_keys) {
-          if (!theme_source[key]?.[variant]) {
-            missing_variants.push(`${variant} variant for theme key: ${key}`)
+      for (const theme_name of theme_names) {
+        const theme_keys = Object.keys(
+          globalThis.MATTERVIZ_THEMES[theme_name as ThemeName],
+        )
+        for (const key of expected_keys) {
+          if (!theme_keys.includes(key)) {
+            missing_variants.push(`${key} missing from theme: ${theme_name}`)
           }
         }
       }
@@ -333,18 +306,16 @@ describe(`Theme System`, () => {
       expect(missing_variants).toEqual([])
     })
 
-    test(`all theme variants have consistent structure`, () => {
-      const theme_source = globalThis.MATTERVIZ_THEME_SOURCE as
-        | Record<string, Record<string, string>>
-        | undefined
-      if (!theme_source) return
+    test(`all theme variants have consistent keys`, () => {
+      const theme_names = Object.keys(globalThis.MATTERVIZ_THEMES)
+      const first_theme = globalThis.MATTERVIZ_THEMES[theme_names[0] as ThemeName]
+      const expected_keys = Object.keys(first_theme)
 
-      const theme_keys = Object.keys(theme_source)
-      const variants = Object.keys(COLOR_THEMES)
-
-      for (const variant of variants) {
-        const variant_keys = theme_keys.filter((key) => theme_source[key]?.[variant])
-        expect(variant_keys).toHaveLength(theme_keys.length)
+      for (const theme_name of theme_names) {
+        const theme_keys = Object.keys(
+          globalThis.MATTERVIZ_THEMES[theme_name as ThemeName],
+        )
+        expect(theme_keys).toEqual(expected_keys)
       }
     })
   })


### PR DESCRIPTION
- Fixes VSCode webview builds by moving development and test configuration to Vite, updating build scripts, and running extension tests in CI.
- Refactors component theming around standardized CSS properties, validates theme names, and removes deprecated theme exports.
- Exposes external customization for structure, trajectory, and plot control toggles and panels, including scatter style, grid, and tick options.
- Adds CSS-driven positioning for histogram and structure control panels.
- Adds dedicated HDF5 URL loading and improves structure drag-and-drop error handling.
- Fixes Periodic Table color fallbacks and info-panel filtering and reactivity.
- Updates tests for the new build, theming, controls, and drag-and-drop behavior.