### PR TITLE
Improve unit tests

### DIFF
--- a/extensions/vscode/tests/extension.test.ts
+++ b/extensions/vscode/tests/extension.test.ts
@@ -1,7 +1,6 @@
 import type { ThemeName } from '$lib/theme/index'
 import { is_trajectory_file } from '$lib/trajectory/parse'
 import { Buffer } from 'node:buffer'
-import type { Stats } from 'node:fs'
 import * as fs from 'node:fs'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import type { ExtensionContext, Tab, TextEditor, Webview } from 'vscode'
@@ -79,11 +78,7 @@ describe(`MatterViz Extension`, () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
-    // Reset mocks before each test
-
     mock_fs.readFileSync = vi.fn().mockReturnValue(`mock content`)
-    mock_fs.writeFileSync = vi.fn()
-    vi.mocked(mock_fs.statSync).mockReturnValue({ size: 1024 } as Stats)
     mock_vscode.window.activeTextEditor = null
 
     // Set up file system watcher mock

--- a/src/lib/SettingsSection.svelte
+++ b/src/lib/SettingsSection.svelte
@@ -113,9 +113,9 @@
     display: flex;
     align-items: center;
     gap: 2pt;
-    padding: 1pt 4pt;
+    padding: var(--reset-btn-padding, 1pt 4pt);
     font-size: 0.65em;
-    border-radius: 2pt;
+    border-radius: var(--reset-btn-border-radius, 2pt);
     background: var(--btn-bg, rgba(0, 0, 0, 0.1));
     color: var(--text-color-muted, #6b7280);
     border: 1px solid var(--border-color, #d1d5db);

--- a/src/lib/app.css
+++ b/src/lib/app.css
@@ -69,6 +69,9 @@ kbd {
 pre code {
   background-color: transparent;
   display: inline-block;
+  padding: 0;
+  margin: 0 -1em;
+  width: 100%;
 }
 pre {
   position: relative;

--- a/src/lib/element/ElementPhoto.svelte
+++ b/src/lib/element/ElementPhoto.svelte
@@ -41,13 +41,13 @@
     width: 100%;
     object-fit: cover;
     margin: 0;
-    border-radius: 4pt;
+    border-radius: var(--element-photo-border-radius, 4pt);
   }
   div {
     aspect-ratio: 1;
     text-align: center;
     display: flex;
-    padding: 3pt;
+    padding: var(--element-photo-padding, 3pt);
     box-sizing: border-box;
     place-items: center;
     background-image: linear-gradient(
@@ -56,7 +56,7 @@
       rgba(0, 0, 100, 0.3)
     );
     color: var(--text-color);
-    border-radius: 4pt;
+    border-radius: var(--element-photo-border-radius, 4pt);
     width: 100%;
     container-type: inline-size;
   }

--- a/src/lib/element/ElementTile.svelte
+++ b/src/lib/element/ElementTile.svelte
@@ -24,7 +24,7 @@
     // at what background color lightness text color switches from black to white
     text_color_threshold?: number
     text_color?: string | null
-    precision?: string | undefined
+    float_fmt?: string
     node?: HTMLElement | null
     label?: string | null
     // array of background colors for multi-segment tiles
@@ -46,7 +46,7 @@
     href = null,
     text_color_threshold = 0.7,
     text_color = $bindable(null),
-    precision = undefined,
+    float_fmt = undefined,
     node = $bindable(null),
     label = null,
     bg_colors = [],
@@ -78,13 +78,13 @@
     }
 
     // Handle numeric values
-    if (typeof val === `number`) return format_num(val, precision)
+    if (typeof val === `number`) return format_num(val, float_fmt)
 
     // Handle string values - check if it's a numeric string
     if (typeof val === `string`) {
       const parsed_num = parseFloat(val)
       if (!isNaN(parsed_num) && isFinite(parsed_num)) {
-        return format_num(parsed_num, precision)
+        return format_num(parsed_num, float_fmt)
       }
       // If show_values is true, return the string as-is to preserve non-numeric strings
       return show_values === true ? val : ``

--- a/src/lib/plot/Histogram.svelte
+++ b/src/lib/plot/Histogram.svelte
@@ -533,7 +533,8 @@
     position: relative;
     width: 100%;
     height: 100%;
-    min-height: 300px;
+    min-height: var(--histogram-min-height, 300px);
+    container-type: inline-size;
   }
   svg {
     width: 100%;

--- a/src/lib/plot/Line.svelte
+++ b/src/lib/plot/Line.svelte
@@ -13,7 +13,7 @@
     area_color?: string
     area_stroke?: string | null
     line_tween?: TweenedOptions<string>
-    line_dash?: string | null
+    line_dash?: string
     [key: string]: unknown
   }
   let {
@@ -24,7 +24,7 @@
     area_color = `rgba(255, 255, 255, 0.1)`,
     area_stroke = null,
     line_tween = {},
-    line_dash = null,
+    line_dash = undefined,
     ...rest
   }: Props = $props()
 

--- a/src/lib/plot/PlotLegend.svelte
+++ b/src/lib/plot/PlotLegend.svelte
@@ -215,7 +215,7 @@
     align-items: center;
     cursor: pointer;
     white-space: nowrap;
-    padding: var(--plot-legend-item-padding, 3px 6px);
+    padding: var(--plot-legend-item-padding, 1px 3px);
     opacity: var(--plot-legend-item-opacity, 1);
     transition: var(--plot-legend-item-transition, opacity 0.3s ease);
     color: var(--plot-legend-item-color);

--- a/src/lib/plot/ScatterPlot.svelte
+++ b/src/lib/plot/ScatterPlot.svelte
@@ -23,6 +23,7 @@
     XyObj,
   } from '$lib/plot'
   import { ColorBar, PlotLegend, ScatterPlotControls, ScatterPoint } from '$lib/plot'
+  import { DEFAULTS } from '$lib/settings'
   import { extent } from 'd3-array'
   import { forceCollide, forceLink, forceSimulation } from 'd3-force'
   import {
@@ -130,7 +131,7 @@
     line_width?: number
     line_color?: string
     line_opacity?: number
-    line_dash?: string | undefined
+    line_dash?: string
     show_points?: boolean
     show_lines?: boolean
     selected_series_idx?: number
@@ -204,7 +205,7 @@
     line_width = $bindable(2),
     line_color = $bindable(`#4682b4`),
     line_opacity = $bindable(1),
-    line_dash = $bindable(undefined),
+    line_dash = $bindable(DEFAULTS.trajectory.scatter_line_dash),
     show_points = $bindable(true),
     show_lines = $bindable(true),
     selected_series_idx = $bindable(0),
@@ -2030,7 +2031,10 @@
     color: var(--text-color);
     white-space: nowrap;
     /* Use line-height to center text vertically without flexbox */
-    line-height: 20px; /* Match foreignObject height */
+    line-height: var(
+      --scatter-axis-label-line-height,
+      20px
+    ); /* Match foreignObject height */
     display: block;
   }
   .current-frame-indicator {

--- a/src/lib/structure/CanvasTooltip.svelte
+++ b/src/lib/structure/CanvasTooltip.svelte
@@ -21,13 +21,14 @@
   .tooltip {
     width: max-content;
     box-sizing: border-box;
-    border-radius: var(--struct-tooltip-border-radius, 5pt);
-    background: var(--struct-tooltip-bg, rgba(0, 0, 0, 0.5));
-    padding: var(--struct-tooltip-padding, 1pt 5pt);
-    color: var(--struct-tooltip-text-color);
-    font-family: var(--struct-tooltip-font-family);
-    font-size: var(--struct-tooltip-font-size);
-    line-height: var(--struct-tooltip-line-height);
+    text-align: var(--canvas-tooltip-text-align, left);
+    border-radius: var(--canvas-tooltip-border-radius, 5pt);
+    background: var(--canvas-tooltip-bg, rgba(0, 0, 0, 0.5));
+    padding: var(--canvas-tooltip-padding, 1pt 5pt);
+    color: var(--canvas-tooltip-text-color);
+    font-family: var(--canvas-tooltip-font-family);
+    font-size: var(--canvas-tooltip-font-size);
+    line-height: var(--canvas-tooltip-line-height);
     pointer-events: none;
   }
 </style>

--- a/src/lib/structure/StructureInfoPanel.svelte
+++ b/src/lib/structure/StructureInfoPanel.svelte
@@ -357,14 +357,11 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    animation: checkmark-appear 0.1s ease-out;
+    animation: fade-in 0.1s ease-out;
   }
-  @keyframes checkmark-appear {
+  @keyframes fade-in {
     0% {
       opacity: 0;
-    }
-    100% {
-      opacity: 1;
     }
   }
   section div.site-item {

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -46,7 +46,7 @@
     active_idx?: number | null
     hovered_site?: Site | null
     active_site?: Site | null
-    precision?: string
+    float_fmt?: string
     auto_rotate?: number
     bond_thickness?: number
     bond_color?: string
@@ -94,7 +94,7 @@
     active_idx = $bindable(null),
     hovered_site = $bindable(null),
     active_site = $bindable(null),
-    precision = `.3~f`,
+    float_fmt = `.3~f`,
     auto_rotate = DEFAULTS.structure.auto_rotate,
     bond_thickness = DEFAULTS.structure.bond_thickness,
     bond_color = DEFAULTS.structure.bond_color,
@@ -490,10 +490,10 @@
       {/each}
     </div>
     <div class="coordinates fractional">
-      abc: ({hovered_site.abc.map((num) => format_num(num, precision)).join(`, `)})
+      abc: ({hovered_site.abc.map((num) => format_num(num, float_fmt)).join(`, `)})
     </div>
     <div class="coordinates cartesian">
-      xyz: ({hovered_site.xyz.map((num) => format_num(num, precision)).join(`, `)}) Å
+      xyz: ({hovered_site.xyz.map((num) => format_num(num, float_fmt)).join(`, `)}) Å
     </div>
     <!-- distance from hovered to active site -->
     {#if active_site && active_site != hovered_site && active_hovered_dist}
@@ -503,9 +503,9 @@
       : direct_distance}
       <div class="distance">
         <strong>dist:</strong>
-        {format_num(pbc_distance, precision)} Å{lattice ? ` (PBC)` : ``}
+        {format_num(pbc_distance, float_fmt)} Å{lattice ? ` (PBC)` : ``}
         {#if lattice && Math.abs(pbc_distance - direct_distance) > 0.1}
-          <small> | direct: {format_num(direct_distance, precision)} Å</small>
+          <small> | direct: {format_num(direct_distance, float_fmt)} Å</small>
         {/if}
       </div>
     {/if}
@@ -527,22 +527,22 @@
     padding: var(--struct-atom-label-padding, 0 3px);
   }
   .elements {
-    margin-bottom: var(--struct-tooltip-elements-margin);
+    margin-bottom: var(--canvas-tooltip-elements-margin);
   }
   .occupancy {
-    font-size: var(--struct-tooltip-occu-font-size);
-    opacity: var(--struct-tooltip-occu-opacity);
-    margin-right: var(--struct-tooltip-occu-margin);
+    font-size: var(--canvas-tooltip-occu-font-size);
+    opacity: var(--canvas-tooltip-occu-opacity);
+    margin-right: var(--canvas-tooltip-occu-margin);
   }
   .elem-name {
-    font-size: var(--struct-tooltip-elem-name-font-size, 0.85em);
-    opacity: var(--struct-tooltip-elem-name-opacity, 0.7);
-    margin: var(--struct-tooltip-elem-name-margin, 0 0 0 0.3em);
-    font-weight: var(--struct-tooltip-elem-name-font-weight, normal);
+    font-size: var(--canvas-tooltip-elem-name-font-size, 0.85em);
+    opacity: var(--canvas-tooltip-elem-name-opacity, 0.7);
+    margin: var(--canvas-tooltip-elem-name-margin, 0 0 0 0.3em);
+    font-weight: var(--canvas-tooltip-elem-name-font-weight, normal);
   }
   .coordinates,
   .distance {
-    font-size: var(--struct-tooltip-coords-font-size);
-    margin: var(--struct-tooltip-coords-margin);
+    font-size: var(--canvas-tooltip-coords-font-size);
+    margin: var(--canvas-tooltip-coords-margin);
   }
 </style>

--- a/src/lib/theme/ThemeControl.svelte
+++ b/src/lib/theme/ThemeControl.svelte
@@ -38,8 +38,8 @@
     background: var(--btn-bg);
     border: var(--panel-border);
     color: var(--text-color);
-    border-radius: 5pt;
-    padding: 4pt 6pt;
+    border-radius: var(--theme-control-border-radius, 5pt);
+    padding: var(--theme-control-padding, 4pt 6pt);
     backdrop-filter: blur(10px);
     transition: all 0.2s ease;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -1271,7 +1271,7 @@
   .slider-container {
     position: relative;
     flex: 1;
-    min-width: 100px;
+    min-width: var(--trajectory-slider-min-width, 100px);
   }
   .step-slider {
     width: 100%;
@@ -1285,8 +1285,8 @@
   .step-tick {
     position: absolute;
     transform: translateX(-50%);
-    width: 1px;
-    height: 4px;
+    width: var(--trajectory-step-tick-width, 1px);
+    height: var(--trajectory-step-tick-height, 4px);
     background: var(--text-color-muted);
     top: -9pt;
   }
@@ -1317,8 +1317,8 @@
   button.filename {
     align-items: center;
     white-space: nowrap;
-    padding: 2pt 4pt;
-    border-radius: 2px;
+    padding: var(--trajectory-filename-padding, 2pt 4pt);
+    border-radius: var(--trajectory-filename-border-radius, 2px);
     max-width: clamp(150px, 20cqw, 250px);
     overflow: hidden;
     text-overflow: ellipsis;
@@ -1366,7 +1366,7 @@
     color: var(--text-color-muted);
   }
   .empty-state :where(h3, p, ul, li, strong) {
-    max-width: 500px;
+    max-width: var(--trajectory-empty-state-max-width, 500px);
     margin-inline: auto;
   }
   .supported-formats {
@@ -1417,7 +1417,7 @@
     align-items: center;
     gap: 1ex;
     width: 100%;
-    padding: 5pt;
+    padding: var(--trajectory-view-mode-option-padding, 5pt);
     background: transparent;
     border-radius: 0;
     text-align: left;

--- a/src/lib/trajectory/TrajectoryInfoPanel.svelte
+++ b/src/lib/trajectory/TrajectoryInfoPanel.svelte
@@ -380,21 +380,17 @@
     top: 50%;
     right: 3pt;
     transform: translateY(-50%);
-    z-index: 10;
     background: var(--panel-bg);
     border-radius: 50%;
     padding: 3pt;
     display: flex;
     align-items: center;
     justify-content: center;
-    animation: checkmark-appear 0.1s ease-out;
+    animation: fade-in 0.1s ease-out;
   }
-  @keyframes checkmark-appear {
+  @keyframes fade-in {
     0% {
       opacity: 0;
-    }
-    100% {
-      opacity: 1;
     }
   }
 </style>

--- a/tests/vitest/DraggablePanel.test.ts
+++ b/tests/vitest/DraggablePanel.test.ts
@@ -1,56 +1,11 @@
 import DraggablePanel from '$lib/DraggablePanel.svelte'
 import { mount, tick } from 'svelte'
 import type { HTMLAttributes } from 'svelte/elements'
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { doc_query } from './setup'
 
-// Mock svelte-multiselect attachments
-vi.mock(`svelte-multiselect/attachments`, () => ({
-  draggable: vi.fn(() => vi.fn()),
-  tooltip: vi.fn(() => vi.fn()),
-}))
-
-// Mock Icon component
-vi.mock(`$lib`, () => ({
-  Icon: vi.fn(({ class: className }) => {
-    // Create a simple span element that Svelte can render
-    const span = document.createElement(`span`)
-    if (className) span.className = className
-    span.textContent = `Icon`
-    return span
-  }),
-}))
-
 describe(`DraggablePanel`, () => {
-  const default_props = {
-    children: () => `Panel Content`,
-    show_panel: true,
-  }
-
-  beforeEach(() => {
-    // Mock getBoundingClientRect
-    Element.prototype.getBoundingClientRect = vi.fn(() => ({
-      width: 200,
-      height: 100,
-      top: 0,
-      left: 0,
-      right: 200,
-      bottom: 100,
-      x: 0,
-      y: 0,
-      toJSON: () => ({}),
-    } as DOMRect))
-
-    // Mock offsetParent
-    Object.defineProperty(Element.prototype, `offsetParent`, {
-      value: null,
-      writable: true,
-    })
-  })
-
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
+  const default_props = { children: () => `Panel Content` }
 
   test(`renders toggle button when show_panel is true`, () => {
     mount(DraggablePanel, { target: document.body, props: default_props })

--- a/tests/vitest/DraggablePanel.test.ts
+++ b/tests/vitest/DraggablePanel.test.ts
@@ -12,12 +12,19 @@ vi.mock(`svelte-multiselect/attachments`, () => ({
 
 // Mock Icon component
 vi.mock(`$lib`, () => ({
-  Icon: vi.fn(() => `Icon`),
+  Icon: vi.fn(({ class: className }) => {
+    // Create a simple span element that Svelte can render
+    const span = document.createElement(`span`)
+    if (className) span.className = className
+    span.textContent = `Icon`
+    return span
+  }),
 }))
 
 describe(`DraggablePanel`, () => {
   const default_props = {
     children: () => `Panel Content`,
+    show_panel: true,
   }
 
   beforeEach(() => {
@@ -96,18 +103,37 @@ describe(`DraggablePanel`, () => {
 
   test(`calls onclose callback when panel is closed`, async () => {
     const onclose = vi.fn()
-    mount(DraggablePanel, { target: document.body, props: { ...default_props, onclose } })
-    const button = doc_query(`button`)
+    mount(DraggablePanel, {
+      target: document.body,
+      props: { ...default_props, onclose, show: true, show_panel: true },
+    })
 
-    // Open panel
+    const button = doc_query(`button`)
     button.click()
     await tick()
+    expect(onclose).toHaveBeenCalled()
+  })
+
+  test(`handles click outside panel correctly`, () => {
+    const onclose = vi.fn()
+    mount(DraggablePanel, {
+      target: document.body,
+      props: { ...default_props, show: true, show_panel: true, onclose },
+    })
+
+    const panel = document.querySelector(`.draggable-panel`) as HTMLElement
+    const button = document.querySelector(`button`) as HTMLElement
+
+    expect(panel).toBeTruthy()
+    expect(button).toBeTruthy()
+
     expect(onclose).not.toHaveBeenCalled()
 
-    // Close panel
-    button.click()
-    await tick()
-    expect(onclose).toHaveBeenCalledTimes(1)
+    // Click outside panel (on document body)
+    document.body.click()
+
+    // Panel should close when clicking outside
+    expect(onclose).toHaveBeenCalled()
   })
 
   test(`closes panel on Escape key`, async () => {
@@ -166,18 +192,6 @@ describe(`DraggablePanel`, () => {
     expect(panel.classList.contains(`custom-panel-class`)).toBe(true)
   })
 
-  test(`uses custom icons when provided`, () => {
-    mount(DraggablePanel, {
-      target: document.body,
-      props: {
-        ...default_props,
-        open_icon: `CustomOpen`,
-        closed_icon: `CustomClosed`,
-      },
-    })
-    expect(document.querySelector(`button`)).toBeTruthy()
-  })
-
   test(`applies max_width style to panel`, () => {
     mount(DraggablePanel, {
       target: document.body,
@@ -185,19 +199,6 @@ describe(`DraggablePanel`, () => {
     })
     const panel = doc_query(`.draggable-panel`)
     expect(panel.style.maxWidth).toBe(`600px`)
-  })
-
-  test(`applies custom offset correctly`, () => {
-    mount(DraggablePanel, {
-      target: document.body,
-      props: {
-        ...default_props,
-        show: true,
-        offset: { x: 10, y: 20 },
-      },
-    })
-    const panel = doc_query(`.draggable-panel`)
-    expect(panel).toBeTruthy()
   })
 
   test(`sets correct ARIA attributes`, () => {
@@ -229,30 +230,6 @@ describe(`DraggablePanel`, () => {
     expect(button.getAttribute(`aria-expanded`)).toBe(`false`)
   })
 
-  test(`applies icon style correctly`, () => {
-    mount(DraggablePanel, {
-      target: document.body,
-      props: { ...default_props, icon_style: `color: red;` },
-    })
-    const button = doc_query(`button`)
-    expect(button).toBeTruthy()
-  })
-
-  test(`handles fullscreen mode correctly`, () => {
-    // Mock body class
-    document.body.classList.add(`fullscreen`)
-
-    mount(DraggablePanel, {
-      target: document.body,
-      props: { ...default_props, show: true },
-    })
-    const panel = doc_query(`.draggable-panel`)
-    expect(panel).toBeTruthy()
-
-    // Clean up
-    document.body.classList.remove(`fullscreen`)
-  })
-
   test(`renders panel header with control buttons`, () => {
     mount(DraggablePanel, {
       target: document.body,
@@ -274,25 +251,5 @@ describe(`DraggablePanel`, () => {
 
     expect(panel.classList.contains(`draggable-panel`)).toBe(true)
     expect(panel.classList.contains(`panel-open`)).toBe(true)
-  })
-
-  test(`handles missing toggle button gracefully`, () => {
-    mount(DraggablePanel, {
-      target: document.body,
-      props: { ...default_props, show: true },
-    })
-    const panel = doc_query(`.draggable-panel`)
-    expect(panel).toBeTruthy()
-  })
-
-  test(`calls on_drag_start callback when provided`, () => {
-    const on_drag_start = vi.fn()
-    mount(DraggablePanel, {
-      target: document.body,
-      props: { ...default_props, show: true, on_drag_start },
-    })
-
-    // The callback should be available for the draggable attachment
-    expect(on_drag_start).toBeDefined()
   })
 })

--- a/tests/vitest/SettingsSection.test.ts
+++ b/tests/vitest/SettingsSection.test.ts
@@ -1,6 +1,6 @@
 import { SettingsSection } from '$lib'
 import { mount } from 'svelte'
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { doc_query } from './setup'
 
 describe(`SettingsSection`, () => {
@@ -23,32 +23,83 @@ describe(`SettingsSection`, () => {
       props: { ...base_props, children: () => `Test content` },
     })
     // h4 should always be present since title is required
-    expect(document.querySelector(`h4`)).toBeTruthy()
     expect(doc_query(`h4`).textContent?.trim()).toBe(`Test Section`)
     expect(doc_query(`section`).textContent?.trim()).toBe(``)
   })
 
-  test(`does not show reset button when values are unchanged from initial state`, () => {
-    mount(SettingsSection, {
-      target: document.body,
-      props: { ...base_props, children: () => `Test content` },
-    })
-    expect(document.querySelector(`button`)).toBeNull()
-  })
-
-  test(`passes through additional props to section element`, () => {
+  test(`does not show reset button initially when values match reference`, () => {
+    // Test that reset button is not shown initially since reference_values = current_values
     mount(SettingsSection, {
       target: document.body,
       props: {
-        ...base_props,
-        children: () => `Test content`,
-        class: `custom-class`,
-        'data-testid': `test-section`,
+        title: `Test Settings`,
+        current_values: { setting1: `value` },
+        on_reset: vi.fn(),
+        children: () => `Settings content`,
       },
     })
 
-    const section = document.querySelector(`section`)
-    expect(section?.className).toContain(`custom-class`)
-    expect(section?.getAttribute(`data-testid`)).toBe(`test-section`)
+    const reset_button = document.querySelector(`.reset-button`)
+    expect(reset_button).toBeFalsy()
+  })
+
+  test(`handles array comparison correctly`, () => {
+    mount(SettingsSection, {
+      target: document.body,
+      props: {
+        title: `Test Settings`,
+        current_values: { setting1: [`a`, `b`, `c`] },
+        on_reset: vi.fn(),
+        children: () => `Settings content`,
+      },
+    })
+
+    const reset_button = document.querySelector(`.reset-button`)
+    expect(reset_button).toBeFalsy() // No changes initially
+  })
+
+  test(`handles nested object arrays correctly`, () => {
+    mount(SettingsSection, {
+      target: document.body,
+      props: {
+        title: `Test Settings`,
+        current_values: { setting1: [{ key: `value1` }, { key: `value2` }] },
+        on_reset: vi.fn(),
+        children: () => `Settings content`,
+      },
+    })
+
+    const reset_button = document.querySelector(`.reset-button`)
+    expect(reset_button).toBeFalsy() // No changes initially
+  })
+
+  test(`handles undefined/null comparisons correctly`, () => {
+    mount(SettingsSection, {
+      target: document.body,
+      props: {
+        title: `Test Settings`,
+        current_values: { setting1: undefined, setting2: null },
+        on_reset: vi.fn(),
+        children: () => `Settings content`,
+      },
+    })
+
+    const reset_button = document.querySelector(`.reset-button`)
+    expect(reset_button).toBeFalsy() // No changes detected
+  })
+
+  test(`handles empty arrays correctly`, () => {
+    mount(SettingsSection, {
+      target: document.body,
+      props: {
+        title: `Test Settings`,
+        current_values: { setting1: [] },
+        on_reset: vi.fn(),
+        children: () => `Settings content`,
+      },
+    })
+
+    const reset_button = document.querySelector(`.reset-button`)
+    expect(reset_button).toBeFalsy() // No changes initially
   })
 })

--- a/tests/vitest/colors.test.ts
+++ b/tests/vitest/colors.test.ts
@@ -199,7 +199,7 @@ describe(`is_color function`, () => {
     [`transparent`, true],
     [`currentcolor`, true],
 
-    // Invalid patterns - incomplete functions (old behavior that should now fail)
+    // Invalid patterns - incomplete functions
     [`rgb`, false],
     [`hsl`, false],
     [`var`, false],

--- a/tests/vitest/colors/index.test.ts
+++ b/tests/vitest/colors/index.test.ts
@@ -1,0 +1,149 @@
+import {
+  default_category_colors,
+  element_color_schemes,
+  get_bg_color,
+  is_color,
+  luminance,
+  pick_color_for_contrast,
+  plot_colors,
+} from '$lib/colors'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe(`colors module`, () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe(`color constants`, () => {
+    it(`has valid hex colors in all schemes`, () => {
+      // Test category colors
+      Object.values(default_category_colors).forEach((color) => {
+        expect(color).toMatch(/^#[0-9a-f]{6}$/i)
+      })
+
+      // Test plot colors
+      expect(plot_colors).toHaveLength(10)
+      plot_colors.forEach((color) => {
+        expect(color).toMatch(/^#[0-9a-f]{6}$/i)
+      })
+      expect(new Set(plot_colors).size).toBe(plot_colors.length)
+
+      // Test element color schemes
+      Object.values(element_color_schemes).forEach((scheme) => {
+        Object.values(scheme).forEach((color) => {
+          expect(color).toMatch(/^#[0-9a-f]{6}$/i)
+        })
+      })
+    })
+  })
+
+  describe(`is_color`, () => {
+    it.each([
+      `#ff0000`,
+      `rgb(255, 0, 0)`,
+      `rgba(255, 0, 0, 0.5)`,
+      `hsl(0, 100%, 50%)`,
+      `hsla(0, 100%, 50%, 0.5)`,
+      `color(display-p3 1 0 0)`,
+      `var(--my-color)`,
+      `red`,
+      `blue`,
+      `green`,
+      `transparent`,
+      `  #ff0000  `,
+      `  red  `,
+    ])(`identifies valid color: %s`, (color) => {
+      expect(is_color(color)).toBe(true)
+    })
+
+    it.each([
+      `rgb`,
+      `hsl`,
+      `var`,
+      `color`,
+      `#gggggg`,
+      `#12`,
+      ``,
+      null,
+      undefined,
+      123,
+      {},
+      [],
+    ])(`rejects invalid color: %s`, (color) => {
+      expect(is_color(color)).toBe(false)
+    })
+  })
+
+  describe(`luminance`, () => {
+    it(`calculates correct luminance values`, () => {
+      expect(luminance(`#000000`)).toBeCloseTo(0, 3) // black
+      expect(luminance(`#ffffff`)).toBeCloseTo(1, 3) // white
+      expect(luminance(`#ff0000`)).toBeCloseTo(0.299, 3) // red
+      expect(luminance(`#00ff00`)).toBeCloseTo(0.587, 3) // green
+      expect(luminance(`#0000ff`)).toBeCloseTo(0.114, 3) // blue
+      expect(luminance(`red`)).toBeCloseTo(0.299, 3) // named color
+    })
+
+    it(`returns values between 0 and 1`, () => {
+      ;[`#000000`, `#ffffff`, `#ff0000`, `#00ff00`, `#0000ff`, `#808080`].forEach(
+        (color) => {
+          const lum = luminance(color)
+          expect(lum).toBeGreaterThanOrEqual(0)
+          expect(lum).toBeLessThanOrEqual(1)
+        },
+      )
+    })
+  })
+
+  describe(`get_bg_color`, () => {
+    it(`handles various scenarios`, () => {
+      expect(get_bg_color(null, `#ff0000`)).toBe(`#ff0000`) // provided bg_color
+      expect(get_bg_color(null)).toBe(`rgba(0, 0, 0, 0)`) // no element, no bg_color
+
+      // Mock element with background color
+      const mock_element = { style: {}, parentElement: null } as HTMLElement
+      const mock_get_computed_style = vi.fn().mockReturnValue({
+        backgroundColor: `#ff0000`,
+      })
+      Object.defineProperty(globalThis, `getComputedStyle`, {
+        value: mock_get_computed_style,
+        writable: true,
+      })
+
+      expect(get_bg_color(mock_element)).toBe(`#ff0000`)
+      expect(mock_get_computed_style).toHaveBeenCalledWith(mock_element)
+    })
+
+    it(`recurses up DOM tree for transparent backgrounds`, () => {
+      const mock_parent = { style: {}, parentElement: null } as HTMLElement
+      const mock_element = { style: {}, parentElement: mock_parent } as HTMLElement
+      const mock_get_computed_style = vi.fn()
+        .mockReturnValueOnce({ backgroundColor: `rgba(0, 0, 0, 0)` })
+        .mockReturnValueOnce({ backgroundColor: `#00ff00` })
+
+      Object.defineProperty(globalThis, `getComputedStyle`, {
+        value: mock_get_computed_style,
+        writable: true,
+      })
+
+      expect(get_bg_color(mock_element)).toBe(`#00ff00`)
+      expect(mock_get_computed_style).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe(`pick_color_for_contrast`, () => {
+    it(`selects appropriate colors based on background`, () => {
+      expect(pick_color_for_contrast(null, `#ffffff`, 0.7, [`black`, `white`])).toBe(
+        `black`,
+      )
+      expect(pick_color_for_contrast(null, `#000000`, 0.7, [`black`, `white`])).toBe(
+        `white`,
+      )
+      expect(pick_color_for_contrast(null, `#404040`, 0.5, [`black`, `white`])).toBe(
+        `white`,
+      )
+      expect(pick_color_for_contrast(null, `#ffffff`, 0.7, [`red`, `blue`])).toBe(`red`)
+      expect(pick_color_for_contrast(null, `#ffffff`)).toBe(`black`) // defaults
+    })
+  })
+})

--- a/tests/vitest/colors/index.test.ts
+++ b/tests/vitest/colors/index.test.ts
@@ -7,13 +7,9 @@ import {
   pick_color_for_contrast,
   plot_colors,
 } from '$lib/colors'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 describe(`colors module`, () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
-
   describe(`color constants`, () => {
     it(`has valid hex colors in all schemes`, () => {
       // Test category colors

--- a/tests/vitest/composition/index.test.ts
+++ b/tests/vitest/composition/index.test.ts
@@ -1,27 +1,30 @@
-import * as composition_module from '$lib/composition'
-import * as parse_module from '$lib/composition/parse'
-import { describe, expect, test } from 'vitest'
+import { get_chart_font_scale } from '$lib/composition'
+import { describe, expect, it } from 'vitest'
 
-describe(`composition module exports`, () => {
-  test(`exports all parsing utilities`, () => {
-    expect(parse_module.parse_formula).toBeDefined()
-    expect(parse_module.normalize_composition).toBeDefined()
-    expect(parse_module.composition_to_percentages).toBeDefined()
-    expect(parse_module.get_total_atoms).toBeDefined()
-    expect(parse_module.parse_composition).toBeDefined()
-    expect(parse_module.atomic_num_to_symbols).toBeDefined()
-    expect(parse_module.atomic_symbol_to_num).toBeDefined()
+describe(`get_chart_font_scale`, () => {
+  it(`returns base scale when text fits`, () => {
+    expect(get_chart_font_scale(1.0, `Short`, 100)).toBe(1.0)
   })
 
-  test(`exports all components and utilities from main index`, () => {
-    expect(composition_module.Composition).toBeDefined()
-    expect(composition_module.PieChart).toBeDefined()
-    expect(composition_module.BubbleChart).toBeDefined()
-    expect(composition_module.BarChart).toBeDefined()
-    expect(composition_module.parse_formula).toBeDefined()
-    expect(composition_module.normalize_composition).toBeDefined()
-    expect(composition_module.composition_to_percentages).toBeDefined()
-    expect(composition_module.get_total_atoms).toBeDefined()
-    expect(composition_module.parse_composition).toBeDefined()
+  it(`scales down when text is too wide`, () => {
+    const result = get_chart_font_scale(1.0, `Very Long Text`, 50)
+    expect(result).toBeLessThan(1.0)
+    expect(result).toBeGreaterThan(0)
+  })
+
+  it(`respects minimum scale factor`, () => {
+    const result = get_chart_font_scale(1.0, `Extremely Long Text`, 10, 0.5)
+    expect(result).toBe(0.5)
+  })
+
+  it(`handles edge cases`, () => {
+    expect(get_chart_font_scale(1.0, `Text`, 0)).toBe(1.0) // zero space
+    expect(get_chart_font_scale(1.0, `Text`, -10)).toBe(1.0) // negative space
+    expect(get_chart_font_scale(1.0, ``, 100)).toBe(1.0) // empty text
+  })
+
+  it(`uses custom parameters`, () => {
+    const result = get_chart_font_scale(1.0, `Test`, 20, 0.7, 20)
+    expect(result).toBeLessThan(1.0)
   })
 })

--- a/tests/vitest/decompress.test.ts
+++ b/tests/vitest/decompress.test.ts
@@ -211,8 +211,7 @@ describe(`decompress utility functions`, () => {
       expect(result.filename).toBe(`test.json.zip`) // Extension not removed
     })
 
-    // Note: FileReader error handling tests are complex to mock in vitest
     // The main functionality (reading regular and compressed files) is tested above
-    // Error handling would be better tested in integration tests
+    // Error handling is better tested in integration tests
   })
 })

--- a/tests/vitest/decompress.test.ts
+++ b/tests/vitest/decompress.test.ts
@@ -4,7 +4,7 @@ import {
   detect_compression_format,
   remove_compression_extension,
 } from '$lib/io/decompress'
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { describe, expect, test } from 'vitest'
 
 describe(`decompress utility functions`, () => {
   describe(`remove_compression_extension`, () => {
@@ -54,10 +54,6 @@ describe(`decompress utility functions`, () => {
   })
 
   describe(`decompress_data`, () => {
-    beforeEach(() => {
-      vi.clearAllMocks()
-    })
-
     test(`should throw error when DecompressionStream is not supported`, async () => {
       const original_decompression_stream = globalThis.DecompressionStream
       // @ts-expect-error - intentionally deleting for test

--- a/tests/vitest/io/fetch.test.ts
+++ b/tests/vitest/io/fetch.test.ts
@@ -13,12 +13,6 @@ const mock_create_object_url = vi.fn()
 const mock_revoke_object_url = vi.fn()
 
 describe(`fetch_zipped`, () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    // Reset globalThis.download
-    delete (globalThis as Record<string, unknown>).download
-  })
-
   test(`fetches and decompresses data successfully`, async () => {
     const mock_data = { test: `data` }
     const mock_response = {
@@ -108,7 +102,6 @@ describe(`download`, () => {
         createObjectURL: mock_create_object_url,
         revokeObjectURL: mock_revoke_object_url,
       },
-      writable: true,
     })
     mock_create_object_url.mockReturnValue(`blob:mock-url`)
   })

--- a/tests/vitest/io/fetch.test.ts
+++ b/tests/vitest/io/fetch.test.ts
@@ -1,0 +1,152 @@
+import { download, fetch_zipped } from '$lib/io/fetch'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+vi.mock(`$lib/io/decompress`, () => ({ decompress_data: vi.fn() }))
+globalThis.fetch = vi.fn()
+
+// Mock DOM elements and methods
+const mock_create_element = vi.fn()
+const mock_append_child = vi.fn()
+const mock_click = vi.fn()
+const mock_remove = vi.fn()
+const mock_create_object_url = vi.fn()
+const mock_revoke_object_url = vi.fn()
+
+describe(`fetch_zipped`, () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Reset globalThis.download
+    delete (globalThis as Record<string, unknown>).download
+  })
+
+  test(`fetches and decompresses data successfully`, async () => {
+    const mock_data = { test: `data` }
+    const mock_response = {
+      ok: true,
+      body: `compressed_data`,
+      url: `https://example.com/test.json.gz`,
+    } as unknown as Response
+    vi.mocked(fetch).mockResolvedValue(mock_response)
+    const { decompress_data } = await import(`$lib/io/decompress`)
+    vi.mocked(decompress_data).mockResolvedValue(JSON.stringify(mock_data))
+
+    const result = await fetch_zipped(`https://example.com/test.json.gz`)
+
+    expect(fetch).toHaveBeenCalledWith(`https://example.com/test.json.gz`)
+    expect(decompress_data).toHaveBeenCalledWith(`compressed_data`, `gzip`)
+    expect(result).toEqual(mock_data)
+  })
+
+  test(`returns null when response is not ok`, async () => {
+    const mock_response = {
+      ok: false,
+      status: 404,
+      statusText: `Not Found`,
+      url: `https://example.com/notfound.json.gz`,
+    } as unknown as Response
+    vi.mocked(fetch).mockResolvedValue(mock_response)
+    const console_spy = vi.spyOn(console, `error`).mockImplementation(() => {})
+
+    const result = await fetch_zipped(`https://example.com/notfound.json.gz`)
+
+    expect(result).toBeNull()
+    expect(console_spy).toHaveBeenCalledWith(
+      `404 Not Found for https://example.com/notfound.json.gz`,
+    )
+    console_spy.mockRestore()
+  })
+
+  test(`returns blob when unzip is false`, async () => {
+    const mock_blob = new Blob([`test data`], { type: `application/json` })
+    const mock_response = {
+      ok: true,
+      blob: () => Promise.resolve(mock_blob),
+    } as unknown as Response
+    vi.mocked(fetch).mockResolvedValue(mock_response)
+
+    const result = await fetch_zipped(`https://example.com/test.json`, { unzip: false })
+
+    expect(result).toBe(mock_blob)
+  })
+
+  test(`handles JSON parsing errors`, async () => {
+    const mock_response = { ok: true, body: `compressed_data` } as unknown as Response
+    vi.mocked(fetch).mockResolvedValue(mock_response)
+    const { decompress_data } = await import(`$lib/io/decompress`)
+    vi.mocked(decompress_data).mockResolvedValue(`invalid json`)
+
+    await expect(fetch_zipped(`https://example.com/test.json.gz`)).rejects.toThrow()
+  })
+})
+
+describe(`download`, () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    // Mock DOM elements
+    mock_create_element.mockReturnValue({
+      style: {},
+      href: ``,
+      download: ``,
+      click: mock_click,
+      remove: mock_remove,
+    })
+
+    // Mock document methods
+    Object.defineProperty(document, `createElement`, {
+      value: mock_create_element,
+      writable: true,
+    })
+    Object.defineProperty(document.body, `appendChild`, {
+      value: mock_append_child,
+      writable: true,
+    })
+
+    // Mock URL methods
+    Object.defineProperty(globalThis, `URL`, {
+      value: {
+        createObjectURL: mock_create_object_url,
+        revokeObjectURL: mock_revoke_object_url,
+      },
+      writable: true,
+    })
+    mock_create_object_url.mockReturnValue(`blob:mock-url`)
+  })
+
+  test(`downloads string data using default browser download`, () => {
+    download(`test data`, `test.txt`, `text/plain`)
+
+    expect(mock_create_element).toHaveBeenCalledWith(`a`)
+    expect(mock_append_child).toHaveBeenCalled()
+    expect(mock_click).toHaveBeenCalled()
+    expect(mock_remove).toHaveBeenCalled()
+    expect(mock_create_object_url).toHaveBeenCalled()
+    expect(mock_revoke_object_url).toHaveBeenCalledWith(`blob:mock-url`)
+  })
+
+  test(`downloads blob data using default browser download`, () => {
+    const data = new Blob([`test data`], { type: `text/plain` })
+    download(data, `test.txt`, `text/plain`)
+
+    expect(mock_create_element).toHaveBeenCalledWith(`a`)
+    expect(mock_append_child).toHaveBeenCalled()
+    expect(mock_click).toHaveBeenCalled()
+    expect(mock_remove).toHaveBeenCalled()
+    expect(mock_create_object_url).toHaveBeenCalled()
+    expect(mock_revoke_object_url).toHaveBeenCalledWith(`blob:mock-url`)
+  })
+
+  test(`uses global download override when available`, () => {
+    const mock_global_download = vi.fn()
+    ;(globalThis as Record<string, unknown>).download = mock_global_download
+
+    download(`test data`, `test.txt`, `text/plain`)
+
+    expect(mock_global_download).toHaveBeenCalledWith(
+      `test data`,
+      `test.txt`,
+      `text/plain`,
+    )
+    expect(mock_create_element).not.toHaveBeenCalled()
+  })
+})

--- a/tests/vitest/io/index.test.ts
+++ b/tests/vitest/io/index.test.ts
@@ -12,7 +12,6 @@ describe(`handle_url_drop`, () => {
     callback = vi.fn()
     get_data = vi.fn()
     drag_event = { dataTransfer: { getData: get_data } } as unknown as DragEvent
-    vi.clearAllMocks()
   })
 
   test.each([
@@ -44,10 +43,6 @@ describe(`handle_url_drop`, () => {
 })
 
 describe(`load_from_url`, () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
-
   const create_mock_response = (content: string | ArrayBuffer, headers = {}) => {
     const response = new Response(content, { headers })
     if (content instanceof ArrayBuffer) {

--- a/tests/vitest/io/parse.test.ts
+++ b/tests/vitest/io/parse.test.ts
@@ -24,7 +24,7 @@ import vasp4_format from '$site/structures/vasp4-format.poscar?raw'
 import { readFileSync } from 'fs'
 import process from 'node:process'
 import { join } from 'path'
-import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest'
+import { beforeEach, describe, expect, it, test, vi } from 'vitest'
 import { gunzipSync } from 'zlib'
 import { get_test_structure } from '../setup'
 
@@ -33,9 +33,6 @@ import { get_test_structure } from '../setup'
 let console_error_spy: ReturnType<typeof vi.spyOn>
 beforeEach(() => {
   console_error_spy = vi.spyOn(console, `error`).mockImplementation(() => {})
-})
-afterEach(() => {
-  console_error_spy.mockRestore()
 })
 
 // Load compressed phonopy files using Node.js built-in decompression

--- a/tests/vitest/io/parse.test.ts
+++ b/tests/vitest/io/parse.test.ts
@@ -1269,10 +1269,6 @@ describe(`parse_structure_file`, () => {
   })
 
   describe(`data passing and transformation logic`, () => {
-    // Using the actual implementation from shared utility
-    // This ensures tests validate the real production logic
-    // rather than potentially outdated mock implementations
-
     test.each([
       [`simple direct structure`, {
         sites: [{ species: [{ element: `H` }], abc: [0, 0, 0] }],

--- a/tests/vitest/labels.test.ts
+++ b/tests/vitest/labels.test.ts
@@ -25,10 +25,9 @@ test(`format_num`, () => {
   expect(format_num(0.1)).toBe(`0.1`)
   expect(format_num(0.01)).toBe(`0.01`)
   expect(format_num(0.001)).toBe(`0.001`)
-  // TODO: figure out how to make format_num(-0.0001) = '1e-4'
-  expect(format_num(-0.000_1)).toBe(`−0.0001`) // want −1e-4
-  expect(format_num(-0.000_01)).toBe(`−0.00001`) // want −1e-5
-  expect(format_num(-0.000_001)).toBe(`−0.000001`) // want −1e-6
+  expect(format_num(-0.000_1)).toBe(`−0.0001`)
+  expect(format_num(-0.000_01)).toBe(`−0.00001`)
+  expect(format_num(-0.000_001)).toBe(`−0.000001`)
   expect(format_num(-0.000_000_1)).toBe(`−1e-7`)
 
   expect(format_num(-1.1)).toBe(`−1.1`)

--- a/tests/vitest/periodic-table/ElementTile.test.ts
+++ b/tests/vitest/periodic-table/ElementTile.test.ts
@@ -33,16 +33,6 @@ describe(`ElementTile`, () => {
       expect(number.textContent).toBe(rand_element.number.toString())
     })
 
-    test(`renders as div by default`, () => {
-      mount(ElementTile, {
-        target: document.body,
-        props: { element: rand_element },
-      })
-
-      const node = doc_query(`.element-tile`)
-      expect(node.tagName).toBe(`DIV`)
-    })
-
     test(`renders as anchor when href is provided`, () => {
       const href = `/element/${rand_element.symbol}`
       mount(ElementTile, {
@@ -148,11 +138,11 @@ describe(`ElementTile`, () => {
       expect(document.querySelector(`.value`)).toBeNull()
     })
 
-    test(`formats value with precision`, () => {
+    test(`formats value with float_fmt`, () => {
       const value = 42.123456
       mount(ElementTile, {
         target: document.body,
-        props: { element: rand_element, value, precision: `.2f` },
+        props: { element: rand_element, value, float_fmt: `.2f` },
       })
 
       const value_element = doc_query(`.value`)
@@ -204,24 +194,14 @@ describe(`ElementTile`, () => {
       expect(symbol.getAttribute(`style`)).toBe(symbol_style)
     })
 
-    test(`applies active class when active=true`, () => {
+    test.each([true, false])(`applies active class when active=%s`, (active) => {
       mount(ElementTile, {
         target: document.body,
-        props: { element: rand_element, active: true },
+        props: { element: rand_element, active },
       })
 
       const node = doc_query(`.element-tile`)
-      expect(node.classList.contains(`active`)).toBe(true)
-    })
-
-    test(`does not apply active class when active=false`, () => {
-      mount(ElementTile, {
-        target: document.body,
-        props: { element: rand_element, active: false },
-      })
-
-      const node = doc_query(`.element-tile`)
-      expect(node.classList.contains(`active`)).toBe(false)
+      expect(node.classList.contains(`active`)).toBe(active)
     })
 
     test(`applies category class based on element category`, () => {
@@ -246,42 +226,6 @@ describe(`ElementTile`, () => {
 
       const name_element = doc_query(`.name`)
       expect(name_element.textContent).toBe(custom_label)
-    })
-
-    test(`shows element name when label is null`, () => {
-      mount(ElementTile, {
-        target: document.body,
-        props: { element: rand_element, label: null },
-      })
-
-      const name_element = doc_query(`.name`)
-      expect(name_element.textContent).toBe(rand_element.name)
-    })
-  })
-
-  describe(`node binding`, () => {
-    test(`renders without error when node binding is used`, () => {
-      // Test that the component renders without errors when node is bound
-      mount(ElementTile, {
-        target: document.body,
-        props: { element: rand_element },
-      })
-
-      const node = doc_query(`.element-tile`)
-      expect(node.classList.contains(`element-tile`)).toBe(true)
-    })
-  })
-
-  describe(`text_color_threshold prop`, () => {
-    test(`uses custom text_color_threshold`, () => {
-      // This test verifies the prop is accepted and passed to pick_color_for_contrast
-      mount(ElementTile, {
-        target: document.body,
-        props: { element: rand_element, text_color_threshold: 0.5 },
-      })
-
-      const node = doc_query(`.element-tile`)
-      expect(node).toBeTruthy() // Basic check that component renders
     })
   })
 
@@ -455,14 +399,14 @@ describe(`ElementTile`, () => {
       expect(document.querySelector(`.value`)).toBeNull()
     })
 
-    test(`handles empty string precision`, () => {
+    test(`handles empty string float_fmt`, () => {
       mount(ElementTile, {
         target: document.body,
-        props: { element: rand_element, value: 42.123, precision: `` },
+        props: { element: rand_element, value: 42.123, float_fmt: `` },
       })
 
       const value_element = doc_query(`.value`)
-      // Empty precision defaults to format_num default behavior
+      // Empty float_fmt defaults to format_num default behavior
       expect(value_element.textContent).toBe(`42.1`)
     })
   })

--- a/tests/vitest/periodic-table/PeriodicTable.test.svelte.ts
+++ b/tests/vitest/periodic-table/PeriodicTable.test.svelte.ts
@@ -422,11 +422,7 @@ describe(`PeriodicTable`, () => {
 
   describe(`color value heatmaps`, () => {
     test.each([
-      [
-        [`#ff0000`, `#00ff00`, `#0000ff`],
-        [`#ff0000`, `#00ff00`, `#0000ff`],
-        `array`,
-      ],
+      [[`#ff0000`, `#00ff00`, `#0000ff`], [`#ff0000`, `#00ff00`, `#0000ff`], `array`],
       [
         { H: `#ff0000`, He: `#00ff00`, Li: `#0000ff` },
         [`#ff0000`, `#00ff00`, `#0000ff`],
@@ -456,18 +452,12 @@ describe(`PeriodicTable`, () => {
 
     test.each([
       [
-        [
-          [`#ff0000`, `#00ff00`],
-          [`#0000ff`, `#ffff00`],
-        ],
+        [[`#ff0000`, `#00ff00`], [`#0000ff`, `#ffff00`]],
         [`diagonal-top`, `diagonal-bottom`],
         `two colors`,
       ],
       [
-        [
-          [`#ff0000`, `#00ff00`, `#0000ff`],
-          [`#ffff00`, `#ff00ff`, `#00ffff`],
-        ],
+        [[`#ff0000`, `#00ff00`, `#0000ff`], [`#ffff00`, `#ff00ff`, `#00ffff`]],
         [`horizontal-top`, `horizontal-middle`, `horizontal-bottom`],
         `three colors`,
       ],

--- a/tests/vitest/plot/ColorScaleSelect.test.ts
+++ b/tests/vitest/plot/ColorScaleSelect.test.ts
@@ -41,20 +41,6 @@ describe(`ColorScaleSelect`, () => {
     expect(select_wrapper).toBeTruthy()
   })
 
-  test(`uses placeholder prop`, () => {
-    /** Renders the component with a custom placeholder. */
-    const placeholder_text = `Choose a scale...`
-    mount(ColorScaleSelect, {
-      target: document.body,
-      props: { placeholder: placeholder_text, selected: [] },
-    })
-
-    // Verify component mounts. Direct assertion of placeholder text
-    // is difficult due to svelte-multiselect's internal rendering.
-    const multiselect_container = doc_query(`.multiselect`)
-    expect(multiselect_container).toBeTruthy()
-  })
-
   test(`binds value and selected correctly (initial state)`, () => {
     /** Tests if initial value and selected props are rendered correctly. */
     const selected_value: string | null = `viridis`
@@ -71,10 +57,7 @@ describe(`ColorScaleSelect`, () => {
 
     // Check initial state rendered by svelte-multiselect
     const initial_selection = doc_query(`.selected`)
-    expect(initial_selection?.textContent?.trim()).toBe(`viridis`)
-
-    // Note: Testing updates via external prop changes is difficult in Svelte 5
-    // with happy-dom. This test focuses on initial render.
+    expect(initial_selection?.textContent?.trim()).toBe(selected_array[0])
   })
 
   test(`passes colorbar props to ColorBar snippet`, async () => {
@@ -83,7 +66,6 @@ describe(`ColorScaleSelect`, () => {
       tick_align: `secondary` as const,
       title_side: `right` as const,
       wrapper_style: `border: 1px dashed red;`,
-      // style: `background-color: lightgray;`, // Removed problematic style check
     }
 
     mount(ColorScaleSelect, {

--- a/tests/vitest/plot/ColorScaleSelect.test.ts
+++ b/tests/vitest/plot/ColorScaleSelect.test.ts
@@ -1,14 +1,10 @@
 import { ColorScaleSelect } from '$lib'
 import type { D3ColorSchemeName } from '$lib/colors'
 import { mount } from 'svelte'
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { doc_query } from '../setup'
 
 describe(`ColorScaleSelect`, () => {
-  beforeEach(() => {
-    vi.useFakeTimers()
-  })
-
   test(`renders with default options derived from d3-scale-chromatic`, () => {
     /** Renders the component with default props. */
     mount(ColorScaleSelect, { target: document.body })

--- a/tests/vitest/plot/Line.test.ts
+++ b/tests/vitest/plot/Line.test.ts
@@ -2,19 +2,9 @@ import { Line } from '$lib'
 import { interpolatePath } from 'd3-interpolate-path'
 import { mount } from 'svelte'
 import { sineIn } from 'svelte/easing'
-import { beforeEach, describe, expect, test } from 'vitest'
+import { describe, expect, test } from 'vitest'
 
 describe(`Line`, () => {
-  // Setup container
-  const container_style = `width: 800px; height: 600px; position: relative;`
-  let target_div: HTMLDivElement
-
-  beforeEach(() => {
-    target_div = document.createElement(`div`)
-    target_div.setAttribute(`style`, container_style)
-    document.body.appendChild(target_div)
-  })
-
   // Parameterized test for default and custom styles
   test.each([
     {
@@ -71,12 +61,12 @@ describe(`Line`, () => {
     const origin: [number, number] = [0, 200]
 
     const component = mount(Line, {
-      target: target_div,
+      target: document.body,
       props: { points, origin, ...props }, // Spread additional props
     })
 
     expect(component).toBeTruthy()
-    const paths = target_div.querySelectorAll(`path`)
+    const paths = document.querySelectorAll(`path`)
     expect(paths.length).toBe(2)
 
     const line_path = paths[0]
@@ -107,15 +97,15 @@ describe(`Line`, () => {
       [200, 100],
     ] as [number, number][]
     mount(Line, {
-      target: target_div,
+      target: document.body,
       props: { points: points_3, origin, line_tween: { duration: 0 } },
     })
 
-    const paths_3 = target_div.querySelectorAll(`path`)
+    const paths_3 = document.querySelectorAll(`path`)
     expect(paths_3[0].getAttribute(`d`)).toMatch(/^M0,100C.*100,0.*C.*200,100$/)
 
     // Clean up target before remounting
-    target_div.innerHTML = ``
+    document.body.innerHTML = ``
 
     // Test with 2 points (expects line 'L')
     const points_2 = [
@@ -123,11 +113,11 @@ describe(`Line`, () => {
       [100, 0],
     ] as [number, number][]
     mount(Line, {
-      target: target_div, // Reuse the cleaned div
+      target: document.body, // Reuse the cleaned div
       props: { points: points_2, origin, line_tween: { duration: 0 } },
     })
 
-    const paths_2 = target_div.querySelectorAll(`path`)
+    const paths_2 = document.querySelectorAll(`path`)
     expect(paths_2[0].getAttribute(`d`)).toMatch(/^M0,100L100,0$/)
   })
 
@@ -139,11 +129,11 @@ describe(`Line`, () => {
     const origin: [number, number] = [0, 100] // Y origin at 100
 
     mount(Line, {
-      target: target_div,
+      target: document.body,
       props: { points, origin, line_tween: { duration: 0 } },
     })
 
-    const area_path = target_div.querySelectorAll(`path`)[1]
+    const area_path = document.querySelectorAll(`path`)[1]
     expect(area_path.getAttribute(`d`)).toMatch(/^M0,50L100,0L100,100L0,100Z$/)
   })
 
@@ -155,12 +145,12 @@ describe(`Line`, () => {
     const origin: [number, number] = [0, 100]
 
     const component = mount(Line, {
-      target: target_div,
+      target: document.body,
       props: { points, origin, tween_duration: 100 },
     })
 
     expect(component).toBeTruthy() // Verify component mounts
-    const paths = target_div.querySelectorAll(`path`)
+    const paths = document.querySelectorAll(`path`)
     expect(paths.length).toBe(2) // Check paths exist
   })
 
@@ -169,11 +159,11 @@ describe(`Line`, () => {
     const origin: [number, number] = [0, 100]
 
     mount(Line, {
-      target: target_div,
+      target: document.body,
       props: { points, origin, tween_duration: 0 },
     })
 
-    const paths = target_div.querySelectorAll(`path`)
+    const paths = document.querySelectorAll(`path`)
     expect(paths.length).toBe(2)
     expect(paths[0].getAttribute(`d`)).toBe(``)
     expect(paths[1].getAttribute(`d`)).toBe(``)
@@ -184,11 +174,11 @@ describe(`Line`, () => {
     const origin: [number, number] = [0, 100]
 
     mount(Line, {
-      target: target_div,
+      target: document.body,
       props: { points, origin, line_tween: { duration: 0 } },
     })
 
-    const paths = target_div.querySelectorAll(`path`)
+    const paths = document.querySelectorAll(`path`)
     expect(paths.length).toBe(2)
     expect(paths[0].getAttribute(`d`)).toMatch(/^M50,50Z?$/)
     expect(paths[1].getAttribute(`d`)).toMatch(/^M50,50Z?L50,100L50,100Z$/)
@@ -208,12 +198,12 @@ describe(`Line`, () => {
     }
 
     const component = mount(Line, {
-      target: target_div,
+      target: document.body,
       props: { points, origin, line_tween: custom_tween },
     })
 
     expect(component).toBeTruthy() // Primary check: Component mounts without error
-    const paths = target_div.querySelectorAll(`path`)
+    const paths = document.querySelectorAll(`path`)
     expect(paths.length).toBe(2)
     // Further checks on internal tween state are difficult in unit tests,
     // but mounting confirms the props were accepted.
@@ -231,11 +221,11 @@ describe(`Line`, () => {
     }
 
     mount(Line, {
-      target: target_div,
+      target: document.body,
       props: { points, origin, ...rest_props },
     })
 
-    const paths = target_div.querySelectorAll(`path`)
+    const paths = document.querySelectorAll(`path`)
     expect(paths.length).toBe(2)
 
     // Check that both paths received the rest props

--- a/tests/vitest/plot/ScatterPlot.test.ts
+++ b/tests/vitest/plot/ScatterPlot.test.ts
@@ -1,11 +1,9 @@
 import { ScatterPlot } from '$lib'
 import type { DataSeries } from '$lib/plot'
 import { mount } from 'svelte'
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 
 // Test helpers
-const container_style = `width: 800px; height: 600px; position: relative;`
-
 function mount_scatter(props: Record<string, unknown>) {
   const component = mount(ScatterPlot, { target: document.body, props })
   const scatter = document.querySelector(`.scatter`)
@@ -50,12 +48,6 @@ const multi_series = [
 ]
 
 describe(`ScatterPlot`, () => {
-  beforeEach(() => {
-    const container = document.createElement(`div`)
-    container.setAttribute(`style`, container_style)
-    document.body.appendChild(container)
-  })
-
   test.each([
     {
       name: `basic`,

--- a/tests/vitest/plot/ScatterPoint.test.ts
+++ b/tests/vitest/plot/ScatterPoint.test.ts
@@ -257,9 +257,7 @@ describe(`ScatterPoint`, () => {
   )
 
   describe(`Tween Behavior`, () => {
-    beforeEach(() => {
-      vi.useFakeTimers()
-    })
+    beforeEach(vi.useFakeTimers)
 
     test.each([
       {

--- a/tests/vitest/state.test.ts
+++ b/tests/vitest/state.test.ts
@@ -8,20 +8,7 @@ import {
   tooltip,
 } from '$lib/state.svelte'
 import { AUTO_THEME, COLOR_THEMES, THEME_TYPE } from '$lib/theme'
-import { beforeEach, describe, expect, test, vi } from 'vitest'
-
-// Mock localStorage for theme state tests
-const local_storage_mock = {
-  getItem: vi.fn(),
-  setItem: vi.fn(),
-  removeItem: vi.fn(),
-  clear: vi.fn(),
-}
-
-Object.defineProperty(globalThis, `localStorage`, {
-  value: local_storage_mock,
-  writable: true,
-})
+import { describe, expect, test } from 'vitest'
 
 test(`theme_state has correct initial values`, () => {
   // This test checks the actual initial values without any beforeEach reset
@@ -31,28 +18,6 @@ test(`theme_state has correct initial values`, () => {
 })
 
 describe(`State Management`, () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    // Reset all states to initial values
-    Object.assign(selected, {
-      category: null,
-      element: null,
-      last_element: null,
-      heatmap_key: null,
-    })
-    Object.assign(colors, {
-      category: { ...default_category_colors },
-      element: { ...default_element_colors },
-    })
-    Object.assign(tooltip, { show: false, x: 0, y: 0, title: ``, items: [] })
-    Object.assign(periodic_table_state, {
-      show_bonding_info: false,
-      show_oxidation_state: false,
-      highlighted_elements: [],
-    })
-    Object.assign(theme_state, { mode: AUTO_THEME, system_mode: COLOR_THEMES.light })
-  })
-
   describe(`selected state`, () => {
     test(`allows category mutations`, () => {
       selected.category = `alkali metal`

--- a/tests/vitest/structure/Structure.test.ts
+++ b/tests/vitest/structure/Structure.test.ts
@@ -52,7 +52,7 @@ function create_drop_event(files: File[]): DragEvent {
 
 // Tests for Structure component functionality
 describe(`Structure`, () => {
-  test(`open control panel when clicking toggle button`, async () => {
+  test(`open control panel when clicking toggle button`, () => {
     mount(Structure, {
       target: document.body,
       props: { structure, controls_open: false, show_controls: true },
@@ -63,7 +63,6 @@ describe(`Structure`, () => {
     expect(controls_toggle).toBeTruthy()
 
     controls_toggle.click()
-    await tick()
 
     // Check that the control panel is now visible by looking for control elements
     expect(document.querySelector(`.controls-panel`)).toBeTruthy()
@@ -92,7 +91,6 @@ describe(`Structure`, () => {
     )
     expect(structure_controls_toggle).toBeTruthy()
     structure_controls_toggle.click()
-    await tick()
 
     if (action === `Download`) {
       globalThis.URL.createObjectURL = vi.fn()
@@ -124,7 +122,6 @@ describe(`Structure`, () => {
       expect(copy_btn, `copy button for ${format}`).toBeTruthy()
 
       copy_btn.click()
-      await tick()
       // Wait for Svelte to re-render the component
       await new Promise((resolve) => setTimeout(resolve, 50))
 
@@ -163,7 +160,6 @@ describe(`Structure`, () => {
     expect(fullscreen_button).toBeTruthy()
 
     fullscreen_button.click()
-    await tick()
 
     expect(requestFullscreenMock).toHaveBeenCalledOnce()
 
@@ -174,7 +170,6 @@ describe(`Structure`, () => {
     })
 
     fullscreen_button.click()
-    await tick()
     expect(exitFullscreenMock).toHaveBeenCalledOnce()
 
     // Reset fullscreenElement
@@ -209,7 +204,6 @@ describe(`Structure`, () => {
 
     // Wait for async processing to complete
     await new Promise((resolve) => setTimeout(resolve, 100))
-    await tick()
 
     // Verify that the file drop handler was called
     expect(structure_loaded).toBe(true)
@@ -242,7 +236,6 @@ describe(`Structure`, () => {
 
     // Wait for async processing to complete
     await new Promise((resolve) => setTimeout(resolve, 100))
-    await tick()
 
     expect(event_handled).toBe(true)
     expect(file_content).toBe(`test content`)
@@ -275,7 +268,6 @@ describe(`Structure`, () => {
 
     // Wait for async processing to complete
     await new Promise((resolve) => setTimeout(resolve, 100))
-    await tick()
 
     // Verify that the file drop handler was called
     expect(structure_loaded).toBe(true)
@@ -298,7 +290,6 @@ describe(`Structure`, () => {
 
     // Wait for async processing to complete
     await new Promise((resolve) => setTimeout(resolve, 100))
-    await tick()
 
     // Check that the structure was loaded (should show structure info)
     expect(document.body.textContent).toContain(`Ba Ti O3`)
@@ -557,7 +548,6 @@ test.each([
     // Test 3: Toggle projection and verify change
     projection_select.value = target_projection
     projection_select.dispatchEvent(new Event(`change`, { bubbles: true }))
-    await tick()
     expect(projection_select.value).toBe(target_projection)
 
     // Test 4: Other scene properties remain functional after projection change
@@ -573,57 +563,15 @@ test.each([
 
     radius_input.value = `2.0`
     radius_input.dispatchEvent(new Event(`input`, { bubbles: true }))
-    await tick()
     expect(parseFloat(radius_input.value)).toBeCloseTo(2.0, 1)
 
     // Test 5: State persistence across component updates (simplified for Svelte 5)
     // In a real app, scene_props would be reactive - here we just verify the projection persists
-    await tick()
     if (projection_select) {
       expect(projection_select.value).toBe(target_projection) // Projection should persist
     }
   },
 )
-
-// Test advanced camera logic functionality
-test(`camera projection conditional logic and zoom speed handling`, async () => {
-  const _component = mount(Structure, {
-    target: document.body,
-    props: {
-      structure,
-      controls_open: true,
-      scene_props: { camera_projection: `perspective`, zoom_speed: 0.5 },
-      show_controls: true,
-    },
-  })
-  await tick()
-
-  const projection_select = doc_query<HTMLSelectElement>(`.controls-panel select`)
-  const zoom_speed_input = document.querySelector(
-    `input[type="number"][min="0.1"][max="0.8"]`,
-  ) as HTMLInputElement
-
-  // Test zoom speed logic exists and functions for both projections
-  expect(zoom_speed_input).toBeTruthy()
-
-  // Test orbit controls conditional logic by switching projections via UI
-  const test_projections = [`orthographic`, `perspective`] as const
-  const promises: Promise<void>[] = []
-
-  for (const projection of test_projections) {
-    if (projection_select) {
-      projection_select.value = projection
-      projection_select.dispatchEvent(new Event(`change`, { bubbles: true }))
-      promises.push(tick())
-    }
-
-    // Component should render without errors (would fail if conditional logic is broken)
-    expect(document.querySelector(`.structure`)).toBeTruthy()
-    expect(zoom_speed_input).toBeTruthy() // Controls should remain functional
-  }
-
-  await Promise.all(promises)
-})
 
 // Test critical default value validation that could cause runtime errors
 test(`critical default values are valid to prevent runtime errors`, () => {
@@ -665,7 +613,7 @@ describe(`atom label controls`, () => {
     { axis: `Z`, idx: 2, initial: 0.8, new_value: -0.3 },
   ])(
     `$axis offset control works correctly`,
-    async ({ idx, initial, new_value }) => {
+    ({ idx, initial, new_value }) => {
       const offset = [0, 0, 0] as Vec3
       offset[idx] = initial
 
@@ -678,7 +626,6 @@ describe(`atom label controls`, () => {
           scene_props: { show_site_labels: true, site_label_offset: offset },
         },
       })
-      await tick()
 
       const offset_inputs = document.querySelectorAll(
         `input[type="number"][min="-1"][max="1"][step="0.1"]`,
@@ -690,12 +637,11 @@ describe(`atom label controls`, () => {
 
       input.value = new_value.toString()
       input.dispatchEvent(new Event(`input`, { bubbles: true }))
-      await tick()
       expect(parseFloat(input.value)).toBeCloseTo(new_value, 1)
     },
   )
 
-  test(`color controls work correctly`, async () => {
+  test(`color controls work correctly`, () => {
     mount(Structure, {
       target: document.body,
       props: {
@@ -705,7 +651,6 @@ describe(`atom label controls`, () => {
         scene_props: { show_site_labels: true, site_label_color: `#ff0000` },
       },
     })
-    await tick()
 
     const color_inputs = document.querySelectorAll(`input[type="color"]`)
     expect(color_inputs.length).toBeGreaterThanOrEqual(2)
@@ -714,14 +659,12 @@ describe(`atom label controls`, () => {
     const text_color = color_inputs[0] as HTMLInputElement
     text_color.value = `#00ff00`
     text_color.dispatchEvent(new Event(`input`, { bubbles: true }))
-    await tick()
     expect(text_color.value).toBe(`#00ff00`)
 
     // Test background color
     const bg_color = color_inputs[1] as HTMLInputElement
     bg_color.value = `#0000ff`
     bg_color.dispatchEvent(new Event(`input`, { bubbles: true }))
-    await tick()
     expect(bg_color.value).toBe(`#0000ff`)
 
     // Test opacity
@@ -730,11 +673,10 @@ describe(`atom label controls`, () => {
     ) as HTMLInputElement
     opacity_input.value = `0.5`
     opacity_input.dispatchEvent(new Event(`input`, { bubbles: true }))
-    await tick()
     expect(parseFloat(opacity_input.value)).toBeCloseTo(0.5, 2)
   })
 
-  test(`size and padding controls work correctly`, async () => {
+  test(`size and padding controls work correctly`, () => {
     mount(Structure, {
       target: document.body,
       props: {
@@ -748,7 +690,6 @@ describe(`atom label controls`, () => {
         },
       },
     })
-    await tick()
 
     const size_input = document.querySelector(
       `input[type="range"][min="0.5"][max="2"][step="0.1"]`,
@@ -764,13 +705,12 @@ describe(`atom label controls`, () => {
     padding_input.value = `6`
     size_input.dispatchEvent(new Event(`input`, { bubbles: true }))
     padding_input.dispatchEvent(new Event(`input`, { bubbles: true }))
-    await tick()
 
     expect(parseFloat(size_input.value)).toBeCloseTo(1.8, 1)
     expect(parseInt(padding_input.value)).toBe(6)
   })
 
-  test(`input constraints are correct`, async () => {
+  test(`input constraints are correct`, () => {
     mount(Structure, {
       target: document.body,
       props: {
@@ -780,7 +720,6 @@ describe(`atom label controls`, () => {
         scene_props: { show_site_labels: true },
       },
     })
-    await tick()
 
     const size_input = document.querySelector(
       `input[type="range"][min="0.5"][max="2"][step="0.1"]`,
@@ -813,7 +752,7 @@ describe(`atom label controls`, () => {
     })
   })
 
-  test(`state isolation between instances works`, async () => {
+  test(`state isolation between instances works`, () => {
     // Mount first instance
     mount(Structure, {
       target: document.body,
@@ -824,7 +763,6 @@ describe(`atom label controls`, () => {
         scene_props: { show_site_labels: true, site_label_offset: [0, 0.75, 0.2] },
       },
     })
-    await tick()
 
     // Mount second instance
     mount(Structure, {
@@ -836,7 +774,6 @@ describe(`atom label controls`, () => {
         scene_props: { show_site_labels: true, site_label_offset: [0, 0.75, 0.7] },
       },
     })
-    await tick()
 
     const all_offset_inputs = document.querySelectorAll(
       `input[type="number"][min="-1"][max="1"][step="0.1"]`,
@@ -851,7 +788,6 @@ describe(`atom label controls`, () => {
 
     instance1_z.value = `0.9`
     instance1_z.dispatchEvent(new Event(`input`, { bubbles: true }))
-    await tick()
 
     expect(parseFloat(instance1_z.value)).toBeCloseTo(0.9, 1)
     expect(parseFloat(instance2_z.value)).toBeCloseTo(0.7, 1)

--- a/tests/vitest/structure/Structure.test.ts
+++ b/tests/vitest/structure/Structure.test.ts
@@ -6,7 +6,7 @@ import { DEFAULTS } from '$lib/settings'
 import { structures } from '$site/structures'
 import { readFileSync } from 'fs'
 import { mount, tick } from 'svelte'
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { gunzipSync } from 'zlib'
 import { doc_query } from '../setup'
 
@@ -347,10 +347,6 @@ test(`pbc_dist with realistic structure scenarios`, () => {
 })
 
 describe(`Structure component nested JSON handling`, () => {
-  beforeEach(() => {
-    document.body.innerHTML = ``
-  })
-
   test.each([
     [`valid structure with sites`, {
       sites: [{

--- a/tests/vitest/structure/StructureLegend.test.ts
+++ b/tests/vitest/structure/StructureLegend.test.ts
@@ -2,21 +2,12 @@ import type { CompositionType } from '$lib'
 import { default_element_colors } from '$lib/colors'
 import { colors } from '$lib/state.svelte'
 import StructureLegend from '$lib/structure/StructureLegend.svelte'
-import { mount, tick } from 'svelte'
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { mount } from 'svelte'
+import { describe, expect, test, vi } from 'vitest'
 import { doc_query } from '../setup'
 
 describe(`StructureLegend Component`, () => {
-  const mock_elements: CompositionType = {
-    Fe: 2,
-    O: 3,
-    H: 1.5,
-    C: 12.123456789,
-  }
-
-  beforeEach(() => {
-    colors.element = { ...default_element_colors }
-  })
+  const mock_elements = { Fe: 2, O: 3, H: 1.5, C: 12.123456789 }
 
   test.each([
     {
@@ -73,7 +64,7 @@ describe(`StructureLegend Component`, () => {
     }
   })
 
-  test(`color picker functionality`, async () => {
+  test(`color picker functionality`, () => {
     mount(StructureLegend, {
       target: document.body,
       props: { elements: { Fe: 2 }, elem_color_picker_title: `Custom title` },
@@ -87,11 +78,9 @@ describe(`StructureLegend Component`, () => {
     // Test color change and reset
     color_input.value = `#ff0000`
     color_input.dispatchEvent(new Event(`input`, { bubbles: true }))
-    await tick()
     expect(colors.element.Fe).toBe(`#ff0000`)
 
     label.dispatchEvent(new MouseEvent(`dblclick`, { bubbles: true }))
-    await tick()
     expect(colors.element.Fe).toBe(default_element_colors.Fe)
   })
 

--- a/tests/vitest/structure/pbc.test.ts
+++ b/tests/vitest/structure/pbc.test.ts
@@ -144,7 +144,7 @@ test.each([
   {
     content: nacl_poscar,
     filename: `NaCl-cubic.poscar`,
-    expected_min_images: 19, // Updated after fixing duplicates bug: 19 images found (was 28 with duplicates)
+    expected_min_images: 19,
     expected_max_images: 25,
     description: `8 atoms (4 Na + 4 Cl) in cubic structure`,
   },
@@ -609,7 +609,7 @@ test(`image atom generation should not create duplicates`, () => {
       const distance = euclidean_dist(pos1, pos2)
 
       // No two image atoms should be at exactly the same position
-      // Fail test if image atoms are too close (likely duplicates pointing at a bug in the detection algorithm)
+      // Fail test if image atoms are too close (likely duplicates suggesting a bug in the detection logic)
       expect(distance).toBeGreaterThan(1e-6)
     }
   }

--- a/tests/vitest/theme/ThemeControl.test.ts
+++ b/tests/vitest/theme/ThemeControl.test.ts
@@ -1,0 +1,61 @@
+import ThemeControl from '$lib/theme/ThemeControl.svelte'
+import { mount } from 'svelte'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { doc_query } from '../setup'
+
+vi.mock(`$lib/theme`, () => ({
+  apply_theme_to_dom: vi.fn(),
+  save_theme_preference: vi.fn(),
+  THEME_OPTIONS: [
+    { value: `light`, label: `Light`, icon: `☀️` },
+    { value: `dark`, label: `Dark`, icon: `🌙` },
+    { value: `auto`, label: `Auto`, icon: `🔄` },
+  ],
+}))
+
+vi.mock(`$lib/state.svelte`, () => ({ theme_state: { mode: `light` } }))
+
+describe(`ThemeControl`, () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    document.body.innerHTML = ``
+  })
+
+  test(`renders select element with theme options`, () => {
+    mount(ThemeControl, { target: document.body, props: {} })
+
+    const select = doc_query(`select.theme-control`)
+    expect(select).toBeTruthy()
+    expect(select.tagName).toBe(`SELECT`)
+
+    const options = select.querySelectorAll(`option`)
+    expect(options).toHaveLength(3)
+    expect(options[0].value).toBe(`light`)
+    expect(options[0].textContent).toContain(`☀️ Light`)
+    expect(options[1].value).toBe(`dark`)
+    expect(options[1].textContent).toContain(`🌙 Dark`)
+    expect(options[2].value).toBe(`auto`)
+    expect(options[2].textContent).toContain(`🔄 Auto`)
+  })
+
+  test(`applies custom class when provided`, () => {
+    mount(ThemeControl, {
+      target: document.body,
+      props: { class: `custom-theme-control` },
+    })
+
+    const select = doc_query(`select.theme-control.custom-theme-control`)
+    expect(select).toBeTruthy()
+  })
+
+  test(`forwards additional props to select element`, () => {
+    mount(ThemeControl, {
+      target: document.body,
+      props: { 'data-testid': `theme-select`, 'aria-label': `Select theme` },
+    })
+
+    const select = doc_query(`select.theme-control`)
+    expect(select.getAttribute(`data-testid`)).toBe(`theme-select`)
+    expect(select.getAttribute(`aria-label`)).toBe(`Select theme`)
+  })
+})

--- a/tests/vitest/theme/ThemeControl.test.ts
+++ b/tests/vitest/theme/ThemeControl.test.ts
@@ -1,6 +1,6 @@
 import ThemeControl from '$lib/theme/ThemeControl.svelte'
 import { mount } from 'svelte'
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { doc_query } from '../setup'
 
 vi.mock(`$lib/theme`, () => ({
@@ -16,11 +16,6 @@ vi.mock(`$lib/theme`, () => ({
 vi.mock(`$lib/state.svelte`, () => ({ theme_state: { mode: `light` } }))
 
 describe(`ThemeControl`, () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    document.body.innerHTML = ``
-  })
-
   test(`renders select element with theme options`, () => {
     mount(ThemeControl, { target: document.body, props: {} })
 

--- a/tests/vitest/theme/index.test.ts
+++ b/tests/vitest/theme/index.test.ts
@@ -14,12 +14,6 @@ import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 describe(`Theme System`, () => {
   beforeEach(() => {
-    // Reset DOM and localStorage before each test
-    document.documentElement.style.cssText = ``
-    document.documentElement.removeAttribute(`data-theme`)
-    localStorage.clear()
-    vi.clearAllMocks()
-
     // Mock global theme data
     globalThis.MATTERVIZ_THEMES = {
       light: { surface_bg: `#ffffff`, text_color: `#000000` },


### PR DESCRIPTION
- Adds unit tests for theme controls, fetch/download helpers, and color utilities while removing low- or zero-value tests.
- Replaces fixed spacing and sizing across settings, element, legend, and tooltip components with customizable CSS properties.
- Renames `precision` to `float_fmt` and tightens related prop types and defaults.
- Expands settings and UI coverage for reset-button visibility and color formatting, and removes redundant async waits and setup.