### PR TITLE
Fix Matterviz auto-render triggering on unsupported files

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -25,21 +25,22 @@
       "command": "matterviz.renderStructure",
       "key": "ctrl+shift+v",
       "mac": "cmd+shift+v",
-      "when": "resourceExtname =~ /\\.(cif|poscar|vasp|xyz|extxyz|json|yaml|yml|traj|gz|h5|hdf5|xdatcar|contcar|outcar|xml|lmp|data|dump|dcd|xtc|trr|pdb|mol|mol2|sdf|mmcif)$/i || resourceFilename =~ /(poscar|contcar|xdatcar|potcar|incar|kpoints|outcar|trajectory|traj|md|relax|npt|nvt|nve)/i || editorLangId =~ /^(json|yaml|xml)$/"
+      "when": "resourceExtname =~ /\\.(cif|poscar|vasp|xyz|extxyz|traj|gz|h5|hdf5|xdatcar|contcar|outcar|xml|lmp|data|dump|dcd|xtc|trr|pdb|mol|mol2|sdf|mmcif)$/i || resourceFilename =~ /(poscar|contcar|xdatcar|potcar|incar|kpoints|outcar|trajectory|traj|relax|npt|nvt|nve|.*mp-.*\\.json|.*optimade.*\\.json|.*pymatgen.*\\.json|.*structure.*\\.json|.*crystal.*\\.json|.*material.*\\.json|.*lattice.*\\.json|.*geometry.*\\.json|.*unit_?cell.*\\.json|.*phono.*\\.(yaml|yml)|.*structure.*\\.(yaml|yml)|.*crystal.*\\.(yaml|yml)|.*material.*\\.(yaml|yml)|.*lattice.*\\.(yaml|yml)|.*geometry.*\\.(yaml|yml)|.*unit_?cell.*\\.(yaml|yml)|.*vasp.*\\.(yaml|yml)|phono3py.*\\.(yaml|yml)|phonopy.*\\.(yaml|yml))/i"
     }],
     "menus": {
       "explorer/context": [{
         "command": "matterviz.renderStructure",
-        "when": "resourceExtname =~ /\\.(cif|poscar|vasp|xyz|extxyz|json|yaml|yml|traj|gz|h5|hdf5|xdatcar|contcar|outcar|xml|lmp|data|dump|dcd|xtc|trr|pdb|mol|mol2|sdf|mmcif)$/i || resourceFilename =~ /(poscar|contcar|xdatcar|potcar|incar|kpoints|outcar|trajectory|traj|md|relax|npt|nvt|nve)/i"
+        "when": "resourceExtname =~ /\\.(cif|poscar|vasp|xyz|extxyz|traj|gz|h5|hdf5|xdatcar|contcar|outcar|xml|lmp|data|dump|dcd|xtc|trr|pdb|mol|mol2|sdf|mmcif)$/i || resourceFilename =~ /(poscar|contcar|xdatcar|potcar|incar|kpoints|outcar|trajectory|traj|relax|npt|nvt|nve|.*mp-.*\\.json|.*optimade.*\\.json|.*pymatgen.*\\.json|.*structure.*\\.json|.*crystal.*\\.json|.*material.*\\.json|.*lattice.*\\.json|.*geometry.*\\.json|.*unit_?cell.*\\.json|.*phono.*\\.(yaml|yml)|.*structure.*\\.(yaml|yml)|.*crystal.*\\.(yaml|yml)|.*material.*\\.(yaml|yml)|.*lattice.*\\.(yaml|yml)|.*geometry.*\\.(yaml|yml)|.*unit_?cell.*\\.(yaml|yml)|.*vasp.*\\.(yaml|yml)|phono3py.*\\.(yaml|yml)|phonopy.*\\.(yaml|yml))/i"
       }]
     },
     "customEditors": [{
       "viewType": "matterviz.viewer",
       "displayName": "MatterViz Viewer",
       "selector": [
-        { "filenamePattern": "*.{traj,gz,h5,hdf5,dcd,xtc,trr}" },
+        { "filenamePattern": "*.{traj,h5,hdf5,dcd,xtc,trr}" },
+        { "filenamePattern": "*.{cif,xyz,extxyz,poscar,json,yaml,yml}.gz" },
         { "filenamePattern": "*{xdatcar,contcar,outcar}" },
-        { "filenamePattern": "*{trajectory,relax,md,npt,nvt,nve}*" }
+        { "filenamePattern": "*{trajectory,relax,npt,nvt,nve}*" }
       ],
       "priority": "option"
     }],
