### PR TITLE
Fix VSCode PNG export

### DIFF
--- a/extensions/vscode/src/webview/main.ts
+++ b/extensions/vscode/src/webview/main.ts
@@ -97,6 +97,11 @@ export const setup_vscode_download = (): void => {
     data: string | Blob,
     filename: string,
   ): void => {
+    if (!filename || filename.trim() === ``) {
+      console.error(`Invalid filename=${filename} provided to download`)
+      return
+    }
+
     try {
       if (typeof data === `string`) {
         vscode.postMessage({
@@ -115,6 +120,11 @@ export const setup_vscode_download = (): void => {
             filename,
             is_binary: true,
           })
+        }
+        reader.onerror = () => {
+          const msg = `Failed to read binary data for download`
+          console.error(msg)
+          vscode.postMessage({ command: `error`, text: msg })
         }
         reader.readAsDataURL(data)
       }

--- a/extensions/vscode/tests/webview.test.ts
+++ b/extensions/vscode/tests/webview.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { base64_to_array_buffer } from '../src/webview/main'
+
+declare global { // download function added by VSCode integration
+  var download: (content: string | Blob, filename: string, contentType: string) => void
+}
 
 describe(`Webview Integration - ASE Binary Trajectory Support`, () => {
   test.each([
@@ -18,7 +22,7 @@ describe(`Webview Integration - ASE Binary Trajectory Support`, () => {
     },
   )
 
-  test(`base64_to_array_buffer handles ASE trajectory file header correctly`, () => {
+  test(`handles ASE trajectory file header correctly`, () => {
     const ase_header = new Uint8Array([
       0x2d,
       0x20,
@@ -37,40 +41,21 @@ describe(`Webview Integration - ASE Binary Trajectory Support`, () => {
       0x61,
       0x6a,
     ])
-    const base64 = btoa(String.fromCharCode(...ase_header))
-    const result = base64_to_array_buffer(base64)
-
+    const result = base64_to_array_buffer(btoa(String.fromCharCode(...ase_header)))
     expect(result.byteLength).toBe(ase_header.length)
-    expect(Array.from(new Uint8Array(result))).toEqual(Array.from(ase_header))
     expect(new TextDecoder().decode(result.slice(0, 8))).toBe(`- of Ulm`)
   })
 
-  test(`base64_to_array_buffer preserves byte order and handles performance`, () => {
-    // Test byte order preservation
-    const test_bytes = new Uint8Array([
-      0x00,
-      0x01,
-      0x02,
-      0x03,
-      0xFF,
-      0xFE,
-      0xFD,
-      0xFC,
-    ])
-    const base64 = btoa(String.fromCharCode(...test_bytes))
-    const result = base64_to_array_buffer(base64)
+  test(`preserves byte order and handles performance`, () => {
+    const test_bytes = new Uint8Array([0x00, 0x01, 0x02, 0x03, 0xFF, 0xFE, 0xFD, 0xFC])
+    const result = base64_to_array_buffer(btoa(String.fromCharCode(...test_bytes)))
     expect(Array.from(new Uint8Array(result))).toEqual(Array.from(test_bytes))
 
-    // Test performance with large data
     const large_data = new Uint8Array(10000).fill(42)
-    const large_base64 = btoa(String.fromCharCode(...large_data))
     const start = performance.now()
-    const large_result = base64_to_array_buffer(large_base64)
+    const large_result = base64_to_array_buffer(btoa(String.fromCharCode(...large_data)))
     expect(performance.now() - start).toBeLessThan(100)
     expect(large_result.byteLength).toBe(large_data.length)
-    const result_array = new Uint8Array(large_result)
-    expect(result_array[0]).toBe(42)
-    expect(result_array[result_array.length - 1]).toBe(42)
   })
 
   test.each([1024, 8192, 32768])(
@@ -78,11 +63,8 @@ describe(`Webview Integration - ASE Binary Trajectory Support`, () => {
     (size) => {
       const data = new Uint8Array(size)
       for (let idx = 0; idx < size; idx++) data[idx] = idx % 256
-
-      const base64 = btoa(String.fromCharCode(...data))
-      const result = base64_to_array_buffer(base64)
+      const result = base64_to_array_buffer(btoa(String.fromCharCode(...data)))
       const result_array = new Uint8Array(result)
-
       expect(result.byteLength).toBe(size)
       expect(result_array[0]).toBe(0)
       expect(result_array[255]).toBe(255)
@@ -91,7 +73,6 @@ describe(`Webview Integration - ASE Binary Trajectory Support`, () => {
   )
 
   test(`ASE trajectory file regression test - simulates VS Code extension flow`, () => {
-    // ASE signature + tag
     const ase_data = new Uint8Array([
       0x2d,
       0x20,
@@ -119,15 +100,66 @@ describe(`Webview Integration - ASE Binary Trajectory Support`, () => {
       0x00, // "ASE-Trajectory"
       ...new Array(176).fill(0), // Mock trajectory data
     ])
-
-    const base64_content = btoa(String.fromCharCode(...ase_data))
-    const result = base64_to_array_buffer(base64_content)
+    const result = base64_to_array_buffer(btoa(String.fromCharCode(...ase_data)))
     const result_array = new Uint8Array(result)
-
     expect(result.byteLength).toBe(ase_data.length)
     expect(new TextDecoder().decode(result_array.slice(0, 8))).toBe(`- of Ulm`)
-    expect(
-      new TextDecoder().decode(result_array.slice(8, 24)).replace(/\0/g, ``),
-    ).toBe(`ASE-Trajectory`)
+    expect(new TextDecoder().decode(result_array.slice(8, 24)).replace(/\0/g, ``)).toBe(
+      `ASE-Trajectory`,
+    )
+  })
+})
+
+describe(`VSCode Download Integration`, () => {
+  test(`sets up global download override when VSCode API is available`, async () => {
+    const mock_post_message = vi.fn()
+    globalThis.acquireVsCodeApi = vi.fn(() => ({
+      postMessage: mock_post_message,
+      setState: vi.fn(),
+      getState: vi.fn(),
+    }))
+    const { setup_vscode_download } = await import(`../src/webview/main`)
+    setup_vscode_download()
+    expect(typeof globalThis.download).toBe(`function`)
+    globalThis.download(`test content`, `test.json`, `application/json`)
+    expect(mock_post_message).toHaveBeenCalledWith({
+      command: `saveAs`,
+      content: `test content`,
+      filename: `test.json`,
+      is_binary: false,
+    })
+  })
+
+  test(`handles binary data (PNG) correctly`, async () => {
+    vi.resetModules() // Reset modules to clear cached vscode_api variable in webview/main.ts
+    const mock_file_reader = {
+      onload: null as ((event: { target: { result: string } }) => void) | null,
+      readAsDataURL: vi.fn(),
+      result: null as string | null,
+    }
+    globalThis.FileReader = vi.fn(() => mock_file_reader) as unknown as typeof FileReader
+    const mock_post_message = vi.fn()
+    globalThis.acquireVsCodeApi = vi.fn(() => ({
+      postMessage: mock_post_message,
+      setState: vi.fn(),
+      getState: vi.fn(),
+    }))
+    const { setup_vscode_download } = await import(`../src/webview/main`)
+    setup_vscode_download()
+    globalThis.download(
+      new Blob([`fake png data`], { type: `image/png` }),
+      `structure.png`,
+      `image/png`,
+    )
+    expect(mock_file_reader.readAsDataURL).toHaveBeenCalledWith(expect.any(Blob))
+    const data_url = `data:image/png;base64,ZmFrZSBwbmcgZGF0YQ==`
+    mock_file_reader.result = data_url
+    if (mock_file_reader.onload) mock_file_reader.onload({ target: { result: data_url } })
+    expect(mock_post_message).toHaveBeenCalledWith({
+      command: `saveAs`,
+      content: data_url,
+      filename: `structure.png`,
+      is_binary: true,
+    })
   })
 })

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "svelte": "./dist/index.js",
   "bugs": "https://github.com/janosh/matterviz/issues",
   "dependencies": {
-    "@sveltejs/kit": "^2.25.1",
+    "@sveltejs/kit": "^2.25.2",
     "@threlte/core": "^8.1.3",
     "@threlte/extras": "^9.4.2",
     "@types/d3-force": "^3.0.10",
@@ -29,14 +29,14 @@
     "h5wasm": "^0.8.3",
     "highlight.js": "^11.11.1",
     "js-yaml": "^4.1.0",
-    "svelte": "^5.36.10",
+    "svelte": "^5.36.15",
     "svelte-multiselect": "11.2.2",
     "three": "^0.178.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.54.1",
     "@rollup/plugin-yaml": "^4.1.2",
-    "@stylistic/eslint-plugin": "^5.2.0",
+    "@stylistic/eslint-plugin": "^5.2.2",
     "@sveltejs/adapter-static": "3.0.8",
     "@sveltejs/package": "^2.4.0",
     "@sveltejs/vite-plugin-svelte": "^6.1.0",
@@ -65,8 +65,8 @@
     "svelte-preprocess": "^6.0.3",
     "svelte2tsx": "^0.7.41",
     "typescript": "5.8.3",
-    "typescript-eslint": "^8.37.0",
-    "vite": "^7.0.5",
+    "typescript-eslint": "^8.38.0",
+    "vite": "^7.0.6",
     "vitest": "^3.2.4"
   },
   "keywords": [
@@ -144,5 +144,7 @@
     }
   },
   "types": "./dist/index.d.ts",
-  "files": ["dist"]
+  "files": [
+    "dist"
+  ]
 }

--- a/src/lib/DraggablePanel.svelte
+++ b/src/lib/DraggablePanel.svelte
@@ -156,7 +156,8 @@
     if (!show || has_been_dragged || currently_dragging) return
 
     if (resize_timeout) clearTimeout(resize_timeout)
-    resize_timeout = setTimeout(() => {
+    const current_timeout = setTimeout(() => {
+      if (resize_timeout !== current_timeout) return
       if (show && toggle_panel_btn && !has_been_dragged && panel_div) {
         const pos = calculate_position()
         initial_position = pos
@@ -164,6 +165,7 @@
         panel_div.style.top = pos.top
       }
     }, 50) // Debounce resize events
+    resize_timeout = current_timeout
   }
 
   // Position panel when shown

--- a/src/lib/DraggablePanel.svelte
+++ b/src/lib/DraggablePanel.svelte
@@ -149,6 +149,23 @@
     action()
   }
 
+  // Debounced resize handler for better performance
+  let resize_timeout: ReturnType<typeof setTimeout> | undefined = $state(undefined)
+
+  function handle_resize() { // Only reposition if panel is visible and hasn't been manually dragged
+    if (!show || has_been_dragged || currently_dragging) return
+
+    if (resize_timeout) clearTimeout(resize_timeout)
+    resize_timeout = setTimeout(() => {
+      if (show && toggle_panel_btn && !has_been_dragged && panel_div) {
+        const pos = calculate_position()
+        initial_position = pos
+        panel_div.style.left = pos.left
+        panel_div.style.top = pos.top
+      }
+    }, 50) // Debounce resize events
+  }
+
   // Position panel when shown
   $effect(() => {
     if (show && toggle_panel_btn && !has_been_dragged) {
@@ -166,7 +183,7 @@
   })
 </script>
 
-<svelte:window onkeydown={on_keydown} />
+<svelte:window onkeydown={on_keydown} onresize={handle_resize} />
 <svelte:document onclick={handle_click_outside} />
 
 {#if show_panel}

--- a/src/lib/composition/parse.ts
+++ b/src/lib/composition/parse.ts
@@ -28,7 +28,7 @@ function is_atomic_number_composition(obj: Record<string | number, number>): boo
 
 // Convert a composition with atomic numbers to element symbols
 // Example: {26: 2, 8: 3} -> {Fe: 2, O: 3}
-export function convert_atomic_numbers_to_symbols(
+export function atomic_num_to_symbols(
   atomic_composition: Record<number, number>,
 ): CompositionType {
   const composition: CompositionType = {}
@@ -48,7 +48,7 @@ export function convert_atomic_numbers_to_symbols(
 
 // Convert a composition with element symbols to atomic numbers
 // Example: {Fe: 2, O: 3} -> {26: 2, 8: 3}
-export function convert_symbols_to_atomic_numbers(
+export function atomic_symbol_to_num(
   symbol_composition: CompositionType,
 ): Record<number, number> {
   const atomic_composition: Record<number, number> = {}
@@ -129,7 +129,7 @@ export function normalize_composition(
   // If it's an atomic number composition, convert to symbols first
   if (is_atomic_number_composition(composition)) {
     const atomic_comp = composition as Record<number, number>
-    const symbol_comp = convert_atomic_numbers_to_symbols(atomic_comp)
+    const symbol_comp = atomic_num_to_symbols(atomic_comp)
     return normalize_composition(symbol_comp)
   }
 

--- a/src/lib/structure/StructureControls.svelte
+++ b/src/lib/structure/StructureControls.svelte
@@ -592,7 +592,7 @@
           console.warn(`Canvas element not found for PNG export`)
         }
       }}
-      title="{save_png_btn_text} (${png_dpi} DPI)"
+      title="{save_png_btn_text} ({png_dpi} DPI)"
     >
       {save_png_btn_text}
     </button>

--- a/src/site/structures/index.ts
+++ b/src/site/structures/index.ts
@@ -2,7 +2,7 @@ import { type PymatgenStructure } from '$lib/index'
 import { detect_structure_type, is_optimade_json, parse_optimade_json } from '$lib/io'
 import type { FileInfo } from '$site'
 
-export const structures = Object.entries(
+export const structures = Object.entries( // JSON structure files (OPTIMADE/pymatgen format) as JS objects
   import.meta.glob(`./*.json`, {
     eager: true,
     import: `default`,
@@ -33,9 +33,9 @@ export const structures = Object.entries(
 
 export const structure_map = new Map(structures.map((struct) => [struct.id, struct]))
 
-export const structure_files: FileInfo[] = (Object.entries(
+export const structure_files: FileInfo[] = (Object.entries( // all structure files as raw text
   import.meta.glob(
-    `$site/structures/*.{json,poscar,xyz,cif,yaml}`,
+    `$site/structures/*`,
     { eager: true, query: `?raw`, import: `default` },
   ),
 ) as [string, string][]).map(

--- a/src/site/structures/index.ts
+++ b/src/site/structures/index.ts
@@ -35,7 +35,7 @@ export const structure_map = new Map(structures.map((struct) => [struct.id, stru
 
 export const structure_files: FileInfo[] = (Object.entries(
   import.meta.glob(
-    `$site/structures/*.{poscar,xyz,cif,yaml}`,
+    `$site/structures/*.{json,poscar,xyz,cif,yaml}`,
     { eager: true, query: `?raw`, import: `default` },
   ),
 ) as [string, string][]).map(

--- a/tests/vitest/composition/index.test.ts
+++ b/tests/vitest/composition/index.test.ts
@@ -8,8 +8,8 @@ describe(`composition module exports`, () => {
     expect(parse_module.composition_to_percentages).toBeDefined()
     expect(parse_module.get_total_atoms).toBeDefined()
     expect(parse_module.parse_composition).toBeDefined()
-    expect(parse_module.convert_atomic_numbers_to_symbols).toBeDefined()
-    expect(parse_module.convert_symbols_to_atomic_numbers).toBeDefined()
+    expect(parse_module.atomic_num_to_symbols).toBeDefined()
+    expect(parse_module.atomic_symbol_to_num).toBeDefined()
   })
 
   test(`exports all components and utilities from main index`, async () => {

--- a/tests/vitest/composition/parse.test.ts
+++ b/tests/vitest/composition/parse.test.ts
@@ -1,9 +1,9 @@
 import type { AnyStructure, CompositionType, ElementSymbol } from '$lib'
 import { atomic_number_to_symbol } from '$lib/composition'
 import {
+  atomic_num_to_symbols,
+  atomic_symbol_to_num,
   composition_to_percentages,
-  convert_atomic_numbers_to_symbols,
-  convert_symbols_to_atomic_numbers,
   get_alphabetical_formula,
   get_electro_neg_formula,
   get_total_atoms,
@@ -21,13 +21,13 @@ describe(`atomic number utilities`, () => {
   ])(
     `should convert atomic numbers to symbols for %s (%s)`,
     (input, expected, _description) => {
-      expect(convert_atomic_numbers_to_symbols(input)).toEqual(expected)
+      expect(atomic_num_to_symbols(input)).toEqual(expected)
     },
   )
 
   test(`should handle duplicate atomic numbers in conversion`, () => {
     // This would be represented as an object with the same key, so it should sum
-    expect(convert_atomic_numbers_to_symbols({ 1: 1, 8: 1 })).toEqual({
+    expect(atomic_num_to_symbols({ 1: 1, 8: 1 })).toEqual({
       H: 1,
       O: 1,
     })
@@ -39,7 +39,7 @@ describe(`atomic number utilities`, () => {
   ])(
     `should throw error for invalid atomic numbers %o`,
     (input, expected_error) => {
-      expect(() => convert_atomic_numbers_to_symbols(input)).toThrow(
+      expect(() => atomic_num_to_symbols(input)).toThrow(
         expected_error,
       )
     },
@@ -52,12 +52,12 @@ describe(`atomic number utilities`, () => {
   ])(
     `should convert symbols to atomic numbers for %s (%s)`,
     (input, expected, _description) => {
-      expect(convert_symbols_to_atomic_numbers(input)).toEqual(expected)
+      expect(atomic_symbol_to_num(input)).toEqual(expected)
     },
   )
 
   test(`should throw error for invalid element symbols in conversion`, () => {
-    expect(() => convert_symbols_to_atomic_numbers({ Xx: 1 } as CompositionType)).toThrow(
+    expect(() => atomic_symbol_to_num({ Xx: 1 } as CompositionType)).toThrow(
       `Invalid element symbol: Xx`,
     )
   })
@@ -391,8 +391,8 @@ describe(`edge cases and error handling`, () => {
 
   test(`should be consistent between conversion functions`, () => {
     const original_symbols = { Fe: 2, O: 3, H: 1 }
-    const atomic_numbers = convert_symbols_to_atomic_numbers(original_symbols)
-    const back_to_symbols = convert_atomic_numbers_to_symbols(atomic_numbers)
+    const atomic_numbers = atomic_symbol_to_num(original_symbols)
+    const back_to_symbols = atomic_num_to_symbols(atomic_numbers)
 
     expect(back_to_symbols).toEqual(original_symbols)
   })


### PR DESCRIPTION
Closes #102.

- Saves binary downloads such as PNG files correctly from the VSCode webview while retaining text-download support.
- Fixes the PNG export tooltip to show the correct DPI.
- Renames composition utility functions and updates their callers.
- Debounces window resize handling for draggable-panel positioning.
- Adds tests for binary saving, webview download integration and errors, and the renamed utilities.