### PR TITLE
Support on-the-fly 4D energy above hull calculation

### DIFF
--- a/extensions/vscode/src/webview/main.ts
+++ b/extensions/vscode/src/webview/main.ts
@@ -65,9 +65,7 @@ class VSCodeFrameLoader implements FrameLoader {
     frame_index: number,
   ): Promise<TrajectoryFrame | null> {
     return new Promise((resolve, reject) => {
-      const request_id = globalThis.crypto?.randomUUID?.() ??
-        Math.random().toString(36).slice(2, 15)
-
+      const request_id = crypto.randomUUID()
       let timer: ReturnType<typeof setTimeout> | null = null
       const handler = (event: MessageEvent) => {
         const { command, request_id: id, error, frame } = event.data
@@ -262,7 +260,7 @@ function request_large_file_content(
   if (!vscode_api) throw new Error(`VS Code API not available`)
 
   return new Promise((resolve, reject) => {
-    const request_id = Math.random().toString(36).slice(2, 15)
+    const request_id = crypto.randomUUID()
 
     let timer: ReturnType<typeof setTimeout> | null = null
     const handler = (event: MessageEvent) => {

--- a/src/lib/math.ts
+++ b/src/lib/math.ts
@@ -322,3 +322,24 @@ export function get_coefficient_of_variation(values: number[]): number {
     ? Math.sqrt(variance) / Math.abs(mean)
     : Math.sqrt(variance)
 }
+
+// Compute 4x4 determinant (used for 4D barycentric coordinates)
+export function det_4x4(matrix: number[][]): number {
+  const [a, b, c, d] = matrix
+  const [a0, a1, a2, a3] = a
+  const [b0, b1, b2, b3] = b
+  const [c0, c1, c2, c3] = c
+  const [d0, d1, d2, d3] = d
+  return (a0 *
+      (b1 * (c2 * d3 - c3 * d2) - b2 * (c1 * d3 - c3 * d1) + b3 * (c1 * d2 - c2 * d1)) -
+    a1 *
+      (b0 * (c2 * d3 - c3 * d2) - b2 * (c0 * d3 - c3 * d0) + b3 * (c0 * d2 - c2 * d0)) +
+    a2 *
+      (b0 * (c1 * d3 - c3 * d1) - b1 * (c0 * d3 - c3 * d0) + b3 * (c0 * d1 - c1 * d0)) -
+    a3 * (b0 * (c1 * d2 - c2 * d1) - b1 * (c0 * d2 - c2 * d0) + b2 * (c0 * d1 - c1 * d0)))
+}
+
+// 3D cross product
+export function cross_3d(a: Vec3, b: Vec3): Vec3 {
+  return [a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0]]
+}

--- a/src/lib/phase-diagram/PhaseDiagramControls.svelte
+++ b/src/lib/phase-diagram/PhaseDiagramControls.svelte
@@ -30,6 +30,8 @@
     on_hull_faces_change?: (value: boolean) => void
     hull_face_color?: string
     on_hull_face_color_change?: (value: string) => void
+    hull_face_opacity?: number
+    on_hull_face_opacity_change?: (value: number) => void
     energy_source_mode?: `precomputed` | `on-the-fly` // whether to read formation and above hull distance from entries or compute them on the fly
     has_precomputed_hull?: boolean
     can_compute_hull?: boolean
@@ -63,6 +65,8 @@
     on_hull_faces_change,
     hull_face_color = `#0072B2`,
     on_hull_face_color_change,
+    hull_face_opacity = $bindable(0.06),
+    on_hull_face_opacity_change,
     energy_threshold = $bindable(0),
     label_energy_threshold = $bindable(0.1),
     max_energy_threshold = 0.5,
@@ -273,25 +277,44 @@
     {/if}
   {/if}
 
-  <!-- Hull faces toggle (for 3D ternary diagrams) -->
+  <!-- Hull faces toggle (for 3D ternary and 4D quaternary diagrams) -->
   {#if show_hull_faces !== undefined}
     <div class="control-row">
-      <span class="control-label">3D Hull</span>
+      <span class="control-label">Hull Faces</span>
       <label {@attach tooltip({ content: `Toggle convex hull faces` })}>
         <input
           type="checkbox"
           checked={show_hull_faces}
           oninput={(e) => on_hull_faces_change?.((e.target as HTMLInputElement).checked)}
         />
-        <span>Show faces</span>
+        <span>Show</span>
       </label>
-      <span class="control-label" style="min-width: auto">Hull color</span>
-      <input
-        type="color"
-        value={hull_face_color}
-        oninput={(e) => on_hull_face_color_change?.((e.target as HTMLInputElement).value)}
-        {@attach tooltip({ content: `Set hull face color` })}
-      />
+      <div style="display: flex; gap: 6px; align-items: center; flex: 1">
+        <input
+          type="color"
+          value={hull_face_color}
+          oninput={(e) => on_hull_face_color_change?.((e.target as HTMLInputElement).value)}
+          {@attach tooltip({ content: `Set hull face color` })}
+          style="width: 40px; height: 28px"
+        />
+        <input
+          type="range"
+          min="0"
+          max="1"
+          step="0.01"
+          value={hull_face_opacity}
+          oninput={(e) =>
+          on_hull_face_opacity_change?.(
+            parseFloat((e.target as HTMLInputElement).value),
+          )}
+          {@attach tooltip({ content: `Hull face opacity (0 = transparent, 1 = opaque)` })}
+          class="threshold-slider"
+          style="flex: 1; min-width: 80px"
+        />
+        <span style="font-size: 0.75em; min-width: 2em; text-align: right">{
+            (hull_face_opacity * 100).toFixed(0)
+          }%</span>
+      </div>
     </div>
   {/if}
 

--- a/src/lib/phase-diagram/PhaseDiagramControls.svelte
+++ b/src/lib/phase-diagram/PhaseDiagramControls.svelte
@@ -302,11 +302,9 @@
           min="0"
           max="1"
           step="0.01"
-          value={hull_face_opacity}
-          oninput={(e) =>
-          on_hull_face_opacity_change?.(
-            parseFloat((e.target as HTMLInputElement).value),
-          )}
+          aria-label="Hull face opacity"
+          bind:value={hull_face_opacity}
+          oninput={() => on_hull_face_opacity_change?.(hull_face_opacity)}
           {@attach tooltip({ content: `Hull face opacity (0 = transparent, 1 = opaque)` })}
           class="threshold-slider"
           style="flex: 1; min-width: 80px"

--- a/src/lib/phase-diagram/PhaseDiagramInfoPane.svelte
+++ b/src/lib/phase-diagram/PhaseDiagramInfoPane.svelte
@@ -252,6 +252,7 @@
         {:else}
           <div
             class="clickable stat-item"
+            data-testid={key ? `pd-${key}` : undefined}
             title="Click to copy: {label}: {value}"
             onclick={() => copy_to_clipboard(item.label, String(item.value), key ?? item.label)}
             role="button"

--- a/src/lib/plot/ScatterPlot.svelte
+++ b/src/lib/plot/ScatterPlot.svelte
@@ -223,7 +223,7 @@
   let svg_bounding_box: DOMRect | null = $state(null) // Store SVG bounds during drag
 
   // Unique component ID to avoid clipPath conflicts between multiple instances
-  let component_id = $state(`scatter-${Math.random().toString(36).substring(2, 9)}`)
+  let component_id = $state(`scatter-${crypto.randomUUID()}`)
   let clip_path_id = $derived(`plot-area-clip-${component_id}`)
 
   // Process series to ensure single visible series are always on y1 (left) axis.

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -218,6 +218,7 @@ export interface SettingsConfig {
       label_energy_threshold: SettingType<number>
       show_hull_faces: SettingType<boolean>
       hull_face_color: SettingType<string>
+      hull_face_opacity: SettingType<number>
       fullscreen: SettingType<boolean>
       info_pane_open: SettingType<boolean>
       legend_pane_open: SettingType<boolean>
@@ -234,6 +235,9 @@ export interface SettingsConfig {
       show_unstable: SettingType<boolean>
       show_stable_labels: SettingType<boolean>
       show_unstable_labels: SettingType<boolean>
+      show_hull_faces: SettingType<boolean>
+      hull_face_color: SettingType<string>
+      hull_face_opacity: SettingType<number>
       energy_threshold: SettingType<number>
       label_energy_threshold: SettingType<number>
       fullscreen: SettingType<boolean>
@@ -1015,6 +1019,12 @@ export const SETTINGS_CONFIG: SettingsConfig = {
         value: `#4caf50`,
         description: `Color for lower hull faces in 3D PD`,
       },
+      hull_face_opacity: {
+        value: 0.3,
+        description: `Opacity for hull faces in 3D PD (0-1)`,
+        minimum: 0,
+        maximum: 1,
+      },
       fullscreen: {
         value: false,
         description: `Start in fullscreen for 3D PD`,
@@ -1079,6 +1089,20 @@ export const SETTINGS_CONFIG: SettingsConfig = {
       show_unstable_labels: {
         value: false,
         description: `Show labels for unstable phases in 4D PD`,
+      },
+      show_hull_faces: {
+        value: true,
+        description: `Show convex hull faces in 4D PD`,
+      },
+      hull_face_color: {
+        value: `#4caf50`,
+        description: `Color for hull faces in 4D PD`,
+      },
+      hull_face_opacity: {
+        value: 0.06,
+        description: `Opacity for hull faces in 4D PD (0-1)`,
+        minimum: 0,
+        maximum: 1,
       },
       energy_threshold: {
         value: 0.1,

--- a/src/site/plot-utils.ts
+++ b/src/site/plot-utils.ts
@@ -41,25 +41,22 @@ export function generate_uniform(
 }
 
 // Generate log-normal distribution data
-export function generate_log_normal(count: number, mu: number, sigma: number): number[] {
-  return Array.from({ length: count }, () => Math.exp(box_muller(mu, sigma)))
-}
+export const generate_log_normal = (count: number, mu: number, sigma: number) =>
+  Array.from({ length: count }, () => Math.exp(box_muller(mu, sigma)))
 
 // Generate power law distribution data
-export function generate_power_law(count: number, alpha: number, x_min = 1): number[] {
-  return Array.from({ length: count }, () => {
+export const generate_power_law = (count: number, alpha: number, x_min = 1) =>
+  Array.from({ length: count }, () => {
     const u = Math.random()
     return x_min * Math.pow(1 - u, -1 / (alpha - 1))
   })
-}
 
 // Generate Pareto distribution data
-export function generate_pareto(count: number, x_min: number, alpha: number): number[] {
-  return Array.from({ length: count }, () => {
+export const generate_pareto = (count: number, x_min: number, alpha: number) =>
+  Array.from({ length: count }, () => {
     const u = Math.random()
     return x_min * Math.pow(u, -1 / alpha)
   })
-}
 
 // Generate gamma distribution data (approximation)
 // Note: This approximation works best for integer alpha values
@@ -94,52 +91,41 @@ export function generate_gamma(count: number, alpha: number, beta: number): numb
 }
 
 // Generate complex mixture distribution
-export function generate_mixture(count: number): number[] {
-  return Array.from({ length: count }, () => {
+export const generate_mixture = (count: number) =>
+  Array.from({ length: count }, () => {
     const rand = Math.random()
     if (rand < 0.3) return box_muller(10, 2) // Normal around 10
     if (rand < 0.6) return box_muller(30, 3) // Normal around 30
     if (rand < 0.8) return box_muller(50, 1.5) // Normal around 50
     return box_muller(70, 4) // Normal around 70
   })
-}
 
 // Generate large dataset for performance testing
-export function generate_large_dataset(
-  count: number,
-  type: `normal` | `uniform`,
-): number[] {
+export const generate_large_dataset = (count: number, type: `normal` | `uniform`) => {
   if (count <= 0) throw new Error(`Count must be positive`)
 
-  switch (type) {
-    case `normal`:
-      return generate_normal(count, 50, 15)
-    case `uniform`:
-      return generate_uniform(count, 0, 100)
-    default:
-      return generate_normal(count, 50, 15)
-  }
+  if (type === `normal`) return generate_normal(count, 50, 15)
+  else if (type === `uniform`) return generate_uniform(count, 0, 100)
+  else return generate_normal(count, 50, 15)
 }
 
 // Generate sparse data with many zeros
-export function generate_sparse_data(count: number): number[] {
-  return Array.from({ length: count }, () => {
+export const generate_sparse_data = (count: number) =>
+  Array.from({ length: count }, () => {
     if (Math.random() < 0.7) return 0 // 70% zeros
     return Math.random() * 100 // 30% random values
   })
-}
 
 // Generate scientific measurement data
-export function generate_scientific_data(count: number): number[] {
-  return Array.from({ length: count }, () => {
+export const generate_scientific_data = (count: number) =>
+  Array.from({ length: count }, () => {
     const base = Math.random() * 1000
     const noise = (Math.random() - 0.5) * 0.1 * base
     return Math.max(0, base + noise)
   })
-}
 
 // Weighted choice function for discrete distributions
-export function weighted_choice(weights: number[]): number {
+export const weighted_choice = (weights: number[]): number => {
   const total_weight = weights.reduce((sum, weight) => {
     if (!Number.isFinite(weight) || weight < 0) throw new RangeError(`invalid weights`)
     return sum + weight
@@ -156,18 +142,17 @@ export function weighted_choice(weights: number[]): number {
 }
 
 // Generate bimodal distribution data
-export function generate_bimodal(count: number): number[] {
-  return Array.from({ length: count }, () => {
+export const generate_bimodal = (count: number) =>
+  Array.from({ length: count }, () => {
     const use_first_mode = Math.random() < 0.6
     const mean = use_first_mode ? 20 : 60
     const std_dev = use_first_mode ? 8 : 12
     return box_muller(mean, std_dev)
   })
-}
 
 // Generate right-skewed distribution data
-export function generate_skewed(count: number): number[] {
-  return Array.from({ length: count }, () => {
+export const generate_skewed = (count: number) =>
+  Array.from({ length: count }, () => {
     // Sum of exponentials approximates gamma
     let sum = 0
     for (let k = 0; k < 3; k++) {
@@ -175,52 +160,48 @@ export function generate_skewed(count: number): number[] {
     }
     return sum
   })
-}
 
 // Generate discrete distribution data with jitter
-export function generate_discrete(count: number): number[] {
-  const weights = [0.05, 0.08, 0.12, 0.15, 0.18, 0.199, 0.149, 0.05, 0.015, 0.005]
-  return Array.from({ length: count }, () => {
+export const generate_discrete = (
+  count: number,
+  weights: number[] = [0.05, 0.08, 0.12, 0.15, 0.18, 0.199, 0.149, 0.05, 0.015, 0.005],
+) =>
+  Array.from({ length: count }, () => {
     const choice = weighted_choice(weights)
     return choice + 1 + Math.random() * 0.8 - 0.4 // Add jitter
   })
-}
 
 // Generate age distribution data
-export function generate_age_distribution(count: number): number[] {
-  return Array.from({ length: count }, () => {
+export const generate_age_distribution = (count: number) =>
+  Array.from({ length: count }, () => {
     const rand = Math.random()
     if (rand < 0.25) return Math.random() * 18 // 0-18
     if (rand < 0.6) return Math.random() * 25 + 18 // 18-43
     if (rand < 0.85) return Math.random() * 22 + 43 // 43-65
     return Math.random() * 25 + 65 // 65-90
   })
-}
 
 // Generate financial data (stock prices with trends)
-export function generate_financial_data(count: number): number[] {
-  let price = 100
-  return Array.from({ length: count }, () => {
+export const generate_financial_data = (count: number, price: number = 100) =>
+  Array.from({ length: count }, () => {
     const change = (Math.random() - 0.5) * 10 // Random price change
     price = Math.max(1, price + change) // Ensure positive price
     return price
   })
-}
 
 // Generate mixed data with multiple patterns
-export function generate_mixed_data(count: number): number[] {
-  return Array.from({ length: count }, () => {
+export const generate_mixed_data = (count: number) =>
+  Array.from({ length: count }, () => {
     const rand = Math.random()
     if (rand < 0.4) return box_muller(20, 5) // Normal around 20
     if (rand < 0.7) return box_muller(60, 8) // Normal around 60
     if (rand < 0.85) return Math.random() * 100 // Uniform
     return -Math.log(Math.max(Math.random(), Number.EPSILON)) * 10 // Exponential
   })
-}
 
 // Generate complex distribution with multiple overlapping patterns
-export function generate_complex_distribution(count: number): number[] {
-  return Array.from({ length: count }, () => {
+export const generate_complex_distribution = (count: number) =>
+  Array.from({ length: count }, () => {
     const rand = Math.random()
     if (rand < 0.25) return box_muller(15, 3) // Peak 1
     if (rand < 0.5) return box_muller(35, 4) // Peak 2
@@ -228,4 +209,3 @@ export function generate_complex_distribution(count: number): number[] {
     if (rand < 0.85) return box_muller(75, 6) // Peak 4
     return Math.random() * 100 // Background noise
   })
-}

--- a/tests/playwright/phase-diagram/phase-diagram-2d.test.ts
+++ b/tests/playwright/phase-diagram/phase-diagram-2d.test.ts
@@ -67,10 +67,9 @@ test.describe(`PhaseDiagram2D (Binary)`, () => {
     const { info } = await open_info_and_controls(pd2d)
 
     const get_visible_unstable = async () => {
-      const row = info.getByText(`Visible unstable`).locator(`..`)
-      const text = await row.textContent()
+      const text = await info.getByTestId(`pd-visible-unstable`).textContent()
       // Format: Visible unstable: X / Y
-      const match = text?.match(/Visible unstable:\s*(\d+)\s*\/\s*(\d+)/)
+      const match = text?.match(/(\d+)\s*\/\s*(\d+)/)
       return match ? { x: parseInt(match[1]), y: parseInt(match[2]) } : { x: 0, y: 0 }
     }
 
@@ -121,9 +120,8 @@ test.describe(`PhaseDiagram2D (Binary)`, () => {
     await expect(controls.getByText(`Points`, { exact: true })).toBeVisible()
 
     const get_visible_unstable = async () => {
-      const row = info.getByText(`Visible unstable`).locator(`..`)
-      const text = await row.textContent()
-      const match = text?.match(/Visible unstable:\s*(\d+)\s*\/\s*(\d+)/)
+      const text = await info.getByTestId(`pd-visible-unstable`).textContent()
+      const match = text?.match(/(\d+)\s*\/\s*(\d+)/)
       return match ? parseInt(match[1]) : 0
     }
     const before = await get_visible_unstable()

--- a/tests/playwright/phase-diagram/phase-diagram-4d.test.ts
+++ b/tests/playwright/phase-diagram/phase-diagram-4d.test.ts
@@ -98,6 +98,8 @@ test.describe(`PhaseDiagram4D (Quaternary)`, () => {
       return dt
     }, data)
 
+    // Dispatch dragover first for broader browser engine parity (esp. WebKit)
+    await diagram.dispatchEvent(`dragover`, { dataTransfer: data_transfer })
     await diagram.dispatchEvent(`drop`, { dataTransfer: data_transfer })
 
     // Open info pane to read visible counts
@@ -112,11 +114,25 @@ test.describe(`PhaseDiagram4D (Quaternary)`, () => {
     const unstable_text = await info.getByText(/Visible unstable/i).locator(`..`)
       .textContent()
     expect(unstable_text).toBeTruthy()
+    const unstable_match = unstable_text?.match(
+      /Visible unstable[^0-9]*([0-9]+)\s*\/\s*([0-9]+)/i,
+    )
+    expect(unstable_match).toBeTruthy()
+    const u_visible = Number(unstable_match?.[1])
+    const u_total = Number(unstable_match?.[2])
+    expect(Number.isFinite(u_visible) && Number.isFinite(u_total)).toBe(true)
 
     // Expect stable entries to include at minimum the 4 elemental refs + 1 marked stable
     const stable_text = await info.getByText(/Visible stable/i).locator(`..`)
       .textContent()
-    expect(stable_text).toMatch(/[5-7] \/ [5-7]/) // Allow for computed stable entries
+    const stable_match = stable_text?.match(
+      /Visible stable[^0-9]*([0-9]+)\s*\/\s*([0-9]+)/i,
+    )
+    expect(stable_match).toBeTruthy()
+    const s_visible = Number(stable_match?.[1])
+    const s_total = Number(stable_match?.[2])
+    expect(s_visible).toBeGreaterThanOrEqual(5)
+    expect(s_total).toBeGreaterThanOrEqual(5)
   })
 
   test(`displays energy above hull color bar in energy mode`, async ({ page }) => {

--- a/tests/playwright/phase-diagram/phase-diagram-4d.test.ts
+++ b/tests/playwright/phase-diagram/phase-diagram-4d.test.ts
@@ -111,23 +111,17 @@ test.describe(`PhaseDiagram4D (Quaternary)`, () => {
     // With on-the-fly computation enabled, entries without precomputed e_above_hull
     // will have it computed automatically. The quaternary entry with energy=-3
     // will be evaluated against the hull and may be stable or slightly unstable
-    const unstable_text = await info.getByText(/Visible unstable/i).locator(`..`)
-      .textContent()
+    const unstable_text = await info.getByTestId(`pd-visible-unstable`).textContent()
     expect(unstable_text).toBeTruthy()
-    const unstable_match = unstable_text?.match(
-      /Visible unstable[^0-9]*([0-9]+)\s*\/\s*([0-9]+)/i,
-    )
+    const unstable_match = unstable_text?.match(/([0-9]+)\s*\/\s*([0-9]+)/)
     expect(unstable_match).toBeTruthy()
     const u_visible = Number(unstable_match?.[1])
     const u_total = Number(unstable_match?.[2])
     expect(Number.isFinite(u_visible) && Number.isFinite(u_total)).toBe(true)
 
     // Expect stable entries to include at minimum the 4 elemental refs + 1 marked stable
-    const stable_text = await info.getByText(/Visible stable/i).locator(`..`)
-      .textContent()
-    const stable_match = stable_text?.match(
-      /Visible stable[^0-9]*([0-9]+)\s*\/\s*([0-9]+)/i,
-    )
+    const stable_text = await info.getByTestId(`pd-visible-stable`).textContent()
+    const stable_match = stable_text?.match(/([0-9]+)\s*\/\s*([0-9]+)/)
     expect(stable_match).toBeTruthy()
     const s_visible = Number(stable_match?.[1])
     const s_total = Number(stable_match?.[2])

--- a/tests/vitest/phase-diagram/thermodynamics.test.ts
+++ b/tests/vitest/phase-diagram/thermodynamics.test.ts
@@ -41,7 +41,8 @@ function entry(
   return {
     composition,
     energy,
-    entry_id: opts.entry_id,
+    entry_id: opts.entry_id ??
+      `test-${Object.keys(composition).join(`-`)}-${crypto.randomUUID()}`,
     correction: opts.correction,
     energy_per_atom: opts.energy_per_atom,
     e_form_per_atom: opts.e_form_per_atom,
@@ -348,7 +349,7 @@ describe(`4D convex hull for quaternary phase diagrams`, () => {
       { x: 1, y: 0, z: 0, w: 0 },
       { x: 0, y: 1, z: 0, w: 0 },
       { x: 0, y: 0, z: 1, w: 0 },
-      { x: 0.25, y: 0.25, z: 0.25, w: -0.1 }, // On hull
+      { x: 0.25, y: 0.25, z: 0.25, w: -0.1 }, // On or below hull (evaluates to zero distance)
       { x: 0.25, y: 0.25, z: 0.25, w: 0.1 }, // Above hull
     ]
 
@@ -357,7 +358,7 @@ describe(`4D convex hull for quaternary phase diagrams`, () => {
 
     expect(distances.length).toBe(points.length)
 
-    // Points on hull should have ~0 distance
+    // Points on or below the hull should have ~0 distance
     expect(distances[4]).toBeCloseTo(0, 6)
 
     // Point above hull should have positive distance
@@ -614,15 +615,6 @@ describe(`4D hull validation against quaternary phase diagram data`, () => {
 
     const avg_error = total_error / testable_entries.length
     const match_rate = (matches_within_tolerance / testable_entries.length) * 100
-
-    console.log(
-      `\n${filename}:
-      Entries: ${testable_entries.length}
-      Hull facets: ${hull.length}
-      Avg error: ${avg_error.toExponential(3)} eV/atom
-      Max error: ${max_error.toExponential(3)} eV/atom
-      Match rate (±${tolerance} eV/atom): ${match_rate.toFixed(1)}%`,
-    )
 
     // We expect very high agreement
     expect(match_rate).toBeGreaterThan(95)


### PR DESCRIPTION
- Calculates quaternary phase-diagram hull distances on the fly when precomputed values are absent.
- Adds toggleable 4D hull faces with a keyboard shortcut.
- Adds a 0–1 `hull_face_opacity` setting and UI control for both 3D and 4D phase diagrams, alongside hull-face color controls.