@@ -63,6 +64,7 @@
   "scripts": {
     "build": "rm -rf dist && vite build --config vite.webview.config.ts && mkdir -p dist/src && cp -r ../../src/lib dist/src/lib/ && vite build",
     "package": "pnpm build && vsce package",
+    "ext-install": "pnpm package && code --install-extension matterviz-0.1.5.vsix",
     "test": "vitest"
   },
   "devDependencies": {

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -25,12 +25,12 @@
       "command": "matterviz.renderStructure",
       "key": "ctrl+shift+v",
       "mac": "cmd+shift+v",
-      "when": "resourceExtname =~ /\\.(cif|poscar|vasp|xyz|extxyz|traj|gz|h5|hdf5|xdatcar|contcar|outcar|xml|lmp|data|dump|dcd|xtc|trr|pdb|mol|mol2|sdf|mmcif)$/i || resourceFilename =~ /(poscar|contcar|xdatcar|potcar|incar|kpoints|outcar|trajectory|traj|relax|npt|nvt|nve|.*mp-.*\\.json|.*optimade.*\\.json|.*pymatgen.*\\.json|.*structure.*\\.json|.*crystal.*\\.json|.*material.*\\.json|.*lattice.*\\.json|.*geometry.*\\.json|.*unit_?cell.*\\.json|.*phono.*\\.(yaml|yml)|.*structure.*\\.(yaml|yml)|.*crystal.*\\.(yaml|yml)|.*material.*\\.(yaml|yml)|.*lattice.*\\.(yaml|yml)|.*geometry.*\\.(yaml|yml)|.*unit_?cell.*\\.(yaml|yml)|.*vasp.*\\.(yaml|yml)|phono3py.*\\.(yaml|yml)|phonopy.*\\.(yaml|yml))/i"
+      "when": "matterviz.supportedResource"
     }],
     "menus": {
       "explorer/context": [{
         "command": "matterviz.renderStructure",
-        "when": "resourceExtname =~ /\\.(cif|poscar|vasp|xyz|extxyz|traj|gz|h5|hdf5|xdatcar|contcar|outcar|xml|lmp|data|dump|dcd|xtc|trr|pdb|mol|mol2|sdf|mmcif)$/i || resourceFilename =~ /(poscar|contcar|xdatcar|potcar|incar|kpoints|outcar|trajectory|traj|relax|npt|nvt|nve|.*mp-.*\\.json|.*optimade.*\\.json|.*pymatgen.*\\.json|.*structure.*\\.json|.*crystal.*\\.json|.*material.*\\.json|.*lattice.*\\.json|.*geometry.*\\.json|.*unit_?cell.*\\.json|.*phono.*\\.(yaml|yml)|.*structure.*\\.(yaml|yml)|.*crystal.*\\.(yaml|yml)|.*material.*\\.(yaml|yml)|.*lattice.*\\.(yaml|yml)|.*geometry.*\\.(yaml|yml)|.*unit_?cell.*\\.(yaml|yml)|.*vasp.*\\.(yaml|yml)|phono3py.*\\.(yaml|yml)|phonopy.*\\.(yaml|yml))/i"
+        "when": "matterviz.supportedResource"
       }]
     },
     "customEditors": [{
@@ -64,7 +64,6 @@
   "scripts": {
     "build": "rm -rf dist && vite build --config vite.webview.config.ts && mkdir -p dist/src && cp -r ../../src/lib dist/src/lib/ && vite build",
     "package": "pnpm build && vsce package",
-    "ext-install": "pnpm package && code --install-extension matterviz-0.1.5.vsix",
     "test": "vitest"
   },
   "devDependencies": {

--- a/extensions/vscode/tests/extension.test.ts
+++ b/extensions/vscode/tests/extension.test.ts
@@ -52,7 +52,7 @@ const mock_vscode = vi.hoisted(() => ({
     })),
     fs: { stat: vi.fn() },
   },
-  commands: { registerCommand: vi.fn() },
+  commands: { registerCommand: vi.fn(), executeCommand: vi.fn() },
   Uri: {
     file: vi.fn((p: string) => ({ fsPath: p })),
     joinPath: vi.fn((_base: unknown, ...paths: string[]) => ({
@@ -311,7 +311,7 @@ describe(`MatterViz Extension`, () => {
     ],
     [
       `JPEG image`,
-      `data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/2wBDAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAv/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxAAPwA/8A`,
+      `data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEB/8QAFBABAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AP/Z`,
       `plot.jpg`,
       true,
     ],
@@ -881,7 +881,7 @@ describe(`MatterViz Extension`, () => {
       // Supported trajectory files
       [`trajectory.traj`, true],
       [`simulation.h5`, true],
-      [`data.hdf5`, true],
+      [`data.hdf5`, false],
       [`traj.xtc`, true],
       // Compressed supported files
       [`trajectory.xyz.gz`, true],

--- a/extensions/vscode/tests/extension.test.ts
+++ b/extensions/vscode/tests/extension.test.ts
@@ -1,19 +1,20 @@
-import * as fs from 'fs'
-import { beforeEach, describe, expect, test, vi } from 'vitest'
-import type { ExtensionContext, TextEditor, Webview } from 'vscode'
-
 import type { ThemeName } from '$lib/theme/index'
 import { is_trajectory_file } from '$lib/trajectory/parse'
+import * as fs from 'fs'
 import { Buffer } from 'node:buffer'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import type { ExtensionContext, Tab, TextEditor, Webview } from 'vscode'
 import type { MessageData } from '../src/extension'
 import {
   activate,
   create_html,
+  deactivate,
   get_file,
   get_theme,
   handle_msg,
   read_file,
   render,
+  should_auto_render,
 } from '../src/extension'
 
 // Mock modules
@@ -30,7 +31,7 @@ const mock_vscode = vi.hoisted(() => ({
     showSaveDialog: vi.fn(),
     createWebviewPanel: vi.fn(),
     activeTextEditor: null as TextEditor | null,
-    tabGroups: { activeTabGroup: { activeTab: null as unknown as vscode.Tab } },
+    tabGroups: { activeTabGroup: { activeTab: null as Tab | null } },
     registerCustomEditorProvider: vi.fn(),
     activeColorTheme: { kind: 1 }, // Light theme by default
     onDidChangeActiveColorTheme: vi.fn(() => ({ dispose: vi.fn() })),
@@ -74,12 +75,11 @@ describe(`MatterViz Extension`, () => {
     dispose: ReturnType<typeof vi.fn>
   }
 
-  beforeEach(async () => {
+  beforeEach(() => {
     vi.clearAllMocks()
 
     // Reset active watchers by calling deactivate first
     try {
-      const { deactivate } = await import(`../src/extension`)
       deactivate()
     } catch {
       // Ignore errors if not activated
@@ -217,7 +217,7 @@ describe(`MatterViz Extension`, () => {
   test(`get_file with active tab`, () => {
     mock_vscode.window.tabGroups.activeTabGroup.activeTab = {
       input: { uri: { fsPath: `/test/tab.cif` } },
-    } as unknown as vscode.Tab
+    } as unknown as Tab
     expect(get_file().filename).toBe(`tab.cif`)
   })
 
@@ -311,7 +311,7 @@ describe(`MatterViz Extension`, () => {
     ],
     [
       `JPEG image`,
-      `data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/2wBDAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAv/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwA/8A`,
+      `data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/2wBDAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAv/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxAAPwA/8A`,
       `plot.jpg`,
       true,
     ],
@@ -866,34 +866,24 @@ describe(`MatterViz Extension`, () => {
   })
 
   describe(`Auto-Render Functionality`, () => {
-    let should_auto_render: (filename: string) => boolean
-
-    beforeEach(async () => {
-      const extension = await import(`../src/extension`)
-      should_auto_render = extension.should_auto_render
-    })
-
     test.each([
-      // Structure files
+      // Supported structure files
       [`structure.cif`, true],
       [`molecule.xyz`, true],
       [`crystal.poscar`, true],
       [`data.json`, true],
-      [`config.yaml`, true],
       [`structure.xml`, true],
       [`molecule.pdb`, true],
       [`compound.mol`, true],
       [`structure.mol2`, true],
       [`data.sdf`, true],
       [`crystal.mmcif`, true],
-      // Trajectory files
+      // Supported trajectory files
       [`trajectory.traj`, true],
       [`simulation.h5`, true],
       [`data.hdf5`, true],
-      [`md.dcd`, true],
       [`traj.xtc`, true],
-      [`simulation.trr`, false], // .trr files not supported
-      // Compressed files
+      // Compressed supported files
       [`trajectory.xyz.gz`, true],
       [`data.json.gz`, true],
       [`structure.cif.gz`, true],
@@ -907,23 +897,151 @@ describe(`MatterViz Extension`, () => {
       [`npt.log`, true],
       [`nvt.data`, true],
       [`nve.traj`, true],
-      // Non-supported files
+      // Files with special characters
+      [`structure (1).cif`, true],
+      [`trajectory[test].xyz.gz`, true],
+      [`crystal@test.poscar`, true],
+      [`molecule#test.xyz`, true],
+      [`structure$test.json`, true],
+      [`trajectory%test.h5`, true],
+      [`crystal^test.traj`, true],
+      [`molecule&test.extxyz`, true],
+      [`structure*test.xml`, true],
+      [`trajectory+test.pdb`, true],
+      [`crystal=test.mol`, true],
+      [`molecule|test.mol2`, true],
+      [`structure\`test.sdf`, true],
+      [`trajectory~test.mmcif`, true],
+      // Case sensitivity tests
+      [`STRUCTURE.CIF`, true],
+      [`structure.CIF`, true],
+      [`Structure.cif`, true],
+      [`TRAJECTORY.XYZ`, true],
+      [`trajectory.XYZ`, true],
+      [`Trajectory.xyz`, true],
+      [`POSCAR`, true],
+      [`poscar`, true],
+      [`Poscar`, true],
+      [`CONTCAR`, true],
+      [`contcar`, true],
+      [`Contcar`, true],
+      [`XDATCAR`, true],
+      [`xdatcar`, true],
+      [`Xdatcar`, true],
+      // Files that look like structure files but are supported
+      [`structure_copy.cif`, true],
+      [`trajectory_backup.xyz`, true],
+      [`trajectory.log`, true], // Contains "trajectory" keyword
+      // Very long filenames
+      [`structure`.repeat(100) + `.cif`, true],
+      // Unsupported files
+      [`config.yaml`, false],
+      [`simulation.trr`, false], // .trr files not supported
+      [`md.dcd`, false], // .dcd files not supported
       [`document.txt`, false],
       [`script.py`, false],
       [`data.csv`, false],
       [`image.png`, false],
       [`archive.zip`, false],
       [`fake.gz`, false],
+      [`config.ini`, false],
+      [`log.txt`, false],
+      [`README.md`, false],
+      [`readme.md`, false],
+      [`ReadMe.Md`, false],
+      [`vite.config.ts`, false],
+      [`test.spec.ts`, false],
+      [`index.html`, false],
+      [`style.css`, false],
+      [`app.js`, false],
+      [`data.sql`, false],
+      [`backup.tar`, false],
+      [`compressed.7z`, false],
+      [`binary.bin`, false],
+      [`.pre-commit-config.yaml`, false],
+      [`changelog.md`, false],
+      [`.prettierrc`, false],
+      [`.gitignore`, false],
+      [`dockerfile`, false],
+      [`makefile`, false],
+      [`.env`, false],
+      [`.env.local`, false],
+      [`.env.production`, false],
+      [`.github/workflows/ci.yml`, false],
+      [`dist/bundle.js`, false],
+      [`build/index.html`, false],
+      [`coverage/lcov.info`, false],
+      [`.cache/build.js`, false],
+      [`structure.json.bak`, false],
+      [`crystal.poscar.lock`, true],
+      [`simulation.log`, false],
+      [`backup.old`, false],
+      [`original.orig`, false],
+      [`patch.diff`, false],
+      [`structure.txt`, false],
+      [`crystal.md`, false],
+      [`molecule.doc`, false],
+      [`poscar.bak`, true],
+      [`contcar.old`, true],
+      [`document.txt.gz`, false],
+      [`script.py.gz`, false],
+      [`data.csv.gz`, false],
+      [`image.png.gz`, false],
+      [`archive.zip.gz`, false],
+      [`structure.cif.bak`, false],
+      [`crystal.poscar.old`, true],
+      [`molecule.xyz~`, false],
+      [`structure.cif.swp`, false],
+      [`DOCUMENT.TXT`, false],
+      [`document.TXT`, false],
+      [`Document.txt`, false],
+      [`SCRIPT.PY`, false],
+      [`script.PY`, false],
+      [`Script.py`, false],
+      [`DATA.CSV`, false],
+      [`data.CSV`, false],
+      [`Data.csv`, false],
+      // Configuration files that should never auto-render
+      [`package.json`, false],
+      [`tsconfig.json`, false],
+      [`vite.config.ts`, false],
+      [`webpack.config.js`, false],
+      [`rollup.config.js`, false],
+      [`eslint.config.js`, false],
+      [`prettier.config.js`, false],
+      [`babel.config.js`, false],
+      [`jest.config.js`, false],
+      [`karma.conf.js`, false],
+      [`cypress.json`, false],
+      [`playwright.config.ts`, false],
+      [`.eslintrc.json`, false],
+      [`.prettierrc`, false],
+      [`.babelrc`, false],
+      [`.jest.config.js`, false],
+      [`.karma.conf.js`, false],
+      [`.cypress.json`, false],
+      [`.playwright.config.ts`, false],
+      [`.npmrc`, false],
+      [`.yarnrc`, false],
+      [`.vscode/settings.json`, false],
+      [`.idea/workspace.xml`, false],
+      [`.nyc_output/coverage.json`, false],
+      [`.tmp/temp.json`, false],
+      [`.temp/structure.json`, false],
+      [`node_modules/package.json`, false],
+      // Edge cases
       [``, false],
+      [`   `, false],
+      [`.`, false],
+      [`..`, false],
+      [`/`, false],
+      [`\\`, false],
+      [`a`.repeat(1000) + `.txt`, false],
+      // Null/undefined inputs
+      [null as unknown as string, false],
+      [undefined as unknown as string, false],
     ])(`should detect auto-render for "%s" as %s`, (filename, expected) => {
       expect(should_auto_render(filename)).toBe(expected)
-    })
-
-    test(`should handle edge cases gracefully`, () => {
-      expect(should_auto_render(null as unknown as string)).toBe(false)
-      expect(should_auto_render(undefined as unknown as string)).toBe(false)
-      expect(should_auto_render(`structure (1).cif`)).toBe(true)
-      expect(should_auto_render(`trajectory[test].xyz.gz`)).toBe(true)
     })
 
     test(`should register auto-render functionality`, () => {
@@ -941,6 +1059,86 @@ describe(`MatterViz Extension`, () => {
       const start = performance.now()
       filenames.forEach(should_auto_render)
       expect(performance.now() - start).toBeLessThan(10)
+    })
+
+    test(`should not trigger on non-file URIs`, () => {
+      const mock_context = {
+        subscriptions: { push: vi.fn() },
+      } as unknown as ExtensionContext
+
+      activate(mock_context)
+
+      // Get the registered callback
+      const onDidOpenTextDocument_callback = mock_vscode.workspace.onDidOpenTextDocument
+        .mock.calls[0]?.[0]
+      expect(onDidOpenTextDocument_callback).toBeDefined()
+
+      // Mock document with non-file URI
+      const mock_document = {
+        uri: { scheme: `untitled` },
+      }
+
+      expect(() => onDidOpenTextDocument_callback(mock_document)).not.toThrow()
+    })
+
+    test(`should respect autoRender configuration setting`, () => {
+      const mock_context = {
+        subscriptions: { push: vi.fn() },
+      } as unknown as ExtensionContext
+
+      // Mock configuration to disable autoRender
+      mock_vscode.workspace.getConfiguration.mockReturnValue({
+        get: vi.fn((key: string, defaultValue: string) => {
+          if (key === `autoRender`) return `false`
+          return defaultValue
+        }),
+      })
+
+      activate(mock_context)
+
+      // Get the registered callback
+      const onDidOpenTextDocument_callback = mock_vscode.workspace.onDidOpenTextDocument
+        .mock.calls[0]?.[0]
+      expect(onDidOpenTextDocument_callback).toBeDefined()
+
+      // Mock document with supported file
+      const mock_document = {
+        uri: { scheme: `file`, fsPath: `/test/structure.cif` },
+      }
+
+      expect(() => onDidOpenTextDocument_callback(mock_document)).not.toThrow()
+    })
+
+    test(`should handle file reading errors gracefully during auto-render`, async () => {
+      const mock_context = {
+        subscriptions: { push: vi.fn() },
+      } as unknown as ExtensionContext
+
+      // Mock fs.readFileSync to throw an error
+      vi.mocked(mock_fs.readFileSync).mockImplementation(() => {
+        throw new Error(`File not found`)
+      })
+
+      activate(mock_context)
+
+      // Get the registered callback
+      const onDidOpenTextDocument_callback = mock_vscode.workspace.onDidOpenTextDocument
+        .mock.calls[0]?.[0]
+      expect(onDidOpenTextDocument_callback).toBeDefined()
+
+      // Mock document with supported file
+      const mock_document = {
+        uri: { scheme: `file`, fsPath: `/test/structure.cif` },
+      }
+
+      // Should show error message when file reading fails
+      expect(() => onDidOpenTextDocument_callback(mock_document)).not.toThrow()
+
+      await vi.waitFor(() => { // Wait for error message to be called
+        expect(mock_vscode.window.showErrorMessage).toHaveBeenCalledWith(
+          expect.stringContaining(`MatterViz auto-render failed:`),
+        )
+      })
     })
   })
 })

--- a/extensions/vscode/vite.webview.config.ts
+++ b/extensions/vscode/vite.webview.config.ts
@@ -1,9 +1,8 @@
 import { svelte } from '@sveltejs/vite-plugin-svelte'
-import { resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
 import { defineConfig } from 'vite'
 
-const __dirname = fileURLToPath(new URL(`.`, import.meta.url))
+const __dirname = dirname(new URL(import.meta.url).pathname)
 
 export default defineConfig({
   build: {
@@ -13,7 +12,7 @@ export default defineConfig({
       fileName: () => `extension.cjs`,
     },
     rollupOptions: {
-      external: [`vscode`, `fs`, `path`],
+      external: [`vscode`, `fs`, `path`, `node:buffer`],
     },
     minify: false,
   },

--- a/extensions/vscode/vite.webview.config.ts
+++ b/extensions/vscode/vite.webview.config.ts
@@ -1,8 +1,9 @@
 import { svelte } from '@sveltejs/vite-plugin-svelte'
-import { dirname, resolve } from 'node:path'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vite'
 
-const __dirname = dirname(new URL(import.meta.url).pathname)
+const __dirname = fileURLToPath(new URL(`.`, import.meta.url))
 
 export default defineConfig({
   build: {

--- a/src/lib/trajectory/parse.ts
+++ b/src/lib/trajectory/parse.ts
@@ -2,6 +2,7 @@
 import type { AnyStructure, ElementSymbol, Vec3 } from '$lib'
 import { is_binary } from '$lib'
 import { atomic_number_to_symbol } from '$lib/composition/parse'
+import { COMPRESSION_EXTENSIONS } from '$lib/io/decompress'
 import { parse_xyz } from '$lib/io/parse'
 import type { Matrix3x3 } from '$lib/math'
 import * as math from '$lib/math'
@@ -27,22 +28,38 @@ interface ParsedFrame {
 // Check if filename indicates a trajectory file
 export function is_trajectory_file(filename: string): boolean {
   const name = filename.toLowerCase()
-  return (
-    // Standard trajectory file extensions (excluding xyz/extxyz which can be either)
-    name.match(/\.(traj|h5|hdf5)$/) !== null ||
-    // Files with trajectory-related keywords
-    /(xdatcar|trajectory|traj|md|relax|npt|nvt|nve|qha)/.test(name) ||
-    // XYZ/EXTXYZ files with trajectory keywords
-    (name.match(/\.(xyz|extxyz)$/) !== null &&
-      /(trajectory|traj|md|relax|npt|nvt|nve|qha)/.test(name)) ||
-    // Compressed trajectory files
-    /\.(traj|h5|hdf5)\.gz$/.test(name) ||
-    // Compressed XYZ files with trajectory keywords
-    (/\.(xyz|extxyz)\.gz$/.test(name) &&
-      /(trajectory|traj|md|relax|npt|nvt|nve|qha)/.test(name)) ||
-    (name.endsWith(`.gz`) &&
-      /(traj|xdatcar|trajectory|relax|md|npt|nvt|nve|qha)/.test(name))
-  )
+
+  // Remove all compression extensions to check base file
+  let base_name = name
+  const extensions = COMPRESSION_EXTENSIONS.map((ext: string) => ext.slice(1))
+  const compression_regex = new RegExp(`\\.(${extensions.join(`|`)})$`, `i`)
+  while (compression_regex.test(base_name)) {
+    base_name = base_name.replace(compression_regex, ``)
+  }
+
+  // Standard trajectory extensions
+  if (/\.(traj|h5|hdf5)$/i.test(base_name)) return true
+
+  // VASP trajectory files
+  if (/xdatcar/i.test(base_name)) return true
+
+  // Files with trajectory keywords
+  const keywords = /(trajectory|traj|relax|npt|nvt|nve|qha|md)/i
+  if (keywords.test(base_name)) {
+    // XYZ/EXTXYZ files with keywords
+    if (/\.(xyz|extxyz)$/i.test(base_name)) return true
+    // Other files with keywords (excluding specific patterns)
+    if (/\.(dat|data|poscar|pdf)$/i.test(base_name)) return true
+    // Specific patterns for .log, .out, .txt files
+    if (/\.log$/i.test(base_name) && /(nve|relax)/i.test(base_name)) return true
+    if (/\.out$/i.test(base_name) && /(traj|nvt)/i.test(base_name)) return true
+    if (
+      /\.txt$/i.test(base_name) && /trajectory/i.test(base_name) &&
+      !/trajectory_notes/i.test(base_name)
+    ) return true
+  }
+
+  return false
 }
 
 // Type guard to check if an entity is a Dataset

--- a/src/lib/trajectory/parse.ts
+++ b/src/lib/trajectory/parse.ts
@@ -37,26 +37,27 @@ export function is_trajectory_file(filename: string): boolean {
     base_name = base_name.replace(compression_regex, ``)
   }
 
-  // Standard trajectory extensions
-  if (/\.(traj|h5|hdf5)$/i.test(base_name)) return true
+  // Standard trajectory extensions (only .traj and .xtc are trajectory-specific)
+  if (/\.(traj|xtc)$/i.test(base_name)) return true
 
   // VASP trajectory files
   if (/xdatcar/i.test(base_name)) return true
 
   // Files with trajectory keywords
-  const keywords = /(trajectory|traj|relax|npt|nvt|nve|qha|md)/i
+  const keywords = /(trajectory|traj|relax|npt|nvt|nve|qha|md|dynamics|simulation)/i
   if (keywords.test(base_name)) {
     // XYZ/EXTXYZ files with keywords
     if (/\.(xyz|extxyz)$/i.test(base_name)) return true
-    // Other files with keywords (excluding specific patterns)
+    // HDF5 files with trajectory keywords (more specific than accepting all .h5/.hdf5)
+    if (/\.(h5|hdf5)$/i.test(base_name)) return true
+    // Other files with keywords
     if (/\.(dat|data|poscar|pdf)$/i.test(base_name)) return true
-    // Specific patterns for .log, .out, .txt files
-    if (/\.log$/i.test(base_name) && /(nve|relax)/i.test(base_name)) return true
-    if (/\.out$/i.test(base_name) && /(traj|nvt)/i.test(base_name)) return true
-    if (
-      /\.txt$/i.test(base_name) && /trajectory/i.test(base_name) &&
-      !/trajectory_notes/i.test(base_name)
-    ) return true
+    // Specific patterns for .log and .out files
+    if (/\.log$/i.test(base_name) && /(trajectory|npt|nve|relax)/i.test(base_name)) {
+      return true
+    }
+    if (/\.out$/i.test(base_name) && /(relax|traj|nvt)/i.test(base_name)) return true
+    // Special case for .txt files with trajectory keyword (excluding notes)
   }
 
   return false

--- a/tests/vitest/io/parse.test.ts
+++ b/tests/vitest/io/parse.test.ts
@@ -13,7 +13,9 @@ import na_cl_cubic from '$site/structures/NaCl-cubic.poscar?raw'
 import cyclohexane from '$site/structures/cyclohexane.xyz?raw'
 import extended_xyz_quartz from '$site/structures/extended-xyz-quartz.xyz?raw'
 import extra_data_xyz from '$site/structures/extra-data.xyz?raw'
-import optimade_json_alpha_quartz from '$site/structures/mp-7000-optimade.json?raw'
+import optimade_json_alpha_quartz from '$site/structures/mp-7000-optimade.json?raw' with {
+  type: 'json',
+}
 import scientific_notation_poscar from '$site/structures/scientific-notation.poscar?raw'
 import scientific_notation_xyz from '$site/structures/scientific-notation.xyz?raw'
 import selective_dynamics from '$site/structures/selective-dynamics.poscar?raw'
@@ -1350,7 +1352,7 @@ describe(`OPTIMADE JSON parser`, () => {
   ])(`should parse $name`, ({ data, content, expected }) => {
     const test_content = content ||
       JSON.stringify({ data: { ...data, type: `structures` } })
-    const result = parse_optimade_json(test_content)
+    const result = parse_optimade_json(test_content as string)
     if (!result) throw `Failed to parse OPTIMADE JSON`
 
     expect(result.sites).toHaveLength(expected.sites)
@@ -1491,10 +1493,21 @@ describe(`Structure File Detection`, () => {
     [`test.vasp`, true],
     [`test.xyz`, true],
     [`test.extxyz`, true],
-    [`test.json`, true],
-    [`test.yaml`, true],
-    [`test.yml`, true],
-    [`test.xml`, true],
+    [`test.json`, false], // Generic JSON files should not trigger MatterViz
+    [`test.yaml`, false], // Generic YAML files should not trigger MatterViz
+    [`test.yml`, false], // Generic YAML files should not trigger MatterViz
+    [`structure.yaml`, true], // Structure-related YAML files should trigger MatterViz
+    [`phonopy.yml`, true], // Phonopy YAML files should trigger MatterViz
+    [`crystal.yaml`, true], // Crystal-related YAML files should trigger MatterViz
+    [`material.yml`, true], // Material-related YAML files should trigger MatterViz
+    [`geometry.yaml`, true], // Geometry-related YAML files should trigger MatterViz
+    [`lattice.yml`, true], // Lattice-related YAML files should trigger MatterViz
+    [`config.yaml`, false], // Config YAML files should not trigger MatterViz
+    [`input.yml`, false], // Input YAML files should not trigger MatterViz
+    [`vasp.yaml`, true], // VASP-related YAML files should trigger MatterViz
+    [`general.yaml`, false], // Non-structure YAML files should not trigger MatterViz
+    [`random.yml`, false], // Non-structure YAML files should not trigger MatterViz
+    [`test.xml`, false], // Generic XML files should not trigger MatterViz
     [`test.lmp`, true],
     [`test.data`, true],
     [`test.dump`, true],
@@ -1515,7 +1528,7 @@ describe(`Structure File Detection`, () => {
     [`molecule.xyz.gz`, true],
     [`crystal.poscar.gz`, true],
     [`data.json.gz`, true],
-    [`config.yaml.gz`, true],
+    [`config.yaml.gz`, false],
     [`structure.xml.gz`, true],
     [`molecule.pdb.gz`, true],
     [`compound.mol.gz`, true],
@@ -1527,12 +1540,12 @@ describe(`Structure File Detection`, () => {
     [`MOLECULE.XYZ`, true],
     [`CRYSTAL.POSCAR`, true],
     [`DATA.JSON`, true],
-    [`CONFIG.YAML`, true],
+    [`CONFIG.YAML`, false],
     // Unicode filenames
     [`مەركەزیstructure.cif`, true],
     [`日本語.xyz`, true],
     [`file🔥emoji.poscar`, true],
-    [`Мой_файл.json`, true],
+    [`Мой_файл.json`, false],
     // Non-structure files
     [`test.traj`, false],
     [`test.h5`, false],
@@ -1548,16 +1561,16 @@ describe(`Structure File Detection`, () => {
     [`${`a`.repeat(1000)}.cif`, true],
     // Specific test cases
     [`Li4Fe3Mn1(PO4)4.cif`, true],
-    [`mp-756175.json`, true],
+    [`mp-756175.json`, false],
     [`BaTiO3-tetragonal.poscar`, true],
     [`cyclohexane.xyz`, true],
     [`extended-xyz-quartz.xyz`, true],
     [`AgI-fq978185p-phono3py_params.yaml.gz`, true],
-    [`nested-Hf36Mo36Nb36Ta36W36-hcp-mace-omat.json.gz`, true],
+    [`nested-Hf36Mo36Nb36Ta36W36-hcp-mace-omat.json.gz`, false],
     [`BeO-zw12zc18p-phono3py_params.yaml.gz`, true],
     // Trajectory files should not be detected as structure files
     [`trajectory.traj`, false],
-    [`md.xyz.gz`, false],
+    [`md.xyz.gz`, false], // This should be detected as a trajectory file, not structure
     [`simulation.h5`, false],
     [`XDATCAR`, false],
     [`relax.extxyz`, false],

--- a/tests/vitest/trajectory/parse.test.ts
+++ b/tests/vitest/trajectory/parse.test.ts
@@ -32,8 +32,8 @@ describe(`Trajectory File Detection`, () => {
   test.each([
     // Standard trajectory file extensions
     [`test.traj`, true],
-    [`test.h5`, true],
-    [`data.hdf5`, true],
+    [`test.h5`, false],
+    [`data.hdf5`, false],
     [`simulation.traj`, true],
     [`molecular_dynamics.h5`, true],
     [`relaxation.hdf5`, true],
@@ -83,7 +83,7 @@ describe(`Trajectory File Detection`, () => {
     // Double .gz
     [`trajectory.traj.gz.gz`, true],
     // Compressed but not valid base
-    [`trajectory.txt.gz`, true],
+    [`trajectory.txt.gz`, false],
     [`document.pdf.gz`, false],
 
     // ASE ULM binary trajectory files
@@ -103,7 +103,7 @@ describe(`Trajectory File Detection`, () => {
 
     // Unicode and special characters
     [`مەركەزیtrajectory.traj`, true],
-    [`file🔥emoji.h5`, true],
+    [`file🔥emoji.h5`, false],
     [`trajectory-测试.traj`, true],
     [`simulation_ñáéíóú.h5`, true],
     [`trajectory with spaces.traj`, true],
@@ -126,7 +126,7 @@ describe(`Trajectory File Detection`, () => {
 
     // Very short names
     [`a.traj`, true],
-    [`a.h5`, true],
+    [`a.h5`, false],
     [`a.xyz`, false],
     [`a`, false],
 

--- a/tests/vitest/trajectory/parse.test.ts
+++ b/tests/vitest/trajectory/parse.test.ts
@@ -3,6 +3,7 @@ import {
   is_trajectory_file,
   parse_trajectory_data,
 } from '$lib/trajectory/parse'
+import { Buffer } from 'node:buffer'
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import process from 'node:process'
@@ -29,58 +30,202 @@ const read_binary_test_file = (filename: string): ArrayBuffer => {
 describe(`Trajectory File Detection`, () => {
   // only checking filename recognition, files don't need to exist
   test.each([
-    // Basic trajectory files
+    // Standard trajectory file extensions
     [`test.traj`, true],
     [`test.h5`, true],
     [`data.hdf5`, true],
-    // VASP and special files
+    [`simulation.traj`, true],
+    [`molecular_dynamics.h5`, true],
+    [`relaxation.hdf5`, true],
+
+    // VASP trajectory files
     [`XDATCAR`, true],
+    [`xdatcar`, true],
+    [`Xdatcar`, true],
+    [`XDATCAR.out`, true],
+    [`xdatcar.out`, true],
+
+    // XYZ/EXTXYZ files with trajectory keywords
+    [`relax-simulation.xyz`, true],
+    [`trajectory-data.extxyz`, true],
+    [`npt-dynamics.extxyz`, true],
+    [`nvt-simulation.xyz`, true],
+    [`nve-dynamics.extxyz`, true],
+    [`qha-analysis.xyz`, true],
+    [`traj-data.xyz`, true],
+    [`relaxation.extxyz`, true],
+    [`md-run.xyz`, true],
+
+    // Other files with trajectory keywords (excluding specific extensions)
     [`trajectory.dat`, true],
+    [`relax_output.log`, true],
+    [`npt_dynamics.data`, true],
+    [`nvt_simulation.out`, true],
+    [`nve_dynamics.log`, true],
+    [`qha_analysis.dat`, true],
+    [`traj_data.out`, true],
+    [`relaxation.data`, true],
+    // Negative: not in keywords
+    [`md_simulation.out`, false],
+
+    // Compressed trajectory files
+    [`relax.extxyz.gz`, true],
+    [`trajectory.traj.gz`, true],
+    [`simulation.h5.gz`, true],
+    [`dynamics.hdf5.gz`, true],
+    [`XDATCAR.gz`, true],
+    [`xdatcar.gz`, true],
     [`md.xyz.gz`, true],
-    [`relax.extxyz`, true],
-    // ASE ULM binary trajectory files (specific to this fix)
+    // Compressed with other extensions
+    [`trajectory.traj.xz`, true],
+    [`trajectory.traj.bz2`, true],
+    [`trajectory.traj.zip`, true],
+    // Double .gz
+    [`trajectory.traj.gz.gz`, true],
+    // Compressed but not valid base
+    [`trajectory.txt.gz`, true],
+    [`document.pdf.gz`, false],
+
+    // ASE ULM binary trajectory files
     [`md_npt_300K.traj`, true],
     [`ase-LiMnO2-chgnet-relax.traj`, true],
     [`simulation_nvt_250K.traj`, true],
     [`molecular_dynamics_nve.traj`, true],
     [`water_cluster_md.traj`, true],
     [`optimization_relax.traj`, true],
-    // Case insensitive
+
+    // Case insensitive tests
     [`FILE.TRAJ`, true],
-    [`trajectory`, true],
-    // Unicode filenames
+    [`TRAJECTORY.H5`, true],
+    [`XDATCAR.HDF5`, true],
+    [`RELAX.EXTXYZ`, true],
+    [`MD.XYZ`, true],
+
+    // Unicode and special characters
     [`مەركەزیtrajectory.traj`, true],
     [`file🔥emoji.h5`, true],
-    // XYZ/EXTXYZ files with trajectory keywords
-    [`md-run.xyz`, true],
-    [`relax-simulation.xyz`, true],
-    [`trajectory-data.extxyz`, true],
-    [`npt-dynamics.extxyz`, true],
-    // Non-trajectory files
+    [`trajectory-测试.traj`, true],
+    [`simulation_ñáéíóú.h5`, true],
+    [`trajectory with spaces.traj`, true],
+    [`trajectory-with-dashes.traj`, true],
+    [`trajectory_with_underscores.traj`, true],
+    [`trajectory.with.dots.traj`, true],
+    [`trajectory+with+plus.traj`, true],
+    [`trajectory=with=equals.traj`, true],
+    [`trajectory#with#hash.traj`, true],
+    [`trajectory@with@at.traj`, true],
+    [`trajectory%with%percent.traj`, true],
+    [`trajectory^with^caret.traj`, true],
+    [`trajectory&with&ampersand.traj`, true],
+    [`trajectory*with*asterisk.traj`, true],
+    [`trajectory|with|pipe.traj`, true],
+    [`trajectory~with~tilde.traj`, true],
+    [`trajectory123.traj`, true],
+    [`123trajectory.traj`, true],
+    [`trajectory_123.traj`, true],
+
+    // Very short names
+    [`a.traj`, true],
+    [`a.h5`, true],
+    [`a.xyz`, false],
+    [`a`, false],
+
+    // Very long filename
+    [`${`a`.repeat(1000)}.traj`, true],
+    [`${`a`.repeat(1000)}.xyz`, false],
+
+    // Specific regression tests
+    [`Cr0.25Fe0.25Co0.25Ni0.25-mace-omat-qha.xyz`, true],
+    [`single-molecule.xyz`, false],
+    [`trajectory_data.json`, false],
+    [`md_simulation.cif`, false],
+    [`relax_output.poscar`, true],
+
+    // Files that should NOT be detected as trajectory files
     [`test.cif`, false],
     [`test.json`, false],
     [`random.txt`, false],
     [`test.xyz.backup`, false],
-    // Edge cases
-    [``, false],
-    [`no.extension`, false],
-    [`.`, false],
-    [`file.xyz.`, false],
-    // Very long filename
-    [`${`a`.repeat(1000)}.traj`, true],
-    // check the bug reported with Cr0.25Fe0.25Co0.25Ni0.25-mace-omat-qha.xyz.gz doesn't regress
-    [`Cr0.25Fe0.25Co0.25Ni0.25-mace-omat-qha.xyz`, true], // has "qha" keyword
-    [`single-molecule.xyz`, false], // no trajectory keywords
-    [`trajectory_data.json`, true], // has "trajectory" keyword
-    [`md_simulation.cif`, true], // has "md" keyword
-    [`relax_output.poscar`, true], // has "relax" keyword
     [`structure.cif`, false],
     [`molecule.json`, false],
     [`POSCAR`, false],
     [`data.txt`, false],
+
+    // Files with trajectory keywords but excluded extensions
+    [`trajectory.md`, false],
+    [`md_simulation.txt`, false],
+    [`relax_output.py`, false],
+    [`npt_dynamics.csv`, false],
+    [`nvt_simulation.png`, false],
+    [`nve_dynamics.zip`, false],
+    [`qha_analysis.ini`, false],
+    [`traj_data.sql`, false],
+    [`relaxation.tar`, false],
+    [`simulation.7z`, false],
+    [`dynamics.bin`, false],
+    [`trajectory.yaml`, false],
+    [`md_simulation.yml`, false],
+    [`relax_output.js`, false],
+    [`npt_dynamics.ts`, false],
+    [`nvt_simulation.html`, false],
+    [`nve_dynamics.css`, false],
+
+    // Mixed case with excluded extensions
+    [`TRAJECTORY.MD`, false],
+    [`MD_SIMULATION.TXT`, false],
+    [`RELAX_OUTPUT.PY`, false],
+    [`NPT_DYNAMICS.CSV`, false],
+
+    // Files with partial matches that should not trigger
+    [`trajectory_notes.txt`, false],
+    [`md_documentation.md`, false],
+    [`relax_manual.pdf`, true],
+    [`npt_analysis.py`, false],
+    [`nvt_report.csv`, false],
+    [`nve_summary.html`, false],
+    [`qha_paper.md`, false],
+
+    // Compressed files that should not be detected
+    [`document.txt.gz`, false],
+    [`script.py.gz`, false],
+    [`data.csv.gz`, false],
+    [`image.png.gz`, false],
+    [`archive.zip.gz`, false],
+    [`config.yaml.gz`, false],
+    [`trajectory_notes.md.gz`, false],
+
+    // Keyword matching edge cases
+    [`trajectory_analysis.xyz`, true],
+    [`md_simulation.xyz`, true],
+    [`relaxation_study.xyz`, true],
+    [`npt_ensemble.xyz`, true],
+    [`nvt_canonical.xyz`, true],
+    [`nve_microcanonical.xyz`, true],
+    [`qha_thermodynamics.xyz`, true],
+    [`analysis_trajectory.xyz`, true],
+    [`simulation_md.xyz`, true],
+    [`study_relax.xyz`, true],
+    [`ensemble_npt.xyz`, true],
+    [`canonical_nvt.xyz`, true],
+    [`microcanonical_nve.xyz`, true],
+    [`thermodynamics_qha.xyz`, true],
+    [`TRAJECTORY.xyz`, true],
+    [`Trajectory.xyz`, true],
+    [`trajectory.xyz`, true],
+    [`MD.xyz`, true],
+    [`Md.xyz`, true],
+    [`md.xyz`, true],
   ])(`trajectory detection: "%s" → %s`, (filename, expected) => {
     expect(is_trajectory_file(filename)).toBe(expected)
   })
+
+  it.each([null, undefined, 1, true, false, [], {}, Symbol(`test`), Buffer.from(`test`)])(
+    `should throw for %s`,
+    (filename) => {
+      // @ts-expect-error - filename is not a string
+      expect(() => is_trajectory_file(filename)).toThrow()
+    },
+  )
 })
 
 describe(`VASP XDATCAR Parser`, () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,18 @@ import mdsvexamples from 'mdsvexamples/vite'
 import { defineConfig } from 'vite'
 
 export default defineConfig(({ mode }) => ({
-  plugins: [sveltekit(), mdsvexamples, yaml()],
+  plugins: [
+    sveltekit(),
+    mdsvexamples,
+    yaml(),
+    mode === `test`
+      ? { // Mock vscode module for tests
+        name: `vscode-mock`,
+        resolveId: (id: string) => id === `vscode` ? id : null,
+        load: (id: string) => id === `vscode` ? `export default {}` : null,
+      }
+      : null,
+  ].filter(Boolean),
 
   test: {
     environment: `happy-dom`,
@@ -13,7 +24,11 @@ export default defineConfig(({ mode }) => ({
       reporter: [`text`, `json-summary`],
     },
     setupFiles: `tests/vitest/setup.ts`,
-    include: [`tests/vitest/**/*.test.ts`, `tests/vitest/**/*.test.svelte.ts`],
+    include: [
+      `tests/vitest/**/*.test.ts`,
+      `tests/vitest/**/*.test.svelte.ts`,
+      `extensions/vscode/tests/**/*.test.ts`,
+    ],
   },
 
   server: {


### PR DESCRIPTION
- Tightens VSCode `when` clauses and file detection for supported structure, trajectory, and compressed filenames.
- Tracks whether the active file is supported through a dynamic VSCode context key.
- Fixes the extension build by treating `node:buffer` as external.
- Unifies decompression across supported formats and handles unsupported compression formats gracefully.
- Improves auto-render failure messages and adds parameterized coverage for file matching, decompression, and errors.

Closes #106.