### PR TITLE
`show_site_indices` option for `Structure`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,6 +15,7 @@ export default [
       ],
       '@stylistic/quotes': [`error`, `backtick`, { avoidEscape: true }],
       'svelte/no-at-html-tags': `off`,
+      'svelte/no-navigation-without-resolve': `off`,
     },
   },
   {

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -36,7 +36,7 @@
         "command": "matterviz.render_structure",
         "key": "ctrl+shift+v",
         "mac": "cmd+shift+v",
-        "when": "matterviz.supported_resource"
+        "when": "matterviz.supported_resource && editorLangId != 'markdown'"
       }
     ],
     "menus": {
@@ -274,6 +274,11 @@
           "type": "boolean",
           "default": false,
           "description": "Show element labels on atoms"
+        },
+        "matterviz.structure.show_site_indices": {
+          "type": "boolean",
+          "default": false,
+          "description": "Show site index numbers on atoms"
         },
         "matterviz.structure.site_label_size": {
           "type": "number",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "matterviz",
+  "name": "matterviz-vscode",
   "displayName": "MatterViz",
   "description": "Visualize crystal structures and MD trajectories in VSCode",
   "version": "0.1.9",

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -492,6 +492,7 @@ function handle_file_change(
         data: updated_file,
         type: is_trajectory_file(filename) ? `trajectory` : `structure`,
         theme: get_theme(),
+        ...(meta || {}),
       })
     } catch (error) {
       console.error(`[MatterViz] Failed to read updated file ${file_path}:`, error)

--- a/src/fetch-elem-images.ts
+++ b/src/fetch-elem-images.ts
@@ -83,7 +83,8 @@ for (const { name, number } of elements) {
 
 // Process all downloads in parallel
 if (download_promises.length > 0) {
-  const results = await Promise.all(download_promises)
+  const settled = await Promise.allSettled(download_promises)
+  const results = settled.flatMap((r) => (r.status === `fulfilled` ? [r.value] : []))
 
   // Update image source file with all results
   const img_src_out = `./src/lib/element-image-urls.json`

--- a/src/lib/InfoCard.svelte
+++ b/src/lib/InfoCard.svelte
@@ -3,7 +3,8 @@
   import type { Snippet } from 'svelte'
   import type { HTMLAttributes } from 'svelte/elements'
 
-  interface Props extends HTMLAttributes<HTMLElementTagNameMap[`section`]> {
+  interface Props<T extends keyof HTMLElementTagNameMap = `section`>
+    extends HTMLAttributes<HTMLElementTagNameMap[T]> {
     data?: {
       title: string
       value?: string | number | number[] | null
@@ -15,7 +16,7 @@
     title?: string
     fallback?: string
     fmt?: string
-    as?: keyof HTMLElementTagNameMap
+    as?: T
     title_snippet?: Snippet
     fallback_snippet?: Snippet
   }

--- a/src/lib/SettingsSection.svelte
+++ b/src/lib/SettingsSection.svelte
@@ -82,7 +82,7 @@
   }
 </script>
 
-<h4>
+<h4 id="settings-section-title">
   {title}
 
   {#if has_changes}
@@ -97,7 +97,7 @@
     </button>
   {/if}
 </h4>
-<section {...rest}>
+<section {...rest} aria-labelledby="settings-section-title">
   {@render children()}
 </section>
 

--- a/src/lib/app.css
+++ b/src/lib/app.css
@@ -4,9 +4,6 @@
   --page-bg: #090019;
   --max-text-width: 50em;
 
-  --github-corner-color: var(--page-bg);
-  --github-corner-bg: var(--text-color);
-
   --sms-max-width: 20em;
   --sms-text-color: var(--text-color);
 }
@@ -45,8 +42,7 @@ a {
   text-decoration: none;
 }
 
-button,
-a.btn {
+button, a.btn {
   color: var(--text-color);
   cursor: pointer;
   border: none;
@@ -56,8 +52,7 @@ a.btn {
 a:hover {
   color: var(--accent-hover-color, orange);
 }
-code,
-kbd {
+code, kbd {
   overflow-wrap: break-word;
   padding: 1pt 3pt;
   border-radius: 3pt;

--- a/src/lib/element/BohrAtom.svelte
+++ b/src/lib/element/BohrAtom.svelte
@@ -65,7 +65,14 @@
   let viewBox = $derived(`-${size / 2}, -${size / 2}, ${size}, ${size}`)
 </script>
 
-<svg fill={base_fill} {viewBox} role="img" aria-label={name} {...rest}>
+<svg
+  fill={base_fill}
+  {viewBox}
+  role={name || symbol ? `img` : undefined}
+  aria-label={(name || symbol) || undefined}
+  aria-hidden={name || symbol ? undefined : `true`}
+  {...rest}
+>
   <!-- nucleus -->
   <circle class="nucleus" {..._nucleus_props}>
     {#if name}

--- a/src/lib/element/ElementHeading.svelte
+++ b/src/lib/element/ElementHeading.svelte
@@ -4,7 +4,6 @@
 
   interface Props extends HTMLAttributes<HTMLHeadingElement> {
     element: ChemicalElement
-    style?: string
   }
   let { element, ...rest }: Props = $props()
 </script>

--- a/src/lib/labels.ts
+++ b/src/lib/labels.ts
@@ -46,6 +46,26 @@ export const heatmap_labels: Partial<Record<string, keyof ChemicalElement>> = Ob
 // set default number format globally
 export const default_fmt: [string, string] = [`,.3~s`, `.3~g`]
 
+// Unicode glyphs for common fractions used by format_fractional()
+export const FRACTION_GLYPHS: ReadonlyArray<readonly [number, string]> = [
+  [0, `0`],
+  [1 / 12, `¹⁄₁₂`],
+  [1 / 8, `⅛`],
+  [1 / 6, `⅙`],
+  [1 / 5, `⅕`],
+  [1 / 4, `¼`],
+  [1 / 3, `⅓`],
+  [2 / 5, `⅖`],
+  [1 / 2, `½`],
+  [3 / 5, `⅗`],
+  [2 / 3, `⅔`],
+  [3 / 4, `¾`],
+  [4 / 5, `⁴⁄₅`],
+  [5 / 6, `⁵⁄₆`],
+  [7 / 8, `⁷⁄₈`],
+  [11 / 12, `¹¹⁄₁₂`],
+]
+
 // fmt as number only allowed to support [].map(format_num) without type error
 export const format_num = (num: number, fmt?: string | number) => {
   if (num === null) return ``
@@ -61,29 +81,11 @@ export function format_fractional(value: number): string {
   if (!Number.isFinite(value)) return String(value)
   const x = ((value % 1) + 1) % 1 // wrap into [0,1)
   const eps = 1e-3
-  const specials: [number, string][] = [
-    [0, `0`],
-    [1 / 12, `¹⁄₁₂`],
-    [1 / 8, `⅛`],
-    [1 / 6, `⅙`],
-    [1 / 5, `⅕`],
-    [1 / 4, `¼`],
-    [1 / 3, `⅓`],
-    [2 / 5, `⅖`],
-    [1 / 2, `½`],
-    [3 / 5, `⅗`],
-    [2 / 3, `⅔`],
-    [3 / 4, `¾`],
-    [4 / 5, `⁴⁄₅`],
-    [5 / 6, `⁵⁄₆`],
-    [7 / 8, `⁷⁄₈`],
-    [11 / 12, `¹¹⁄₁₂`],
-  ]
-  for (const [target, glyph] of specials) {
+  for (const [target, glyph] of FRACTION_GLYPHS) {
     if (target === 0) { if (Math.abs(x - target) <= eps) return glyph }
     else if (Math.abs(x - target) < eps) return glyph
   }
-  for (const [target, glyph] of specials) {
+  for (const [target, glyph] of FRACTION_GLYPHS) {
     if (target !== 0 && Math.abs((1 - x) - target) < eps) return glyph
   }
   return format_num(value, `.4~`)

--- a/src/lib/math.ts
+++ b/src/lib/math.ts
@@ -65,14 +65,13 @@ export function pbc_dist(
   const inv_matrix = lattice_inv ?? matrix_inverse_3x3(lattice_matrix)
 
   // Convert Cartesian coordinates to fractional coordinates
-  const frac1 = mat3x3_vec3_multiply(inv_matrix, pos1)
-  const frac2 = mat3x3_vec3_multiply(inv_matrix, pos2)
-
-  // Calculate fractional distance vector
-  const frac_diff = add(frac1, scale(frac2, -1))
+  const [fx1, fy1, fz1] = mat3x3_vec3_multiply(inv_matrix, pos1)
+  const [fx2, fy2, fz2] = mat3x3_vec3_multiply(inv_matrix, pos2)
 
   // Apply minimum image convention: wrap to [-0.5, 0.5)
-  const wrapped_frac_diff = frac_diff.map((x) => x - Math.round(x)) as Vec3
+  const wrapped_frac_diff = [fx1 - fx2, fy1 - fy2, fz1 - fz2].map((x) =>
+    x - Math.round(x)
+  ) as Vec3
 
   // Convert back to Cartesian coordinates
   const cart_diff = mat3x3_vec3_multiply(lattice_matrix, wrapped_frac_diff)
@@ -86,7 +85,9 @@ export function matrix_inverse_3x3(matrix: Matrix3x3): Matrix3x3 {
 
   const det = det_3x3(matrix)
 
-  if (Math.abs(det) < EPS) throw new Error(`Matrix is singular and cannot be inverted`)
+  if (!Number.isFinite(det) || Math.abs(det) < EPS) {
+    throw new Error(`Matrix is singular or ill-conditioned; cannot invert`)
+  }
 
   const inv_det = 1 / det
 

--- a/src/lib/periodic-table/TableInset.svelte
+++ b/src/lib/periodic-table/TableInset.svelte
@@ -9,12 +9,12 @@
   let { as = `aside`, children, ...rest }: Props = $props()
 </script>
 
-<svelte:element this={as} {...rest}>
+<svelte:element this={as} {...rest} class="table-inset {rest.class ?? ``}">
   {@render children?.()}
 </svelte:element>
 
 <style>
-  aside, div {
+  .table-inset {
     display: grid;
     box-sizing: border-box;
     grid-row: var(--ptable-inset-row, 1 / span 3);

--- a/src/lib/plot/ColorScaleSelect.svelte
+++ b/src/lib/plot/ColorScaleSelect.svelte
@@ -7,8 +7,8 @@
 
   interface Props extends Omit<ComponentProps<typeof Select>, `options`> {
     options?: D3InterpolateName[]
-    value?: string
-    selected?: string[]
+    value?: D3InterpolateName
+    selected?: D3InterpolateName[]
     minSelect?: number
     placeholder?: string
     colorbar?: ComponentProps<typeof ColorBar>
@@ -17,7 +17,7 @@
     options = Object.keys(d3_sc).filter((key) =>
       key.startsWith(`interpolate`)
     ) as D3InterpolateName[],
-    value = $bindable(`interpolateViridis`),
+    value = $bindable(options[0] as D3InterpolateName),
     selected = $bindable([]),
     minSelect = 0,
     placeholder = `Select a color scale`,

--- a/src/lib/plot/Histogram.svelte
+++ b/src/lib/plot/Histogram.svelte
@@ -176,7 +176,8 @@
 
   let histogram_data = $derived.by(() => {
     if (!selected_series.length || !width || !height) return []
-    const hist_generator = bin().domain([auto_ranges.x[0], auto_ranges.x[1]])
+    const hist_generator = bin()
+      .domain([ranges.current.x[0], ranges.current.x[1]])
       .thresholds(bins)
     return selected_series.map((series_data, series_idx) => {
       const bins_arr = hist_generator(series_data.y)
@@ -542,7 +543,7 @@
     height: var(--histogram-height, 100%);
     min-height: var(--histogram-min-height, 300px);
     container-type: size; /* enable cqh for panes if explicit height is set */
-    z-index: var(--histogram-z-index);
+    z-index: var(--histogram-z-index, auto);
   }
   svg {
     width: 100%;

--- a/src/lib/plot/data-transform.ts
+++ b/src/lib/plot/data-transform.ts
@@ -39,10 +39,12 @@ export function create_data_points(
 ): Point[] {
   return series
     .filter(filter_fn || ((s) => s.visible ?? true))
-    .flatMap(({ x: xs, y: ys }) => {
+    .flatMap(({ x: xs, y: ys }, series_idx) => {
       const length = Math.min(xs.length, ys.length)
       if (xs.length !== ys.length) {
-        console.warn(`length mismatch: x.length=${xs.length} vs y.length=${ys.length}`)
+        console.warn(
+          `length mismatch in series ${series_idx}: x.length=${xs.length} vs y.length=${ys.length}`,
+        )
       }
       return xs.slice(0, length).map((x, idx) => ({ x, y: ys[idx] }))
     })

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -262,7 +262,7 @@ export const SETTINGS_CONFIG: SettingsConfig = {
       description: `Show orientation gizmo in the corner of structure viewer`,
     },
     camera_position: {
-      value: [0, 0, 0],
+      value: [0, 0, 0] as const,
       description: `Initial camera position [x, y, z]`,
       minItems: 3,
       maxItems: 3,
@@ -318,7 +318,7 @@ export const SETTINGS_CONFIG: SettingsConfig = {
       maximum: 10,
     },
     rotation: {
-      value: [0, 0, 0],
+      value: [0, 0, 0] as const,
       description:
         `Manual rotation around X, Y, Z axes, displayed in degrees [0, 360] but normalized as radians to [-π, π] for each of [x, y, z]. Combines additively with auto-rotation when both are active.`,
       minItems: 3,
@@ -355,7 +355,7 @@ export const SETTINGS_CONFIG: SettingsConfig = {
       maximum: 20,
     },
     site_label_offset: {
-      value: [0, 0.5, 0],
+      value: [0, 0.5, 0] as const,
       description: `3D offset for atom labels [x, y, z]`,
       minItems: 3,
       maxItems: 3,
@@ -463,7 +463,7 @@ export const SETTINGS_CONFIG: SettingsConfig = {
       maximum: 60,
     },
     fps_range: {
-      value: [0.2, 30],
+      value: [0.2, 30] as const,
       description: `Allowed range for playback speed [min, max]`,
       minItems: 2,
       maxItems: 2,

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -56,6 +56,7 @@ export interface SettingsConfig {
 
     // Labels & Lighting
     show_site_labels: SettingType<boolean>
+    show_site_indices: SettingType<boolean>
     site_label_size: SettingType<number>
     site_label_color: SettingType<string>
     site_label_bg_color: SettingType<string>
@@ -328,6 +329,10 @@ export const SETTINGS_CONFIG: SettingsConfig = {
     show_site_labels: {
       value: false,
       description: `Show element labels on atoms`,
+    },
+    show_site_indices: {
+      value: false,
+      description: `Show site index numbers on atoms`,
     },
     site_label_size: {
       value: 1,

--- a/src/lib/structure/Lattice.svelte
+++ b/src/lib/structure/Lattice.svelte
@@ -138,7 +138,6 @@
     {/if}
 
     <!-- NOTE below is an untested fix for the lattice vectors being much too small when deployed even though they look correct in local dev -->
-
     {#if show_cell_vectors}
       <T.Group position={vector_origin}>
         {#each matrix as vec, idx (vec)}

--- a/src/lib/structure/Lattice.svelte
+++ b/src/lib/structure/Lattice.svelte
@@ -4,7 +4,7 @@
   import type { Vec3 } from '$lib/math'
   import * as math from '$lib/math'
   import { DEFAULTS } from '$lib/settings'
-  import { CanvasTooltip, type LatticeProps } from '$lib/structure'
+  import { CanvasTooltip } from '$lib/structure'
   import { T } from '@threlte/core'
   import {
     BoxGeometry,
@@ -15,6 +15,18 @@
     Vector3,
   } from 'three'
 
+  interface Props {
+    matrix?: math.Matrix3x3
+    cell_edge_color?: string
+    cell_surface_color?: string
+    cell_edge_width?: number // thickness of the cell edges
+    cell_edge_opacity?: number // opacity of the cell edges
+    cell_surface_opacity?: number // opacity of the cell surfaces
+    show_cell_vectors?: boolean // whether to show the lattice vectors
+    vector_colors?: readonly [string, string, string] // lattice vector colors
+    vector_origin?: Vec3 // lattice vector origin (all arrows start from this point)
+    float_fmt?: string
+  }
   let {
     matrix = undefined,
     cell_edge_color = DEFAULTS.structure.cell_edge_color,
@@ -26,7 +38,7 @@
     vector_colors = [`red`, `green`, `blue`],
     vector_origin = [-1, -1, -1] as Vec3,
     float_fmt = `.2f`,
-  }: LatticeProps = $props()
+  }: Props = $props()
 
   let hovered_idx = $state<number | null>(null) // track hovered vector
   let lattice_center = $derived(

--- a/src/lib/structure/StructureControls.svelte
+++ b/src/lib/structure/StructureControls.svelte
@@ -576,7 +576,7 @@
     </label>
   </SettingsSection>
 
-  {#if scene_props.show_site_labels}
+  {#if scene_props.show_site_labels || scene_props.show_site_indices}
     <hr />
     <SettingsSection
       title="Labels"

--- a/src/lib/structure/StructureControls.svelte
+++ b/src/lib/structure/StructureControls.svelte
@@ -225,6 +225,7 @@
       show_bonds: scene_props.show_bonds,
       show_image_atoms,
       show_site_labels: scene_props.show_site_labels,
+      show_site_indices: scene_props.show_site_indices,
       show_force_vectors: scene_props.show_force_vectors,
       show_cell_vectors: lattice_props.show_cell_vectors,
     }}
@@ -233,6 +234,7 @@
         show_atoms: DEFAULTS.structure.show_atoms,
         show_bonds: DEFAULTS.structure.show_bonds,
         show_site_labels: DEFAULTS.structure.show_site_labels,
+        show_site_indices: DEFAULTS.structure.show_site_indices,
         show_force_vectors: DEFAULTS.structure.show_force_vectors,
       })
       show_image_atoms = DEFAULTS.structure.show_image_atoms
@@ -261,6 +263,14 @@
     >
       <input type="checkbox" bind:checked={scene_props.show_site_labels} />
       Site Labels
+    </label>
+    <label
+      {@attach tooltip({
+        content: SETTINGS_CONFIG.structure.show_site_indices.description,
+      })}
+    >
+      <input type="checkbox" bind:checked={scene_props.show_site_indices} />
+      Site Indices
     </label>
     {#if has_forces}
       <label

--- a/src/lib/structure/StructureControls.svelte
+++ b/src/lib/structure/StructureControls.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import type { AnyStructure, LatticeProps } from '$lib'
-  import { DraggablePane, SettingsSection } from '$lib'
+  import type { AnyStructure } from '$lib'
+  import { DraggablePane, Lattice, SettingsSection } from '$lib'
   import type { ColorSchemeName } from '$lib/colors'
   import { axis_colors, element_color_schemes } from '$lib/colors'
   import { export_canvas_as_png } from '$lib/io/export'
@@ -21,7 +21,7 @@
     // Scene properties (bindable from parent)
     scene_props?: ComponentProps<typeof StructureScene>
     // Lattice properties (bindable from parent)
-    lattice_props?: LatticeProps
+    lattice_props?: ComponentProps<typeof Lattice>
     // Display options (bindable from parent)
     show_image_atoms?: boolean
     // Supercell options (bindable from parent)

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -602,11 +602,9 @@
         {@const color = entry.color}
         {#if site}
           {@const xyz = site.xyz}
-          {@const species = site.species}
-          {@const highlight_radius = atom_radius * (same_size_atoms
-          ? 1
-          : species.reduce((sum, spec) =>
-            sum + spec.occu * (atomic_radii[spec.element] ?? 1), 0))}
+          {@const highlight_radius = atom_data.find((atom) =>
+          atom.site_idx === entry.site_idx
+        )?.radius ?? atom_radius}
           <T.Mesh
             position={xyz}
             scale={1.2 * highlight_radius}
@@ -657,8 +655,10 @@
               idx
               ([element, occu, oxi_state])
             }
-              {@const oxi_str = oxi_state != null && oxi_state !== 0
-              ? `<sup>${oxi_state}${oxi_state > 0 ? `+` : `-`}</sup>`
+              {@const oxi_str = (oxi_state != null && oxi_state !== 0)
+              ? `<sup>${Math.abs(oxi_state)}${
+                oxi_state > 0 ? `+` : `−`
+              }</sup>`
               : ``}
               {@const element_name = element_data.find((elem) =>
               elem.symbol === element

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -238,7 +238,7 @@
     if (orbit_controls && camera_projection) {
       // Small delay to ensure camera switch is complete
       setTimeout(() => {
-        // Explicitly set the target to the rotation center
+        // Structure is positioned with rotation_target as the center
         orbit_controls.target.set(...rotation_target)
         orbit_controls.update()
       }, 10)
@@ -407,19 +407,47 @@
 <T.DirectionalLight position={[3, 10, 10]} intensity={directional_light} />
 <T.AmbientLight intensity={ambient_light} />
 
-<!-- Apply manual rotation to the entire structure -->
-<T.Group {rotation}>
-  {#if show_atoms}
-    <!-- Instanced rendering for full occupancy atoms -->
-    {#each instanced_atom_groups as group (group.element + group.radius)}
-      <Extras.InstancedMesh
-        key="{group.element}-{group.radius}-{group.atoms.length}"
-        range={group.atoms.length}
-      >
-        <T.SphereGeometry args={[0.5, sphere_segments, sphere_segments]} />
-        <T.MeshStandardMaterial color={group.color} />
-        {#each group.atoms as atom (atom.site_idx)}
-          <Extras.Instance
+<!-- Apply manual rotation around center: translate to origin, rotate, translate back -->
+<T.Group position={rotation_target}>
+  <T.Group {rotation}>
+    <T.Group position={math.scale(rotation_target, -1)}>
+      {#if show_atoms}
+        <!-- Instanced rendering for full occupancy atoms -->
+        {#each instanced_atom_groups as group (group.element + group.radius)}
+          <Extras.InstancedMesh
+            key="{group.element}-{group.radius}-{group.atoms.length}"
+            range={group.atoms.length}
+          >
+            <T.SphereGeometry args={[0.5, sphere_segments, sphere_segments]} />
+            <T.MeshStandardMaterial color={group.color} />
+            {#each group.atoms as atom (atom.site_idx)}
+              <Extras.Instance
+                position={atom.position}
+                scale={atom.radius}
+                onpointerenter={() => {
+                  hovered_idx = atom.site_idx
+                  active_tooltip = `atom`
+                  hovered_bond_data = null
+                }}
+                onpointerleave={() => {
+                  hovered_idx = null
+                  active_tooltip = null
+                }}
+                onclick={(event: MouseEvent) => {
+                  const site_idx = atom.site_idx
+                  toggle_selection(site_idx, event)
+                }}
+              />
+            {/each}
+          </Extras.InstancedMesh>
+        {/each}
+
+        <!-- Regular rendering for partial occupancy atoms -->
+        {#each atom_data.filter((atom) => atom.has_partial_occupancy) as
+          atom
+          (atom.site_idx + atom.element + atom.occupancy)
+        }
+          <T.Group
             position={atom.position}
             scale={atom.radius}
             onpointerenter={() => {
@@ -435,302 +463,289 @@
               const site_idx = atom.site_idx
               toggle_selection(site_idx, event)
             }}
+          >
+            <T.Mesh>
+              <T.SphereGeometry
+                args={[
+                  0.5,
+                  sphere_segments,
+                  sphere_segments,
+                  atom.start_phi,
+                  2 * Math.PI * atom.occupancy,
+                ]}
+              />
+              <T.MeshStandardMaterial color={atom.color} />
+            </T.Mesh>
+
+            {#if atom.has_partial_occupancy}
+              <T.Mesh rotation={[0, atom.start_phi, 0]}>
+                <T.CircleGeometry args={[0.5, sphere_segments]} />
+                <T.MeshStandardMaterial color={atom.color} side={2} />
+              </T.Mesh>
+              <T.Mesh rotation={[0, atom.end_phi, 0]}>
+                <T.CircleGeometry args={[0.5, sphere_segments]} />
+                <T.MeshStandardMaterial color={atom.color} side={2} />
+              </T.Mesh>
+            {/if}
+          </T.Group>
+
+          {#if show_site_labels}
+            {@render site_label_snippet(atom.element, atom.position, atom.site_idx)}
+          {/if}
+        {/each}
+
+        <!-- Site labels for instanced atoms -->
+        {#if show_site_labels}
+          {#each instanced_atom_groups as group (group.element + group.radius)}
+            {#each group.atoms as atom (atom.site_idx)}
+              {@render site_label_snippet(atom.element, atom.position, atom.site_idx)}
+            {/each}
+          {/each}
+        {/if}
+      {/if}
+
+      {#if force_data.length > 0}
+        {#each force_data as force (force.position.join(`,`) + force.vector.join(`,`))}
+          <Vector {...force} />
+        {/each}
+      {/if}
+
+      {#if bond_pairs.length > 0}
+        {#each bond_pairs as bond_data (JSON.stringify(bond_data))}
+          {@const site_a = structure?.sites[bond_data.site_idx_1]}
+          {@const site_b = structure?.sites[bond_data.site_idx_2]}
+          {@const get_majority_color = (site: typeof site_a) => {
+          if (!site?.species || site.species.length === 0) return bond_color
+          // Find species with highest occupancy
+          const majority_species = site.species.reduce((max, spec) =>
+            spec.occu > max.occu ? spec : max
+          )
+          return colors.element?.[majority_species.element] || bond_color
+        }}
+          {@const from_color = get_majority_color(site_a)}
+          {@const to_color = get_majority_color(site_b)}
+          <Bond
+            from={bond_data.pos_1}
+            to={bond_data.pos_2}
+            thickness={bond_thickness}
+            {from_color}
+            {to_color}
+            color={bond_color}
+            {bond_data}
+            {bonding_strategy}
+            {active_tooltip}
+            {hovered_bond_data}
+            onbondhover={(data) => hovered_bond_data = data}
+            ontooltipchange={(type) => active_tooltip = type}
           />
         {/each}
-      </Extras.InstancedMesh>
-    {/each}
+      {/if}
 
-    <!-- Regular rendering for partial occupancy atoms -->
-    {#each atom_data.filter((atom) => atom.has_partial_occupancy) as
-      atom
-      (atom.site_idx + atom.element + atom.occupancy)
-    }
-      <T.Group
-        position={atom.position}
-        scale={atom.radius}
-        onpointerenter={() => {
-          hovered_idx = atom.site_idx
-          active_tooltip = `atom`
-          hovered_bond_data = null
-        }}
-        onpointerleave={() => {
-          hovered_idx = null
-          active_tooltip = null
-        }}
-        onclick={(event: MouseEvent) => {
-          const site_idx = atom.site_idx
-          toggle_selection(site_idx, event)
-        }}
-      >
-        <T.Mesh>
-          <T.SphereGeometry
-            args={[
-              0.5,
-              sphere_segments,
-              sphere_segments,
-              atom.start_phi,
-              2 * Math.PI * atom.occupancy,
-            ]}
-          />
-          <T.MeshStandardMaterial color={atom.color} />
-        </T.Mesh>
-
-        {#if atom.has_partial_occupancy}
-          <T.Mesh rotation={[0, atom.start_phi, 0]}>
-            <T.CircleGeometry args={[0.5, sphere_segments]} />
-            <T.MeshStandardMaterial color={atom.color} side={2} />
-          </T.Mesh>
-          <T.Mesh rotation={[0, atom.end_phi, 0]}>
-            <T.CircleGeometry args={[0.5, sphere_segments]} />
-            <T.MeshStandardMaterial color={atom.color} side={2} />
+      <!-- highlight hovered, active and selected sites -->
+      {#each [
+          {
+            kind: `hover`,
+            site: hovered_site,
+            opacity: 0.28,
+            color: `white`,
+            site_idx: hovered_idx,
+          },
+          ...((selected_sites ?? []).map((idx) => ({
+            kind: `selected`,
+            site: structure?.sites?.[idx] ?? null,
+            site_idx: idx,
+            opacity: pulse_opacity,
+            color: selection_highlight_color,
+          }))),
+        ] as
+        entry
+        (`${entry.kind}-${entry.site_idx}`)
+      }
+        {@const site = entry.site}
+        {@const opacity = entry.opacity}
+        {@const color = entry.color}
+        {#if site}
+          {@const xyz = site.xyz}
+          {@const species = site.species}
+          {@const highlight_radius = atom_radius * (same_size_atoms
+          ? 1
+          : species.reduce((sum, spec) =>
+            sum + spec.occu * (atomic_radii[spec.element] ?? 1), 0))}
+          <T.Mesh
+            position={xyz}
+            scale={1.2 * highlight_radius}
+            onclick={(event: MouseEvent) => {
+              if (entry?.site_idx !== null && Number.isInteger(entry.site_idx)) {
+                toggle_selection(entry.site_idx, event)
+              }
+            }}
+          >
+            <T.SphereGeometry args={[0.5, 22, 22]} />
+            <T.MeshStandardMaterial
+              {color}
+              transparent
+              {opacity}
+              emissive={color}
+              emissiveIntensity={entry.kind === `selected` ? 0.5 : 0.2}
+              depthTest={false}
+              depthWrite={false}
+            />
           </T.Mesh>
         {/if}
-      </T.Group>
-
-      {#if show_site_labels}
-        {@render site_label_snippet(atom.element, atom.position, atom.site_idx)}
-      {/if}
-    {/each}
-
-    <!-- Site labels for instanced atoms -->
-    {#if show_site_labels}
-      {#each instanced_atom_groups as group (group.element + group.radius)}
-        {#each group.atoms as atom (atom.site_idx)}
-          {@render site_label_snippet(atom.element, atom.position, atom.site_idx)}
-        {/each}
       {/each}
-    {/if}
-  {/if}
 
-  {#if force_data.length > 0}
-    {#each force_data as force (force.position.join(`,`) + force.vector.join(`,`))}
-      <Vector {...force} />
-    {/each}
-  {/if}
-
-  {#if bond_pairs.length > 0}
-    {#each bond_pairs as bond_data (JSON.stringify(bond_data))}
-      {@const site_a = structure?.sites[bond_data.site_idx_1]}
-      {@const site_b = structure?.sites[bond_data.site_idx_2]}
-      {@const get_majority_color = (site: typeof site_a) => {
-      if (!site?.species || site.species.length === 0) return bond_color
-      // Find species with highest occupancy
-      const majority_species = site.species.reduce((max, spec) =>
-        spec.occu > max.occu ? spec : max
-      )
-      return colors.element?.[majority_species.element] || bond_color
-    }}
-      {@const from_color = get_majority_color(site_a)}
-      {@const to_color = get_majority_color(site_b)}
-      <Bond
-        from={bond_data.pos_1}
-        to={bond_data.pos_2}
-        thickness={bond_thickness}
-        {from_color}
-        {to_color}
-        color={bond_color}
-        {bond_data}
-        {bonding_strategy}
-        {active_tooltip}
-        {hovered_bond_data}
-        onbondhover={(data) => hovered_bond_data = data}
-        ontooltipchange={(type) => active_tooltip = type}
-      />
-    {/each}
-  {/if}
-
-  <!-- highlight hovered, active and selected sites -->
-  {#each [
-      {
-        kind: `hover`,
-        site: hovered_site,
-        opacity: 0.28,
-        color: `white`,
-        site_idx: hovered_idx,
-      },
-      ...((selected_sites ?? []).map((idx) => ({
-        kind: `selected`,
-        site: structure?.sites?.[idx] ?? null,
-        site_idx: idx,
-        opacity: pulse_opacity,
-        color: selection_highlight_color,
-      }))),
-    ] as
-    entry
-    (`${entry.kind}-${entry.site_idx}`)
-  }
-    {@const site = entry.site}
-    {@const opacity = entry.opacity}
-    {@const color = entry.color}
-    {#if site}
-      {@const xyz = site.xyz}
-      {@const species = site.species}
-      {@const highlight_radius = atom_radius * (same_size_atoms
-      ? 1
-      : species.reduce((sum, spec) =>
-        sum + spec.occu * (atomic_radii[spec.element] ?? 1), 0))}
-      <T.Mesh
-        position={xyz}
-        scale={1.2 * highlight_radius}
-        onclick={(event: MouseEvent) => {
-          if (entry?.site_idx !== null && Number.isInteger(entry.site_idx)) {
-            toggle_selection(entry.site_idx, event)
-          }
-        }}
-      >
-        <T.SphereGeometry args={[0.5, 22, 22]} />
-        <T.MeshStandardMaterial
-          {color}
-          transparent
-          {opacity}
-          emissive={color}
-          emissiveIntensity={entry.kind === `selected` ? 0.5 : 0.2}
-          depthTest={false}
-          depthWrite={false}
-        />
-      </T.Mesh>
-    {/if}
-  {/each}
-
-  <!-- selection order labels (1, 2, 3, ...) for measured sites -->
-  {#if structure?.sites && (measured_sites?.length ?? 0) > 0}
-    {#each measured_sites as site_index, loop_idx (site_index)}
-      {@const site = structure.sites[site_index]}
-      {#if site}
-        {@const pos = math.add(site.xyz, site_label_offset)}
-        <Extras.HTML center position={pos}>
-          <span class="selection-label">{loop_idx + 1}</span>
-        </Extras.HTML>
+      <!-- selection order labels (1, 2, 3, ...) for measured sites -->
+      {#if structure?.sites && (measured_sites?.length ?? 0) > 0}
+        {#each measured_sites as site_index, loop_idx (site_index)}
+          {@const site = structure.sites[site_index]}
+          {#if site}
+            {@const pos = math.add(site.xyz, site_label_offset)}
+            <Extras.HTML center position={pos}>
+              <span class="selection-label">{loop_idx + 1}</span>
+            </Extras.HTML>
+          {/if}
+        {/each}
       {/if}
-    {/each}
-  {/if}
 
-  <!-- hovered site tooltip -->
-  {#if hovered_site && !camera_is_moving && active_tooltip === `atom`}
-    <CanvasTooltip position={hovered_site.xyz}>
-      <!-- Element symbols with occupancies for disordered sites -->
-      <div class="elements">
-        {#each hovered_site.species ?? [] as
-          { element, occu, oxidation_state: oxi_state },
-          idx
-          ([element, occu, oxi_state])
-        }
-          {@const oxi_str = oxi_state != null && oxi_state !== 0
-          ? `<sup>${oxi_state}${oxi_state > 0 ? `+` : `-`}</sup>`
-          : ``}
-          {@const element_name = element_data.find((elem) =>
-          elem.symbol === element
-        )?.name ??
-          ``}
-          {#if idx > 0}&thinsp;{/if}
-          {#if occu !== 1}<span class="occupancy">{format_num(occu, `.3~f`)}</span>{/if}
-          <strong>{element}{@html oxi_str}</strong>
-          {#if element_name}<span class="elem-name">{element_name}</span>{/if}
-        {/each}
-      </div>
-      <div class="coordinates fractional">
-        abc: ({hovered_site.abc.map((num) => format_num(num, float_fmt)).join(`, `)})
-      </div>
-      <div class="coordinates cartesian">
-        xyz: ({hovered_site.xyz.map((num) => format_num(num, float_fmt)).join(`, `)}) Å
-      </div>
-    </CanvasTooltip>
-  {/if}
+      <!-- hovered site tooltip -->
+      {#if hovered_site && !camera_is_moving && active_tooltip === `atom`}
+        {@const abc = hovered_site.abc.map((x) => format_num(x, float_fmt)).join(`, `)}
+        {@const xyz = hovered_site.xyz.map((x) => format_num(x, float_fmt)).join(`, `)}
+        <CanvasTooltip position={hovered_site.xyz}>
+          <!-- Element symbols with occupancies for disordered sites -->
+          <div class="elements">
+            {#each hovered_site.species ?? [] as
+              { element, occu, oxidation_state: oxi_state },
+              idx
+              ([element, occu, oxi_state])
+            }
+              {@const oxi_str = oxi_state != null && oxi_state !== 0
+              ? `<sup>${oxi_state}${oxi_state > 0 ? `+` : `-`}</sup>`
+              : ``}
+              {@const element_name = element_data.find((elem) =>
+              elem.symbol === element
+            )?.name ??
+              ``}
+              {#if idx > 0}&thinsp;{/if}
+              {#if occu !== 1}<span class="occupancy">{
+                  format_num(occu, `.3~f`)
+                }</span>{/if}
+              <strong>{element}{@html oxi_str}</strong>
+              {#if element_name}<span class="elem-name">{element_name}</span>{/if}
+            {/each}
+          </div>
+          <div class="coordinates fractional">abc: ({abc})</div>
+          <div class="coordinates cartesian">xyz: ({xyz}) Å</div>
+        </CanvasTooltip>
+      {/if}
 
-  {#if lattice}
-    <Lattice matrix={lattice.matrix} {...lattice_props} />
-  {/if}
+      {#if lattice}
+        <Lattice matrix={lattice.matrix} {...lattice_props} />
+      {/if}
 
-  <!-- Measurement overlays for measured sites -->
-  {#if structure?.sites && (measured_sites?.length ?? 0) > 0}
-    {#if measure_mode === `distance`}
-      {#each measured_sites as idx_i, loop_idx (idx_i)}
-        {#each measured_sites.slice(loop_idx + 1) as idx_j (idx_i + `-` + idx_j)}
-          {@const site_i = structure.sites[idx_i]}
-          {@const site_j = structure.sites[idx_j]}
-          {@const pos_i = site_i.xyz}
-          {@const pos_j = site_j.xyz}
-          <Bond from={pos_i} to={pos_j} thickness={0.06} color="#cccccc" />
-          {@const midpoint = [
-      (pos_i[0] + pos_j[0]) / 2,
-      (pos_i[1] + pos_j[1]) / 2,
-      (pos_i[2] + pos_j[2]) / 2,
-    ] as Vec3}
-          {@const direct = math.euclidean_dist(pos_i, pos_j)}
-          {@const pbc = lattice ? distance_pbc(pos_i, pos_j, lattice.matrix) : direct}
-          {@const differ = lattice ? Math.abs(pbc - direct) > 1e-6 : false}
-          <Extras.HTML center position={midpoint}>
-            <span class="measure-label">
-              {#if differ}
-                PBC: {format_num(pbc, float_fmt)} Å<br /><small>
-                  Direct: {format_num(direct, float_fmt)} Å</small>
-              {:else}
-                {format_num(pbc, float_fmt)} Å
-              {/if}
-            </span>
-          </Extras.HTML>
-        {/each}
-      {/each}
-    {:else if measure_mode === `angle` && measured_sites.length >= 3}
-      {#each measured_sites as idx_center (idx_center)}
-        {@const center = structure.sites[idx_center]}
-        {#each measured_sites.filter((x) => x !== idx_center) as
-          idx_a,
-          loop_idx
-          (idx_center + `-` + idx_a)
-        }
-          {#each measured_sites.filter((x) => x !== idx_center).slice(loop_idx + 1) as
-            idx_b
-            (idx_center + `-` + idx_a + `-` + idx_b)
-          }
-            {@const site_a = structure.sites[idx_a]}
-            {@const site_b = structure.sites[idx_b]}
-            {@const [v1, v2] = smart_displacement_vectors(
-      center.xyz,
-      site_a.xyz,
-      site_b.xyz,
-      lattice?.matrix,
-      center.abc,
-      site_a.abc,
-      site_b.abc,
-    )}
-            {@const n1 = Math.hypot(v1[0], v1[1], v1[2])}
-            {@const n2 = Math.hypot(v2[0], v2[1], v2[2])}
-            {@const angle_deg = angle_between_vectors(v1, v2, `degrees`)}
-            {#if n1 > math.EPS && n2 > math.EPS}
-              <!-- draw rays from center to the two sites -->
-              <Bond from={center.xyz} to={site_a.xyz} thickness={0.05} color="#bbbbbb" />
-              <Bond from={center.xyz} to={site_b.xyz} thickness={0.05} color="#bbbbbb" />
-              {@const bisector = [
-      v1[0] / n1 + v2[0] / n2,
-      v1[1] / n1 + v2[1] / n2,
-      v1[2] / n1 + v2[2] / n2,
-    ] as Vec3}
-              {@const bis_norm = Math.sqrt(bisector[0] ** 2 + bisector[1] ** 2 + bisector[2] ** 2) ||
-      1}
-              {@const offset_dir = [
-      bisector[0] / bis_norm,
-      bisector[1] / bis_norm,
-      bisector[2] / bis_norm,
-    ] as Vec3}
-              {@const label_pos = [
-      center.xyz[0] + offset_dir[0] * 0.6,
-      center.xyz[1] + offset_dir[1] * 0.6,
-      center.xyz[2] + offset_dir[2] * 0.6,
-    ] as Vec3}
-              <Extras.HTML center position={label_pos}>
-                <span class="measure-label">{format_num(angle_deg, float_fmt)}°</span>
+      <!-- Measurement overlays for measured sites -->
+      {#if structure?.sites && (measured_sites?.length ?? 0) > 0}
+        {#if measure_mode === `distance`}
+          {#each measured_sites as idx_i, loop_idx (idx_i)}
+            {#each measured_sites.slice(loop_idx + 1) as idx_j (idx_i + `-` + idx_j)}
+              {@const site_i = structure.sites[idx_i]}
+              {@const site_j = structure.sites[idx_j]}
+              {@const pos_i = site_i.xyz}
+              {@const pos_j = site_j.xyz}
+              <Bond from={pos_i} to={pos_j} thickness={0.06} color="#cccccc" />
+              {@const midpoint = [
+          (pos_i[0] + pos_j[0]) / 2,
+          (pos_i[1] + pos_j[1]) / 2,
+          (pos_i[2] + pos_j[2]) / 2,
+        ] as Vec3}
+              {@const direct = math.euclidean_dist(pos_i, pos_j)}
+              {@const pbc = lattice ? distance_pbc(pos_i, pos_j, lattice.matrix) : direct}
+              {@const differ = lattice ? Math.abs(pbc - direct) > 1e-6 : false}
+              <Extras.HTML center position={midpoint}>
+                <span class="measure-label">
+                  {#if differ}
+                    PBC: {format_num(pbc, float_fmt)} Å<br /><small>
+                      Direct: {format_num(direct, float_fmt)} Å</small>
+                  {:else}
+                    {format_num(pbc, float_fmt)} Å
+                  {/if}
+                </span>
               </Extras.HTML>
-            {/if}
+            {/each}
           {/each}
-        {/each}
-      {/each}
-    {/if}
-  {/if}
+        {:else if measure_mode === `angle` && measured_sites.length >= 3}
+          {#each measured_sites as idx_center (idx_center)}
+            {@const center = structure.sites[idx_center]}
+            {#each measured_sites.filter((x) => x !== idx_center) as
+              idx_a,
+              loop_idx
+              (idx_center + `-` + idx_a)
+            }
+              {#each measured_sites.filter((x) => x !== idx_center).slice(loop_idx + 1) as
+                idx_b
+                (idx_center + `-` + idx_a + `-` + idx_b)
+              }
+                {@const site_a = structure.sites[idx_a]}
+                {@const site_b = structure.sites[idx_b]}
+                {@const [v1, v2] = smart_displacement_vectors(
+          center.xyz,
+          site_a.xyz,
+          site_b.xyz,
+          lattice?.matrix,
+          center.abc,
+          site_a.abc,
+          site_b.abc,
+        )}
+                {@const n1 = Math.hypot(v1[0], v1[1], v1[2])}
+                {@const n2 = Math.hypot(v2[0], v2[1], v2[2])}
+                {@const angle_deg = angle_between_vectors(v1, v2, `degrees`)}
+                {#if n1 > math.EPS && n2 > math.EPS}
+                  <!-- draw rays from center to the two sites -->
+                  <Bond
+                    from={center.xyz}
+                    to={site_a.xyz}
+                    thickness={0.05}
+                    color="#bbbbbb"
+                  />
+                  <Bond
+                    from={center.xyz}
+                    to={site_b.xyz}
+                    thickness={0.05}
+                    color="#bbbbbb"
+                  />
+                  {@const bisector = [
+          v1[0] / n1 + v2[0] / n2,
+          v1[1] / n1 + v2[1] / n2,
+          v1[2] / n1 + v2[2] / n2,
+        ] as Vec3}
+                  {@const bis_norm =
+          Math.sqrt(bisector[0] ** 2 + bisector[1] ** 2 + bisector[2] ** 2) ||
+          1}
+                  {@const offset_dir = [
+          bisector[0] / bis_norm,
+          bisector[1] / bis_norm,
+          bisector[2] / bis_norm,
+        ] as Vec3}
+                  {@const label_pos = [
+          center.xyz[0] + offset_dir[0] * 0.6,
+          center.xyz[1] + offset_dir[1] * 0.6,
+          center.xyz[2] + offset_dir[2] * 0.6,
+        ] as Vec3}
+                  <Extras.HTML center position={label_pos}>
+                    <span class="measure-label">{format_num(angle_deg, float_fmt)}°</span>
+                  </Extras.HTML>
+                {/if}
+              {/each}
+            {/each}
+          {/each}
+        {/if}
+      {/if}
+    </T.Group>
+  </T.Group>
 </T.Group>
 
 <style>
-  :global(.responsive-gizmo) {
+  :global(.structure .responsive-gizmo) {
     width: clamp(70px, 18cqmin, 100px) !important;
     height: clamp(70px, 18cqmin, 100px) !important;
   }

--- a/src/lib/structure/index.ts
+++ b/src/lib/structure/index.ts
@@ -189,16 +189,3 @@ export interface StructureHandlerData {
   scene_props?: ComponentProps<typeof StructureScene>
   lattice_props?: ComponentProps<typeof Lattice>
 }
-
-export interface LatticeProps {
-  matrix?: Matrix3x3
-  cell_edge_color?: string
-  cell_surface_color?: string
-  cell_edge_width?: number // thickness of the cell edges
-  cell_edge_opacity?: number // opacity of the cell edges
-  cell_surface_opacity?: number // opacity of the cell surfaces
-  show_cell_vectors?: boolean // whether to show the lattice vectors
-  vector_colors?: readonly [string, string, string] // lattice vector colors
-  vector_origin?: Vec3 // lattice vector origin (all arrows start from this point)
-  float_fmt?: string
-}

--- a/src/lib/structure/parse.ts
+++ b/src/lib/structure/parse.ts
@@ -128,7 +128,7 @@ export function parse_poscar(content: string): ParsedStructure | null {
     }
 
     // Parse lattice vectors (lines 3-5)
-    const parse_vector = (line: string, line_num: number) => {
+    const parse_vector = (line: string, line_num: number): Vec3 => {
       const coords = line.trim().split(/\s+/).map(parse_coordinate)
       if (coords.length !== 3) {
         throw `Invalid lattice vector on line ${line_num}: expected 3 coordinates, got ${coords.length}`
@@ -149,11 +149,11 @@ export function parse_poscar(content: string): ParsedStructure | null {
     }
 
     // Scale lattice vectors
-    const scaled_lattice = [
-      lattice_vecs[0].map((x) => x * scale_factor),
-      lattice_vecs[1].map((x) => x * scale_factor),
-      lattice_vecs[2].map((x) => x * scale_factor),
-    ] as Matrix3x3
+    const scaled_lattice: Matrix3x3 = [
+      math.scale(lattice_vecs[0], scale_factor),
+      math.scale(lattice_vecs[1], scale_factor),
+      math.scale(lattice_vecs[2], scale_factor),
+    ]
 
     // Parse element symbols and atom counts (may span multiple lines)
     let line_index = 5

--- a/src/lib/structure/pbc.ts
+++ b/src/lib/structure/pbc.ts
@@ -33,6 +33,10 @@ export function find_image_atoms(
   )
   const displacement_eps_sq = (Number.EPSILON * lattice_norm) ** 2
 
+  // Note: tolerance (default 0.05) determines boundary detection for image generation,
+  // while FRACTIONAL_EPS (1e-9) nudges image placement slightly inside cell boundaries
+  // to avoid wrap inconsistencies. These serve different purposes, not to be conflated.
+
   for (const [idx, site] of structure.sites.entries()) {
     // Find edge dimensions and translation directions
     const edge_dims: { dim: number; direction: number }[] = []

--- a/src/lib/trajectory/plotting.ts
+++ b/src/lib/trajectory/plotting.ts
@@ -11,6 +11,8 @@ const ENERGY_PROPERTIES = [`energy`, `total_energy`, `potential_energy`]
 const FORCE_PROPERTIES = [`force`, `fmax`, `f`]
 const DEFAULT_VISIBLE = new Set([`energy`, `force_max`, `stress_frobenius`])
 
+type VisibleProp = Readonly<{ property: string; unit: string }>
+
 export interface PlotSeriesOptions {
   property_config?: Record<string, { label: string; unit: string }>
   colors?: readonly string[]
@@ -485,7 +487,7 @@ export function generate_streaming_plot_series(
   })
 
   const all_series: DataSeries[] = []
-  const visible_props: { property: string; unit: string }[] = []
+  const visible_props: VisibleProp[] = []
   let color_idx = 0
 
   for (const property_key of all_properties) {
@@ -555,7 +557,7 @@ function has_significant_variation(values: number[], tolerance = 1e-6): boolean 
 function determine_axis_from_groups(
   property: string,
   unit: string,
-  visible_properties: { property: string; unit: string }[],
+  visible_properties: VisibleProp[],
 ): `y1` | `y2` {
   const mock_series = visible_properties.map(({ property: prop, unit: u }) => ({
     label: prop,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -50,10 +50,10 @@
     <code
       {@attach tooltip()}
       title="For use in JavaScript/TypeScript/NodeJS."
-      style="display: inline-flex; gap: 4pt"
+      style="display: inline-flex; gap: 4pt; line-height: 1.3"
     >
       <a href="https://www.npmjs.com/package/matterviz">
-        <Icon icon="NPM" style="transform: scale(2.4); padding-inline: 8pt" />
+        <Icon icon="NPM" style="transform: scale(2.4); padding-inline: 12pt" />
       </a>
       install matterviz
       <CopyButton content="npm install matterviz" style="background: transparent" />

--- a/src/routes/test/structure/+page.svelte
+++ b/src/routes/test/structure/+page.svelte
@@ -92,6 +92,16 @@
       const mode = url_params.get(`performance_mode`)
       if (mode === `speed` || mode === `quality`) performance_mode = mode
     }
+
+    // Site labeling parameters
+    if (url_params.has(`show_site_labels`)) {
+      const param = url_params.get(`show_site_labels`)
+      scene_props.show_site_labels = param === `true`
+    }
+    if (url_params.has(`show_site_indices`)) {
+      const param = url_params.get(`show_site_indices`)
+      scene_props.show_site_indices = param === `true`
+    }
   })
 
   $effect(() => { // Listen for custom events from tests

--- a/src/routes/test/structure/+page.svelte
+++ b/src/routes/test/structure/+page.svelte
@@ -53,7 +53,7 @@
     if (url_params.has(`camera_projection`)) {
       const cam_projection = url_params.get(`camera_projection`)
       if (cam_projection === `perspective` || cam_projection === `orthographic`) {
-        scene_props = { ...scene_props, camera_projection: cam_projection }
+        scene_props.camera_projection = cam_projection
       }
     }
 

--- a/src/site/plot-utils.ts
+++ b/src/site/plot-utils.ts
@@ -141,7 +141,7 @@ export function generate_scientific_data(count: number): number[] {
 // Weighted choice function for discrete distributions
 export function weighted_choice(weights: number[]): number {
   const total_weight = weights.reduce((sum, weight) => {
-    if (!Number.isFinite(weight) || weight < 0) throw new Error(`invalid weights`)
+    if (!Number.isFinite(weight) || weight < 0) throw new RangeError(`invalid weights`)
     return sum + weight
   }, 0)
   if (weights.length === 0 || total_weight <= 0) throw new Error(`invalid weights`)

--- a/tests/playwright/structure-scene.test.ts
+++ b/tests/playwright/structure-scene.test.ts
@@ -435,6 +435,109 @@ test.describe(`StructureScene Component Tests`, () => {
     expect(console_errors).toHaveLength(0)
   })
 
+  // Site labeling functionality tests
+  test(`site labels display correctly for ordered and disordered sites`, async ({ page }) => {
+    const canvas = page.locator(`#test-structure canvas`)
+    const console_errors = setup_console_monitoring(page)
+
+    // Enable site labels via URL parameter for easier testing
+    await page.goto(`/test/structure?show_site_labels=true`, { waitUntil: `networkidle` })
+    await canvas.waitFor({ state: `visible`, timeout: 5000 })
+
+    // Take screenshot to verify labels are rendered
+    const labeled_screenshot = await canvas.screenshot()
+    expect(labeled_screenshot.length).toBeGreaterThan(1000)
+
+    // No console errors during label rendering
+    expect(console_errors).toHaveLength(0)
+  })
+
+  test(`site indices display correctly and start from 1`, async ({ page }) => {
+    const canvas = page.locator(`#test-structure canvas`)
+    const console_errors = setup_console_monitoring(page)
+
+    // Enable site indices via URL parameter
+    await page.goto(`/test/structure?show_site_indices=true`, {
+      waitUntil: `networkidle`,
+    })
+    await canvas.waitFor({ state: `visible`, timeout: 5000 })
+
+    // Take screenshot to verify indices are rendered
+    const indexed_screenshot = await canvas.screenshot()
+    expect(indexed_screenshot.length).toBeGreaterThan(1000)
+
+    // No console errors during index rendering
+    expect(console_errors).toHaveLength(0)
+  })
+
+  test(`combined site labels and indices display correctly`, async ({ page }) => {
+    const canvas = page.locator(`#test-structure canvas`)
+    const console_errors = setup_console_monitoring(page)
+
+    // Enable both site labels and indices via URL parameters
+    await page.goto(`/test/structure?show_site_labels=true&show_site_indices=true`, {
+      waitUntil: `networkidle`,
+    })
+    await canvas.waitFor({ state: `visible`, timeout: 5000 })
+
+    // Take screenshot to verify combined labels are rendered
+    const combined_screenshot = await canvas.screenshot()
+    expect(combined_screenshot.length).toBeGreaterThan(1000)
+
+    // No console errors during combined label rendering
+    expect(console_errors).toHaveLength(0)
+  })
+
+  test(`disordered sites show combined element-occupancy format without overlapping labels`, async ({ page }) => {
+    const canvas = page.locator(`#test-structure canvas`)
+    const console_errors = setup_console_monitoring(page)
+
+    // Enable site labels to test disordered site formatting
+    await page.goto(`/test/structure?show_site_labels=true`, { waitUntil: `networkidle` })
+    await canvas.waitFor({ state: `visible`, timeout: 5000 })
+
+    // Look for sites with partial occupancy by searching positions
+    const positions = [
+      { x: 200, y: 200 },
+      { x: 300, y: 250 },
+      { x: 400, y: 200 },
+      { x: 250, y: 300 },
+      { x: 350, y: 150 },
+    ]
+
+    for (const position of positions) {
+      await safe_canvas_hover(page, canvas, position)
+
+      const tooltip = page.locator(`.tooltip:has(.coordinates)`)
+      try {
+        await tooltip.waitFor({ state: `visible`, timeout: 500 })
+
+        // Check for occupancy indicators (partial occupancy sites)
+        const occupancy_spans = tooltip.locator(`.occupancy`)
+        const occupancy_count = await occupancy_spans.count()
+
+        if (occupancy_count > 0) {
+          // Found a disordered site, verify format
+          for (let idx = 0; idx < occupancy_count; idx++) {
+            const occupancy_text = await occupancy_spans.nth(idx).textContent()
+            expect(occupancy_text).toMatch(/^0\.\d*[1-9]$|^1$/) // Valid occupancy format
+          }
+          break
+        }
+      } catch {
+        // Continue to next position if tooltip doesn't appear
+        continue
+      }
+    }
+
+    // Take screenshot regardless of whether we found disordered sites
+    const screenshot = await canvas.screenshot()
+    expect(screenshot.length).toBeGreaterThan(1000)
+
+    // No console errors during disordered site rendering
+    expect(console_errors).toHaveLength(0)
+  })
+
   // Structure stability test
   test(`maintains structural stability over time`, async ({ page }) => {
     const canvas = page.locator(`#test-structure canvas`)

--- a/tests/playwright/structure-scene.test.ts
+++ b/tests/playwright/structure-scene.test.ts
@@ -42,14 +42,16 @@ async function safe_canvas_hover(
 async function find_hoverable_atom(page: Page): Promise<XyObj | null> {
   const canvas = page.locator(`#test-structure canvas`)
 
-  // Use cached position if available
-  if (cached_atom_position) {
-    await safe_canvas_hover(page, canvas, cached_atom_position)
-    const structure_tooltip = page.locator(`.tooltip:has(.coordinates)`)
-    await structure_tooltip.waitFor({ state: `visible`, timeout: 300 })
-    return cached_atom_position
+  if (cached_atom_position) { // Use cached position if available
+    try {
+      await safe_canvas_hover(page, canvas, cached_atom_position)
+      const structure_tooltip = page.locator(`.tooltip:has(.coordinates)`)
+      await structure_tooltip.waitFor({ state: `visible`, timeout: 300 })
+      return cached_atom_position
+    } catch {
+      cached_atom_position = null // fall through to probing positions below
+    }
   }
-
   const positions = [
     { x: 300, y: 200 },
     { x: 250, y: 150 },
@@ -506,7 +508,7 @@ test.describe(`StructureScene Component Tests`, () => {
     expect(texts.some((t) => /[A-Z][a-z]?\s*-\s*\d+/.test(t))).toBe(true)
   })
 
-  test(`disordered sites show combined element-occupancy format without overlapping labels`, async ({ page }) => {
+  test(`disordered sites show combined element-occupancy format`, async ({ page }) => {
     const canvas = page.locator(`#test-structure canvas`)
     const console_errors = setup_console_monitoring(page)
 

--- a/tests/playwright/structure.test.ts
+++ b/tests/playwright/structure.test.ts
@@ -335,13 +335,25 @@ test.describe(`Structure Component Tests`, () => {
     expect(await site_labels_checkbox.isChecked()).toBe(true)
     expect(await site_indices_checkbox.isChecked()).toBe(true)
 
+    // Verify Labels section is visible when site labels are enabled
+    await expect(control_pane.locator(`h4:has-text("Labels")`)).toBeVisible()
+
     // Disable one at a time to test independence
     await site_labels_checkbox.uncheck()
     expect(await site_labels_checkbox.isChecked()).toBe(false)
     expect(await site_indices_checkbox.isChecked()).toBe(true)
 
+    // Labels section should remain visible when Site Indices is still enabled (either labels OR indices show label controls)
+    await expect(control_pane.locator(`h4:has-text("Labels")`)).toBeVisible()
+
+    // Disable both - Labels section should hide when neither is enabled
     await site_indices_checkbox.uncheck()
     expect(await site_indices_checkbox.isChecked()).toBe(false)
+    await expect(control_pane.locator(`h4:has-text("Labels")`)).not.toBeVisible()
+
+    // Re-enable site indices only - Label controls section should appear again
+    await site_indices_checkbox.check()
+    await expect(control_pane.locator(`h4:has-text("Labels")`)).toBeVisible()
   })
 
   test(`label controls appear when site labels are enabled`, async ({ page }) => {
@@ -2945,6 +2957,10 @@ test.describe(`Camera Projection Toggle Tests`, () => {
 
       // Reset button should disappear
       await expect(labels_reset).not.toBeVisible()
+
+      // check that Labels control section hides after disabling labels
+      await show_labels_checkbox.uncheck()
+      await expect(page.locator(`h4:has-text("Labels")`)).not.toBeVisible()
     })
 
     test(`multiple sections can have reset buttons simultaneously`, async ({ page }) => {

--- a/tests/playwright/structure.test.ts
+++ b/tests/playwright/structure.test.ts
@@ -273,6 +273,77 @@ test.describe(`Structure Component Tests`, () => {
     expect(await site_labels_checkbox.count()).toBe(1)
   })
 
+  test(`show_site_indices can be toggled`, async ({ page }) => {
+    // Use helper function to reliably open controls pane
+    const { pane_div: control_pane } = await open_structure_control_pane(page)
+
+    const site_indices_label = control_pane.locator(`label:has-text("Site Indices")`)
+    const site_indices_checkbox = site_indices_label.locator(`input[type="checkbox"]`)
+
+    await expect(site_indices_label).toBeVisible()
+
+    // Get initial state (could be true or false depending on settings)
+    const initial_state = await site_indices_checkbox.isChecked()
+
+    // Toggle to opposite state
+    if (initial_state) {
+      await site_indices_checkbox.uncheck()
+      expect(await site_indices_checkbox.isChecked()).toBe(false)
+      await site_indices_checkbox.check()
+      expect(await site_indices_checkbox.isChecked()).toBe(true)
+    } else {
+      await site_indices_checkbox.check()
+      expect(await site_indices_checkbox.isChecked()).toBe(true)
+      await site_indices_checkbox.uncheck()
+      expect(await site_indices_checkbox.isChecked()).toBe(false)
+    }
+  })
+
+  test(`show_site_indices controls are properly labeled`, async ({ page }) => {
+    // Use helper function to reliably open controls pane
+    const { pane_div } = await open_structure_control_pane(page)
+
+    const site_indices_label = pane_div.locator(
+      `label:has-text("Site Indices")`,
+    )
+    const site_indices_checkbox = site_indices_label.locator(
+      `input[type="checkbox"]`,
+    )
+
+    await expect(site_indices_label).toBeVisible()
+    await expect(site_indices_checkbox).toBeVisible()
+    expect(await site_indices_label.count()).toBe(1)
+    expect(await site_indices_checkbox.count()).toBe(1)
+  })
+
+  test(`both site labels and site indices can be enabled simultaneously`, async ({ page }) => {
+    // Use helper function to reliably open controls pane
+    const { pane_div: control_pane } = await open_structure_control_pane(page)
+
+    const site_labels_checkbox = control_pane.locator(
+      `label:has-text("Site Labels") input[type="checkbox"]`,
+    )
+    const site_indices_checkbox = control_pane.locator(
+      `label:has-text("Site Indices") input[type="checkbox"]`,
+    )
+
+    // Enable both
+    await site_labels_checkbox.check()
+    await site_indices_checkbox.check()
+
+    // Verify both are enabled
+    expect(await site_labels_checkbox.isChecked()).toBe(true)
+    expect(await site_indices_checkbox.isChecked()).toBe(true)
+
+    // Disable one at a time to test independence
+    await site_labels_checkbox.uncheck()
+    expect(await site_labels_checkbox.isChecked()).toBe(false)
+    expect(await site_indices_checkbox.isChecked()).toBe(true)
+
+    await site_indices_checkbox.uncheck()
+    expect(await site_indices_checkbox.isChecked()).toBe(false)
+  })
+
   test(`label controls appear when site labels are enabled`, async ({ page }) => {
     // Use helper function to reliably open controls pane
     const { pane_div } = await open_structure_control_pane(page)
@@ -2844,24 +2915,26 @@ test.describe(`Camera Projection Toggle Tests`, () => {
 
     test(`labels section reset button appears when labels are shown`, async ({ page }) => {
       // Enable site labels first
-      const show_labels_checkbox = page.locator(`text=Site Labels`).locator(`..`).locator(
-        `input[type="checkbox"]`,
+      const show_labels_checkbox = page.locator(
+        `label:has-text("Site Labels") input[type="checkbox"]`,
       )
       await show_labels_checkbox.check()
 
       // Wait for labels section to appear
-      await expect(page.locator(`text=Labels`)).toBeVisible()
+      await expect(page.locator(`h4:has-text("Labels")`)).toBeVisible()
 
       // Change label size
-      const size_range = page.locator(`text=Size`).locator(`..`).locator(
-        `input[type="range"]`,
+      const size_range = page.locator(`h4:has-text("Labels")`).locator(
+        `xpath=following-sibling::*[1]`,
+      ).locator(
+        `label:has-text("Size") input[type="range"]`,
       )
       await size_range.fill(`1.5`)
 
       // Reset button should appear in Labels section
-      const labels_reset = page.locator(`text=Labels`).locator(`..`).locator(`button`, {
-        hasText: `Reset`,
-      })
+      const labels_reset = page.locator(`h4:has-text("Labels")`).locator(
+        `button.reset-button`,
+      )
       await expect(labels_reset).toBeVisible()
 
       // Click reset button

--- a/tests/vitest/DraggablePane.test.ts
+++ b/tests/vitest/DraggablePane.test.ts
@@ -14,7 +14,7 @@ describe(`DraggablePane`, () => {
 
   test(`renders toggle when show_pane`, () => {
     mount(DraggablePane, { target: document.body, props: default_props })
-    expect(document.querySelector(`button`)).toBeTruthy()
+    expect(document.querySelector(`.pane-toggle`)).toBeTruthy()
   })
 
   test(`no toggle when !show_pane`, () => {
@@ -22,7 +22,7 @@ describe(`DraggablePane`, () => {
       target: document.body,
       props: { ...default_props, show_pane: false },
     })
-    expect(document.querySelector(`button`)).toBeFalsy()
+    expect(document.querySelector(`.pane-toggle`)).toBeFalsy()
   })
 
   test(`pane renders when show`, () => {

--- a/tests/vitest/math.test.ts
+++ b/tests/vitest/math.test.ts
@@ -975,7 +975,7 @@ describe(`tensor conversion utilities`, () => {
     it(`throws error for singular matrix`, () => {
       const singular_matrix: math.Matrix3x3 = [[1, 2, 3], [2, 4, 6], [3, 6, 9]] // determinant = 0
       expect(() => math.matrix_inverse_3x3(singular_matrix)).toThrow(
-        `Matrix is singular and cannot be inverted`,
+        `Matrix is singular or ill-conditioned; cannot invert`,
       )
     })
 
@@ -987,7 +987,7 @@ describe(`tensor conversion utilities`, () => {
         [0, 0, 1e-10],
       ]
       expect(() => math.matrix_inverse_3x3(small_det_matrix)).toThrow(
-        `Matrix is singular and cannot be inverted`,
+        `Matrix is singular or ill-conditioned; cannot invert`,
       )
 
       // Large numbers
@@ -1016,7 +1016,7 @@ describe(`tensor conversion utilities`, () => {
 
         if (Math.abs(det) < 1e-10) {
           expect(() => math.matrix_inverse_3x3(matrix)).toThrow(
-            `Matrix is singular and cannot be inverted`,
+            `Matrix is singular or ill-conditioned; cannot invert`,
           )
         } else {
           const inv = math.matrix_inverse_3x3(matrix)

--- a/tests/vitest/plot/Histogram.test.ts
+++ b/tests/vitest/plot/Histogram.test.ts
@@ -25,13 +25,6 @@ function get_y_tick_numbers(): number[] {
   )
 }
 
-async function set_size_and_tick(): Promise<number[]> {
-  // Allow Svelte to flush reactive updates
-  await Promise.resolve()
-  await new Promise((resolve) => setTimeout(resolve, 0))
-  return get_y_tick_numbers()
-}
-
 describe(`Histogram`, () => {
   // Ensure non-zero client size for happy-dom before each mount
   const ensure_client_size = () => {
@@ -67,7 +60,7 @@ describe(`Histogram`, () => {
     ensure_client_size()
     mount_histogram({ series, bins })
     await Promise.resolve()
-    const ticks = await set_size_and_tick()
+    const ticks = get_y_tick_numbers()
     expect(ticks.length).toBeGreaterThan(0)
     const max_tick = Math.max(...ticks)
     expect(max_tick).toBeGreaterThanOrEqual(expected_min_max[0])
@@ -85,7 +78,7 @@ describe(`Histogram`, () => {
       bins: 5,
     })
     await Promise.resolve()
-    const ticks = await set_size_and_tick()
+    const ticks = get_y_tick_numbers()
     const max_tick = Math.max(...ticks)
     expect(max_tick).toBeGreaterThanOrEqual(5)
   })
@@ -96,14 +89,14 @@ describe(`Histogram`, () => {
     ensure_client_size()
     mount_histogram({ series, bins: 9 })
     await Promise.resolve()
-    const ticks_many = await set_size_and_tick()
+    const ticks_many = get_y_tick_numbers()
     const max_many = Math.max(...ticks_many)
 
     document.body.innerHTML = ``
     ensure_client_size()
     mount_histogram({ series, bins: 3 })
     await Promise.resolve()
-    const ticks_few = await set_size_and_tick()
+    const ticks_few = get_y_tick_numbers()
     const max_few = Math.max(...ticks_few)
 
     expect(max_few).toBeGreaterThanOrEqual(max_many)
@@ -114,7 +107,7 @@ describe(`Histogram`, () => {
     ensure_client_size()
     mount_histogram({ series: [{ x: [], y: [1, 1, 1, 1, 1] }], bins: 5, y_lim: [0, 3] })
     await Promise.resolve()
-    const ticks = await set_size_and_tick()
+    const ticks = get_y_tick_numbers()
     const max_tick = Math.max(...ticks)
     expect(max_tick).toBeLessThanOrEqual(3)
   })
@@ -125,7 +118,7 @@ describe(`Histogram`, () => {
     ensure_client_size()
     mount_histogram({ series, bins: 5 })
     await Promise.resolve()
-    const ticks_full = await set_size_and_tick()
+    const ticks_full = get_y_tick_numbers()
     const full_max = Math.max(...ticks_full)
     const full_hist = bin().thresholds(5)(series[0].y)
     const full_expected = d3max(full_hist, (b) => b.length) || 0
@@ -135,7 +128,7 @@ describe(`Histogram`, () => {
     ensure_client_size()
     mount_histogram({ series, bins: 5, x_lim: [0, 3] })
     await Promise.resolve()
-    const ticks_zoom = await set_size_and_tick()
+    const ticks_zoom = get_y_tick_numbers()
     const zoom_max = Math.max(...ticks_zoom)
     const zoom_hist = bin().domain([0, 3]).thresholds(5)(series[0].y)
     const zoom_expected = d3max(zoom_hist, (b) => b.length) || 0
@@ -153,7 +146,7 @@ describe(`Histogram`, () => {
       y_lim: [1, null],
     })
     await Promise.resolve()
-    const ticks = await set_size_and_tick()
+    const ticks = get_y_tick_numbers()
     // log scale should not include non-positive ticks
     expect(Math.min(...ticks)).toBeGreaterThan(0)
   })

--- a/tests/vitest/structure/bonding.test.ts
+++ b/tests/vitest/structure/bonding.test.ts
@@ -256,8 +256,8 @@ describe(`Electronegativity-Based Bonding`, () => {
       metal_nonmetal_bonus: 1.5,
     })
     const metal_bonds = bonding.electroneg_ratio(make_metal_structure(), {
-      max_distance_ratio: 2.5,
-      metal_metal_penalty: 0.5,
+      max_distance_ratio: 2,
+      metal_metal_penalty: 0.7,
       metal_nonmetal_bonus: 1.5,
     })
     const ionic_density = ionic_bonds.length / 4

--- a/tests/vitest/structure/bonding.test.ts
+++ b/tests/vitest/structure/bonding.test.ts
@@ -189,6 +189,8 @@ describe(`Molecular Bonding Analysis`, () => {
   test(`benzene has aromatic C-C bonds`, () => {
     const bonds = bonding.electroneg_ratio(test_molecules.benzene, {
       max_distance_ratio: 2.0,
+      metal_metal_penalty: 0.5,
+      metal_nonmetal_bonus: 1.5,
     })
     expect(bonds.length).toBeGreaterThanOrEqual(6)
     const cc_bonds = bonds.filter((bond) =>
@@ -200,6 +202,8 @@ describe(`Molecular Bonding Analysis`, () => {
   test(`ethanol has multiple bond types`, () => {
     const bonds = bonding.electroneg_ratio(test_molecules.ethanol, {
       max_distance_ratio: 2.0,
+      metal_metal_penalty: 0.5,
+      metal_nonmetal_bonus: 1.5,
     })
     expect(bonds.length).toBeGreaterThanOrEqual(8)
     const bond_distances = bonds.map((bond) => bond.bond_length)
@@ -246,8 +250,16 @@ describe(`Crystal Structure Bonding`, () => {
 
 describe(`Electronegativity-Based Bonding`, () => {
   test(`favors metal-nonmetal bonds over metal-metal bonds`, () => {
-    const ionic_bonds = bonding.electroneg_ratio(make_ionic_structure())
-    const metal_bonds = bonding.electroneg_ratio(make_metal_structure())
+    const ionic_bonds = bonding.electroneg_ratio(make_ionic_structure(), {
+      max_distance_ratio: 2.5,
+      metal_metal_penalty: 0.5,
+      metal_nonmetal_bonus: 1.5,
+    })
+    const metal_bonds = bonding.electroneg_ratio(make_metal_structure(), {
+      max_distance_ratio: 2.5,
+      metal_metal_penalty: 0.5,
+      metal_nonmetal_bonus: 1.5,
+    })
     const ionic_density = ionic_bonds.length / 4
     // The algorithm should generally prefer ionic bonds, but the exact ratio may vary
     // Check that both structures produce reasonable bond counts
@@ -266,8 +278,16 @@ describe(`Electronegativity-Based Bonding`, () => {
       { xyz: [0, 0, 0], element: `C` },
       { xyz: [1.5, 0, 0], element: `C` },
     ])
-    const ionic_bonds = bonding.electroneg_ratio(na_cl_structure)
-    const covalent_bonds = bonding.electroneg_ratio(c_c_structure)
+    const ionic_bonds = bonding.electroneg_ratio(na_cl_structure, {
+      max_distance_ratio: 2.5,
+      metal_metal_penalty: 0.5,
+      metal_nonmetal_bonus: 1.5,
+    })
+    const covalent_bonds = bonding.electroneg_ratio(c_c_structure, {
+      max_distance_ratio: 2.5,
+      metal_metal_penalty: 0.5,
+      metal_nonmetal_bonus: 1.5,
+    })
     expect(ionic_bonds).toHaveLength(1)
     expect(covalent_bonds).toHaveLength(1)
     expect(ionic_bonds[0].bond_length).toBeCloseTo(2.3, 1)
@@ -429,7 +449,9 @@ describe(`CrystalNN-Inspired Improvements`, () => {
 
     // H-H should be stronger at 1.5Å than C-C at 1.5Å due to relative distance ratios
     if (h_bonds.length > 0 && c_bonds.length > 0) {
-      expect(h_bonds[0].strength).toBeGreaterThan(c_bonds[0].strength)
+      const h_max = Math.max(...h_bonds.map((b) => b.strength))
+      const c_max = Math.max(...c_bonds.map((b) => b.strength))
+      expect(h_max).toBeGreaterThan(c_max)
     }
   })
 


### PR DESCRIPTION
closes #145

- Add an off-by-default `show_site_indices` setting to `SettingsConfig` and expose it in the VS Code extension.
- Bind the setting in `StructureControls.svelte` and `StructureScene.svelte` and render site indices accordingly.
- Render site labels and indices together without overlap.
- Add Playwright coverage for labels and indices in the supported display combinations.