### PR TITLE
Structure from string

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
         exclude: changelog\.md$
 
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v9.33.0
+    rev: v9.35.0
     hooks:
       - id: eslint
         types: [file]

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -1,3 +1,4 @@
+import { COMPRESSION_EXTENSIONS_REGEX } from '$lib/constants'
 import { DEFAULTS, type DefaultSettings, merge } from '$lib/settings'
 import { is_structure_file } from '$lib/structure/parse'
 import { AUTO_THEME, COLOR_THEMES, is_valid_theme_mode, type ThemeName } from '$lib/theme'
@@ -125,7 +126,8 @@ const update_supported_resource_context = (uri?: vscode.Uri): void => {
 export const read_file = (file_path: string): FileData => {
   const filename = path.basename(file_path)
   // Binary files that should be read as base64
-  const is_binary = /\.(gz|gzip|zip|bz2|xz|traj|h5|hdf5)$/i.test(filename)
+  const is_binary = COMPRESSION_EXTENSIONS_REGEX.test(filename) ||
+    /\.(traj|h5|hdf5)$/i.test(filename)
 
   // Check file size to avoid loading huge files into memory
   let file_size: number

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -95,6 +95,10 @@ const active_frame_loaders = new Map<string, FrameLoaderData>()
 // Check if a file should be auto-rendered
 export const should_auto_render = (filename: string): boolean => {
   if (!filename || typeof filename !== `string`) return false
+
+  // xyz/extxyz files should always be auto-rendered (detection happens with content)
+  if (/\.(xyz|extxyz)(?:\.(gz|gzip|zip|bz2|xz))?$/i.test(filename)) return true
+
   return is_structure_file(filename) || is_trajectory_file(filename)
 }
 

--- a/extensions/vscode/src/webview/main.ts
+++ b/extensions/vscode/src/webview/main.ts
@@ -23,20 +23,20 @@ import type {
 import Trajectory from '$lib/trajectory/Trajectory.svelte'
 import { mount, unmount } from 'svelte'
 
-interface FileData {
+export interface FileData {
   filename: string
   content: string
   isCompressed: boolean
 }
 
-interface MatterVizData {
+export interface MatterVizData {
   type: `trajectory` | `structure`
   data: FileData
   theme: ThemeName
   defaults?: DefaultSettings
 }
 
-interface ParseResult {
+export interface ParseResult {
   type: `trajectory` | `structure`
   data: unknown
   filename: string
@@ -44,12 +44,12 @@ interface ParseResult {
   streaming_info?: { supports_streaming: boolean; file_path: string }
 }
 
-interface MatterVizApp {
+export interface MatterVizApp {
   $on?(type: string, callback: (event: Event) => void): () => void
   $set?(props: Partial<Record<string, unknown>>): void
 }
 
-interface FileChangeMessage {
+export interface FileChangeMessage {
   command: `fileUpdated` | `fileDeleted`
   file_path?: string
   data?: FileData
@@ -106,15 +106,15 @@ class VSCodeFrameLoader implements FrameLoader {
   }
 }
 
-interface TrajectoryData {
+export interface TrajectoryData {
   frames?: { structure?: { sites?: unknown[] } }[]
 }
 
-interface StructureData {
+export interface StructureData {
   sites?: unknown[]
 }
 
-interface VSCodeAPI {
+export interface VSCodeAPI {
   postMessage(message: unknown): void
 }
 
@@ -393,7 +393,7 @@ const parse_file_content = async (
   }
 
   // Try trajectory parsing first if it looks like a trajectory
-  if (is_trajectory_file(filename)) {
+  if (is_trajectory_file(filename, content)) {
     try {
       const data = await parse_trajectory_data(content, filename)
       return { type: `trajectory`, data, filename }

--- a/extensions/vscode/tests/extension.test.ts
+++ b/extensions/vscode/tests/extension.test.ts
@@ -149,8 +149,9 @@ describe(`MatterViz Extension`, () => {
     [`water_cluster_md.traj`, true, true], // ASE binary trajectory
     [`optimization_relax.traj`, true, true], // ASE binary trajectory
     [`regular_text.traj`, true, true], // .traj files are always binary
-    [`test.xyz`, true, false], // .xyz files are now always considered potential trajectories
-    [`test.extxyz`, true, false], // .extxyz files are always considered potential trajectories
+    // filename-only based .xyz/.extxyz detection always assumes structure, requires file content to look for frames and recognize as trajectory
+    [`test.xyz`, false, false],
+    [`test.extxyz`, false, false],
     [`test.cif`, false, false], // Not a trajectory file
   ])(
     `ASE trajectory file handling: "%s" → trajectory:%s, binary:%s`,

--- a/extensions/vscode/tests/webview.test.ts
+++ b/extensions/vscode/tests/webview.test.ts
@@ -111,13 +111,15 @@ describe(`Webview Integration - ASE Binary Trajectory Support`, () => {
 })
 
 describe(`VSCode Download Integration`, () => {
-  test(`sets up global download override when VSCode API is available`, () => {
+  test(`sets up global download override when VSCode API is available`, async () => {
+    vi.resetModules() // Reset modules to clear cached vscode_api variable in webview/main.ts
     const mock_post_message = vi.fn()
     globalThis.acquireVsCodeApi = vi.fn(() => ({
       postMessage: mock_post_message,
       setState: vi.fn(),
       getState: vi.fn(),
     }))
+    const { setup_vscode_download } = await import(`../src/webview/main`)
     setup_vscode_download()
     expect(typeof globalThis.download).toBe(`function`)
     globalThis.download(`test content`, `test.json`, `application/json`)

--- a/src/lib/InfoCard.svelte
+++ b/src/lib/InfoCard.svelte
@@ -31,8 +31,7 @@
     ...rest
   }: Props = $props()
 
-  // rename fmt as default_fmt internally
-  let default_fmt = $derived(fmt)
+  let default_fmt = $derived(fmt) // rename fmt to default_fmt for internal use
 </script>
 
 <svelte:element this={as} {...rest} class="info-card {rest.class ?? ``}">

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,14 +1,14 @@
 // Shared keyword constants for file type detection across the codebase
 
 // compression formats and their file extensions
-export const COMPRESSION_FORMATS = Object.freeze({
-  gzip: [`.gz`, `.gzip`],
-  deflate: [`.deflate`],
-  'deflate-raw': [`.z`],
-  zip: [`.zip`], // Browser DecompressionStream doesn't support ZIP
-  xz: [`.xz`], // Browser DecompressionStream doesn't support XZ
-  bz2: [`.bz2`], // Browser DecompressionStream doesn't support BZ2
-}) as Record<string, readonly string[]>
+export const COMPRESSION_FORMATS = {
+  gzip: [`.gz`, `.gzip`] as const,
+  deflate: [`.deflate`] as const,
+  'deflate-raw': [`.z`] as const,
+  zip: [`.zip`] as const, // Browser DecompressionStream doesn't support ZIP
+  xz: [`.xz`] as const, // Browser DecompressionStream doesn't support XZ
+  bz2: [`.bz2`] as const, // Browser DecompressionStream doesn't support BZ2
+} as const satisfies Record<string, readonly string[]>
 
 // All detectable compression extensions
 export const COMPRESSION_EXTENSIONS = Object.freeze([
@@ -65,6 +65,7 @@ export const TRAJ_EXTENSIONS_REGEX = new RegExp(
 )
 export const STRUCTURE_EXTENSIONS = Object.freeze([
   `.cif`,
+  `.mcif`,
   `.poscar`,
   `.vasp`,
   `.lmp`,
@@ -93,7 +94,8 @@ export const TRAJ_FALLBACK_EXTENSIONS_REGEX = new RegExp(
 )
 
 // Special regex patterns
-export const VASP_FILES_REGEX = /(poscar|contcar|potcar|incar|kpoints|outcar)/i
+export const VASP_FILES_REGEX =
+  /(?:^|[\\/_.-])(poscar|contcar|potcar|incar|kpoints|outcar)(?:[\\/_.-]|$)/i
 export const XDATCAR_REGEX = /xdatcar/i
 export const CONFIG_DIRS_REGEX =
   /(?:^|[\\/])(\.vscode|\.idea|\.nyc_output|\.cache|\.tmp|\.temp|node_modules|dist|build|coverage)(?:[\\/]|$)/i

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,108 @@
+// Shared keyword constants for file type detection across the codebase
+
+// compression formats and their file extensions
+export const COMPRESSION_FORMATS = {
+  gzip: [`.gz`, `.gzip`],
+  deflate: [`.deflate`],
+  'deflate-raw': [`.z`],
+  zip: [`.zip`], // Browser DecompressionStream doesn't support ZIP
+  xz: [`.xz`], // Browser DecompressionStream doesn't support XZ
+  bz2: [`.bz2`], // Browser DecompressionStream doesn't support BZ2
+} as const
+
+// All detectable compression extensions
+export const COMPRESSION_EXTENSIONS = [
+  ...Object.values(COMPRESSION_FORMATS).flat(),
+] as const
+
+// Keywords that indicate a file is likely a trajectory file
+export const TRAJ_KEYWORDS = [
+  `trajectory`,
+  `traj`,
+  `relax`,
+  `npt`,
+  `nvt`,
+  `nve`,
+  `qha`,
+  `md`,
+  `dynamics`,
+  `simulation`,
+] as const
+
+// Keywords that indicate a file is likely a structure file
+export const STRUCT_KEYWORDS = [
+  `structure`,
+  `phono`,
+  `vasp`,
+  `crystal`,
+  `material`,
+  `lattice`,
+  `geometry`,
+  `unit_cell`,
+  `unitcell`,
+  `atoms`,
+  `sites`,
+  `data`,
+  `phono3py`,
+  `phonopy`,
+] as const
+
+// Regex patterns for keyword matching
+export const TRAJ_KEYWORDS_REGEX = new RegExp(
+  `(^|[-_.])(${TRAJ_KEYWORDS.join(`|`)})([-_.]|$)`,
+  `i`,
+)
+
+export const STRUCT_KEYWORDS_REGEX = new RegExp(`(${STRUCT_KEYWORDS.join(`|`)})`, `i`)
+
+export const TRAJ_KEYWORDS_SIMPLE_REGEX = new RegExp(`(${TRAJ_KEYWORDS.join(`|`)})`, `i`)
+
+// File extensions for different file types
+export const TRAJ_EXTENSIONS = [`.traj`, `.xtc`] as const
+export const TRAJ_EXTENSIONS_REGEX = new RegExp(
+  `\\.(${TRAJ_EXTENSIONS.map((ext) => ext.slice(1)).join(`|`)})$`,
+  `i`,
+)
+export const STRUCTURE_EXTENSIONS = [
+  `.cif`,
+  `.poscar`,
+  `.vasp`,
+  `.lmp`,
+  `.data`,
+  `.dump`,
+  `.pdb`,
+  `.mol`,
+  `.mol2`,
+  `.sdf`,
+  `.mmcif`,
+] as const
+export const STRUCTURE_EXTENSIONS_REGEX = new RegExp(
+  `\\.(${STRUCTURE_EXTENSIONS.map((ext) => ext.slice(1)).join(`|`)})$`,
+  `i`,
+)
+export const TRAJ_FALLBACK_EXTENSIONS = [
+  `.dat`,
+  `.data`,
+  `.log`,
+  `.out`,
+  `.json`,
+] as const
+export const TRAJ_FALLBACK_EXTENSIONS_REGEX = new RegExp(
+  `\\.(${TRAJ_FALLBACK_EXTENSIONS.map((ext) => ext.slice(1)).join(`|`)})$`,
+  `i`,
+)
+
+// Special regex patterns
+export const VASP_FILES_REGEX = /(poscar|contcar|potcar|incar|kpoints|outcar)/i
+export const XDATCAR_REGEX = /xdatcar/i
+export const CONFIG_DIRS_REGEX =
+  /(\.vscode|\.idea|\.nyc_output|\.cache|\.tmp|\.temp|node_modules|dist|build|coverage)\//i
+export const MD_SIM_EXCLUDE_REGEX =
+  /md_simulation\.(out|txt|yml|py|csv|html|css|md|js|ts)$/i
+export const XYZ_EXTXYZ_REGEX = /\.(xyz|extxyz)$/i
+
+// Compression extensions regex (shared across files)
+export const COMPRESSION_EXTENSIONS_REGEX = new RegExp(
+  `\\.(${COMPRESSION_EXTENSIONS.map((ext) => ext.slice(1)).join(`|`)})$`,
+  `i`,
+)

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,22 +1,22 @@
 // Shared keyword constants for file type detection across the codebase
 
 // compression formats and their file extensions
-export const COMPRESSION_FORMATS = {
+export const COMPRESSION_FORMATS = Object.freeze({
   gzip: [`.gz`, `.gzip`],
   deflate: [`.deflate`],
   'deflate-raw': [`.z`],
   zip: [`.zip`], // Browser DecompressionStream doesn't support ZIP
   xz: [`.xz`], // Browser DecompressionStream doesn't support XZ
   bz2: [`.bz2`], // Browser DecompressionStream doesn't support BZ2
-} as const
+}) as Record<string, readonly string[]>
 
 // All detectable compression extensions
-export const COMPRESSION_EXTENSIONS = [
+export const COMPRESSION_EXTENSIONS = Object.freeze([
   ...Object.values(COMPRESSION_FORMATS).flat(),
-] as const
+]) as readonly string[]
 
 // Keywords that indicate a file is likely a trajectory file
-export const TRAJ_KEYWORDS = [
+export const TRAJ_KEYWORDS = Object.freeze([
   `trajectory`,
   `traj`,
   `relax`,
@@ -27,10 +27,10 @@ export const TRAJ_KEYWORDS = [
   `md`,
   `dynamics`,
   `simulation`,
-] as const
+]) as readonly string[]
 
 // Keywords that indicate a file is likely a structure file
-export const STRUCT_KEYWORDS = [
+export const STRUCT_KEYWORDS = Object.freeze([
   `structure`,
   `phono`,
   `vasp`,
@@ -45,7 +45,7 @@ export const STRUCT_KEYWORDS = [
   `data`,
   `phono3py`,
   `phonopy`,
-] as const
+]) as readonly string[]
 
 // Regex patterns for keyword matching
 export const TRAJ_KEYWORDS_REGEX = new RegExp(
@@ -58,12 +58,12 @@ export const STRUCT_KEYWORDS_REGEX = new RegExp(`(${STRUCT_KEYWORDS.join(`|`)})`
 export const TRAJ_KEYWORDS_SIMPLE_REGEX = new RegExp(`(${TRAJ_KEYWORDS.join(`|`)})`, `i`)
 
 // File extensions for different file types
-export const TRAJ_EXTENSIONS = [`.traj`, `.xtc`] as const
+export const TRAJ_EXTENSIONS = Object.freeze([`.traj`, `.xtc`]) as readonly string[]
 export const TRAJ_EXTENSIONS_REGEX = new RegExp(
   `\\.(${TRAJ_EXTENSIONS.map((ext) => ext.slice(1)).join(`|`)})$`,
   `i`,
 )
-export const STRUCTURE_EXTENSIONS = [
+export const STRUCTURE_EXTENSIONS = Object.freeze([
   `.cif`,
   `.poscar`,
   `.vasp`,
@@ -75,18 +75,18 @@ export const STRUCTURE_EXTENSIONS = [
   `.mol2`,
   `.sdf`,
   `.mmcif`,
-] as const
+]) as readonly string[]
 export const STRUCTURE_EXTENSIONS_REGEX = new RegExp(
   `\\.(${STRUCTURE_EXTENSIONS.map((ext) => ext.slice(1)).join(`|`)})$`,
   `i`,
 )
-export const TRAJ_FALLBACK_EXTENSIONS = [
+export const TRAJ_FALLBACK_EXTENSIONS = Object.freeze([
   `.dat`,
   `.data`,
   `.log`,
   `.out`,
   `.json`,
-] as const
+]) as readonly string[]
 export const TRAJ_FALLBACK_EXTENSIONS_REGEX = new RegExp(
   `\\.(${TRAJ_FALLBACK_EXTENSIONS.map((ext) => ext.slice(1)).join(`|`)})$`,
   `i`,
@@ -96,7 +96,7 @@ export const TRAJ_FALLBACK_EXTENSIONS_REGEX = new RegExp(
 export const VASP_FILES_REGEX = /(poscar|contcar|potcar|incar|kpoints|outcar)/i
 export const XDATCAR_REGEX = /xdatcar/i
 export const CONFIG_DIRS_REGEX =
-  /(\.vscode|\.idea|\.nyc_output|\.cache|\.tmp|\.temp|node_modules|dist|build|coverage)\//i
+  /(?:^|[\\/])(\.vscode|\.idea|\.nyc_output|\.cache|\.tmp|\.temp|node_modules|dist|build|coverage)(?:[\\/]|$)/i
 export const MD_SIM_EXCLUDE_REGEX =
   /md_simulation\.(out|txt|yml|py|csv|html|css|md|js|ts)$/i
 export const XYZ_EXTXYZ_REGEX = /\.(xyz|extxyz)$/i

--- a/src/lib/io/decompress.ts
+++ b/src/lib/io/decompress.ts
@@ -10,10 +10,9 @@ export type CompressionExtension = (typeof COMPRESSION_EXTENSIONS)[number]
 export function detect_compression_format(
   filename: string,
 ): CompressionFormat | null {
+  const lower = filename.toLowerCase()
   for (const [format, extensions] of Object.entries(COMPRESSION_FORMATS)) {
-    if (extensions.some((ext) => filename.endsWith(ext))) {
-      return format as CompressionFormat
-    }
+    if (extensions.some((ext) => lower.endsWith(ext))) return format as CompressionFormat
   }
   return null
 }

--- a/src/lib/io/decompress.ts
+++ b/src/lib/io/decompress.ts
@@ -1,12 +1,11 @@
-import { COMPRESSION_EXTENSIONS, COMPRESSION_FORMATS } from '$lib/constants'
+import {
+  COMPRESSION_EXTENSIONS,
+  COMPRESSION_EXTENSIONS_REGEX,
+  COMPRESSION_FORMATS,
+} from '$lib/constants'
 
 export type CompressionFormat = keyof typeof COMPRESSION_FORMATS
 export type CompressionExtension = (typeof COMPRESSION_EXTENSIONS)[number]
-
-export function remove_compression_extension(filename: string): string {
-  const extensions = COMPRESSION_EXTENSIONS.map((ext) => ext.slice(1))
-  return filename.replace(new RegExp(`\\.(${extensions.join(`|`)})$`), ``)
-}
 
 export function detect_compression_format(
   filename: string,
@@ -39,10 +38,11 @@ export async function decompress_data(
         },
       })
       : data
-    const unzip = new DecompressionStream(format)
-    return await new Response(stream?.pipeThrough(unzip)).text()
+    if (!stream) throw new Error(`Invalid data stream`)
+    const unzip = new DecompressionStream(format as `gzip` | `deflate` | `deflate-raw`)
+    return await new Response(stream.pipeThrough(unzip)).text()
   } catch (error) {
-    throw `Failed to decompress ${format} file: ${error}`
+    throw new Error(`Failed to decompress ${format} file: ${error}`)
   }
 }
 
@@ -50,7 +50,7 @@ export function decompress_file(
   file: File,
 ): Promise<{ content: string; filename: string }> {
   const format = detect_compression_format(file.name)
-  const compressed = format && format !== `zip` && format !== `xz` && format !== `bz2` // Treat unsupported as uncompressed
+  const is_supported = Boolean(format && ![`zip`, `xz`, `bz2`].includes(format))
 
   return new Promise((resolve, reject) => {
     const reader = new FileReader()
@@ -58,11 +58,11 @@ export function decompress_file(
     reader.onload = async (event) => {
       try {
         const result = event.target?.result
-        if (!result) throw `Failed to read file`
+        if (!result) throw new Error(`Failed to read file`)
 
-        if (compressed) {
+        if (is_supported && format) {
           const content = await decompress_data(result as ArrayBuffer, format)
-          const filename = remove_compression_extension(file.name)
+          const filename = file.name.replace(COMPRESSION_EXTENSIONS_REGEX, ``)
           resolve({ content, filename })
         } else {
           resolve({ content: result as string, filename: file.name })
@@ -74,7 +74,7 @@ export function decompress_file(
 
     reader.onerror = () => reject(new Error(`Failed to read file ${file.name}`))
 
-    if (compressed) reader.readAsArrayBuffer(file)
+    if (is_supported) reader.readAsArrayBuffer(file)
     else reader.readAsText(file)
   })
 }

--- a/src/lib/io/decompress.ts
+++ b/src/lib/io/decompress.ts
@@ -1,20 +1,6 @@
-// compression formats and their file extensions
-const COMPRESSION_FORMATS = {
-  gzip: [`.gz`, `.gzip`],
-  deflate: [`.deflate`],
-  'deflate-raw': [`.z`],
-  zip: [`.zip`], // Browser DecompressionStream doesn't support ZIP
-  xz: [`.xz`], // Browser DecompressionStream doesn't support XZ
-  bz2: [`.bz2`], // Browser DecompressionStream doesn't support BZ2
-} as const
+import { COMPRESSION_EXTENSIONS, COMPRESSION_FORMATS } from '$lib/constants'
 
 export type CompressionFormat = keyof typeof COMPRESSION_FORMATS
-
-// All detectable compression extensions
-export const COMPRESSION_EXTENSIONS = [
-  ...Object.values(COMPRESSION_FORMATS).flat(),
-] as const
-
 export type CompressionExtension = (typeof COMPRESSION_EXTENSIONS)[number]
 
 export function remove_compression_extension(filename: string): string {

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -191,14 +191,7 @@
       const parsed = parse_any_structure(structure_string, `string`)
       if (parsed) {
         structure = parsed
-        untrack(() =>
-          on_file_load?.({
-            structure: parsed,
-            filename: `string`,
-            file_size: new Blob([structure_string]).size,
-            total_atoms: parsed.sites?.length || 0,
-          })
-        )
+        untrack(() => emit_file_load_event(parsed, `string`, structure_string))
       } else {
         throw new Error(`Failed to parse structure from string`)
       }

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -62,6 +62,8 @@
     selected_sites?: number[]
     // explicit measured sites for distance/angle overlays
     measured_sites?: number[]
+    // structure content as string (alternative to providing structure directly or via data_url)
+    structure_string?: string
     children?: Snippet<[{ structure?: AnyStructure }]>
     on_file_load?: EventHandler
     on_error?: EventHandler
@@ -106,6 +108,7 @@
     fullscreen_toggle = DEFAULTS.structure.fullscreen_toggle,
     bottom_left,
     data_url,
+    structure_string,
     on_file_drop,
     spinner_props = {},
     loading = $bindable(false),
@@ -177,6 +180,35 @@
           loading = false
           on_error?.({ error_msg, filename: data_url })
         })
+    }
+  })
+
+  $effect(() => { // Parse structure from string when structure_string is provided
+    if (!structure_string || data_url) return
+    loading = true
+    error_msg = undefined
+    try {
+      const parsed = parse_any_structure(structure_string, `string`)
+      if (parsed) {
+        structure = parsed
+        untrack(() =>
+          on_file_load?.({
+            structure: parsed,
+            filename: `string`,
+            file_size: new Blob([structure_string]).size,
+            total_atoms: parsed.sites?.length || 0,
+          })
+        )
+      } else {
+        throw new Error(`Failed to parse structure from string`)
+      }
+    } catch (err) {
+      error_msg = `Failed to parse structure from string: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+      untrack(() => on_error?.({ error_msg, filename: `string` }))
+    } finally {
+      loading = false
     }
   })
 

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -29,7 +29,7 @@
 
   interface Props
     extends
-      Omit<ControlProps, `children`>,
+      Omit<ControlProps, `children` | `onclose`>,
       Omit<HTMLAttributes<HTMLDivElement>, `children`> {
     scene_props?: ComponentProps<typeof StructureScene>
     // only show the buttons when hovering over the canvas on desktop screens

--- a/src/lib/structure/parse.ts
+++ b/src/lib/structure/parse.ts
@@ -1197,14 +1197,10 @@ export function parse_structure_file(
     const ext = base_filename.split(`.`).pop()
 
     // Try to detect format by file extension
-    if (ext === `xyz`) {
-      return parse_xyz(content)
-    }
+    if (ext === `xyz`) return parse_xyz(content)
 
     // CIF files
-    if (ext === `cif`) {
-      return parse_cif(content)
-    }
+    if (ext === `cif`) return parse_cif(content)
 
     // JSON files - try OPTIMADE JSON structure format first, then pymatgen
     if (ext === `json`) {
@@ -1217,9 +1213,7 @@ export function parse_structure_file(
         }
         // Otherwise, try to parse as pymatgen/nested structure JSON
         const structure = find_structure_in_json(parsed)
-        if (structure) {
-          return structure
-        }
+        if (structure) return structure
         console.error(`JSON file does not contain a valid structure format`)
         return null
       } catch (error) {
@@ -1578,12 +1572,6 @@ export function is_structure_file(filename: string): boolean {
   if (/\.(cif|poscar|vasp|lmp|data|dump|pdb|mol|mol2|sdf|mmcif)$/i.test(name)) return true
   if (/(poscar|contcar|potcar|incar|kpoints|outcar)/i.test(name)) return true
 
-  // .xyz files: structure unless they have trajectory keywords, .extxyz files: trajectory by default
-  if (/\.extxyz$/i.test(name)) return false
-  if (/\.xyz$/i.test(name)) {
-    return !/(trajectory|traj|relax|npt|nvt|nve|qha|md|dynamics|simulation)/i.test(name)
-  }
-
   // Keyword-based detection for YAML/JSON/XML
   const structure_keywords =
     /(structure|phono|vasp|crystal|material|lattice|geometry|unit_?cell|atoms|sites|data|phono3?py)/i
@@ -1591,6 +1579,9 @@ export function is_structure_file(filename: string): boolean {
     /(trajectory|traj|relax|npt|nvt|nve|qha|md|dynamics|simulation)/i
   const config_dirs =
     /(\.vscode|\.idea|\.nyc_output|\.cache|\.tmp|\.temp|node_modules|dist|build|coverage)\//i
+
+  // .xyz/.extxyz files: structure unless they have trajectory keywords
+  if (/\.(xyz|extxyz)$/i.test(name)) return !trajectory_keywords.test(name)
 
   if (/\.(yaml|yml)$/i.test(name) && structure_keywords.test(name)) return true
   if (/\.xml$/i.test(name) && structure_keywords.test(name)) return true

--- a/src/lib/structure/parse.ts
+++ b/src/lib/structure/parse.ts
@@ -1203,7 +1203,7 @@ export function parse_structure_file(
     const ext = base_filename.split(`.`).pop()
 
     // Try to detect format by file extension
-    if (ext === `xyz`) return parse_xyz(content)
+    if (ext === `xyz` || ext === `extxyz`) return parse_xyz(content)
 
     // CIF files
     if (ext === `cif`) return parse_cif(content)
@@ -1611,17 +1611,15 @@ export const detect_structure_type = (
   if (name_to_check.endsWith(`.json`)) {
     try {
       const parsed = JSON.parse(content)
-      // Check for OPTIMADE JSON format (has data.attributes.lattice_vectors)
-      if (parsed.data?.attributes?.lattice_vectors) return `crystal`
-      // Check for dimension_types (OPTIMADE format)
-      if (parsed.data?.attributes?.dimension_types?.some((dim: number) => dim > 0)) {
+      // Check for crystal indicators: lattice, lattice_vectors, or periodic dimensions
+      if (
+        parsed.lattice ||
+        parsed.data?.attributes?.lattice_vectors ||
+        parsed.data?.attributes?.dimension_types?.some((dim: number) => dim > 0) ||
+        parsed.data?.attributes?.nperiodic_dimensions > 0
+      ) {
         return `crystal`
       }
-      // Check for pymatgen JSON format (has lattice property)
-      if (parsed.lattice) return `crystal`
-      // Check for other crystal indicators
-      if (parsed.data?.attributes?.nperiodic_dimensions > 0) return `crystal`
-
       return `molecule`
     } catch {
       return `unknown`

--- a/src/lib/trajectory/parse.ts
+++ b/src/lib/trajectory/parse.ts
@@ -76,9 +76,9 @@ const FORMAT_PATTERNS = {
   },
 
   xyz_multi: (data: string, filename?: string) => {
-    if (!filename?.toLowerCase().match(/\.(xyz|extxyz)(?:\.(?:gz|gzip|zip|bz2|xz))?$/)) {
-      return false
-    }
+    const lower = filename?.toLowerCase() ?? ``
+    const base = lower.replace(COMPRESSION_EXTENSIONS_REGEX, ``)
+    if (!/\.(xyz|extxyz)$/.test(base)) return false
     return count_xyz_frames(data) >= 2
   },
 } as const
@@ -1379,11 +1379,8 @@ async function parse_with_unified_loader(
     }
   }
 
-  on_progress?.({
-    current: 100,
-    total: 100,
-    stage: `Ready: ${total_frames} frames indexed`,
-  })
+  const stage = `Ready: ${total_frames} frames indexed`
+  on_progress?.({ current: 100, total: 100, stage })
 
   return {
     frames,
@@ -1391,7 +1388,7 @@ async function parse_with_unified_loader(
       source_format: filename.toLowerCase().endsWith(`.traj`)
         ? `ase_trajectory`
         : `xyz_trajectory`,
-      frame_count: frames.length,
+      frame_count: total_frames,
     },
     total_frames,
     indexed_frames: frame_index,

--- a/src/lib/trajectory/parse.ts
+++ b/src/lib/trajectory/parse.ts
@@ -4,6 +4,7 @@ import { is_binary } from '$lib'
 import { atomic_number_to_symbol } from '$lib/composition/parse'
 import {
   COMPRESSION_EXTENSIONS_REGEX,
+  CONFIG_DIRS_REGEX,
   MD_SIM_EXCLUDE_REGEX,
   TRAJ_EXTENSIONS_REGEX,
   TRAJ_FALLBACK_EXTENSIONS_REGEX,
@@ -84,6 +85,7 @@ const FORMAT_PATTERNS = {
 
 // Check if file is a trajectory (supports both filename-only and content-based detection)
 export function is_trajectory_file(filename: string, content?: string): boolean {
+  if (CONFIG_DIRS_REGEX.test(filename)) return false
   let base_name = filename.toLowerCase()
   while (COMPRESSION_EXTENSIONS_REGEX.test(base_name)) {
     base_name = base_name.replace(COMPRESSION_EXTENSIONS_REGEX, ``)
@@ -93,7 +95,7 @@ export function is_trajectory_file(filename: string, content?: string): boolean 
   if (/\.(xyz|extxyz)$/i.test(base_name)) {
     if (content) return count_xyz_frames(content) >= 2
     // Use filename-based detection for auto-render (compressed or not)
-    return TRAJ_KEYWORDS_SIMPLE_REGEX.test(filename.toLowerCase())
+    return TRAJ_KEYWORDS_SIMPLE_REGEX.test(base_name)
   }
 
   // Always detect these specific trajectory formats

--- a/src/routes/(demos)/structure/+page.md
+++ b/src/routes/(demos)/structure/+page.md
@@ -1,6 +1,3 @@
-<script>
-</script>
-
 # Structure
 
 ```svelte example

--- a/src/routes/(demos)/structure/+page.md
+++ b/src/routes/(demos)/structure/+page.md
@@ -95,3 +95,66 @@ Showcasing structures with different crystal systems.
   }
 </style>
 ```
+
+## Load Structure from String
+
+You can load structures directly from text content using the `structure_string` prop, supporting various formats (CIF, POSCAR, XYZ, JSON, etc.).
+
+```svelte example
+<script>
+  import { Structure } from 'matterviz'
+  import { format_num } from '$lib'
+  import c2ho_scientific_notation_xyz from '$site/molecules/C2HO-scientific-notation.xyz?raw'
+  import c5_extra_data_xyz from '$site/molecules/C5-extra-data.xyz?raw'
+  import cyclohexane from '$site/molecules/cyclohexane.xyz?raw'
+  import aviary_CuF3K_triolith from '$site/structures/aviary-CuF3K-triolith.poscar?raw'
+  import ba_ti_o3_tetragonal from '$site/structures/BaTiO3-tetragonal.poscar?raw'
+  import mof_issue_127 from '$site/structures/mof-issue-127.cif?raw'
+  import na_cl_cubic from '$site/structures/NaCl-cubic.poscar?raw'
+  import ru_p_complex_cif from '$site/structures/P24Ru4H252C296S24N16.cif?raw'
+  import pf_sd_1601634_cif from '$site/structures/PF-sd-1601634.cif?raw'
+  import extended_xyz_quartz from '$site/structures/quartz.extxyz?raw'
+  import scientific_notation_poscar from '$site/structures/scientific-notation.poscar?raw'
+  import selective_dynamics from '$site/structures/selective-dynamics.poscar?raw'
+  import tio2_cif from '$site/structures/TiO2.cif?raw'
+  import vasp4_format from '$site/structures/vasp4-format.poscar?raw'
+
+  const structure_files = [
+    { name: `MOF (CIF)`, content: mof_issue_127 },
+    { name: `Ru Complex (CIF)`, content: ru_p_complex_cif },
+    { name: `PF Structure (CIF)`, content: pf_sd_1601634_cif },
+    { name: `Cyclohexane (XYZ)`, content: cyclohexane },
+    { name: `C2HO (XYZ)`, content: c2ho_scientific_notation_xyz },
+    { name: `C5 (XYZ)`, content: c5_extra_data_xyz },
+    { name: `CuF3K (POSCAR)`, content: aviary_CuF3K_triolith },
+    { name: `BaTiO3 (POSCAR)`, content: ba_ti_o3_tetragonal },
+    { name: `NaCl (POSCAR)`, content: na_cl_cubic },
+    { name: `Quartz (ExtXYZ)`, content: extended_xyz_quartz },
+    { name: `Scientific Notation (POSCAR)`, content: scientific_notation_poscar },
+    { name: `Selective Dynamics (POSCAR)`, content: selective_dynamics },
+    { name: `TiO2 (CIF)`, content: tio2_cif },
+    { name: `VASP4 Format (POSCAR)`, content: vasp4_format },
+  ]
+
+  let selected_idx = $state(0)
+  let parsed_structure = $state(undefined)
+  let selected_file = $derived(structure_files[selected_idx])
+</script>
+
+<label style="display: block; margin-block: 1em">
+  Structure:
+  <select bind:value={selected_idx}>
+    {#each structure_files as file, idx (file.name)}
+      <option value={idx}>{file.name}</option>
+    {/each}
+  </select>
+  &ensp;(parsed <strong>{parsed_structure?.sites?.length || 0}</strong> atoms from {
+    format_num(selected_file.content.length)
+  }B)
+</label>
+
+<Structure
+  structure_string={selected_file.content}
+  bind:structure={parsed_structure}
+/>
+```

--- a/tests/vitest/decompress.test.ts
+++ b/tests/vitest/decompress.test.ts
@@ -2,36 +2,10 @@ import {
   decompress_data,
   decompress_file,
   detect_compression_format,
-  remove_compression_extension,
 } from '$lib/io/decompress'
 import { describe, expect, test } from 'vitest'
 
 describe(`decompress utility functions`, () => {
-  describe(`remove_compression_extension`, () => {
-    test.each([
-      [`test.json.gz`, `test.json`],
-      [`structure.poscar.gzip`, `structure.poscar`],
-      [`data.xyz.gz`, `data.xyz`],
-      [`file.cif.gzip`, `file.cif`],
-      [`data.deflate`, `data`], // deflate format
-      [`structure.z`, `structure`], // deflate-raw format
-      [`archive.zip`, `archive`], // zip format
-      [`file.xz`, `file`], // xz format
-      [`data.bz2`, `data`], // bz2 format
-      [`test.json`, `test.json`], // no compression extension
-      [`file.txt`, `file.txt`],
-      [`multiple.gz.json.gz`, `multiple.gz.json`], // only removes last .gz
-      [`file.gzip.txt`, `file.gzip.txt`], // gzip not at end
-      [`file.deflate.txt`, `file.deflate.txt`], // deflate not at end
-      [`file.zip.txt`, `file.zip.txt`], // zip not at end
-      [`file.xz.txt`, `file.xz.txt`], // xz not at end
-      [`file.bz2.txt`, `file.bz2.txt`], // bz2 not at end
-      [``, ``],
-    ])(`should transform "%s" to "%s"`, (input: string, expected: string) => {
-      expect(remove_compression_extension(input)).toBe(expected)
-    })
-  })
-
   describe(`detect_compression_format`, () => {
     test.each([
       [`test.json.gz`, `gzip`],

--- a/tests/vitest/structure/Structure.test.svelte.ts
+++ b/tests/vitest/structure/Structure.test.svelte.ts
@@ -2,6 +2,7 @@ import type { AnyStructure, Vec3 } from '$lib'
 import { Structure } from '$lib'
 import { euclidean_dist, type Matrix3x3, pbc_dist } from '$lib/math'
 import { DEFAULTS } from '$lib/settings'
+import type { StructureHandlerData } from '$lib/structure'
 import * as exports from '$lib/structure/export'
 import { structures } from '$site/structures'
 import { readFileSync } from 'fs'
@@ -804,5 +805,157 @@ describe(`atom label controls`, () => {
 
     expect(parseFloat(instance1_z.value)).toBeCloseTo(0.9, 1)
     expect(parseFloat(instance2_z.value)).toBeCloseTo(0.7, 1)
+  })
+})
+
+describe(`Structure string parsing`, () => {
+  const test_data = [
+    [`POSCAR`, SAMPLE_POSCAR_CONTENT, 5, [`Ba`, `Ti`, `O`], true],
+    [`XYZ`, `3\nH2O\nO 0.0 0.0 0.119\nH 0.0 0.763 -0.477\nH 0.0 -0.763 -0.477`, 3, [
+      `O`,
+      `H`,
+    ], false],
+    [
+      `CIF`,
+      `data_test\n_cell_length_a 5.0\n_cell_length_b 5.0\n_cell_length_c 5.0\n_cell_angle_alpha 90\n_cell_angle_beta 90\n_cell_angle_gamma 90\nloop_\n_atom_site_label\n_atom_site_type_symbol\n_atom_site_fract_x\n_atom_site_fract_y\n_atom_site_fract_z\n_atom_site_occupancy\nNa1 Na 0.0 0.0 0.0 1.0\nCl1 Cl 0.5 0.5 0.5 1.0`,
+      2,
+      [`Na`, `Cl`],
+      true,
+    ],
+    [
+      `JSON`,
+      JSON.stringify({
+        sites: [{
+          species: [{ element: `H`, occu: 1, oxidation_state: 0 }],
+          abc: [0, 0, 0],
+          xyz: [0, 0, 0],
+          label: `H1`,
+          properties: {},
+        }],
+      }),
+      1,
+      [`H`],
+      false,
+    ],
+  ] as const
+
+  test.each(test_data)(
+    `parses %s format correctly`,
+    async (_format, content, atoms, elements, has_lattice) => {
+      let parsed = $state<AnyStructure | undefined>(undefined)
+      let loaded = false
+
+      mount(Structure, {
+        target: document.body,
+        props: {
+          structure_string: content,
+          get structure() {
+            return parsed
+          },
+          set structure(val) {
+            parsed = val
+          },
+          on_file_load: (data) => {
+            loaded = true
+            expect(data.total_atoms).toBe(atoms)
+            expect(data.filename).toBe(`string`)
+          },
+        },
+      })
+
+      await tick()
+      expect(parsed).toBeDefined()
+      if (parsed) {
+        expect(parsed.sites).toHaveLength(atoms)
+        elements.forEach((el) =>
+          expect(parsed?.sites.map((s) => s.species[0].element)).toContain(el)
+        )
+        expect(!!(`lattice` in parsed && parsed.lattice)).toBe(has_lattice)
+      }
+      expect(loaded).toBe(true)
+    },
+  )
+
+  test.each([
+    [`invalid content`, `not parseable`],
+    [`malformed JSON`, `{bad`],
+  ])(`handles %s gracefully`, async (_, content) => {
+    let errored = false
+    mount(Structure, {
+      target: document.body,
+      props: { structure_string: content, on_error: () => errored = true },
+    })
+    await tick()
+    expect(errored).toBe(true)
+  })
+
+  test(`structure binding works correctly`, async () => {
+    let parsed = $state<AnyStructure | undefined>(undefined)
+    mount(Structure, {
+      target: document.body,
+      props: {
+        structure_string: SAMPLE_POSCAR_CONTENT,
+        get structure() {
+          return parsed
+        },
+        set structure(val) {
+          parsed = val
+        },
+      },
+    })
+    await tick()
+    expect(parsed?.sites).toHaveLength(5)
+  })
+
+  test(`loading state works correctly`, async () => {
+    let loading = $state(false)
+    mount(Structure, {
+      target: document.body,
+      props: {
+        structure_string: SAMPLE_POSCAR_CONTENT,
+        get loading() {
+          return loading
+        },
+        set loading(val) {
+          loading = val
+        },
+      },
+    })
+    await tick()
+    expect(loading).toBe(false)
+  })
+
+  test(`file size emission works correctly`, async () => {
+    let size = 0
+    mount(Structure, {
+      target: document.body,
+      props: {
+        structure_string: SAMPLE_POSCAR_CONTENT,
+        on_file_load: (data: StructureHandlerData) => {
+          size = data.file_size || 0
+        },
+      },
+    })
+    await tick()
+    expect(size).toBe(new Blob([SAMPLE_POSCAR_CONTENT]).size)
+  })
+
+  test(`prioritizes data_url over structure_string`, async () => {
+    let filename = ``
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(SAMPLE_POSCAR_CONTENT),
+    })
+    mount(Structure, {
+      target: document.body,
+      props: {
+        data_url: `/test.poscar`,
+        structure_string: `ignored`,
+        on_file_load: (data) => filename = data.filename || ``,
+      },
+    })
+    await tick()
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    expect(filename).toBe(`test.poscar`)
   })
 })

--- a/tests/vitest/structure/parse.test.ts
+++ b/tests/vitest/structure/parse.test.ts
@@ -646,12 +646,10 @@ O1   O   0.410  0.270  0.120  1.000
 O2   O   0.410  0.140  0.880  1.000`
 
   it(`should detect CIF format by extension`, () => {
-    const result = parse_structure_file(
-      QUARTZ_CIF_FOR_DETECTION,
-      `quartz.cif`,
-    )
+    const result = parse_structure_file(QUARTZ_CIF_FOR_DETECTION, `quartz.cif`)
     if (!result) throw `Failed to parse CIF`
     expect(result.sites).toHaveLength(3)
+    expect(result.lattice?.a).toBe(4.916)
   })
 
   test(`parses P24Ru4H252C296S24N16.cif (COD 7008984) with correct totals and composition`, () => {
@@ -2502,7 +2500,7 @@ describe(`Structure File Detection`, () => {
     [`test.poscar`, true],
     [`test.vasp`, true],
     [`test.xyz`, true],
-    [`test.extxyz`, false], // .extxyz files are now classified as potential trajectories
+    [`test.extxyz`, true],
     [`test.json`, false], // Generic JSON files should not trigger MatterViz
     [`test.yaml`, false], // Generic YAML files should not trigger MatterViz
     [`test.yml`, false], // Generic YAML files should not trigger MatterViz
@@ -2574,13 +2572,14 @@ describe(`Structure File Detection`, () => {
     [`mp-756175.json`, false],
     [`BaTiO3-tetragonal.poscar`, true],
     [`cyclohexane.xyz`, true],
-    [`quartz.extxyz`, false],
+    [`cyclohexane.extxyz`, true],
+    [`quartz.extxyz`, true],
     [`AgI-fq978185p-phono3py.yaml.gz`, true],
     [`nested-Hf36Mo36Nb36Ta36W36-hcp-mace-omat.json.gz`, false],
     [`BeO-zw12zc18p-phono3py.yaml.gz`, true],
-    // Trajectory files should not be detected as structure files
+    // filenames containing trajectory keywords should not be detected as structure files
     [`trajectory.traj`, false],
-    [`md.xyz.gz`, false], // This should be detected as a trajectory file, not structure
+    [`md.xyz.gz`, false],
     [`simulation.h5`, false],
     [`XDATCAR`, false],
     [`relax.extxyz`, false],

--- a/tests/vitest/structure/parse.test.ts
+++ b/tests/vitest/structure/parse.test.ts
@@ -649,7 +649,7 @@ O2   O   0.410  0.140  0.880  1.000`
     const result = parse_structure_file(QUARTZ_CIF_FOR_DETECTION, `quartz.cif`)
     if (!result) throw `Failed to parse CIF`
     expect(result.sites).toHaveLength(3)
-    expect(result.lattice?.a).toBe(4.916)
+    expect(result.lattice?.a).toBeCloseTo(4.916, 6)
   })
 
   test(`parses P24Ru4H252C296S24N16.cif (COD 7008984) with correct totals and composition`, () => {
@@ -1937,7 +1937,7 @@ describe(`parse_structure_file`, () => {
     const end_time = performance.now()
 
     expect(result?.sites).toHaveLength(1)
-    expect(result?.sites[0].species).toContain(`H`)
+    expect(result?.sites[0].species[0]).toBe(`H`)
 
     // Should complete reasonably quickly (less than 100ms for 100 levels)
     // This ensures the recursive parser is efficient and doesn't degrade
@@ -2574,6 +2574,7 @@ describe(`Structure File Detection`, () => {
     [`cyclohexane.xyz`, true],
     [`cyclohexane.extxyz`, true],
     [`quartz.extxyz`, true],
+    [`structure.extxyz.gz`, true],
     [`AgI-fq978185p-phono3py.yaml.gz`, true],
     [`nested-Hf36Mo36Nb36Ta36W36-hcp-mace-omat.json.gz`, false],
     [`BeO-zw12zc18p-phono3py.yaml.gz`, true],

--- a/tests/vitest/structure/parse.test.ts
+++ b/tests/vitest/structure/parse.test.ts
@@ -131,6 +131,12 @@ describe(`POSCAR Parser`, () => {
         `Test\n1.0\n3.0 0.0 0.0\n0.0 3.0 0.0\n0.0 0.0 3.0\nH_pv O/12345abc\n1 1\nDirect\n0.0 0.0 0.0\n0.5 0.5 0.5`,
       expected: { elements: [`H`, `O`] },
     },
+    {
+      name: `scientific notation in malformed coordinates`,
+      content:
+        `Test\n1.0\n3.0 0.0 0.0\n0.0 3.0 0.0\n0.0 0.0 3.0\nH\n1\nDirect\n1e-3-2e-3-3e-3`,
+      expected: { abc: [0.001, 0.998, 0.997] }, // Scientific notation preserved: 1e-3 -2e-3 -3e-3, negative coordinates wrapped
+    },
   ])(`should handle $name`, ({ content, expected }) => {
     const result = parse_poscar(content)
     if (!result) throw `Failed to parse POSCAR`
@@ -212,7 +218,7 @@ describe(`POSCAR Parser`, () => {
       expect(result).toBeNull()
       expect(console_error_spy).toHaveBeenCalledWith(
         `Error parsing POSCAR file:`,
-        expected_error,
+        expect.objectContaining({ message: expected_error }),
       )
     },
   )

--- a/tests/vitest/trajectory/parse.test.ts
+++ b/tests/vitest/trajectory/parse.test.ts
@@ -44,16 +44,16 @@ describe(`Trajectory File Detection`, () => {
     [`XDATCAR.out`, true],
     [`xdatcar.out`, true],
 
-    // xyz/extxyz files now require content-based detection
-    [`relax-simulation.xyz`, false],
-    [`trajectory-data.extxyz`, false],
-    [`npt-dynamics.extxyz`, false],
-    [`nvt-simulation.xyz`, false],
-    [`nve-dynamics.extxyz`, false],
-    [`qha-analysis.xyz`, false],
-    [`traj-data.xyz`, false],
-    [`relaxation.extxyz`, false],
-    [`md-run.xyz`, false],
+    // xyz/extxyz files with trajectory keywords are detected by filename for auto-render
+    [`relax-simulation.xyz`, true], // Has trajectory keyword "relax"
+    [`trajectory-data.extxyz`, true], // Has trajectory keyword "trajectory"
+    [`npt-dynamics.extxyz`, true], // Has trajectory keyword "npt"
+    [`nvt-simulation.xyz`, true], // Has trajectory keyword "nvt"
+    [`nve-dynamics.extxyz`, true], // Has trajectory keyword "nve"
+    [`qha-analysis.xyz`, true], // Has trajectory keyword "qha"
+    [`traj-data.xyz`, true], // Has trajectory keyword "traj"
+    [`relaxation.extxyz`, true], // Has trajectory keyword "relax"
+    [`md-run.xyz`, true], // Has trajectory keyword "md"
 
     // Other files with trajectory keywords (excluding specific extensions)
     [`trajectory.dat`, true],
@@ -68,13 +68,13 @@ describe(`Trajectory File Detection`, () => {
     [`md_simulation.out`, false],
 
     // Compressed trajectory files
-    [`relax.extxyz.gz`, false],
+    [`relax.extxyz.gz`, true], // Has trajectory keyword "relax"
     [`trajectory.traj.gz`, true],
     [`simulation.h5.gz`, true],
     [`dynamics.hdf5.gz`, true],
     [`XDATCAR.gz`, true],
     [`xdatcar.gz`, true],
-    [`md.xyz.gz`, false],
+    [`md.xyz.gz`, true], // Has trajectory keyword "md"
     // Compressed with other extensions
     [`trajectory.traj.xz`, true],
     [`trajectory.traj.bz2`, true],
@@ -97,8 +97,8 @@ describe(`Trajectory File Detection`, () => {
     [`FILE.TRAJ`, true],
     [`TRAJECTORY.H5`, true],
     [`XDATCAR.HDF5`, true],
-    [`RELAX.EXTXYZ`, false],
-    [`MD.XYZ`, false],
+    [`RELAX.EXTXYZ`, true], // Has trajectory keyword "relax"
+    [`MD.XYZ`, true], // Has trajectory keyword "md"
 
     // Unicode and special characters
     [`مەركەزیtrajectory.traj`, true],
@@ -126,19 +126,19 @@ describe(`Trajectory File Detection`, () => {
     // Very short names
     [`a.traj`, true],
     [`a.h5`, false],
-    [`a.xyz`, false], // .xyz files now require content-based detection
+    [`a.xyz`, false], // No trajectory keywords
     [`a`, false],
 
     // Very long filename
     [`${`a`.repeat(1000)}.traj`, true],
-    [`${`a`.repeat(1000)}.xyz`, false], // .xyz files now require content-based detection
+    [`${`a`.repeat(1000)}.xyz`, false], // No trajectory keywords
 
     // Specific regression tests
-    [`Cr0.25Fe0.25Co0.25Ni0.25-mace-omat-qha.xyz`, false],
-    [`single-molecule.xyz`, false], // .xyz files now require content-based detection
+    [`Cr0.25Fe0.25Co0.25Ni0.25-mace-omat-qha.xyz`, true], // Has trajectory keyword "qha"
+    [`single-molecule.xyz`, false], // No trajectory keywords
     [`trajectory_data.json`, true], // JSON files with trajectory keywords are now supported
     [`md_simulation.cif`, false],
-    [`relax_output.poscar`, true],
+    [`relax_output.poscar`, false],
 
     // Files that should NOT be detected as trajectory files
     [`test.cif`, false],
@@ -178,7 +178,7 @@ describe(`Trajectory File Detection`, () => {
     // Files with partial matches that should not trigger
     [`trajectory_notes.txt`, false],
     [`md_documentation.md`, false],
-    [`relax_manual.pdf`, true],
+    [`relax_manual.pdf`, false],
     [`npt_analysis.py`, false],
     [`nvt_report.csv`, false],
     [`nve_summary.html`, false],
@@ -193,40 +193,40 @@ describe(`Trajectory File Detection`, () => {
     [`config.yaml.gz`, false],
     [`trajectory_notes.md.gz`, false],
 
-    // Keyword matching edge cases - xyz files now require content-based detection
-    [`trajectory_analysis.xyz`, false],
-    [`md_simulation.xyz`, false],
-    [`relaxation_study.xyz`, false],
-    [`npt_ensemble.xyz`, false],
-    [`nvt_canonical.xyz`, false],
-    [`nve_microcanonical.xyz`, false],
-    [`qha_thermodynamics.xyz`, false],
-    [`analysis_trajectory.xyz`, false],
-    [`simulation_md.xyz`, false],
-    [`study_relax.xyz`, false],
-    [`ensemble_npt.xyz`, false],
-    [`canonical_nvt.xyz`, false],
-    [`microcanonical_nve.xyz`, false],
-    [`thermodynamics_qha.xyz`, false],
-    [`TRAJECTORY.xyz`, false],
-    [`Trajectory.xyz`, false],
-    [`trajectory.xyz`, false],
-    [`MD.xyz`, false],
-    [`Md.xyz`, false],
-    [`md.xyz`, false],
-    // Machine learning potential trajectories (no traditional keywords)
-    [`V8Ta12W71Re8-mace-omat.xyz`, false],
-    [`CuAgAu_chgnet_relax.xyz`, false],
-    [`bulk_water_dpmd.xyz`, false],
-    [`alloy_simulation_m3gnet.xyz`, false],
+    // Keyword matching edge cases - xyz files with trajectory keywords are detected by filename
+    [`trajectory_analysis.xyz`, true], // Has trajectory keyword "trajectory"
+    [`md_simulation.xyz`, true], // Has trajectory keyword "md"
+    [`relaxation_study.xyz`, true], // Has trajectory keyword "relax"
+    [`npt_ensemble.xyz`, true], // Has trajectory keyword "npt"
+    [`nvt_canonical.xyz`, true], // Has trajectory keyword "nvt"
+    [`nve_microcanonical.xyz`, true], // Has trajectory keyword "nve"
+    [`qha_thermodynamics.xyz`, true], // Has trajectory keyword "qha"
+    [`analysis_trajectory.xyz`, true], // Has trajectory keyword "trajectory"
+    [`simulation_md.xyz`, true], // Has trajectory keyword "md"
+    [`study_relax.xyz`, true], // Has trajectory keyword "relax"
+    [`ensemble_npt.xyz`, true], // Has trajectory keyword "npt"
+    [`canonical_nvt.xyz`, true], // Has trajectory keyword "nvt"
+    [`microcanonical_nve.xyz`, true], // Has trajectory keyword "nve"
+    [`thermodynamics_qha.xyz`, true], // Has trajectory keyword "qha"
+    [`TRAJECTORY.xyz`, true], // Has trajectory keyword "trajectory"
+    [`Trajectory.xyz`, true], // Has trajectory keyword "trajectory"
+    [`trajectory.xyz`, true], // Has trajectory keyword "trajectory"
+    [`MD.xyz`, true], // Has trajectory keyword "md"
+    [`Md.xyz`, true], // Has trajectory keyword "md"
+    [`md.xyz`, true], // Has trajectory keyword "md"
+    // Machine learning potential trajectories (some have trajectory keywords)
+    [`V8Ta12W71Re8-mace-omat.xyz`, false], // No trajectory keywords
+    [`CuAgAu_chgnet_relax.xyz`, true], // Has trajectory keyword "relax"
+    [`bulk_water_dpmd.xyz`, true], // Has trajectory keyword "md"
+    [`alloy_simulation_m3gnet.xyz`, true], // Has trajectory keyword "simulation"
     // Compressed JSON trajectories from various sources
     [`pymatgen-trajectory-data.json.gz`, true],
     [`ase-md-output.json.bz2`, true],
     [`simulation-results.json.xz`, true],
     // Edge cases that should still work
-    [`dataset_structure_0001.xyz`, false], // No keywords but .xyz extension - now requires content
-    [`crystal_optimization.xyz`, false], // Has keyword but also .xyz - now requires content
-    [`mp-1184225.extxyz`, false], // Materials Project format - now requires content
+    [`dataset_structure_0001.xyz`, false], // No trajectory keywords
+    [`crystal_optimization.xyz`, false], // No trajectory keywords (crystal is structure keyword)
+    [`mp-1184225.extxyz`, false], // No trajectory keywords
   ])(`trajectory detection: "%s" → %s`, (filename, expected) => {
     expect(is_trajectory_file(filename)).toBe(expected)
   })
@@ -265,43 +265,28 @@ describe(`Content-Based xyz/extxyz Trajectory Detection`, () => {
         `2\nstep=0 energy=-5.2\nC 0.0 0.0 0.0\nO 1.2 0.0 0.0\n2\nstep=1 energy=-5.1\nC 0.05 0.0 0.0\nO 1.15 0.0 0.0`,
         true,
       ],
-      // More complex multi-frame examples
       [
         `relaxation.xyz`,
         `4\nProperties=species:S:1:pos:R:3 energy=-12.5\nSi 0.0 0.0 0.0\nSi 2.7 0.0 0.0\nO 1.35 0.0 0.0\nO 1.35 1.5 0.0\n4\nProperties=species:S:1:pos:R:3 energy=-12.8\nSi 0.05 0.0 0.0\nSi 2.65 0.0 0.0\nO 1.35 0.0 0.1\nO 1.35 1.45 0.0`,
         true,
       ],
-      // Files with empty lines and comments (should still work)
       [
         `trajectory-with-gaps.xyz`,
         `\n2\nframe 1\nH 0.0 0.0 0.0\nH 1.0 0.0 0.0\n\n2\nframe 2\nH 0.1 0.0 0.0\nH 1.1 0.0 0.0\n`,
         true,
       ],
-      // Large number of frames
-      [
-        `long-trajectory.xyz`,
-        Array.from(
-          { length: 5 },
-          (_, idx) => `2\nstep=${idx}\nH 0.${idx} 0.0 0.0\nH 1.${idx} 0.0 0.0`,
-        ).join(`\n`),
-        true,
-      ],
       // Edge case: exactly 2 frames (should be true)
-      [
-        `two-frames.xyz`,
-        `1\nfirst\nH 0.0 0.0 0.0\n1\nsecond\nH 0.1 0.0 0.0`,
-        true,
-      ],
+      [`two-frames.xyz`, `1\nfirst\nH 0.0 0.0 0.0\n1\nsecond\nH 0.1 0.0 0.0`, true],
     ])(`should detect "%s" as trajectory: %s`, (filename, content, expected) => {
       expect(is_trajectory_file(filename, content)).toBe(expected)
     })
 
     test.each([
-      // Without content, xyz/extxyz files should return false
-      [`single.xyz`, false],
-      [`trajectory.xyz`, false],
-      [`data.extxyz`, false],
-      [`md-simulation.extxyz`, false],
+      // Without content, xyz/extxyz files with trajectory keywords return true for auto-render
+      [`single.xyz`, false], // No trajectory keywords
+      [`trajectory.xyz`, true], // Has trajectory keyword
+      [`data.extxyz`, false], // No trajectory keywords
+      [`md-simulation.extxyz`, true], // Has trajectory keyword
       // Non-xyz files should still work with filename-only detection
       [`simulation.traj`, true],
       [`XDATCAR`, true],
@@ -362,12 +347,12 @@ describe(`Content-Based xyz/extxyz Trajectory Detection`, () => {
       expect(is_trajectory_file(`mixed.xyz`, content)).toBe(true)
     })
 
-    test(`should handle very large trajectories efficiently`, () => {
-      // Create a trajectory with 1000 frames
+    test(`should handle large trajectories efficiently`, () => {
+      // Create a trajectory with 100 frames (reduced for faster tests)
       const frames = Array.from(
-        { length: 1000 },
+        { length: 100 },
         (_, idx) =>
-          `2\nstep=${idx}\nH ${idx * 0.001} 0.0 0.0\nH ${1 + idx * 0.001} 0.0 0.0`,
+          `2\nstep=${idx}\nH ${idx * 0.01} 0.0 0.0\nH ${1 + idx * 0.01} 0.0 0.0`,
       )
       const content = frames.join(`\n`)
 
@@ -376,7 +361,7 @@ describe(`Content-Based xyz/extxyz Trajectory Detection`, () => {
       const duration = performance.now() - start
 
       expect(result).toBe(true)
-      expect(duration).toBeLessThan(1000) // Should complete within 1 second
+      expect(duration).toBeLessThan(100) // Should complete within 100ms
     })
 
     test.each([

--- a/tests/vitest/trajectory/parse.test.ts
+++ b/tests/vitest/trajectory/parse.test.ts
@@ -254,6 +254,7 @@ describe(`Content-Based xyz/extxyz Trajectory Detection`, () => {
         `5\nenergy=-10.5\nC 0.0 0.0 0.0\nH 1.0 0.0 0.0\nH 0.0 1.0 0.0\nH 0.0 0.0 1.0\nH -1.0 0.0 0.0`,
         false,
       ],
+      [`single-frame-lattice.extxyz`, `1\nLattice="5 0 0 0 5 0 0 0 5"\nH 0 0 0\n`, false],
       // Multi-frame XYZ files should return true
       [
         `trajectory.xyz`,

--- a/tests/vitest/trajectory/parse.test.ts
+++ b/tests/vitest/trajectory/parse.test.ts
@@ -44,16 +44,16 @@ describe(`Trajectory File Detection`, () => {
     [`XDATCAR.out`, true],
     [`xdatcar.out`, true],
 
-    // XYZ/EXTXYZ files with trajectory keywords
-    [`relax-simulation.xyz`, true],
-    [`trajectory-data.extxyz`, true],
-    [`npt-dynamics.extxyz`, true],
-    [`nvt-simulation.xyz`, true],
-    [`nve-dynamics.extxyz`, true],
-    [`qha-analysis.xyz`, true],
-    [`traj-data.xyz`, true],
-    [`relaxation.extxyz`, true],
-    [`md-run.xyz`, true],
+    // xyz/extxyz files now require content-based detection
+    [`relax-simulation.xyz`, false],
+    [`trajectory-data.extxyz`, false],
+    [`npt-dynamics.extxyz`, false],
+    [`nvt-simulation.xyz`, false],
+    [`nve-dynamics.extxyz`, false],
+    [`qha-analysis.xyz`, false],
+    [`traj-data.xyz`, false],
+    [`relaxation.extxyz`, false],
+    [`md-run.xyz`, false],
 
     // Other files with trajectory keywords (excluding specific extensions)
     [`trajectory.dat`, true],
@@ -68,13 +68,13 @@ describe(`Trajectory File Detection`, () => {
     [`md_simulation.out`, false],
 
     // Compressed trajectory files
-    [`relax.extxyz.gz`, true],
+    [`relax.extxyz.gz`, false],
     [`trajectory.traj.gz`, true],
     [`simulation.h5.gz`, true],
     [`dynamics.hdf5.gz`, true],
     [`XDATCAR.gz`, true],
     [`xdatcar.gz`, true],
-    [`md.xyz.gz`, true],
+    [`md.xyz.gz`, false],
     // Compressed with other extensions
     [`trajectory.traj.xz`, true],
     [`trajectory.traj.bz2`, true],
@@ -97,8 +97,8 @@ describe(`Trajectory File Detection`, () => {
     [`FILE.TRAJ`, true],
     [`TRAJECTORY.H5`, true],
     [`XDATCAR.HDF5`, true],
-    [`RELAX.EXTXYZ`, true],
-    [`MD.XYZ`, true],
+    [`RELAX.EXTXYZ`, false],
+    [`MD.XYZ`, false],
 
     // Unicode and special characters
     [`مەركەزیtrajectory.traj`, true],
@@ -126,16 +126,16 @@ describe(`Trajectory File Detection`, () => {
     // Very short names
     [`a.traj`, true],
     [`a.h5`, false],
-    [`a.xyz`, true], // .xyz files are now always considered potential trajectories
+    [`a.xyz`, false], // .xyz files now require content-based detection
     [`a`, false],
 
     // Very long filename
     [`${`a`.repeat(1000)}.traj`, true],
-    [`${`a`.repeat(1000)}.xyz`, true], // .xyz files are now always considered potential trajectories
+    [`${`a`.repeat(1000)}.xyz`, false], // .xyz files now require content-based detection
 
     // Specific regression tests
-    [`Cr0.25Fe0.25Co0.25Ni0.25-mace-omat-qha.xyz`, true],
-    [`single-molecule.xyz`, true], // .xyz files are now always considered potential trajectories
+    [`Cr0.25Fe0.25Co0.25Ni0.25-mace-omat-qha.xyz`, false],
+    [`single-molecule.xyz`, false], // .xyz files now require content-based detection
     [`trajectory_data.json`, true], // JSON files with trajectory keywords are now supported
     [`md_simulation.cif`, false],
     [`relax_output.poscar`, true],
@@ -193,40 +193,40 @@ describe(`Trajectory File Detection`, () => {
     [`config.yaml.gz`, false],
     [`trajectory_notes.md.gz`, false],
 
-    // Keyword matching edge cases
-    [`trajectory_analysis.xyz`, true],
-    [`md_simulation.xyz`, true],
-    [`relaxation_study.xyz`, true],
-    [`npt_ensemble.xyz`, true],
-    [`nvt_canonical.xyz`, true],
-    [`nve_microcanonical.xyz`, true],
-    [`qha_thermodynamics.xyz`, true],
-    [`analysis_trajectory.xyz`, true],
-    [`simulation_md.xyz`, true],
-    [`study_relax.xyz`, true],
-    [`ensemble_npt.xyz`, true],
-    [`canonical_nvt.xyz`, true],
-    [`microcanonical_nve.xyz`, true],
-    [`thermodynamics_qha.xyz`, true],
-    [`TRAJECTORY.xyz`, true],
-    [`Trajectory.xyz`, true],
-    [`trajectory.xyz`, true],
-    [`MD.xyz`, true],
-    [`Md.xyz`, true],
-    [`md.xyz`, true],
+    // Keyword matching edge cases - xyz files now require content-based detection
+    [`trajectory_analysis.xyz`, false],
+    [`md_simulation.xyz`, false],
+    [`relaxation_study.xyz`, false],
+    [`npt_ensemble.xyz`, false],
+    [`nvt_canonical.xyz`, false],
+    [`nve_microcanonical.xyz`, false],
+    [`qha_thermodynamics.xyz`, false],
+    [`analysis_trajectory.xyz`, false],
+    [`simulation_md.xyz`, false],
+    [`study_relax.xyz`, false],
+    [`ensemble_npt.xyz`, false],
+    [`canonical_nvt.xyz`, false],
+    [`microcanonical_nve.xyz`, false],
+    [`thermodynamics_qha.xyz`, false],
+    [`TRAJECTORY.xyz`, false],
+    [`Trajectory.xyz`, false],
+    [`trajectory.xyz`, false],
+    [`MD.xyz`, false],
+    [`Md.xyz`, false],
+    [`md.xyz`, false],
     // Machine learning potential trajectories (no traditional keywords)
-    [`V8Ta12W71Re8-mace-omat.xyz`, true],
-    [`CuAgAu_chgnet_relax.xyz`, true],
-    [`bulk_water_dpmd.xyz`, true],
-    [`alloy_simulation_m3gnet.xyz`, true],
+    [`V8Ta12W71Re8-mace-omat.xyz`, false],
+    [`CuAgAu_chgnet_relax.xyz`, false],
+    [`bulk_water_dpmd.xyz`, false],
+    [`alloy_simulation_m3gnet.xyz`, false],
     // Compressed JSON trajectories from various sources
     [`pymatgen-trajectory-data.json.gz`, true],
     [`ase-md-output.json.bz2`, true],
     [`simulation-results.json.xz`, true],
     // Edge cases that should still work
-    [`dataset_structure_0001.xyz`, true], // No keywords but .xyz extension
-    [`crystal_optimization.xyz`, true], // Has keyword but also .xyz
-    [`mp-1184225.extxyz`, true], // Materials Project format
+    [`dataset_structure_0001.xyz`, false], // No keywords but .xyz extension - now requires content
+    [`crystal_optimization.xyz`, false], // Has keyword but also .xyz - now requires content
+    [`mp-1184225.extxyz`, false], // Materials Project format - now requires content
   ])(`trajectory detection: "%s" → %s`, (filename, expected) => {
     expect(is_trajectory_file(filename)).toBe(expected)
   })
@@ -238,6 +238,170 @@ describe(`Trajectory File Detection`, () => {
       expect(() => is_trajectory_file(filename)).toThrow()
     },
   )
+})
+
+describe(`Content-Based xyz/extxyz Trajectory Detection`, () => {
+  describe(`is_trajectory_file with content parameter`, () => {
+    test.each([
+      // Single frame XYZ files should return false
+      [
+        `single-frame.xyz`,
+        `3\ncomment line\nH 0.0 0.0 0.0\nH 1.0 0.0 0.0\nH 0.0 1.0 0.0`,
+        false,
+      ],
+      [
+        `molecule.extxyz`,
+        `5\nenergy=-10.5\nC 0.0 0.0 0.0\nH 1.0 0.0 0.0\nH 0.0 1.0 0.0\nH 0.0 0.0 1.0\nH -1.0 0.0 0.0`,
+        false,
+      ],
+      // Multi-frame XYZ files should return true
+      [
+        `trajectory.xyz`,
+        `3\nframe 1\nH 0.0 0.0 0.0\nH 1.0 0.0 0.0\nH 0.0 1.0 0.0\n3\nframe 2\nH 0.1 0.0 0.0\nH 1.1 0.0 0.0\nH 0.1 1.0 0.0`,
+        true,
+      ],
+      [
+        `md-simulation.extxyz`,
+        `2\nstep=0 energy=-5.2\nC 0.0 0.0 0.0\nO 1.2 0.0 0.0\n2\nstep=1 energy=-5.1\nC 0.05 0.0 0.0\nO 1.15 0.0 0.0`,
+        true,
+      ],
+      // More complex multi-frame examples
+      [
+        `relaxation.xyz`,
+        `4\nProperties=species:S:1:pos:R:3 energy=-12.5\nSi 0.0 0.0 0.0\nSi 2.7 0.0 0.0\nO 1.35 0.0 0.0\nO 1.35 1.5 0.0\n4\nProperties=species:S:1:pos:R:3 energy=-12.8\nSi 0.05 0.0 0.0\nSi 2.65 0.0 0.0\nO 1.35 0.0 0.1\nO 1.35 1.45 0.0`,
+        true,
+      ],
+      // Files with empty lines and comments (should still work)
+      [
+        `trajectory-with-gaps.xyz`,
+        `\n2\nframe 1\nH 0.0 0.0 0.0\nH 1.0 0.0 0.0\n\n2\nframe 2\nH 0.1 0.0 0.0\nH 1.1 0.0 0.0\n`,
+        true,
+      ],
+      // Large number of frames
+      [
+        `long-trajectory.xyz`,
+        Array.from(
+          { length: 5 },
+          (_, idx) => `2\nstep=${idx}\nH 0.${idx} 0.0 0.0\nH 1.${idx} 0.0 0.0`,
+        ).join(`\n`),
+        true,
+      ],
+      // Edge case: exactly 2 frames (should be true)
+      [
+        `two-frames.xyz`,
+        `1\nfirst\nH 0.0 0.0 0.0\n1\nsecond\nH 0.1 0.0 0.0`,
+        true,
+      ],
+    ])(`should detect "%s" as trajectory: %s`, (filename, content, expected) => {
+      expect(is_trajectory_file(filename, content)).toBe(expected)
+    })
+
+    test.each([
+      // Without content, xyz/extxyz files should return false
+      [`single.xyz`, false],
+      [`trajectory.xyz`, false],
+      [`data.extxyz`, false],
+      [`md-simulation.extxyz`, false],
+      // Non-xyz files should still work with filename-only detection
+      [`simulation.traj`, true],
+      [`XDATCAR`, true],
+      [`md-dynamics.h5`, true],
+      [`relax.log`, true],
+      [`npt.dat`, true],
+      [`structure.cif`, false],
+      [`document.txt`, false],
+    ])(`filename-only detection: "%s" → %s`, (filename, expected) => {
+      expect(is_trajectory_file(filename)).toBe(expected)
+    })
+
+    test.each([
+      // Malformed XYZ content should return false
+      [`malformed.xyz`, `invalid\nno atom count\nH 0.0 0.0 0.0`, false],
+      [`broken-count.xyz`, `not_a_number\ncomment\nH 0.0 0.0 0.0`, false],
+      [`incomplete.xyz`, `3\ncomment\nH 0.0 0.0 0.0\nH 1.0 0.0 0.0`, false],
+      // Empty or whitespace content
+      [`empty.xyz`, ``, false],
+      [`whitespace.xyz`, `   \n  \n  `, false],
+      // Invalid atom coordinates
+      [`bad-coords.xyz`, `2\ntest\nH not_a_number 0.0 0.0\nH 1.0 invalid 0.0`, false],
+      // Negative atom counts (should be skipped)
+      [
+        `negative-count.xyz`,
+        `-1\nshould be skipped\nH 0.0 0.0 0.0\n2\nvalid frame\nH 0.0 0.0 0.0\nH 1.0 0.0 0.0`,
+        false,
+      ],
+      // Zero atom counts (should be skipped)
+      [`zero-count.xyz`, `0\nempty frame\n\n1\nvalid frame\nH 0.0 0.0 0.0`, false],
+    ])(`should handle malformed content: "%s" → %s`, (filename, content, expected) => {
+      expect(is_trajectory_file(filename, content)).toBe(expected)
+    })
+
+    test(`should handle mixed valid and invalid frames`, () => {
+      const content = `
+        invalid
+        comment
+        H 0.0 0.0 0.0
+
+        3
+        valid frame 1
+        H 0.0 0.0 0.0
+        H 1.0 0.0 0.0
+        H 0.0 1.0 0.0
+
+        not_a_number
+        invalid frame
+        H 0.0 0.0 0.0
+
+        3
+        valid frame 2
+        H 0.1 0.0 0.0
+        H 1.1 0.0 0.0
+        H 0.1 1.0 0.0
+      `
+
+      expect(is_trajectory_file(`mixed.xyz`, content)).toBe(true)
+    })
+
+    test(`should handle very large trajectories efficiently`, () => {
+      // Create a trajectory with 1000 frames
+      const frames = Array.from(
+        { length: 1000 },
+        (_, idx) =>
+          `2\nstep=${idx}\nH ${idx * 0.001} 0.0 0.0\nH ${1 + idx * 0.001} 0.0 0.0`,
+      )
+      const content = frames.join(`\n`)
+
+      const start = performance.now()
+      const result = is_trajectory_file(`large-trajectory.xyz`, content)
+      const duration = performance.now() - start
+
+      expect(result).toBe(true)
+      expect(duration).toBeLessThan(1000) // Should complete within 1 second
+    })
+
+    test.each([
+      // Files with Lattice information
+      [
+        `crystal-trajectory.extxyz`,
+        `2\nLattice="5.0 0.0 0.0 0.0 5.0 0.0 0.0 0.0 5.0"\nSi 0.0 0.0 0.0\nSi 2.5 2.5 2.5\n2\nLattice="5.1 0.0 0.0 0.0 5.1 0.0 0.0 0.0 5.1"\nSi 0.05 0.0 0.0\nSi 2.45 2.5 2.5`,
+        true,
+      ],
+      // Files with Properties specification
+      [
+        `forces-trajectory.extxyz`,
+        `2\nProperties=species:S:1:pos:R:3:forces:R:3\nH 0.0 0.0 0.0 0.1 0.0 0.0\nH 1.0 0.0 0.0 -0.1 0.0 0.0\n2\nProperties=species:S:1:pos:R:3:forces:R:3\nH 0.05 0.0 0.0 0.08 0.0 0.0\nH 1.05 0.0 0.0 -0.08 0.0 0.0`,
+        true,
+      ],
+      // Files with energy and other metadata
+      [
+        `metadata-trajectory.xyz`,
+        `3\nenergy=-15.2 temperature=300 pressure=1.0\nC 0.0 0.0 0.0\nH 1.0 0.0 0.0\nH 0.0 1.0 0.0\n3\nenergy=-15.1 temperature=305 pressure=1.1\nC 0.01 0.0 0.0\nH 1.01 0.0 0.0\nH 0.01 1.0 0.0`,
+        true,
+      ],
+    ])(`should handle extended XYZ formats: "%s" → %s`, (filename, content, expected) => {
+      expect(is_trajectory_file(filename, content)).toBe(expected)
+    })
+  })
 })
 
 describe(`VASP XDATCAR Parser`, () => {


### PR DESCRIPTION
closes #149

- Add a `structure_string` prop for loading CIF, POSCAR, XYZ, JSON, and other structure text with live parsing, metadata, loading state, and invalid-content errors.
- Detect XYZ/extXYZ trajectories from multi-frame content instead of the file type alone.
- Improve VS Code webview messaging, downloads, and external initialization and cleanup hooks.
- Add selectable structure-string examples to the demo.