### PR TITLE
Set VSCode preferred extension location

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -17,6 +17,7 @@
     "vscode": "^1.96.0"
   },
   "main": "./dist/extension.cjs",
+  "extensionKind": ["ui", "workspace"],
   "activationEvents": [
     "onStartupFinished"
   ],

--- a/extensions/vscode/tests/extension.test.ts
+++ b/extensions/vscode/tests/extension.test.ts
@@ -4,6 +4,7 @@ import { Buffer } from 'node:buffer'
 import * as fs from 'node:fs'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import type { ExtensionContext, Tab, TextEditor, Webview } from 'vscode'
+import pkg from '../package.json' with { type: 'json' }
 import type { MessageData } from '../src/extension'
 import {
   activate,
@@ -74,6 +75,11 @@ describe(`MatterViz Extension`, () => {
     onDidDelete: ReturnType<typeof vi.fn>
     dispose: ReturnType<typeof vi.fn>
   }
+
+  test(`extensionKind should be configured as ["ui", "workspace"] for optimal remote performance`, () => {
+    // https://github.com/janosh/matterviz/issues/129#issuecomment-3193473225
+    expect(pkg.extensionKind).toEqual([`ui`, `workspace`])
+  })
 
   beforeEach(() => {
     vi.clearAllMocks()

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   "svelte": "./dist/index.js",
   "bugs": "https://github.com/janosh/matterviz/issues",
   "dependencies": {
-    "@sveltejs/kit": "^2.27.3",
+    "@sveltejs/kit": "^2.31.1",
     "@threlte/core": "^8.1.4",
-    "@threlte/extras": "^9.4.4",
+    "@threlte/extras": "^9.4.5",
     "@types/d3-force": "^3.0.10",
     "@types/d3-hierarchy": "^3.1.7",
     "@types/js-yaml": "^4.0.9",
@@ -29,8 +29,8 @@
     "h5wasm": "^0.8.3",
     "highlight.js": "^11.11.1",
     "js-yaml": "^4.1.0",
-    "svelte": "^5.38.0",
-    "svelte-multiselect": "11.2.2",
+    "svelte": "^5.38.1",
+    "svelte-multiselect": "11.2.3",
     "three": "^0.179.1"
   },
   "devDependencies": {
@@ -39,7 +39,7 @@
     "@stylistic/eslint-plugin": "^5.2.3",
     "@sveltejs/adapter-static": "3.0.9",
     "@sveltejs/package": "^2.4.1",
-    "@sveltejs/vite-plugin-svelte": "^6.1.1",
+    "@sveltejs/vite-plugin-svelte": "^6.1.2",
     "@types/d3-array": "^3.2.1",
     "@types/d3-color": "^3.1.3",
     "@types/d3-format": "^3.0.4",
@@ -65,8 +65,8 @@
     "svelte-preprocess": "^6.0.3",
     "svelte2tsx": "^0.7.42",
     "typescript": "5.9.2",
-    "typescript-eslint": "^8.39.0",
-    "vite": "^7.1.1",
+    "typescript-eslint": "^8.39.1",
+    "vite": "^7.1.2",
     "vitest": "^3.2.4"
   },
   "keywords": [

--- a/src/routes/[slug]/+page.svelte
+++ b/src/routes/[slug]/+page.svelte
@@ -9,10 +9,10 @@
     ElementPhoto,
     ElementScatter,
     ElementTile,
+    Icon,
     PeriodicTable,
     PropertySelect,
   } from '$lib'
-  import Icon from '$lib/Icon.svelte'
   import { format_num, property_labels } from '$lib/labels'
   import { selected } from '$lib/state.svelte'
   import pkg from '$root/package.json'


### PR DESCRIPTION
Set `"extensionKind": ["ui", "workspace"]` ([docs](https://code.visualstudio.com/api/advanced-topics/extension-host#preferred-extension-location)) so the extension works on login nodes that block MatterViz from allocating memory.

closes #129