### PR TITLE
Customize site labels (size, color, padding, bg color, offset) via `StructureControls.svelte`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "h5wasm": "^0.8.3",
     "highlight.js": "^11.11.1",
     "js-yaml": "^4.1.0",
-    "svelte": "^5.36.17",
+    "svelte": "^5.37.0",
     "svelte-multiselect": "11.2.2",
     "three": "^0.178.0"
   },

--- a/src/lib/DraggablePanel.svelte
+++ b/src/lib/DraggablePanel.svelte
@@ -319,7 +319,7 @@
     box-shadow: 0 0 0 2px rgba(255, 107, 107, 0.2);
   }
   .draggable-panel :global(input[type='range']) {
-    margin-left: auto;
+    margin-left: 4pt;
     width: 100px;
     flex-shrink: 0;
   }

--- a/src/lib/DraggablePanel.svelte
+++ b/src/lib/DraggablePanel.svelte
@@ -279,7 +279,8 @@
     transition: opacity 0.3s, background-color 0.3s, border-color 0.3s, box-shadow 0.3s;
     width: 28em;
     max-width: 90cqw;
-    overflow: auto;
+    overflow-x: hidden;
+    overflow-y: auto;
     max-height: calc(100vh - 3em);
     pointer-events: auto;
   }

--- a/src/lib/composition/BarChart.svelte
+++ b/src/lib/composition/BarChart.svelte
@@ -76,15 +76,15 @@
   let segments = $derived.by(() => {
     const element_entries = Object.entries(composition).filter(([_, amount]) =>
       amount && amount > 0
-    )
+    ) as [ElementSymbol, number][]
     if (element_entries.length === 0) return []
 
     let [above_labels, below_labels] = [0, 0]
     let current_x = 0
 
     return element_entries.map(([element, amount]) => {
-      const percentage = percentages[element as ElementSymbol] || 0
-      const color = element_colors[element as ElementSymbol] || `#cccccc`
+      const percentage = percentages[element] || 0
+      const color = element_colors[element] || `#cccccc`
       const width = (percentage / 100) * size
       const x = current_x
       current_x += width
@@ -115,7 +115,7 @@
       }
 
       return {
-        element: element as ElementSymbol,
+        element,
         amount: amount!,
         percentage,
         color,

--- a/src/lib/composition/BubbleChart.svelte
+++ b/src/lib/composition/BubbleChart.svelte
@@ -57,9 +57,9 @@
     // Create hierarchy data structure for D3 pack
     const hierarchy_data = {
       children: element_entries.map(([element, amount]) => ({
-        element: element as ElementSymbol,
+        element,
         amount: amount!,
-        color: element_colors[element as ElementSymbol] || `#cccccc`,
+        color: element_colors[element] || `#cccccc`,
       })),
     }
 

--- a/src/lib/composition/PieChart.svelte
+++ b/src/lib/composition/PieChart.svelte
@@ -143,11 +143,10 @@
           label_text,
           available_space,
         )
-
-        const color = element_colors[element as ElementSymbol] || `#cccccc`
+        const color = element_colors[element] || `#cccccc`
 
         return {
-          element: element as ElementSymbol,
+          element,
           amount: amount!,
           percentage,
           color,

--- a/src/lib/io/export.ts
+++ b/src/lib/io/export.ts
@@ -233,18 +233,13 @@ export function structure_to_poscar_str(structure?: AnyStructure): string {
   if (!(`lattice` in structure) || !structure.lattice) {
     throw new Error(`No lattice information for POSCAR export`)
   }
-
   const lines: string[] = []
 
-  // Title line
   const title = structure.id || electro_neg_formula(structure) ||
     `Generated from structure`
   lines.push(title)
+  lines.push(`1.0`) // Scale factor (1.0 for direct coordinates)
 
-  // Scale factor (1.0 for direct coordinates)
-  lines.push(`1.0`)
-
-  // Lattice vectors
   const lattice = structure.lattice
   if (lattice.matrix && Array.isArray(lattice.matrix) && lattice.matrix.length >= 3) {
     // Convert 3x3 matrix to 3 vectors

--- a/src/lib/io/export.ts
+++ b/src/lib/io/export.ts
@@ -1,4 +1,4 @@
-import type { AnyStructure } from '$lib'
+import type { AnyStructure, Vec3 } from '$lib'
 import { electro_neg_formula } from '$lib'
 import { download } from '$lib/io/fetch'
 import * as math from '$lib/math'
@@ -210,10 +210,7 @@ export function structure_to_cif_str(structure?: AnyStructure): string {
       // Convert cartesian to fractional coordinates
       const lattice_transposed = math.transpose_3x3_matrix(lattice.matrix)
       const lattice_inv = math.matrix_inverse_3x3(lattice_transposed)
-      frac_coords = math.mat3x3_vec3_multiply(
-        lattice_inv,
-        site.xyz.slice(0, 3) as [number, number, number],
-      )
+      frac_coords = math.mat3x3_vec3_multiply(lattice_inv, site.xyz.slice(0, 3) as Vec3)
     } else {
       throw new Error(`No valid coordinates found for site ${idx}`)
     }
@@ -342,7 +339,7 @@ export function structure_to_poscar_str(structure?: AnyStructure): string {
           const lattice_inv = math.matrix_inverse_3x3(lattice_transposed)
           frac_coords = math.mat3x3_vec3_multiply(
             lattice_inv,
-            site.xyz.slice(0, 3) as [number, number, number],
+            site.xyz.slice(0, 3) as Vec3,
           )
         } else {
           throw new Error(`No valid coordinates found for site`)

--- a/src/lib/io/parse.ts
+++ b/src/lib/io/parse.ts
@@ -114,18 +114,7 @@ function validate_element_symbol(symbol: string, index: number): ElementSymbol {
   }
 
   // Fallback to default elements by atomic number
-  const fallback_elements = [
-    `H`,
-    `He`,
-    `Li`,
-    `Be`,
-    `B`,
-    `C`,
-    `N`,
-    `O`,
-    `F`,
-    `Ne`,
-  ]
+  const fallback_elements = [`H`, `He`, `Li`, `Be`, `B`, `C`, `N`, `O`, `F`, `Ne`]
   const fallback = fallback_elements[index % fallback_elements.length]
   console.warn(
     `Invalid element symbol '${symbol}', using fallback '${fallback}'`,
@@ -583,12 +572,7 @@ const parse_cif_atom_data = (raw_data: string[], indices: Record<string, number>
       throw new Error(`Could not extract element symbol from: ${raw_data.join(` `)}`)
     })()
 
-  return {
-    id: raw_data[label],
-    element: element_symbol,
-    fract_coords: fract_coords as [number, number, number],
-    occupancy: occu,
-  }
+  return { id: raw_data[label], element: element_symbol, fract_coords, occupancy: occu }
 }
 
 // Parse CIF (Crystallographic Information File) format

--- a/src/lib/structure/Bond.svelte
+++ b/src/lib/structure/Bond.svelte
@@ -74,22 +74,16 @@
       const offset_vec = new Vector3()
         .crossVectors(delta_vec, new Vector3(1, 0, 0))
         .normalize()
-      position = from_vec
-        .clone()
-        .add(delta_vec.multiplyScalar(0.5))
-        .add(offset_vec.multiplyScalar(offset * thickness * 2))
-        .toArray() as [number, number, number]
+      position = from_vec.clone().add(delta_vec.multiplyScalar(0.5)).add(
+        offset_vec.multiplyScalar(offset * thickness * 2),
+      ).toArray()
     }
     // calculate rotation
     const quaternion = new Quaternion().setFromUnitVectors(
       new Vector3(0, 1, 0),
       delta_vec.normalize(),
     )
-    const rotation = new Euler().setFromQuaternion(quaternion).toArray() as [
-      number,
-      number,
-      number,
-    ]
+    const rotation = new Euler().setFromQuaternion(quaternion).toArray()
     // return results
     return { height, position, rotation }
   }

--- a/src/lib/structure/Bond.svelte
+++ b/src/lib/structure/Bond.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
+  import type { Vec3 } from '$lib'
   import { STRUCT_DEFAULTS } from '$lib/structure'
   import { T } from '@threlte/core'
   import { CanvasTexture, Euler, Quaternion, Vector3 } from 'three'
 
   interface Props {
-    from: [number, number, number]
-    to: [number, number, number]
+    from: Vec3
+    to: Vec3
     color?: string
     thickness?: number
     offset?: number
@@ -66,13 +67,9 @@
     // length of the bond
     const height = delta_vec.length()
     // calculate position
-    let position: [number, number, number]
+    let position: Vec3
     if (offset === 0) {
-      position = from_vec.clone().add(delta_vec.multiplyScalar(0.5)).toArray() as [
-        number,
-        number,
-        number,
-      ]
+      position = from_vec.clone().add(delta_vec.multiplyScalar(0.5)).toArray()
     } else {
       const offset_vec = new Vector3()
         .crossVectors(delta_vec, new Vector3(1, 0, 0))

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -560,7 +560,7 @@
     right: var(--struct-buttons-right, var(--ctrl-btn-right, 1ex));
     gap: clamp(2pt, 0.5cqw, 6pt);
     /* buttons need higher z-index than StructureLegend to make info/controls panels occlude legend */
-    /* we also need crazy high z-index to to make info/control panel occlude threlte/extras' <HTML> elements for site labels */
+    /* we also need crazy high z-index to make info/control panel occlude threlte/extras' <HTML> elements for site labels */
     z-index: var(--struct-buttons-z-index, 100000000);
     opacity: 0;
     pointer-events: none;

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -470,7 +470,6 @@
           bind:scene_props
           bind:lattice_props
           bind:show_image_atoms
-          bind:show_site_labels
           bind:background_color
           bind:background_opacity
           bind:color_scheme
@@ -503,7 +502,6 @@
         <StructureScene
           structure={scene_structure}
           {...scene_props}
-          {show_site_labels}
           {lattice_props}
           bind:camera_is_moving
         />
@@ -562,7 +560,8 @@
     right: var(--struct-buttons-right, var(--ctrl-btn-right, 1ex));
     gap: clamp(2pt, 0.5cqw, 6pt);
     /* buttons need higher z-index than StructureLegend to make info/controls panels occlude legend */
-    z-index: var(--struct-buttons-z-index, 2);
+    /* we also need crazy high z-index to to make info/control panel occlude threlte/extras' <HTML> elements for site labels */
+    z-index: var(--struct-buttons-z-index, 100000000);
     opacity: 0;
     pointer-events: none;
     transition: opacity 0.2s ease;

--- a/src/lib/structure/StructureControls.svelte
+++ b/src/lib/structure/StructureControls.svelte
@@ -76,28 +76,30 @@
     }
   })
 
-  // Atom label background color management
-  let atom_label_hex_color = $state(scene_props.atom_label_color || `#ffffff`)
+  // Atom label color management
+  let atom_label_hex_color = $state(
+    scene_props.atom_label_color || STRUCT_DEFAULTS.scene_props.atom_label_color,
+  )
+  let atom_label_bg_hex_color = $state(
+    scene_props.atom_label_bg_color ||
+      STRUCT_DEFAULTS.scene_props.atom_label_bg_color,
+  )
   let atom_label_background_opacity = $state(0)
 
-  $effect(() => { // Update scene props when color inputs change
+  $effect(() => {
     scene_props.atom_label_color = atom_label_hex_color
-
-    const hex = atom_label_hex_color.replace(`#`, ``)
-    const r = parseInt(hex.slice(0, 2), 16)
-    const g = parseInt(hex.slice(2, 4), 16)
-    const b = parseInt(hex.slice(4, 6), 16)
     scene_props.atom_label_bg_color =
-      `rgba(${r}, ${g}, ${b}, ${atom_label_background_opacity})`
+      `color-mix(in srgb, ${atom_label_bg_hex_color} ${
+        atom_label_background_opacity * 100
+      }%, transparent)`
   })
 
-  $effect(() => { // Ensure atom_label_offset is always available
-    if (!scene_props.atom_label_offset) {
-      scene_props.atom_label_offset = [
-        ...STRUCT_DEFAULTS.scene_props.atom_label_offset,
-      ]
-    }
-  })
+  // Ensure atom_label_offset is always available
+  if (!scene_props.atom_label_offset) {
+    scene_props.atom_label_offset = [
+      ...STRUCT_DEFAULTS.scene_props.atom_label_offset,
+    ]
+  }
 
   // Copy button feedback state
   let copy_status = $state<
@@ -415,7 +417,7 @@
         Color
         <input type="color" bind:value={atom_label_hex_color} />
       </label>
-      <label>
+      <label class="slider-control">
         Size
         <input
           type="range"
@@ -429,7 +431,7 @@
     <div class="panel-row">
       <label>
         Background
-        <input type="color" bind:value={atom_label_hex_color} />
+        <input type="color" bind:value={atom_label_bg_hex_color} />
       </label>
       <label class="slider-control">
         Opacity

--- a/src/lib/structure/StructureControls.svelte
+++ b/src/lib/structure/StructureControls.svelte
@@ -519,7 +519,7 @@
   <h4>Cell</h4>
   <label>
     <input type="checkbox" bind:checked={lattice_props.show_vectors} />
-    lattice vectors
+    Lattice Vectors
   </label>
   {#each [
       {

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -63,6 +63,11 @@
     sphere_segments?: number
     lattice_props?: ComponentProps<typeof Lattice>
     atom_label?: Snippet<[Site, number]>
+    atom_label_size?: number
+    atom_label_offset?: Vec3
+    atom_label_bg_color?: string
+    atom_label_color?: string
+    atom_label_padding?: number
     camera_is_moving?: boolean // used to prevent tooltip from showing while camera is moving
     orbit_controls?: ComponentProps<typeof OrbitControls>[`ref`]
   }
@@ -80,6 +85,11 @@
     show_atoms = true,
     show_bonds = false,
     show_site_labels = false,
+    atom_label_size = 1,
+    atom_label_offset = $bindable(STRUCT_DEFAULTS.scene_props.atom_label_offset),
+    atom_label_bg_color = `rgba(0, 0, 0, 0)`,
+    atom_label_color = `#ffffff`,
+    atom_label_padding = 3,
     show_force_vectors = false,
     force_vector_scale = STRUCT_DEFAULTS.vector.scale,
     force_vector_color = STRUCT_DEFAULTS.vector.color,
@@ -373,11 +383,23 @@
     </T.Group>
 
     {#if show_site_labels}
-      <HTML center position={atom.position}>
+      <HTML
+        center
+        position={atom.position}
+        position.x={atom.position[0] + atom_label_offset[0]}
+        position.y={atom.position[1] + atom_label_offset[1]}
+        position.z={atom.position[2] + atom_label_offset[2]}
+      >
         {#if atom_label}
           {@render atom_label(structure!.sites[atom.site_idx], atom.site_idx)}
         {:else}
-          <span class="atom-label">{atom.element}</span>
+          <span
+            class="atom-label"
+            style:font-size="{atom_label_size}em"
+            style:background={atom_label_bg_color}
+            style:padding="{atom_label_padding}px"
+            style:color={atom_label_color}
+          >{atom.element}</span>
         {/if}
       </HTML>
     {/if}
@@ -387,11 +409,23 @@
   {#if show_site_labels}
     {#each instanced_atom_groups as group (group.element + group.radius)}
       {#each group.atoms as atom (atom.site_idx)}
-        <HTML center position={atom.position}>
+        <HTML
+          center
+          position={atom.position}
+          position.x={atom.position[0] + atom_label_offset[0]}
+          position.y={atom.position[1] + atom_label_offset[1]}
+          position.z={atom.position[2] + atom_label_offset[2]}
+        >
           {#if atom_label}
             {@render atom_label(structure!.sites[atom.site_idx], atom.site_idx)}
           {:else}
-            <span class="atom-label">{atom.element}</span>
+            <span
+              class="atom-label"
+              style:font-size="{atom_label_size}em"
+              style:background={atom_label_bg_color}
+              style:padding="{atom_label_padding}px"
+              style:color={atom_label_color}
+            >{atom.element}</span>
           {/if}
         </HTML>
       {/each}

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -85,7 +85,7 @@
     show_atoms = true,
     show_bonds = false,
     show_site_labels = false,
-    atom_label_size = 1,
+    atom_label_size = STRUCT_DEFAULTS.scene_props.atom_label_size,
     atom_label_offset = $bindable(STRUCT_DEFAULTS.scene_props.atom_label_offset),
     atom_label_bg_color = `color-mix(in srgb, #000000 0%, transparent)`,
     atom_label_color = `#ffffff`,

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -87,7 +87,7 @@
     show_site_labels = false,
     atom_label_size = 1,
     atom_label_offset = $bindable(STRUCT_DEFAULTS.scene_props.atom_label_offset),
-    atom_label_bg_color = `rgba(0, 0, 0, 0)`,
+    atom_label_bg_color = `color-mix(in srgb, #000000 0%, transparent)`,
     atom_label_color = `#ffffff`,
     atom_label_padding = 3,
     show_force_vectors = false,
@@ -299,6 +299,23 @@
   })
 </script>
 
+{#snippet atom_label_snippet(element: string, position: Vec3, site_idx: number)}
+  {@const [x, y, z] = math.add(position, atom_label_offset)}
+  <HTML center {position} position.x={x} position.y={y} position.z={z}>
+    {#if atom_label}
+      {@render atom_label(structure!.sites[site_idx], site_idx)}
+    {:else}
+      <span
+        class="atom-label"
+        style:font-size="{atom_label_size}em"
+        style:background={atom_label_bg_color}
+        style:padding="{atom_label_padding}px"
+        style:color={atom_label_color}
+      >{element}</span>
+    {/if}
+  </HTML>
+{/snippet}
+
 {#if camera_projection === `perspective`}
   <T.PerspectiveCamera makeDefault position={camera_position} {fov}>
     <OrbitControls {...orbit_controls_props}>
@@ -383,25 +400,7 @@
     </T.Group>
 
     {#if show_site_labels}
-      <HTML
-        center
-        position={atom.position}
-        position.x={atom.position[0] + atom_label_offset[0]}
-        position.y={atom.position[1] + atom_label_offset[1]}
-        position.z={atom.position[2] + atom_label_offset[2]}
-      >
-        {#if atom_label}
-          {@render atom_label(structure!.sites[atom.site_idx], atom.site_idx)}
-        {:else}
-          <span
-            class="atom-label"
-            style:font-size="{atom_label_size}em"
-            style:background={atom_label_bg_color}
-            style:padding="{atom_label_padding}px"
-            style:color={atom_label_color}
-          >{atom.element}</span>
-        {/if}
-      </HTML>
+      {@render atom_label_snippet(atom.element, atom.position, atom.site_idx)}
     {/if}
   {/each}
 
@@ -409,25 +408,7 @@
   {#if show_site_labels}
     {#each instanced_atom_groups as group (group.element + group.radius)}
       {#each group.atoms as atom (atom.site_idx)}
-        <HTML
-          center
-          position={atom.position}
-          position.x={atom.position[0] + atom_label_offset[0]}
-          position.y={atom.position[1] + atom_label_offset[1]}
-          position.z={atom.position[2] + atom_label_offset[2]}
-        >
-          {#if atom_label}
-            {@render atom_label(structure!.sites[atom.site_idx], atom.site_idx)}
-          {:else}
-            <span
-              class="atom-label"
-              style:font-size="{atom_label_size}em"
-              style:background={atom_label_bg_color}
-              style:padding="{atom_label_padding}px"
-              style:color={atom_label_color}
-            >{atom.element}</span>
-          {/if}
-        </HTML>
+        {@render atom_label_snippet(atom.element, atom.position, atom.site_idx)}
       {/each}
     {/each}
   {/if}

--- a/src/lib/structure/index.ts
+++ b/src/lib/structure/index.ts
@@ -46,6 +46,17 @@ export const STRUCT_DEFAULTS = {
     same_size_atoms: false,
     camera_projection: `perspective`,
     zoom_speed: 0.3,
+    atom_label_color: `#ffffff`,
+    atom_label_bg_color: `rgba(0, 0, 0, 0)`,
+    atom_label_padding: 3,
+    atom_label_offset: [0, 0.75, 0] as Vec3,
+  },
+  atom: {
+    font_size: 1,
+    label_font_size: 1,
+    label_offset: [0, 1.5],
+    material_type: `MeshPhongMaterial`,
+    radius: 0.5,
   },
 } as const
 
@@ -83,11 +94,7 @@ export type PymatgenLattice = {
 export type PymatgenMolecule = { sites: Site[]; charge?: number; id?: string }
 export type PymatgenStructure = PymatgenMolecule & { lattice: PymatgenLattice }
 
-export type Edge = {
-  to_jimage: [number, number, number]
-  id: number
-  key: number
-}
+export type Edge = { to_jimage: Vec3; id: number; key: number }
 
 export type Graph = {
   directed: boolean
@@ -210,7 +217,7 @@ export interface StructureHandlerData {
   total_atoms?: number
   error_msg?: string
   is_fullscreen?: boolean
-  camera_position?: [number, number, number]
+  camera_position?: Vec3
   camera_has_moved?: boolean
   color_scheme?: string
   performance_mode?: `quality` | `speed`

--- a/src/lib/structure/index.ts
+++ b/src/lib/structure/index.ts
@@ -47,14 +47,13 @@ export const STRUCT_DEFAULTS = {
     camera_projection: `perspective`,
     zoom_speed: 0.3,
     atom_label_color: `#ffffff`,
-    atom_label_bg_color: `rgba(0, 0, 0, 0)`,
-    atom_label_padding: 3,
-    atom_label_offset: [0, 0.75, 0] as Vec3,
+    atom_label_bg_color: `color-mix(in srgb, #000000 0%, transparent)`,
+    atom_label_padding: 0,
+    atom_label_offset: [0, 0.75, 0] as Vec3, // 3D offset for atom label positioning relative to atom center
   },
   atom: {
     font_size: 1,
     label_font_size: 1,
-    label_offset: [0, 1.5],
     material_type: `MeshPhongMaterial`,
     radius: 0.5,
   },

--- a/src/lib/structure/index.ts
+++ b/src/lib/structure/index.ts
@@ -46,16 +46,11 @@ export const STRUCT_DEFAULTS = {
     same_size_atoms: false,
     camera_projection: `perspective`,
     zoom_speed: 0.3,
+    atom_label_size: 1,
     atom_label_color: `#ffffff`,
     atom_label_bg_color: `color-mix(in srgb, #000000 0%, transparent)`,
     atom_label_padding: 0,
     atom_label_offset: [0, 0.75, 0] as Vec3, // 3D offset for atom label positioning relative to atom center
-  },
-  atom: {
-    font_size: 1,
-    label_font_size: 1,
-    material_type: `MeshPhongMaterial`,
-    radius: 0.5,
   },
 } as const
 

--- a/src/lib/trajectory/parse.ts
+++ b/src/lib/trajectory/parse.ts
@@ -92,7 +92,7 @@ const get_inverse_matrix = (matrix: Matrix3x3): Matrix3x3 => {
 }
 
 const convert_atomic_numbers = (numbers: number[]): ElementSymbol[] =>
-  numbers.map((num) => atomic_number_to_symbol[num] || (`X` as ElementSymbol))
+  numbers.map((num) => atomic_number_to_symbol[num] || `X`)
 
 const create_site = (
   element: ElementSymbol,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,7 +6,7 @@
   let scene_props = $state({ auto_rotate: 0.5 })
 </script>
 
-<h1 style="margin: 0">MatterViz</h1>
+<h1>MatterViz</h1>
 
 <p>
   <code>matterviz</code> is a toolkit for building interactive web UIs for materials
@@ -84,7 +84,6 @@
     gap: 2em;
     max-width: 1400px;
     margin-inline: auto;
-    text-align: center;
     min-width: 300px;
   }
 </style>

--- a/tests/playwright/structure.test.ts
+++ b/tests/playwright/structure.test.ts
@@ -322,6 +322,563 @@ test.describe(`Structure Component Tests`, () => {
     expect(await site_labels_checkbox.count()).toBe(1)
   })
 
+  test(`label controls appear when site labels are enabled`, async ({ page }) => {
+    const controls_dialog = page.locator(
+      `#structure-wrapper .structure .controls-panel`,
+    )
+    const test_page_controls_checkbox = page.locator(
+      `label:has-text("Controls Open") input[type="checkbox"]`,
+    )
+
+    await test_page_controls_checkbox.check()
+    await expect(controls_dialog).toBeVisible()
+
+    // Enable site labels first
+    const site_labels_checkbox = controls_dialog.locator(
+      `label:has-text("site labels") input[type="checkbox"]`,
+    )
+    await site_labels_checkbox.check()
+
+    // Check that Labels section appears
+    const labels_section = controls_dialog.locator(`h4:has-text("Labels")`)
+    await expect(labels_section).toBeVisible()
+
+    // Check that all label controls are present
+    const text_color_label = controls_dialog.locator(`label:has-text("Text Color")`)
+    const background_color_label = controls_dialog.locator(
+      `label:has-text("Background Color")`,
+    )
+    const padding_label = controls_dialog.locator(`label:has-text("Padding")`)
+    const offset_x_label = controls_dialog.locator(`label:has-text("X")`)
+    const offset_y_label = controls_dialog.locator(`label:has-text("Y")`)
+    const offset_z_label = controls_dialog.locator(`label:has-text("Z")`)
+
+    await expect(text_color_label).toBeVisible()
+    await expect(background_color_label).toBeVisible()
+    await expect(padding_label).toBeVisible()
+    await expect(offset_x_label).toBeVisible()
+    await expect(offset_y_label).toBeVisible()
+    await expect(offset_z_label).toBeVisible()
+  })
+
+  test(`label text color control works correctly`, async ({ page }) => {
+    const controls_dialog = page.locator(
+      `#structure-wrapper .structure .controls-panel`,
+    )
+    const test_page_controls_checkbox = page.locator(
+      `label:has-text("Controls Open") input[type="checkbox"]`,
+    )
+
+    await test_page_controls_checkbox.check()
+    await expect(controls_dialog).toBeVisible()
+
+    // Enable site labels
+    const site_labels_checkbox = controls_dialog.locator(
+      `label:has-text("site labels") input[type="checkbox"]`,
+    )
+    await site_labels_checkbox.check()
+
+    // Find text color input
+    const text_color_input = controls_dialog.locator(
+      `label:has-text("Text Color") input[type="color"]`,
+    )
+    await expect(text_color_input).toBeVisible()
+
+    // Get initial value
+    const initial_color = await text_color_input.inputValue()
+    expect(initial_color).toMatch(/^#[0-9a-fA-F]{6}$/)
+
+    // Change color
+    await text_color_input.fill(`#ff0000`)
+    const new_color = await text_color_input.inputValue()
+    expect(new_color).toBe(`#ff0000`)
+
+    // Change to another color
+    await text_color_input.fill(`#00ff00`)
+    const final_color = await text_color_input.inputValue()
+    expect(final_color).toBe(`#00ff00`)
+  })
+
+  test(`label background color control works correctly`, async ({ page }) => {
+    const controls_dialog = page.locator(
+      `#structure-wrapper .structure .controls-panel`,
+    )
+    const test_page_controls_checkbox = page.locator(
+      `label:has-text("Controls Open") input[type="checkbox"]`,
+    )
+
+    await test_page_controls_checkbox.check()
+    await expect(controls_dialog).toBeVisible()
+
+    // Enable site labels
+    const site_labels_checkbox = controls_dialog.locator(
+      `label:has-text("site labels") input[type="checkbox"]`,
+    )
+    await site_labels_checkbox.check()
+
+    // Find background color input
+    const background_color_input = controls_dialog.locator(
+      `label:has-text("Background Color") input[type="color"]`,
+    )
+    await expect(background_color_input).toBeVisible()
+
+    // Get initial value
+    const initial_color = await background_color_input.inputValue()
+    expect(initial_color).toMatch(/^#[0-9a-fA-F]{6}$/)
+
+    // Change color
+    await background_color_input.fill(`#0000ff`)
+    const new_color = await background_color_input.inputValue()
+    expect(new_color).toBe(`#0000ff`)
+
+    // Change to another color
+    await background_color_input.fill(`#ffff00`)
+    const final_color = await background_color_input.inputValue()
+    expect(final_color).toBe(`#ffff00`)
+  })
+
+  test(`label background opacity control works correctly`, async ({ page }) => {
+    const controls_dialog = page.locator(
+      `#structure-wrapper .structure .controls-panel`,
+    )
+    const test_page_controls_checkbox = page.locator(
+      `label:has-text("Controls Open") input[type="checkbox"]`,
+    )
+
+    await test_page_controls_checkbox.check()
+    await expect(controls_dialog).toBeVisible()
+
+    // Enable site labels
+    const site_labels_checkbox = controls_dialog.locator(
+      `label:has-text("site labels") input[type="checkbox"]`,
+    )
+    await site_labels_checkbox.check()
+
+    // Find background opacity controls
+    const opacity_label = controls_dialog.locator(
+      `label:has-text("Background Opacity")`,
+    )
+    const opacity_number_input = opacity_label.locator(`input[type="number"]`)
+    const opacity_range_input = opacity_label.locator(`input[type="range"]`)
+
+    await expect(opacity_label).toBeVisible()
+    await expect(opacity_number_input).toBeVisible()
+    await expect(opacity_range_input).toBeVisible()
+
+    // Check initial value (should be 0 for transparent)
+    const initial_value = await opacity_number_input.inputValue()
+    expect(parseFloat(initial_value)).toBe(0)
+
+    // Test number input
+    await opacity_number_input.fill(`0.5`)
+    const number_value = await opacity_number_input.inputValue()
+    expect(parseFloat(number_value)).toBe(0.5)
+
+    // Test range input
+    await opacity_range_input.fill(`0.8`)
+    const range_value = await opacity_range_input.inputValue()
+    expect(parseFloat(range_value)).toBe(0.8)
+
+    // Verify both inputs are synchronized
+    const final_number_value = await opacity_number_input.inputValue()
+    const final_range_value = await opacity_range_input.inputValue()
+    expect(parseFloat(final_number_value)).toBe(parseFloat(final_range_value))
+  })
+
+  test(`label padding control works correctly`, async ({ page }) => {
+    const controls_dialog = page.locator(
+      `#structure-wrapper .structure .controls-panel`,
+    )
+    const test_page_controls_checkbox = page.locator(
+      `label:has-text("Controls Open") input[type="checkbox"]`,
+    )
+
+    await test_page_controls_checkbox.check()
+    await expect(controls_dialog).toBeVisible()
+
+    // Enable site labels
+    const site_labels_checkbox = controls_dialog.locator(
+      `label:has-text("site labels") input[type="checkbox"]`,
+    )
+    await site_labels_checkbox.check()
+
+    // Find padding controls
+    const padding_label = controls_dialog.locator(
+      `label:has-text("Padding")`,
+    )
+    const padding_number_input = padding_label.locator(`input[type="number"]`)
+    const padding_range_input = padding_label.locator(`input[type="range"]`)
+
+    await expect(padding_label).toBeVisible()
+    await expect(padding_number_input).toBeVisible()
+    await expect(padding_range_input).toBeVisible()
+
+    // Check initial value
+    const initial_value = await padding_number_input.inputValue()
+    expect(parseInt(initial_value)).toBeGreaterThanOrEqual(0)
+
+    // Test number input
+    await padding_number_input.fill(`5`)
+    const number_value = await padding_number_input.inputValue()
+    expect(parseInt(number_value)).toBe(5)
+
+    // Test range input
+    await padding_range_input.fill(`8`)
+    const range_value = await padding_range_input.inputValue()
+    expect(parseInt(range_value)).toBe(8)
+
+    // Verify both inputs are synchronized
+    const final_number_value = await padding_number_input.inputValue()
+    const final_range_value = await padding_range_input.inputValue()
+    expect(parseInt(final_number_value)).toBe(parseInt(final_range_value))
+  })
+
+  test(`label offset X control works correctly`, async ({ page }) => {
+    const controls_dialog = page.locator(
+      `#structure-wrapper .structure .controls-panel`,
+    )
+    const test_page_controls_checkbox = page.locator(
+      `label:has-text("Controls Open") input[type="checkbox"]`,
+    )
+
+    await test_page_controls_checkbox.check()
+    await expect(controls_dialog).toBeVisible()
+
+    // Enable site labels
+    const site_labels_checkbox = controls_dialog.locator(
+      `label:has-text("site labels") input[type="checkbox"]`,
+    )
+    await site_labels_checkbox.check()
+
+    // Find offset X controls
+    const offset_x_label = controls_dialog.locator(
+      `label:has-text("X")`,
+    )
+    const offset_x_number_input = offset_x_label.locator(`input[type="number"]`)
+    const offset_x_range_input = offset_x_label.locator(`input[type="range"]`)
+
+    await expect(offset_x_label).toBeVisible()
+    await expect(offset_x_number_input).toBeVisible()
+    await expect(offset_x_range_input).toBeVisible()
+
+    // Check initial value
+    const initial_value = await offset_x_number_input.inputValue()
+    expect(parseFloat(initial_value)).toBeGreaterThanOrEqual(-1)
+    expect(parseFloat(initial_value)).toBeLessThanOrEqual(1)
+
+    // Test number input
+    await offset_x_number_input.fill(`0.5`)
+    const number_value = await offset_x_number_input.inputValue()
+    expect(parseFloat(number_value)).toBe(0.5)
+
+    // Test range input
+    await offset_x_range_input.fill(`-0.3`)
+    const range_value = await offset_x_range_input.inputValue()
+    expect(parseFloat(range_value)).toBe(-0.3)
+
+    // Verify both inputs are synchronized
+    const final_number_value = await offset_x_number_input.inputValue()
+    const final_range_value = await offset_x_range_input.inputValue()
+    expect(parseFloat(final_number_value)).toBe(parseFloat(final_range_value))
+  })
+
+  test(`label offset Y control works correctly`, async ({ page }) => {
+    const controls_dialog = page.locator(
+      `#structure-wrapper .structure .controls-panel`,
+    )
+    const test_page_controls_checkbox = page.locator(
+      `label:has-text("Controls Open") input[type="checkbox"]`,
+    )
+
+    await test_page_controls_checkbox.check()
+    await expect(controls_dialog).toBeVisible()
+
+    // Enable site labels
+    const site_labels_checkbox = controls_dialog.locator(
+      `label:has-text("site labels") input[type="checkbox"]`,
+    )
+    await site_labels_checkbox.check()
+
+    // Find offset Y controls
+    const offset_y_label = controls_dialog.locator(
+      `label:has-text("Y")`,
+    )
+    const offset_y_number_input = offset_y_label.locator(`input[type="number"]`)
+    const offset_y_range_input = offset_y_label.locator(`input[type="range"]`)
+
+    await expect(offset_y_label).toBeVisible()
+    await expect(offset_y_number_input).toBeVisible()
+    await expect(offset_y_range_input).toBeVisible()
+
+    // Check initial value
+    const initial_value = await offset_y_number_input.inputValue()
+    expect(parseFloat(initial_value)).toBeGreaterThanOrEqual(-1)
+    expect(parseFloat(initial_value)).toBeLessThanOrEqual(1)
+
+    // Test number input
+    await offset_y_number_input.fill(`0.2`)
+    const number_value = await offset_y_number_input.inputValue()
+    expect(parseFloat(number_value)).toBe(0.2)
+
+    // Test range input
+    await offset_y_range_input.fill(`-0.7`)
+    const range_value = await offset_y_range_input.inputValue()
+    expect(parseFloat(range_value)).toBe(-0.7)
+
+    // Verify both inputs are synchronized
+    const final_number_value = await offset_y_number_input.inputValue()
+    const final_range_value = await offset_y_range_input.inputValue()
+    expect(parseFloat(final_number_value)).toBe(parseFloat(final_range_value))
+  })
+
+  test(`label offset Z control works correctly`, async ({ page }) => {
+    const controls_dialog = page.locator(
+      `#structure-wrapper .structure .controls-panel`,
+    )
+    const test_page_controls_checkbox = page.locator(
+      `label:has-text("Controls Open") input[type="checkbox"]`,
+    )
+
+    await test_page_controls_checkbox.check()
+    await expect(controls_dialog).toBeVisible()
+
+    // Enable site labels
+    const site_labels_checkbox = controls_dialog.locator(
+      `label:has-text("site labels") input[type="checkbox"]`,
+    )
+    await site_labels_checkbox.check()
+
+    // Find offset Z controls
+    const offset_z_label = controls_dialog.locator(
+      `label:has-text("Z")`,
+    )
+    const offset_z_number_input = offset_z_label.locator(`input[type="number"]`)
+
+    await expect(offset_z_label).toBeVisible()
+    await expect(offset_z_number_input).toBeVisible()
+
+    // Check initial value
+    const initial_value = await offset_z_number_input.inputValue()
+    expect(parseFloat(initial_value)).toBeGreaterThanOrEqual(-1)
+    expect(parseFloat(initial_value)).toBeLessThanOrEqual(1)
+
+    // Test number input
+    await offset_z_number_input.fill(`0.3`)
+    const number_value = await offset_z_number_input.inputValue()
+    expect(parseFloat(number_value)).toBe(0.3)
+
+    // Test another value
+    await offset_z_number_input.fill(`-0.5`)
+    const final_value = await offset_z_number_input.inputValue()
+    expect(parseFloat(final_value)).toBe(-0.5)
+  })
+
+  test(`label font size control works correctly`, async ({ page }) => {
+    const controls_dialog = page.locator(
+      `#structure-wrapper .structure .controls-panel`,
+    )
+    const test_page_controls_checkbox = page.locator(
+      `label:has-text("Controls Open") input[type="checkbox"]`,
+    )
+
+    await test_page_controls_checkbox.check()
+    await expect(controls_dialog).toBeVisible()
+
+    // Enable site labels
+    const site_labels_checkbox = controls_dialog.locator(
+      `label:has-text("site labels") input[type="checkbox"]`,
+    )
+    await site_labels_checkbox.check()
+
+    // Find font size control
+    const size_label = controls_dialog.locator(
+      `label:has-text("Size")`,
+    )
+    const size_range_input = size_label.locator(`input[type="range"]`)
+
+    await expect(size_label).toBeVisible()
+    await expect(size_range_input).toBeVisible()
+
+    // Check initial value
+    const initial_value = await size_range_input.inputValue()
+    expect(parseFloat(initial_value)).toBeGreaterThanOrEqual(0.5)
+    expect(parseFloat(initial_value)).toBeLessThanOrEqual(2)
+
+    // Test range input
+    await size_range_input.fill(`1.5`)
+    const new_value = await size_range_input.inputValue()
+    expect(parseFloat(new_value)).toBe(1.5)
+
+    // Test another value
+    await size_range_input.fill(`0.8`)
+    const final_value = await size_range_input.inputValue()
+    expect(parseFloat(final_value)).toBe(0.8)
+  })
+
+  test(`label controls have correct input constraints`, async ({ page }) => {
+    const controls_dialog = page.locator(
+      `#structure-wrapper .structure .controls-panel`,
+    )
+    const test_page_controls_checkbox = page.locator(
+      `label:has-text("Controls Open") input[type="checkbox"]`,
+    )
+
+    await test_page_controls_checkbox.check()
+    await expect(controls_dialog).toBeVisible()
+
+    // Enable site labels
+    const site_labels_checkbox = controls_dialog.locator(
+      `label:has-text("site labels") input[type="checkbox"]`,
+    )
+    await site_labels_checkbox.check()
+
+    // Check opacity constraints
+    const opacity_number_input = controls_dialog.locator(
+      `label:has-text("Background Opacity") input[type="number"]`,
+    )
+    await expect(opacity_number_input).toHaveAttribute(`min`, `0`)
+    await expect(opacity_number_input).toHaveAttribute(`max`, `1`)
+    await expect(opacity_number_input).toHaveAttribute(`step`, `0.01`)
+
+    // Check padding constraints
+    const padding_number_input = controls_dialog.locator(
+      `label:has-text("Padding") input[type="number"]`,
+    )
+    await expect(padding_number_input).toHaveAttribute(`min`, `0`)
+    await expect(padding_number_input).toHaveAttribute(`max`, `10`)
+    await expect(padding_number_input).toHaveAttribute(`step`, `1`)
+
+    // Check offset X constraints
+    const offset_x_number_input = controls_dialog.locator(
+      `label:has-text("X") input[type="number"]`,
+    )
+    await expect(offset_x_number_input).toHaveAttribute(`min`, `-1`)
+    await expect(offset_x_number_input).toHaveAttribute(`max`, `1`)
+    await expect(offset_x_number_input).toHaveAttribute(`step`, `0.1`)
+
+    // Check offset Y constraints
+    const offset_y_number_input = controls_dialog.locator(
+      `label:has-text("Y") input[type="number"]`,
+    )
+    await expect(offset_y_number_input).toHaveAttribute(`min`, `-1`)
+    await expect(offset_y_number_input).toHaveAttribute(`max`, `1`)
+    await expect(offset_y_number_input).toHaveAttribute(`step`, `0.1`)
+
+    // Check offset Z constraints
+    const offset_z_number_input = controls_dialog.locator(
+      `label:has-text("Z") input[type="number"]`,
+    )
+    await expect(offset_z_number_input).toHaveAttribute(`min`, `-1`)
+    await expect(offset_z_number_input).toHaveAttribute(`max`, `1`)
+    await expect(offset_z_number_input).toHaveAttribute(`step`, `0.1`)
+
+    // Check font size constraints
+    const size_range_input = controls_dialog.locator(
+      `label:has-text("Size") input[type="range"]`,
+    )
+    await expect(size_range_input).toHaveAttribute(`min`, `0.5`)
+    await expect(size_range_input).toHaveAttribute(`max`, `2`)
+    await expect(size_range_input).toHaveAttribute(`step`, `0.1`)
+  })
+
+  test(`label controls are properly organized in rows`, async ({ page }) => {
+    const controls_dialog = page.locator(
+      `#structure-wrapper .structure .controls-panel`,
+    )
+    const test_page_controls_checkbox = page.locator(
+      `label:has-text("Controls Open") input[type="checkbox"]`,
+    )
+
+    await test_page_controls_checkbox.check()
+    await expect(controls_dialog).toBeVisible()
+
+    // Enable site labels
+    const site_labels_checkbox = controls_dialog.locator(
+      `label:has-text("site labels") input[type="checkbox"]`,
+    )
+    await site_labels_checkbox.check()
+
+    // Check that controls are organized in panel-row divs
+    const panel_rows = controls_dialog.locator(`.panel-row`)
+    const row_count = await panel_rows.count()
+    expect(row_count).toBeGreaterThan(0)
+
+    // Check that text color and size are in the same row
+    const first_row = panel_rows.first()
+    const text_color_in_first_row = first_row.locator(`label:has-text("Text Color")`)
+    const size_in_first_row = first_row.locator(`label:has-text("Size")`)
+    await expect(text_color_in_first_row).toBeVisible()
+    await expect(size_in_first_row).toBeVisible()
+
+    // Check that background color and opacity are in the same row
+    const second_row = panel_rows.nth(1)
+    const background_in_second_row = second_row.locator(
+      `label:has-text("Background Color")`,
+    )
+    const opacity_in_second_row = second_row.locator(
+      `label:has-text("Background Opacity")`,
+    )
+    await expect(background_in_second_row).toBeVisible()
+    await expect(opacity_in_second_row).toBeVisible()
+
+    // Check that offset X, Y, and Z are in the same row
+    const offset_row = panel_rows.nth(3) // Assuming this is the offset row
+    const offset_x_in_row = offset_row.locator(`label:has-text("X")`)
+    const offset_y_in_row = offset_row.locator(`label:has-text("Y")`)
+    const offset_z_in_row = offset_row.locator(`label:has-text("Z")`)
+    await expect(offset_x_in_row).toBeVisible()
+    await expect(offset_y_in_row).toBeVisible()
+    await expect(offset_z_in_row).toBeVisible()
+  })
+
+  test(`label controls persist when toggling site labels`, async ({ page }) => {
+    const controls_dialog = page.locator(
+      `#structure-wrapper .structure .controls-panel`,
+    )
+    const test_page_controls_checkbox = page.locator(
+      `label:has-text("Controls Open") input[type="checkbox"]`,
+    )
+
+    await test_page_controls_checkbox.check()
+    await expect(controls_dialog).toBeVisible()
+
+    // Enable site labels
+    const site_labels_checkbox = controls_dialog.locator(
+      `label:has-text("site labels") input[type="checkbox"]`,
+    )
+    await site_labels_checkbox.check()
+
+    // Set some values
+    const text_color_input = controls_dialog.locator(
+      `label:has-text("Text Color") input[type="color"]`,
+    )
+    const background_color_input = controls_dialog.locator(
+      `label:has-text("Background Color") input[type="color"]`,
+    )
+    const opacity_input = controls_dialog.locator(
+      `label:has-text("Background Opacity") input[type="number"]`,
+    )
+
+    await text_color_input.fill(`#ff0000`)
+    await background_color_input.fill(`#0000ff`)
+    await opacity_input.fill(`0.7`)
+
+    // Disable site labels
+    await site_labels_checkbox.uncheck()
+
+    // Re-enable site labels
+    await site_labels_checkbox.check()
+
+    // Check that values are preserved
+    const new_text_color = await text_color_input.inputValue()
+    const new_background_color = await background_color_input.inputValue()
+    const new_opacity = await opacity_input.inputValue()
+
+    expect(new_text_color).toBe(`#ff0000`)
+    expect(new_background_color).toBe(`#0000ff`)
+    expect(parseFloat(new_opacity)).toBe(0.7)
+  })
+
   test(`gizmo is hidden when prop is set to false`, async ({ page }) => {
     const gizmo_checkbox = page.locator(
       `label:has-text("Show Gizmo") input[type="checkbox"]`,

--- a/tests/vitest/composition/parse.test.ts
+++ b/tests/vitest/composition/parse.test.ts
@@ -1,4 +1,4 @@
-import type { AnyStructure, CompositionType, ElementSymbol } from '$lib'
+import type { AnyStructure, CompositionType } from '$lib'
 import { atomic_number_to_symbol } from '$lib/composition'
 import {
   atomic_num_to_symbols,
@@ -453,35 +453,35 @@ describe(`formula formatting functions`, () => {
     const structure = {
       sites: [
         {
-          species: [{ element: `Fe` as ElementSymbol, occu: 1, oxidation_state: 0 }],
+          species: [{ element: `Fe`, occu: 1, oxidation_state: 0 }],
           abc: [0, 0, 0],
           xyz: [0, 0, 0],
           label: `Fe1`,
           properties: {},
         },
         {
-          species: [{ element: `Fe` as ElementSymbol, occu: 1, oxidation_state: 0 }],
+          species: [{ element: `Fe`, occu: 1, oxidation_state: 0 }],
           abc: [0.5, 0.5, 0.5],
           xyz: [0.5, 0.5, 0.5],
           label: `Fe2`,
           properties: {},
         },
         {
-          species: [{ element: `O` as ElementSymbol, occu: 1, oxidation_state: 0 }],
+          species: [{ element: `O`, occu: 1, oxidation_state: 0 }],
           abc: [0.25, 0.25, 0.25],
           xyz: [0.25, 0.25, 0.25],
           label: `O1`,
           properties: {},
         },
         {
-          species: [{ element: `O` as ElementSymbol, occu: 1, oxidation_state: 0 }],
+          species: [{ element: `O`, occu: 1, oxidation_state: 0 }],
           abc: [0.75, 0.75, 0.75],
           xyz: [0.75, 0.75, 0.75],
           label: `O2`,
           properties: {},
         },
         {
-          species: [{ element: `O` as ElementSymbol, occu: 1, oxidation_state: 0 }],
+          species: [{ element: `O`, occu: 1, oxidation_state: 0 }],
           abc: [0.5, 0, 0],
           xyz: [0.5, 0, 0],
           label: `O3`,

--- a/tests/vitest/composition/parse.test.ts
+++ b/tests/vitest/composition/parse.test.ts
@@ -167,86 +167,48 @@ describe(`composition_to_percentages`, () => {
   describe(`weight-based percentages`, () => {
     test.each([
       // Basic compounds
-      [
-        { H: 2, O: 1 },
-        { H: 11.19, O: 88.81 },
-      ],
-      [
-        { Fe: 2, O: 3 },
-        { Fe: 69.94, O: 30.06 },
-      ],
-      [
-        { Na: 1, Cl: 1 },
-        { Na: 39.34, Cl: 60.66 },
-      ],
-      [
-        { C: 1, O: 2 },
-        { C: 27.29, O: 72.71 },
-      ],
-      [
-        { Ca: 1, C: 1, O: 3 },
-        { Ca: 40.04, C: 11.99, O: 47.96 },
-      ],
-      [
-        { Al: 2, O: 3 },
-        { Al: 52.92, O: 47.08 },
-      ],
-      [
-        { Li: 1, F: 1 },
-        { Li: 26.75, F: 73.25 },
-      ],
-      [
-        { Au: 1, Cl: 3 },
-        { Au: 64.95, Cl: 35.05 },
-      ],
+      [{ H: 2, O: 1 }, { H: 11.19, O: 88.81 }],
+      [{ Fe: 2, O: 3 }, { Fe: 69.94, O: 30.06 }],
+      [{ Na: 1, Cl: 1 }, { Na: 39.34, Cl: 60.66 }],
+      [{ C: 1, O: 2 }, { C: 27.29, O: 72.71 }],
+      [{ Ca: 1, C: 1, O: 3 }, { Ca: 40.04, C: 11.99, O: 47.96 }],
+      [{ Al: 2, O: 3 }, { Al: 52.92, O: 47.08 }],
+      [{ Li: 1, F: 1 }, { Li: 26.75, F: 73.25 }],
+      [{ Au: 1, Cl: 3 }, { Au: 64.95, Cl: 35.05 }],
       // Edge cases
       [{ C: 1 }, { C: 100 }],
       [{ H: 1 }, { H: 100 }],
       [{ Au: 1 }, { Au: 100 }],
-      [
-        { H: 1, Li: 1 },
-        { H: 12.7, Li: 87.3 },
-      ],
-      [
-        { H: 10, Li: 1 },
-        { H: 59.2, Li: 40.8 },
-      ],
-      [
-        { C: 0.5, H: 2 },
-        { C: 74.87, H: 25.13 },
-      ],
-      [
-        { Fe: 0.1, Au: 0.1 },
-        { Fe: 22.1, Au: 77.9 },
-      ],
-      [
-        { H: 1, He: 1, Li: 1, Be: 1, B: 1 },
-        { H: 3.17, He: 12.58, Li: 21.82, Be: 28.35, B: 34.0 },
-      ],
+      [{ H: 1, Li: 1 }, { H: 12.7, Li: 87.3 }],
+      [{ H: 10, Li: 1 }, { H: 59.2, Li: 40.8 }],
+      [{ C: 0.5, H: 2 }, { C: 74.87, H: 25.13 }],
+      [{ Fe: 0.1, Au: 0.1 }, { Fe: 22.1, Au: 77.9 }],
+      [{ H: 1, He: 1, Li: 1, Be: 1, B: 1 }, {
+        H: 3.17,
+        He: 12.58,
+        Li: 21.82,
+        Be: 28.35,
+        B: 34.0,
+      }],
       // Complex compositions
-      [
-        { C: 8, H: 10, N: 4, O: 2 },
-        { C: 49.48, H: 5.19, N: 28.87, O: 16.47 },
-      ],
-      [
-        { Ca: 3, P: 2, O: 8 },
-        { Ca: 38.76, P: 19.97, O: 41.27 },
-      ],
-      [
-        { Fe: 70, Cr: 18, Ni: 8, Mn: 2, Si: 1, C: 1 },
-        { Fe: 71.54, Cr: 17.13, Ni: 8.64, Mn: 2.02, Si: 0.52, C: 0.22 },
-      ],
-      [
-        { Al: 1, Si: 1, O: 5 },
-        { Al: 19.98, Si: 20.79, O: 59.23 },
-      ],
+      [{ C: 8, H: 10, N: 4, O: 2 }, { C: 49.48, H: 5.19, N: 28.87, O: 16.47 }],
+      [{ Ca: 3, P: 2, O: 8 }, { Ca: 38.76, P: 19.97, O: 41.27 }],
+      [{ Fe: 70, Cr: 18, Ni: 8, Mn: 2, Si: 1, C: 1 }, {
+        Fe: 71.54,
+        Cr: 17.13,
+        Ni: 8.64,
+        Mn: 2.02,
+        Si: 0.52,
+        C: 0.22,
+      }],
+      [{ Al: 1, Si: 1, O: 5 }, { Al: 19.98, Si: 20.79, O: 59.23 }],
     ])(
       `should calculate weight percentages correctly for %s`,
       (composition, expected_percentages) => {
         const result = composition_to_percentages(composition, true)
         Object.entries(expected_percentages).forEach(([element, expected]) => {
           const tolerance = Object.keys(expected_percentages).length === 1 ? 0 : 1
-          expect(result[element as ElementSymbol]).toBeCloseTo(
+          expect(result[element as keyof typeof result]).toBeCloseTo(
             expected,
             tolerance,
           )

--- a/tests/vitest/io/export.test.ts
+++ b/tests/vitest/io/export.test.ts
@@ -1,4 +1,4 @@
-import type { ElementSymbol, Species, Vec3 } from '$lib'
+import type { Vec3 } from '$lib'
 import {
   copy_to_clipboard,
   create_structure_filename,
@@ -37,21 +37,21 @@ const simple_structure: AnyStructure = {
   id: `test_h2o`,
   sites: [
     {
-      species: [{ element: `H` as ElementSymbol, occu: 1, oxidation_state: 1 }],
-      xyz: [0.757, 0.586, 0.0] as [number, number, number],
-      abc: [0.1, 0.1, 0.0] as [number, number, number],
+      species: [{ element: `H`, occu: 1, oxidation_state: 1 }],
+      xyz: [0.757, 0.586, 0.0],
+      abc: [0.1, 0.1, 0.0],
       label: `H`,
       properties: {},
     },
     {
-      species: [{ element: `O` as ElementSymbol, occu: 1, oxidation_state: -2 }],
+      species: [{ element: `O`, occu: 1, oxidation_state: -2 }],
       xyz: [0.0, 0.0, 0.0],
       abc: [0.0, 0.0, 0.0],
       label: `O`,
       properties: {},
     },
     {
-      species: [{ element: `H` as ElementSymbol, occu: 1, oxidation_state: 1 }],
+      species: [{ element: `H`, occu: 1, oxidation_state: 1 }],
       xyz: [-0.757, 0.586, 0.0],
       abc: [-0.1, 0.1, 0.0],
       label: `H`,
@@ -61,12 +61,7 @@ const simple_structure: AnyStructure = {
   lattice: {
     matrix: [[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]],
     pbc: [true, true, true],
-    a: 10.0,
-    b: 10.0,
-    c: 10.0,
-    alpha: 90.0,
-    beta: 90.0,
-    gamma: 90.0,
+    ...{ a: 10.0, b: 10.0, c: 10.0, alpha: 90.0, beta: 90.0, gamma: 90.0 },
     volume: 1000.0,
   },
 }
@@ -75,49 +70,49 @@ const complex_structure: AnyStructure = {
   id: `test_complex`,
   sites: [
     {
-      species: [{ element: `Li` as ElementSymbol, occu: 1, oxidation_state: 1 }],
+      species: [{ element: `Li`, occu: 1, oxidation_state: 1 }],
       xyz: [0.0, 0.0, 0.0],
       abc: [0.0, 0.0, 0.0],
       label: `Li`,
       properties: {},
     },
     {
-      species: [{ element: `Fe` as ElementSymbol, occu: 1, oxidation_state: 2 }],
+      species: [{ element: `Fe`, occu: 1, oxidation_state: 2 }],
       xyz: [2.5, 0.0, 0.0],
       abc: [0.5, 0.0, 0.0],
       label: `Fe`,
       properties: {},
     },
     {
-      species: [{ element: `P` as ElementSymbol, occu: 1, oxidation_state: 5 }],
+      species: [{ element: `P`, occu: 1, oxidation_state: 5 }],
       xyz: [0.0, 2.5, 0.0],
       abc: [0.0, 0.5, 0.0],
       label: `P`,
       properties: {},
     },
     {
-      species: [{ element: `O` as ElementSymbol, occu: 1, oxidation_state: -2 }],
+      species: [{ element: `O`, occu: 1, oxidation_state: -2 }],
       xyz: [1.25, 1.25, 0.0],
       abc: [0.25, 0.25, 0.0],
       label: `O`,
       properties: {},
     },
     {
-      species: [{ element: `O` as ElementSymbol, occu: 1, oxidation_state: -2 }],
+      species: [{ element: `O`, occu: 1, oxidation_state: -2 }],
       xyz: [3.75, 1.25, 0.0],
       abc: [0.75, 0.25, 0.0],
       label: `O`,
       properties: {},
     },
     {
-      species: [{ element: `O` as ElementSymbol, occu: 1, oxidation_state: -2 }],
+      species: [{ element: `O`, occu: 1, oxidation_state: -2 }],
       xyz: [1.25, 3.75, 0.0],
       abc: [0.25, 0.75, 0.0],
       label: `O`,
       properties: {},
     },
     {
-      species: [{ element: `O` as ElementSymbol, occu: 1, oxidation_state: -2 }],
+      species: [{ element: `O`, occu: 1, oxidation_state: -2 }],
       xyz: [3.75, 3.75, 0.0],
       abc: [0.75, 0.75, 0.0],
       label: `O`,
@@ -127,12 +122,7 @@ const complex_structure: AnyStructure = {
   lattice: {
     matrix: [[5.0, 0.0, 0.0], [0.0, 5.0, 0.0], [0.0, 0.0, 5.0]],
     pbc: [true, true, true],
-    a: 5.0,
-    b: 5.0,
-    c: 5.0,
-    alpha: 90.0,
-    beta: 90.0,
-    gamma: 90.0,
+    ...{ a: 5.0, b: 5.0, c: 5.0, alpha: 90.0, beta: 90.0, gamma: 90.0 },
     volume: 125.0,
   },
 }
@@ -349,7 +339,7 @@ describe(`Export functionality`, () => {
       const structure_with_abc: AnyStructure = {
         id: `frac_coords`,
         sites: [{
-          species: [{ element: `C` as ElementSymbol, occu: 1, oxidation_state: 0 }],
+          species: [{ element: `C`, occu: 1, oxidation_state: 0 }],
           abc: [0.5, 0.5, 0.5],
           xyz: [0, 0, 0],
           label: `C`,
@@ -385,7 +375,7 @@ describe(`Export functionality`, () => {
         structure: {
           id: `water_molecule`,
           sites: Array(2).fill({
-            species: [{ element: `H` as ElementSymbol, occu: 1, oxidation_state: 1 }],
+            species: [{ element: `H`, occu: 1, oxidation_state: 1 }],
             abc: [0, 0, 0],
             xyz: [0, 0, 0],
             label: `H`,
@@ -400,7 +390,7 @@ describe(`Export functionality`, () => {
         structure: {
           id: `complex_crystal`,
           sites: Array(24).fill({
-            species: [{ element: `Si` as ElementSymbol, occu: 1, oxidation_state: 4 }],
+            species: [{ element: `Si`, occu: 1, oxidation_state: 4 }],
             abc: [0, 0, 0],
             xyz: [0, 0, 0],
             label: `Si`,
@@ -420,7 +410,7 @@ describe(`Export functionality`, () => {
       const structure = {
         id: `lithium_oxide`,
         sites: Array(3).fill({
-          species: [{ element: `Li` as ElementSymbol, occu: 1, oxidation_state: 1 }],
+          species: [{ element: `Li`, occu: 1, oxidation_state: 1 }],
           abc: [0, 0, 0],
           xyz: [0, 0, 0],
           label: `Li`,
@@ -463,9 +453,8 @@ describe(`Export functionality`, () => {
       const structure_no_element: AnyStructure = {
         sites: [{
           species: [
-            { element: undefined, occu: 1, oxidation_state: 0 } as Species & {
-              element: undefined
-            },
+            // @ts-expect-error - test invalid undefined element
+            { element: undefined, occu: 1, oxidation_state: 0 },
           ],
           xyz: [0.0, 0.0, 0.0],
           abc: [0.0, 0.0, 0.0],

--- a/tests/vitest/structure/bonding.test.ts
+++ b/tests/vitest/structure/bonding.test.ts
@@ -17,7 +17,7 @@ function measure_performance(func: () => void): number {
 function make_site(xyz: Vec3, element = `C`): Site {
   return {
     xyz,
-    abc: [0, 0, 0] as [number, number, number], // Placeholder fractional coordinates
+    abc: [0, 0, 0], // Placeholder fractional coords
     species: [
       { element: element as ElementSymbol, occu: 1, oxidation_state: 0 },
     ],

--- a/tests/vitest/structure/bonding.test.ts
+++ b/tests/vitest/structure/bonding.test.ts
@@ -1,4 +1,4 @@
-import type { ElementSymbol } from '$lib'
+import type { ElementSymbol, Vec3 } from '$lib'
 import type { Matrix3x3 } from '$lib/math'
 import type { PymatgenStructure, Site } from '$lib/structure'
 import type { BondingAlgo } from '$lib/structure/bonding'
@@ -14,7 +14,7 @@ function measure_performance(func: () => void): number {
 }
 
 // Helper to create a complete Site object
-function make_site(xyz: [number, number, number], element = `C`): Site {
+function make_site(xyz: Vec3, element = `C`): Site {
   return {
     xyz,
     abc: [0, 0, 0] as [number, number, number], // Placeholder fractional coordinates
@@ -28,7 +28,7 @@ function make_site(xyz: [number, number, number], element = `C`): Site {
 
 // Helper to create a test structure
 function make_structure(
-  sites: Array<{ xyz: [number, number, number]; element?: string }>,
+  sites: Array<{ xyz: Vec3; element?: string }>,
 ): PymatgenStructure {
   return {
     sites: sites.map(({ xyz, element = `C` }) => make_site(xyz, element)),

--- a/tests/vitest/structure/index.test.ts
+++ b/tests/vitest/structure/index.test.ts
@@ -10,7 +10,7 @@ const ref_data: Record<
   {
     amounts: Record<string, number>
     density: number
-    center_of_mass: [number, number, number]
+    center_of_mass: Vec3
     elements: string[]
     alphabetical_formula: string
     electro_neg_formula: string

--- a/tests/vitest/trajectory/extract.test.ts
+++ b/tests/vitest/trajectory/extract.test.ts
@@ -1,4 +1,3 @@
-import type { ElementSymbol, Vec3 } from '$lib'
 import type { Matrix3x3 } from '$lib/math'
 import type { TrajectoryFrame, TrajectoryType } from '$lib/trajectory'
 import {
@@ -30,15 +29,13 @@ function create_basic_frame(
 ) {
   return {
     structure: {
-      sites: [
-        {
-          species: [{ element: `H` as ElementSymbol, occu: 1, oxidation_state: 0 }],
-          abc: [0, 0, 0] as Vec3,
-          xyz: [0, 0, 0] as Vec3,
-          label: `H1`,
-          properties: {},
-        },
-      ],
+      sites: [{
+        species: [{ element: `H`, occu: 1, oxidation_state: 0 }],
+        abc: [0, 0, 0],
+        xyz: [0, 0, 0],
+        label: `H1`,
+        properties: {},
+      }],
       charge: 0,
     },
     step,
@@ -54,17 +51,13 @@ function create_frame_with_lattice(
 ) {
   return {
     structure: {
-      sites: [
-        {
-          species: [
-            { element: `H` as ElementSymbol, occu: 1, oxidation_state: 0 },
-          ],
-          abc: [0, 0, 0] as Vec3,
-          xyz: [0, 0, 0] as Vec3,
-          label: `H1`,
-          properties: {},
-        },
-      ],
+      sites: [{
+        species: [{ element: `H`, occu: 1, oxidation_state: 0 }],
+        abc: [0, 0, 0],
+        xyz: [0, 0, 0],
+        label: `H1`,
+        properties: {},
+      }],
       charge: 0,
       lattice: {
         matrix: [
@@ -116,7 +109,7 @@ describe(`Energy Data Extractor`, () => {
     },
   ])(`should $name`, ({ step, metadata, expected }) => {
     const frame = create_basic_frame(step, metadata)
-    const data = energy_data_extractor(frame, {} as TrajectoryType)
+    const data = energy_data_extractor(frame, {})
     expect(data).toEqual(expected)
   })
 })
@@ -167,7 +160,7 @@ describe(`Force and Stress Data Extractor`, () => {
     },
   ])(`should $name`, ({ step, metadata, expected }) => {
     const frame = create_basic_frame(step, metadata)
-    const data = force_stress_data_extractor(frame, {} as TrajectoryType)
+    const data = force_stress_data_extractor(frame, {})
     expect(data).toEqual(expected)
   })
 })
@@ -215,7 +208,7 @@ describe(`Structural Data Extractor`, () => {
       ? create_frame_with_lattice(step, lattice_params, metadata)
       : create_basic_frame(step, metadata)
 
-    const data = structural_data_extractor(frame, {} as TrajectoryType)
+    const data = structural_data_extractor(frame, {})
     expect(data).toEqual(expected)
   })
 
@@ -227,7 +220,7 @@ describe(`Structural Data Extractor`, () => {
       {}, // No density in metadata
     )
 
-    const data = structural_data_extractor(frame, {} as TrajectoryType)
+    const data = structural_data_extractor(frame, {})
 
     // Should calculate density from structure
     expect(data.density).toBeDefined()
@@ -242,7 +235,7 @@ describe(`Structural Data Extractor`, () => {
       { density: 5.0 }, // Explicit density in metadata
     )
 
-    const data = structural_data_extractor(frame, {} as TrajectoryType)
+    const data = structural_data_extractor(frame, {})
 
     // Should use metadata density
     expect(data.density).toBe(5.0)
@@ -253,24 +246,16 @@ describe(`Full Data Extractor`, () => {
   it(`should combine all extractors`, () => {
     const trajectory: TrajectoryType = {
       frames: [
-        create_frame_with_lattice(
-          0,
-          { a: 1.0, b: 1.0, c: 1.0, volume: 1.0 },
-          {
-            energy: -10.0,
-            force_max: 2.0,
-            density: 2.5,
-          },
-        ),
-        create_frame_with_lattice(
-          1,
-          { a: 1.1, b: 1.1, c: 1.1, volume: 1.331 },
-          {
-            energy: -10.5,
-            force_max: 1.5,
-            density: 2.3,
-          },
-        ),
+        create_frame_with_lattice(0, { a: 1.0, b: 1.0, c: 1.0, volume: 1.0 }, {
+          energy: -10.0,
+          force_max: 2.0,
+          density: 2.5,
+        }),
+        create_frame_with_lattice(1, { a: 1.1, b: 1.1, c: 1.1, volume: 1.331 }, {
+          energy: -10.5,
+          force_max: 1.5,
+          density: 2.3,
+        }),
       ],
       metadata: {
         source_format: `test`,

--- a/tests/vitest/trajectory/index.test.ts
+++ b/tests/vitest/trajectory/index.test.ts
@@ -29,23 +29,14 @@ describe(`Trajectory Validation`, () => {
     {
       name: `validate correct trajectory`,
       trajectory: {
-        frames: [
-          create_frame(0, [
-            create_site(
-              `H` as ElementSymbol,
-              [0, 0, 0] as Vec3,
-              [0, 0, 0] as Vec3,
-              `H1`,
-            ),
-          ]),
-        ],
+        frames: [create_frame(0, [create_site(`H`, [0, 0, 0], [0, 0, 0], `H1`)])],
         metadata: {},
-      } as TrajectoryType,
+      },
       expected_errors: [],
     },
     {
       name: `detect missing frames`,
-      trajectory: { frames: [], metadata: {} } as TrajectoryType,
+      trajectory: { frames: [], metadata: {} },
       expected_errors: [`Trajectory must have at least one frame`],
     },
     {
@@ -59,33 +50,18 @@ describe(`Trajectory Validation`, () => {
     },
     {
       name: `detect empty sites`,
-      trajectory: {
-        frames: [create_frame(0, [])],
-        metadata: {},
-      } as TrajectoryType,
+      trajectory: { frames: [create_frame(0, [])], metadata: {} },
       expected_errors: [`Frame 0 structure has no sites`],
     },
     {
       name: `detect invalid step numbers`,
       // @ts-expect-error Testing invalid step type
       trajectory: {
-        frames: [
-          {
-            structure: {
-              sites: [
-                create_site(
-                  `H` as ElementSymbol,
-                  [0, 0, 0] as Vec3,
-                  [0, 0, 0] as Vec3,
-                  `H1`,
-                ),
-              ],
-              charge: 0,
-            },
-            step: `invalid`,
-            metadata: {},
-          },
-        ],
+        frames: [{
+          structure: { sites: [create_site(`H`, [0, 0, 0], [0, 0, 0], `H1`)], charge: 0 },
+          step: `invalid`,
+          metadata: {},
+        }],
         metadata: {},
       } as TrajectoryType,
       expected_errors: [`Frame 0 missing or invalid step number`],
@@ -103,50 +79,20 @@ describe(`Trajectory Statistics`, () => {
       trajectory: {
         frames: [
           create_frame(1, [
-            create_site(
-              `H` as ElementSymbol,
-              [0, 0, 0] as Vec3,
-              [0, 0, 0] as Vec3,
-              `H1`,
-            ),
-            create_site(
-              `O` as ElementSymbol,
-              [0.5, 0.5, 0.5] as Vec3,
-              [1, 1, 1] as Vec3,
-              `O1`,
-            ),
+            create_site(`H`, [0, 0, 0], [0, 0, 0], `H1`),
+            create_site(`O`, [0.5, 0.5, 0.5], [1, 1, 1], `O1`),
           ]),
           create_frame(2, [
-            create_site(
-              `H` as ElementSymbol,
-              [0.1, 0, 0] as Vec3,
-              [0.1, 0, 0] as Vec3,
-              `H1`,
-            ),
-            create_site(
-              `O` as ElementSymbol,
-              [0.6, 0.5, 0.5] as Vec3,
-              [1.1, 1, 1] as Vec3,
-              `O1`,
-            ),
+            create_site(`H`, [0.1, 0, 0], [0.1, 0, 0], `H1`),
+            create_site(`O`, [0.6, 0.5, 0.5], [1.1, 1, 1], `O1`),
           ]),
           create_frame(5, [
-            create_site(
-              `H` as ElementSymbol,
-              [0.2, 0, 0] as Vec3,
-              [0.2, 0, 0] as Vec3,
-              `H1`,
-            ),
-            create_site(
-              `O` as ElementSymbol,
-              [0.7, 0.5, 0.5] as Vec3,
-              [1.2, 1, 1] as Vec3,
-              `O1`,
-            ),
+            create_site(`H`, [0.2, 0, 0], [0.2, 0, 0], `H1`),
+            create_site(`O`, [0.7, 0.5, 0.5], [1.2, 1, 1], `O1`),
           ]),
         ],
         metadata: {},
-      } as TrajectoryType,
+      },
       expected: {
         frame_count: 3,
         steps: [1, 2, 5],
@@ -160,51 +106,19 @@ describe(`Trajectory Statistics`, () => {
       name: `handle variable atom counts`,
       trajectory: {
         frames: [
-          create_frame(0, [
-            create_site(
-              `H` as ElementSymbol,
-              [0, 0, 0] as Vec3,
-              [0, 0, 0] as Vec3,
-              `H1`,
-            ),
-          ]),
+          create_frame(0, [create_site(`H`, [0, 0, 0], [0, 0, 0], `H1`)]),
           create_frame(1, [
-            create_site(
-              `H` as ElementSymbol,
-              [0, 0, 0] as Vec3,
-              [0, 0, 0] as Vec3,
-              `H1`,
-            ),
-            create_site(
-              `H` as ElementSymbol,
-              [0.5, 0.5, 0.5] as Vec3,
-              [1, 1, 1] as Vec3,
-              `H2`,
-            ),
+            create_site(`H`, [0, 0, 0], [0, 0, 0], `H1`),
+            create_site(`H`, [0.5, 0.5, 0.5], [1, 1, 1], `H2`),
           ]),
           create_frame(2, [
-            create_site(
-              `H` as ElementSymbol,
-              [0, 0, 0] as Vec3,
-              [0, 0, 0] as Vec3,
-              `H1`,
-            ),
-            create_site(
-              `H` as ElementSymbol,
-              [0.3, 0.3, 0.3] as Vec3,
-              [0.6, 0.6, 0.6] as Vec3,
-              `H2`,
-            ),
-            create_site(
-              `O` as ElementSymbol,
-              [0.7, 0.7, 0.7] as Vec3,
-              [1.4, 1.4, 1.4] as Vec3,
-              `O1`,
-            ),
+            create_site(`H`, [0, 0, 0], [0, 0, 0], `H1`),
+            create_site(`H`, [0.3, 0.3, 0.3], [0.6, 0.6, 0.6], `H2`),
+            create_site(`O`, [0.7, 0.7, 0.7], [1.4, 1.4, 1.4], `O1`),
           ]),
         ],
         metadata: {},
-      } as TrajectoryType,
+      },
       expected: {
         frame_count: 3,
         steps: [0, 1, 2],
@@ -217,18 +131,9 @@ describe(`Trajectory Statistics`, () => {
     {
       name: `handle single frame trajectory`,
       trajectory: {
-        frames: [
-          create_frame(42, [
-            create_site(
-              `H` as ElementSymbol,
-              [0, 0, 0] as Vec3,
-              [0, 0, 0] as Vec3,
-              `H1`,
-            ),
-          ]),
-        ],
+        frames: [create_frame(42, [create_site(`H`, [0, 0, 0], [0, 0, 0], `H1`)])],
         metadata: {},
-      } as TrajectoryType,
+      },
       expected: {
         frame_count: 1,
         steps: [42],
@@ -240,7 +145,7 @@ describe(`Trajectory Statistics`, () => {
     },
     {
       name: `handle empty trajectory gracefully`,
-      trajectory: { frames: [], metadata: {} } as TrajectoryType,
+      trajectory: { frames: [], metadata: {} },
       expected: {
         frame_count: 0,
         steps: [],

--- a/tests/vitest/trajectory/plotting.test.ts
+++ b/tests/vitest/trajectory/plotting.test.ts
@@ -1,4 +1,3 @@
-import type { ElementSymbol, Vec3 } from '$lib'
 import type { DataSeries } from '$lib/plot'
 import type { TrajectoryFrame, TrajectoryType } from '$lib/trajectory'
 import {
@@ -41,9 +40,9 @@ function create_trajectory(property_frames: Record<string, number>[]): Trajector
     frames: property_frames.map((props, step) => ({
       structure: {
         sites: [{
-          species: [{ element: `H` as ElementSymbol, occu: 1, oxidation_state: 0 }],
-          abc: [0, 0, 0] as Vec3,
-          xyz: [0, 0, 0] as Vec3,
+          species: [{ element: `H`, occu: 1, oxidation_state: 0 }],
+          abc: [0, 0, 0],
+          xyz: [0, 0, 0],
           label: `H1`,
           properties: {},
         }],


### PR DESCRIPTION
- Adds site-label color, background color, opacity, size, padding, and 3D offset settings.
- Applies the label settings in `StructureScene` and exposes them in a dedicated controls section.
- Keeps draggable panels above surrounding content and restricts them to vertical scrolling.
- Standardizes element-symbol and 3D-vector types, including `Bond` positions and coordinates.
- Adds UI coverage for label visibility, constraints, layout, interaction, and persisted state.