### PR TITLE
Improve legend auto-placement logic in scatter/bar/histogram plots

### DIFF
--- a/src/lib/phase-diagram/PhaseDiagramControls.svelte
+++ b/src/lib/phase-diagram/PhaseDiagramControls.svelte
@@ -216,10 +216,11 @@
     </div>
   {:else}
     <!-- Color scale selector -->
-    <div class="control-row">
+    <div style="display: grid; gap: 8px; grid-template-columns: auto 1fr">
       <span {@attach tooltip({ content: `Choose energy colormap` })}>Color scale</span>
       <ColorScaleSelect
         bind:value={color_scale}
+        selected={[color_scale]}
         placeholder="Select color scale"
         {@attach tooltip({ content: `Set interpolator for energy colors` })}
       />

--- a/src/lib/plot/ColorScaleSelect.svelte
+++ b/src/lib/plot/ColorScaleSelect.svelte
@@ -34,10 +34,11 @@
   bind:selected
   {placeholder}
   liOptionStyle="padding: 3pt 6pt;"
-  liSelectedStyle="width: 100%;"
+  liSelectedStyle="width: 100%; background-color: transparent;"
   ulSelectedStyle="display: contents;"
   inputStyle="min-width: 0;"
   {...rest}
+  style={`min-width: 0; ${rest.style ?? ``}`}
 >
   {#snippet children({ option }: { option: D3InterpolateName })}
     <ColorBar
@@ -46,7 +47,7 @@
       tick_labels={0}
       title_side="left"
       wrapper_style="width: 100%;"
-      title_style="width: 6em; font-size: 1.2em; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; text-align: left;"
+      title_style="width: 6em; font-size: 1.5em; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; text-align: left;"
       {...colorbar}
     />
   {/snippet}

--- a/src/lib/plot/Histogram.svelte
+++ b/src/lib/plot/Histogram.svelte
@@ -233,8 +233,8 @@
     for (const { bins } of histogram_data) {
       for (const bin of bins) {
         if (bin.length > 0) {
-          const bar_x = scales.x(bin.x0!)
-          const bar_y = scales.y(bin.length)
+          const bar_x = padding.l + scales.x((bin.x0! + bin.x1!) / 2)
+          const bar_y = padding.t + scales.y(bin.length)
           if (isFinite(bar_x) && isFinite(bar_y)) {
             // Add multiple points for taller bars to increase their weight
             const weight = Math.ceil(bin.length / 10) // More points for taller bars

--- a/src/lib/plot/HistogramControls.svelte
+++ b/src/lib/plot/HistogramControls.svelte
@@ -20,6 +20,7 @@
     mode?: `single` | `overlay`
     bar_opacity?: number
     bar_stroke_width?: number
+    bar_color?: string
     show_legend?: boolean
     // Display controls
     show_zero_lines?: boolean
@@ -53,6 +54,7 @@
     mode = $bindable(DEFAULTS.trajectory.histogram_mode),
     bar_opacity = $bindable(DEFAULTS.trajectory.histogram_bar_opacity),
     bar_stroke_width = $bindable(DEFAULTS.trajectory.histogram_bar_stroke_width),
+    bar_color = $bindable(`#4682b4`),
     show_legend = $bindable(DEFAULTS.trajectory.histogram_show_legend),
     // Display controls
     show_zero_lines = $bindable(DEFAULTS.plot.show_zero_lines),
@@ -239,7 +241,6 @@
         </label>
       </SettingsSection>
 
-      <hr />
       <SettingsSection
         title="Axis Range"
         current_values={{ x_range, y_range }}
@@ -260,7 +261,6 @@
         <input {...input_props(`y`, `max`, y_range)} />
       </SettingsSection>
 
-      <hr />
       <SettingsSection
         title="Histogram"
         current_values={{ bins, mode, show_legend }}
@@ -314,13 +314,13 @@
         </label>
       </SettingsSection>
 
-      <hr />
       <SettingsSection
         title="Bar Style"
-        current_values={{ bar_opacity, bar_stroke_width }}
+        current_values={{ bar_opacity, bar_stroke_width, bar_color }}
         on_reset={() => {
           bar_opacity = DEFAULTS.trajectory.histogram_bar_opacity
           bar_stroke_width = DEFAULTS.trajectory.histogram_bar_stroke_width
+          bar_color = `#4682b4`
         }}
         class="pane-grid"
         style="grid-template-columns: auto 1fr auto"
@@ -357,9 +357,17 @@
           step="0.1"
           bind:value={bar_stroke_width}
         />
+        {#if visible_series.length === 1}
+          <label for="bar-color-input">Color:</label>
+          <input
+            id="bar-color-input"
+            type="color"
+            bind:value={bar_color}
+            style="grid-column: 2 / 4"
+          />
+        {/if}
       </SettingsSection>
 
-      <hr />
       <SettingsSection
         title="Scale Type"
         current_values={{ x_scale_type, y_scale_type }}
@@ -382,7 +390,6 @@
         </select>
       </SettingsSection>
 
-      <hr />
       <SettingsSection
         title="Ticks"
         current_values={{ x_ticks, y_ticks }}
@@ -415,7 +422,6 @@
         />
       </SettingsSection>
 
-      <hr />
       <SettingsSection
         title="Tick Format"
         current_values={{ x_format, y_format }}

--- a/src/lib/plot/ScatterPlot.svelte
+++ b/src/lib/plot/ScatterPlot.svelte
@@ -792,7 +792,7 @@
 
     const plot_width = width - pad.l - pad.r
     const plot_height = height - pad.t - pad.b
-    const margin = normalize_margin(color_bar?.margin).t || 10
+    const margin = normalize_margin(color_bar?.margin).t ?? 10
 
     // Place opposite of legend: if legend is top, colorbar is bottom
     const is_top = !legend_placement?.position.startsWith(`top`)
@@ -810,9 +810,9 @@
 
     // Skip auto-placement if user set explicit position
     const style = legend?.wrapper_style ?? ``
-    if (/(\b(top|bottom|left|right)\s*:)|(position\s*:\s*absolute)/.test(style)) {
-      return null
-    }
+    if (
+      /(^|[;{]\s*)(top|bottom|left|right)\s*:|position\s*:\s*absolute/.test(style)
+    ) return null
 
     // Responsive mode: always use current best placement
     if (legend?.responsive) return legend_placement

--- a/src/lib/plot/ScatterPlot.svelte
+++ b/src/lib/plot/ScatterPlot.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
-  import { cells_3x3, corner_cells, DraggablePane, Line, symbol_names } from '$lib'
+  import { DraggablePane, Line, symbol_names } from '$lib'
   import type { D3ColorSchemeName, D3InterpolateName } from '$lib/colors'
   import { luminance } from '$lib/colors'
   import * as math from '$lib/math'
   import type {
     AnchorNode,
-    Cell3x3,
-    Corner,
     D3SymbolName,
     DataSeries,
     HoverConfig,
@@ -24,7 +22,13 @@
     UserContentProps,
     XyObj,
   } from '$lib/plot'
-  import { ColorBar, PlotLegend, ScatterPlotControls, ScatterPoint } from '$lib/plot'
+  import {
+    ColorBar,
+    find_best_legend_placement,
+    PlotLegend,
+    ScatterPlotControls,
+    ScatterPoint,
+  } from '$lib/plot'
   import { DEFAULTS } from '$lib/settings'
   import { extent } from 'd3-array'
   import { forceCollide, forceLink, forceSimulation } from 'd3-force'
@@ -289,8 +293,7 @@
   let label_positions = $state<Record<string, XyObj>>({})
 
   // State for initial (non-responsive) legend placement
-  let initial_legend_cell = $state<Cell3x3 | null>(null)
-  let is_initial_legend_placement_calculated = $state(false)
+  let initial_legend_placement = $state<typeof legend_placement | null>(null)
 
   // State for legend dragging
   let legend_is_dragging = $state(false)
@@ -299,58 +302,12 @@
 
   // Module-level constants to avoid repeated allocations
   const DEFAULT_MARGIN = { t: 10, l: 10, b: 10, r: 10 } as const
-  const X_FACTORS = {
-    left: { anchor: 0, transform: `0` },
-    center: { anchor: 0.5, transform: `-50%` },
-    right: { anchor: 1, transform: `-100%` },
-  } as const
-  type XFactorKey = keyof typeof X_FACTORS
-  const Y_FACTORS = {
-    top: { anchor: 0, transform: `0` },
-    middle: { anchor: 0.5, transform: `-50%` },
-    bottom: { anchor: 1, transform: `-100%` },
-  } as const
-  type YFactorKey = keyof typeof Y_FACTORS
 
   function normalize_margin(margin: number | Sides | undefined): Required<Sides> {
     if (typeof margin === `number`) {
       return { t: margin, l: margin, b: margin, r: margin }
     }
     return { ...DEFAULT_MARGIN, ...margin }
-  }
-
-  function get_placement_styles( //  based on grid cell
-    cell: Cell3x3 | null,
-    item_type: `legend` | `colorbar`,
-  ): { left: number; top: number; transform: string } {
-    if (!cell || !width || !height) return { left: 0, top: 0, transform: `` }
-
-    const effective_pad = { t: 0, b: 0, l: 0, r: 0, ...padding }
-    const plot_width = width - effective_pad.l - effective_pad.r
-    const plot_height = height - effective_pad.t - effective_pad.b
-
-    const margin = normalize_margin(
-      item_type === `legend` ? legend?.margin : color_bar?.margin,
-    )
-
-    const [y_part, x_part] = cell.split(`-`) as [YFactorKey, XFactorKey]
-    const x_factor = X_FACTORS[x_part]
-    const y_factor = Y_FACTORS[y_part]
-
-    const base_x = effective_pad.l + plot_width * x_factor.anchor
-    const base_y = effective_pad.t + plot_height * y_factor.anchor
-
-    // Adjust base position by margin depending on anchor point
-    const target_x = base_x +
-      (x_part === `left` ? margin.l : x_part === `right` ? -margin.r : 0)
-    const target_y = base_y +
-      (y_part === `top` ? margin.t : y_part === `bottom` ? -margin.b : 0)
-
-    const transform = x_factor.transform !== `0` || y_factor.transform !== `0`
-      ? `translate(${x_factor.transform}, ${y_factor.transform})`
-      : ``
-
-    return { left: target_x, top: target_y, transform }
   }
 
   // Create raw data points from all series
@@ -692,24 +649,11 @@
     }
   })
 
-  // Calculate point counts per 3x3 grid cell
-  let grid_cell_counts = $derived.by(() => {
-    const counts = cells_3x3.reduce(
-      (acc, cell) => {
-        acc[cell] = 0
-        return acc
-      },
-      {} as Record<Cell3x3, number>,
-    )
+  // Collect all plot points for legend placement calculation
+  let plot_points_for_placement = $derived.by(() => {
+    if (!width || !height || !filtered_series) return []
 
-    if (!width || !height || !filtered_series) return counts
-
-    const plot_width = width - pad.l - pad.r
-    const plot_height = height - pad.t - pad.b
-    const x_boundary1 = pad.l + plot_width / 3
-    const x_boundary2 = pad.l + (2 * plot_width) / 3
-    const y_boundary1 = pad.t + plot_height / 3
-    const y_boundary2 = pad.t + (2 * plot_height) / 3
+    const points: { x: number; y: number }[] = []
 
     for (const series_data of filtered_series) {
       if (!series_data?.filtered_data) continue
@@ -722,23 +666,12 @@
             point.y,
           )
 
-        // Determine grid cell parts
-        const x_part = point_x_coord < x_boundary1
-          ? `left`
-          : point_x_coord < x_boundary2
-          ? `center`
-          : `right`
-        const y_part = point_y_coord < y_boundary1
-          ? `top`
-          : point_y_coord < y_boundary2
-          ? `middle`
-          : `bottom`
-        const cell: Cell3x3 = `${y_part}-${x_part}`
-
-        counts[cell]++
+        if (isFinite(point_x_coord) && isFinite(point_y_coord)) {
+          points.push({ x: point_x_coord, y: point_y_coord })
+        }
       }
     }
-    return counts
+    return points
   })
 
   // Prepare data needed for the legend component
@@ -834,55 +767,58 @@
     })
   })
 
-  // Get best placement cells, prioritizing corners first, then by density
-  let ranked_grid_cells = $derived.by(() => {
-    // Separate corners from non-corners and sort each by density (count)
-    const corners = corner_cells
-      .map((cell) => ({ cell, count: grid_cell_counts[cell] }))
-      .sort((a, b) => a.count - b.count)
-
-    const non_corners = cells_3x3
-      .filter((cell) => !corner_cells.includes(cell as Corner))
-      .map((cell) => ({ cell, count: grid_cell_counts[cell] }))
-      .sort((a, b) => a.count - b.count)
-
-    // Return corners first, then non-corners (extract just the cell names)
-    return [...corners, ...non_corners].map(({ cell }) => cell)
-  })
-
-  // Determine legend and color bar placement
-  let legend_cell = $derived.by(() => {
+  // Calculate best legend placement using new simple system
+  let legend_placement = $derived.by(() => {
     const should_place = legend != null &&
       (legend_data.length > 1 || JSON.stringify(legend) !== `{}`)
-    return should_place && ranked_grid_cells.length > 0 ? ranked_grid_cells[0] : null
+
+    if (!should_place || !width || !height) return null
+
+    const plot_width = width - pad.l - pad.r
+    const plot_height = height - pad.t - pad.b
+
+    return find_best_legend_placement(plot_points_for_placement, {
+      plot_width,
+      plot_height,
+      padding: { t: pad.t, b: pad.b, l: pad.l, r: pad.r },
+      margin: normalize_margin(legend?.margin).t, // Use top margin as default spacing
+      legend_size: { width: 120, height: 80 }, // Estimated legend size
+    })
   })
 
-  let color_bar_cell = $derived.by(() => {
-    const should_place = color_bar && all_color_values.length > 0
-    return should_place && ranked_grid_cells.length > 0
-      ? (ranked_grid_cells.find((cell) => cell !== legend_cell) ?? null)
-      : null
-  })
+  // Calculate color bar placement (simple: opposite corner from legend)
+  let color_bar_placement = $derived.by(() => {
+    if (!color_bar || !all_color_values.length || !width || !height) return null
 
-  // Determine the final placement cell for the legend based on mode
-  let legend_placement_cell = $derived.by(() => {
-    if (!legend_cell) return null // No legend cell assigned
+    const plot_width = width - pad.l - pad.r
+    const plot_height = height - pad.t - pad.b
+    const margin = normalize_margin(color_bar?.margin).t || 10
 
-    const is_responsive = legend?.responsive ?? false
-    const style = legend?.wrapper_style ?? ``
-    // Check if position is explicitly set via top/bottom/left/right or position: absolute
-    const is_fixed_position = typeof style === `string` &&
-      /(\b(top|bottom|left|right)\s*:)|(position\s*:\s*absolute)/.test(style)
+    // Place opposite of legend: if legend is top, colorbar is bottom
+    const is_top = !legend_placement?.position.startsWith(`top`)
 
-    if (is_fixed_position) return null // Fixed position, no auto-placement needed
-
-    if (is_responsive) return legend_cell // Use the current dynamically best cell
-    else {
-      // Not responsive, use initial cell if calculated, else the current best as fallback
-      return is_initial_legend_placement_calculated
-        ? initial_legend_cell
-        : legend_cell
+    return {
+      x: pad.l + plot_width - margin,
+      y: is_top ? pad.t + margin : pad.t + plot_height - margin,
+      transform: is_top ? `translateX(-100%)` : `translate(-100%, -100%)`,
     }
+  })
+
+  // Use responsive or fixed initial placement
+  let active_legend_placement = $derived.by(() => {
+    if (!legend_placement) return null
+
+    // Skip auto-placement if user set explicit position
+    const style = legend?.wrapper_style ?? ``
+    if (/(\b(top|bottom|left|right)\s*:)|(position\s*:\s*absolute)/.test(style)) {
+      return null
+    }
+
+    // Responsive mode: always use current best placement
+    if (legend?.responsive) return legend_placement
+
+    // Fixed mode: use initial placement (set in effect below)
+    return initial_legend_placement ?? legend_placement
   })
 
   // Initialize tweened values for color bar position
@@ -896,54 +832,31 @@
     { duration: 400, ...(legend?.tween ?? {}) },
   )
 
-  // Effect to calculate the initial grid cell ONCE for non-responsive legend
-  // And update legend and color bar tweened positions
+  // Update placement positions (with animation)
   $effect(() => {
-    if (!width || !height) return // Need dimensions
+    if (!width || !height) return
 
-    const is_responsive = legend?.responsive ?? false
-    const style = legend?.wrapper_style ?? ``
-    const is_fixed_position = typeof style === `string` &&
-      /(\b(top|bottom|left|right)\s*:)|(position\s*:\s*absolute)/.test(style)
-
-    // Calculate initial legend cell if needed
-    if (
-      legend_cell &&
-      !is_initial_legend_placement_calculated &&
-      !is_responsive &&
-      !is_fixed_position
-    ) {
-      initial_legend_cell = legend_cell
-      is_initial_legend_placement_calculated = true
+    // Store initial placement for non-responsive mode
+    if (legend_placement && !initial_legend_placement && !legend?.responsive) {
+      initial_legend_placement = legend_placement
     }
 
-    // Reset initial calculation flag if mode changes TO responsive or TO fixed
-    if (
-      (is_responsive || is_fixed_position) && is_initial_legend_placement_calculated
-    ) {
-      is_initial_legend_placement_calculated = false
-      initial_legend_cell = null // Clear stored cell
+    // Update color bar
+    if (color_bar_placement) {
+      tweened_colorbar_coords.set({
+        x: color_bar_placement.x,
+        y: color_bar_placement.y,
+      })
     }
 
-    // Update Color Bar Position
-    if (color_bar_cell) {
-      const { left: target_x, top: target_y } = get_placement_styles(
-        color_bar_cell,
-        `colorbar`,
-      )
-      tweened_colorbar_coords.set({ x: target_x, y: target_y })
-    }
-
-    // Update Legend Position using the calculated placement cell (only if not manually positioned)
-    if (legend_placement_cell && !legend_manual_position) {
-      const { left: target_x, top: target_y } = get_placement_styles(
-        legend_placement_cell,
-        `legend`,
-      )
-      tweened_legend_coords.set({ x: target_x, y: target_y })
-    } else if (legend_manual_position && !legend_is_dragging) {
-      // Use manual position if set and not currently dragging
+    // Update legend (unless manually positioned)
+    if (legend_manual_position && !legend_is_dragging) {
       tweened_legend_coords.set(legend_manual_position)
+    } else if (active_legend_placement && !legend_is_dragging) {
+      tweened_legend_coords.set({
+        x: active_legend_placement.x,
+        y: active_legend_placement.y,
+      })
     }
   })
 
@@ -1301,37 +1214,34 @@
     return unit1 === unit2
   }
 
-  function resolve_unit_conflicts(
-    series: DataSeries[],
-    target_idx: number,
-  ): DataSeries[] {
-    const target_series = series[target_idx]
-    const target_axis = target_series.y_axis ?? `y1`
-
-    return series.map((s, idx) => ({
-      ...s,
-      visible: idx === target_idx ||
-        !(s.visible && (s.y_axis ?? `y1`) === target_axis &&
-          !have_compatible_units(target_series, s)),
-    }))
-  }
-
   // Function to toggle series visibility
   function toggle_series_visibility(series_idx: number) {
-    if (series_idx >= 0 && series_idx < series.length && series[series_idx]) {
-      const toggled_series = series[series_idx]
-      const new_visibility = !(toggled_series.visible ?? true)
+    if (series_idx < 0 || series_idx >= series.length || !series[series_idx]) return
 
-      if (new_visibility) {
-        series = resolve_unit_conflicts(series, series_idx)
-      } else {
-        // Just toggle visibility normally when hiding
-        series = series.map((s, idx) => {
-          if (idx === series_idx) return { ...s, visible: false }
-          return s
-        })
+    const toggled_series = series[series_idx]
+    const new_visibility = !(toggled_series.visible ?? true)
+    const target_axis = toggled_series.y_axis ?? `y1`
+
+    // Only create new objects for series that need to change to preserve series IDs
+    series = series.map((s, idx) => {
+      if (idx === series_idx) {
+        // Toggle the clicked series
+        return { ...s, visible: new_visibility }
       }
-    }
+
+      // If we're showing a series, hide incompatible series on same axis
+      if (new_visibility && (s.y_axis ?? `y1`) === target_axis) {
+        if (!have_compatible_units(toggled_series, s)) {
+          // Only create new object if we need to change visibility
+          if (s.visible ?? true) {
+            return { ...s, visible: false }
+          }
+        }
+      }
+
+      // Keep the SAME object reference for unchanged series (preserves cached ID)
+      return s
+    })
   }
 
   // Function to handle double-click on legend item
@@ -1343,10 +1253,15 @@
 
     if (is_currently_isolated && previous_series_visibility) {
       // Restore previous visibility state
-      series = series.map((s, idx) => ({
-        ...s,
-        visible: previous_series_visibility![idx],
-      }))
+      // Only create new objects for series whose visibility actually changes
+      series = series.map((s, idx) => {
+        const target_visibility = previous_series_visibility![idx]
+        const current_visibility = s?.visible ?? true
+        if (current_visibility !== target_visibility) {
+          return { ...s, visible: target_visibility }
+        }
+        return s // Preserve object reference
+      })
       previous_series_visibility = null // Clear memory
     } else {
       // Isolate the double-clicked series
@@ -1354,10 +1269,15 @@
       if (visible_count > 1) {
         previous_series_visibility = [...current_visibility] // Store current state
       }
-      series = series.map((s, idx) => ({
-        ...s,
-        visible: idx === double_clicked_idx,
-      }))
+      // Only create new objects for series whose visibility needs to change
+      series = series.map((s, idx) => {
+        const target_visibility = idx === double_clicked_idx
+        const current_visibility = s?.visible ?? true
+        if (current_visibility !== target_visibility) {
+          return { ...s, visible: target_visibility }
+        }
+        return s // Preserve object reference
+      })
     }
   }
 
@@ -1366,14 +1286,15 @@
     if (!svg_element) return
 
     legend_is_dragging = true
-    const svg_rect = svg_element.getBoundingClientRect()
-    const current_legend_x = tweened_legend_coords.current.x
-    const current_legend_y = tweened_legend_coords.current.y
 
-    // Calculate offset from mouse to current legend position
+    // Get the actual rendered position of the legend element (accounts for transforms)
+    const legend_element = event.currentTarget as HTMLElement
+    const legend_rect = legend_element.getBoundingClientRect()
+
+    // Calculate offset from mouse to legend's actual rendered position relative to SVG
     legend_drag_offset = {
-      x: event.clientX - svg_rect.left - current_legend_x,
-      y: event.clientY - svg_rect.top - current_legend_y,
+      x: event.clientX - legend_rect.left,
+      y: event.clientY - legend_rect.top,
     }
   }
 
@@ -1381,17 +1302,16 @@
     if (!legend_is_dragging || !svg_element) return
 
     const svg_rect = svg_element.getBoundingClientRect()
+
+    // Calculate new position: mouse position relative to SVG, minus the offset within the legend
     const new_x = event.clientX - svg_rect.left - legend_drag_offset.x
     const new_y = event.clientY - svg_rect.top - legend_drag_offset.y
 
-    // Constrain to plot bounds
+    // Constrain to plot bounds (with some margin)
     const constrained_x = Math.max(0, Math.min(width - 100, new_x)) // Assume legend width ~100px
     const constrained_y = Math.max(0, Math.min(height - 50, new_y)) // Assume legend height ~50px
 
     legend_manual_position = { x: constrained_x, y: constrained_y }
-
-    // Update tweened position immediately during drag
-    tweened_legend_coords.set({ x: constrained_x, y: constrained_y }, { duration: 0 })
   }
 
   function handle_legend_drag_end(_event: MouseEvent) {
@@ -1933,7 +1853,7 @@
     {/if}
 
     <!-- Color Bar -->
-    {#if color_bar && all_color_values.length > 0 && color_bar_cell}
+    {#if color_bar && all_color_values.length > 0 && color_bar_placement}
       {@const color_domain = [
       color_scale.value_range?.[0] ?? auto_color_range[0],
       color_scale.value_range?.[1] ?? auto_color_range[1],
@@ -1946,11 +1866,11 @@
         scale_type={color_scale.type}
         range={color_domain?.every((val) => val != null) ? color_domain : undefined}
         wrapper_style={`
-        position: absolute;
-        left: ${tweened_colorbar_coords.current.x}px;
-        top: ${tweened_colorbar_coords.current.y}px;
-        transform: ${get_placement_styles(color_bar_cell, `colorbar`).transform};
-        ${color_bar?.wrapper_style ?? ``}`}
+          position: absolute;
+          left: ${tweened_colorbar_coords.current.x}px;
+          top: ${tweened_colorbar_coords.current.y}px;
+          transform: ${color_bar_placement?.transform ?? ``};
+          ${color_bar?.wrapper_style ?? ``}`}
         bar_style="width: 280px; height: 20px; {color_bar?.style ?? ``}"
         {...color_bar}
       />
@@ -1958,7 +1878,7 @@
 
     <!-- Legend -->
     <!-- Only render if multiple series or if legend prop was explicitly provided by user (even if empty object) -->
-    {#if legend != null && legend_data.length > 0 && legend_cell &&
+    {#if legend != null && legend_data.length > 0 && legend_placement &&
       (legend_data.length > 1 || (legend != null && JSON.stringify(legend) !== `{}`))}
       <PlotLegend
         series_data={legend_data}
@@ -1973,13 +1893,19 @@
         handle_legend_double_click}
         wrapper_style={`
           position: absolute;
-          left: ${tweened_legend_coords.current.x}px;
-          top: ${tweened_legend_coords.current.y}px;
+          left: ${
+          legend_is_dragging && legend_manual_position
+            ? legend_manual_position.x
+            : tweened_legend_coords.current.x
+        }px;
+          top: ${
+          legend_is_dragging && legend_manual_position
+            ? legend_manual_position.y
+            : tweened_legend_coords.current.y
+        }px;
           transform: ${
-        // Use the derived legend_placement_cell to get the correct transform (only if not manually positioned)
-        legend_manual_position
-          ? ``
-          : get_placement_styles(legend_placement_cell, `legend`).transform};
+          legend_manual_position ? `` : active_legend_placement?.transform ?? ``
+        };
           pointer-events: auto;
           ${legend?.wrapper_style ?? ``}
         `}

--- a/src/lib/plot/ScatterPlotControls.svelte
+++ b/src/lib/plot/ScatterPlotControls.svelte
@@ -283,7 +283,6 @@
         {/if}
       </SettingsSection>
 
-      <hr />
       <SettingsSection
         title="Axis Range"
         current_values={{ x_range, y_range, y2_range }}
@@ -311,7 +310,6 @@
         {/if}
       </SettingsSection>
 
-      <hr />
       <SettingsSection
         title="Tick Format"
         current_values={{ x_format, y_format, y2_format }}
@@ -367,7 +365,6 @@
 
       <!-- Point Style Controls -->
       {#if show_points}
-        <hr />
         <SettingsSection
           title="Point Style"
           current_values={{
@@ -454,7 +451,6 @@
 
       <!-- Line Style Controls -->
       {#if show_lines}
-        <hr />
         <SettingsSection
           title="Line Style"
           current_values={{ line_width, line_color, line_opacity, line_dash }}

--- a/src/lib/plot/layout.ts
+++ b/src/lib/plot/layout.ts
@@ -1,3 +1,5 @@
+import type { Sides } from '$lib/plot'
+
 // Constrain tooltip position within chart bounds
 export function constrain_tooltip_position(
   base_x: number,
@@ -24,4 +26,118 @@ export function get_chart_dimensions(
   padding: { t: number; b: number; l: number; r: number },
 ) {
   return { width: width - padding.l - padding.r, height: height - padding.t - padding.b }
+}
+
+// Simple, performant legend auto-placement for plot components
+// Finds the least populated region inside the plot area for placing the legend
+
+export type PlacementPosition =
+  | `top-left`
+  | `top-right`
+  | `bottom-left`
+  | `bottom-right`
+  | `top-center`
+  | `right-center`
+  | `bottom-center`
+  | `left-center`
+
+export interface LegendPlacement {
+  x: number // left position in px
+  y: number // top position in px
+  transform: string // CSS transform for alignment
+  position: PlacementPosition // which position was chosen
+}
+
+export interface PlacementConfig {
+  plot_width: number
+  plot_height: number
+  padding: Required<Sides>
+  margin?: number
+  legend_size?: { width: number; height: number }
+}
+
+// Define anchor positions with their transform origins
+export const PLACEMENT_ANCHORS: Record<
+  PlacementPosition,
+  { anchor: { x: number; y: number }; transform: string }
+> = {
+  // Corners (priority 1)
+  'top-left': { anchor: { x: 0, y: 0 }, transform: `` },
+  'top-right': { anchor: { x: 1, y: 0 }, transform: `translateX(-100%)` },
+  'bottom-left': { anchor: { x: 0, y: 1 }, transform: `translateY(-100%)` },
+  'bottom-right': { anchor: { x: 1, y: 1 }, transform: `translate(-100%, -100%)` },
+  // Edge midpoints (priority 2)
+  'top-center': { anchor: { x: 0.5, y: 0 }, transform: `translateX(-50%)` },
+  'right-center': { anchor: { x: 1, y: 0.5 }, transform: `translate(-100%, -50%)` },
+  'bottom-center': { anchor: { x: 0.5, y: 1 }, transform: `translate(-50%, -100%)` },
+  'left-center': { anchor: { x: 0, y: 0.5 }, transform: `translateY(-50%)` },
+}
+
+// Priority order: corners first, then edge midpoints
+export const PLACEMENT_PRIORITY: PlacementPosition[] = [
+  `top-left`,
+  `top-right`,
+  `bottom-left`,
+  `bottom-right`,
+  `top-center`,
+  `right-center`,
+  `bottom-center`,
+  `left-center`,
+]
+
+// Find the best placement position for a legend
+export function find_best_legend_placement(
+  points: { x: number; y: number }[],
+  config: PlacementConfig,
+): LegendPlacement {
+  const { plot_width, plot_height, padding, margin = 10 } = config
+  const { width = 120, height = 80 } = config.legend_size ?? {}
+
+  // Detection radius for point counting (legend diagonal / 2)
+  const radius = Math.sqrt(width ** 2 + height ** 2) / 2
+  const radius_sq = radius * radius
+
+  let best_position: PlacementPosition = `top-right`
+  let min_count = Infinity
+
+  // Try each position in priority order, pick the one with fewest nearby points
+  for (const position of PLACEMENT_PRIORITY) {
+    const { anchor } = PLACEMENT_ANCHORS[position]
+
+    // Calculate position coordinates
+    const base_x = padding.l + plot_width * anchor.x
+    const base_y = padding.t + plot_height * anchor.y
+
+    // Apply margin
+    const x = base_x +
+      (anchor.x === 0 ? margin : anchor.x === 1 ? -margin : 0)
+    const y = base_y +
+      (anchor.y === 0 ? margin : anchor.y === 1 ? -margin : 0)
+
+    // Count nearby points
+    let count = 0
+    for (const point of points) {
+      const dx = point.x - x
+      const dy = point.y - y
+      if (dx * dx + dy * dy <= radius_sq) count++
+    }
+
+    // Update best if this position is less crowded
+    if (count < min_count) {
+      min_count = count
+      best_position = position
+    }
+  }
+
+  // Calculate final placement for the winning position
+  const { anchor, transform } = PLACEMENT_ANCHORS[best_position]
+  const base_x = padding.l + plot_width * anchor.x
+  const base_y = padding.t + plot_height * anchor.y
+
+  return {
+    x: base_x + (anchor.x === 0 ? margin : anchor.x === 1 ? -margin : 0),
+    y: base_y + (anchor.y === 0 ? margin : anchor.y === 1 ? -margin : 0),
+    transform,
+    position: best_position,
+  }
 }

--- a/src/lib/plot/layout.ts
+++ b/src/lib/plot/layout.ts
@@ -114,11 +114,15 @@ export function find_best_legend_placement(
     const y = base_y +
       (anchor.y === 0 ? margin : anchor.y === 1 ? -margin : 0)
 
+    // Calculate rectangle center for distance measurement
+    const center_x = x + width * (0.5 - anchor.x)
+    const center_y = y + height * (0.5 - anchor.y)
+
     // Count nearby points
     let count = 0
     for (const point of points) {
-      const dx = point.x - x
-      const dy = point.y - y
+      const dx = point.x - center_x
+      const dy = point.y - center_y
       if (dx * dx + dy * dy <= radius_sq) count++
     }
 

--- a/src/lib/structure/StructureControls.svelte
+++ b/src/lib/structure/StructureControls.svelte
@@ -298,7 +298,6 @@
     </label>
   </SettingsSection>
 
-  <hr />
   <h4>Export</h4>
   <div class="export-buttons">
     {#each export_formats as { label, format } (format)}
@@ -352,7 +351,6 @@
     </label>
   </div>
 
-  <hr />
   <SettingsSection
     title="Camera"
     current_values={{
@@ -503,7 +501,6 @@
     </div>
   </SettingsSection>
 
-  <hr />
   <SettingsSection
     title="Atoms"
     current_values={{
@@ -577,7 +574,6 @@
   </SettingsSection>
 
   {#if scene_props.show_site_labels || scene_props.show_site_indices}
-    <hr />
     <SettingsSection
       title="Labels"
       current_values={{
@@ -676,7 +672,6 @@
   {/if}
 
   {#if has_forces && scene_props.show_force_vectors}
-    <hr />
     <SettingsSection
       title="Force Vectors"
       current_values={{
@@ -715,7 +710,6 @@
   {/if}
 
   {#if has_lattice}
-    <hr />
     <SettingsSection
       title="Cell"
       current_values={{
@@ -813,7 +807,6 @@
     </SettingsSection>
   {/if}
 
-  <hr />
   <SettingsSection
     title="Background"
     current_values={{
@@ -851,7 +844,6 @@
     </div>
   </SettingsSection>
 
-  <hr />
   <SettingsSection
     title="Lighting"
     current_values={{
@@ -906,7 +898,6 @@
   </SettingsSection>
 
   {#if scene_props.show_bonds && scene_props.show_bonds !== `never`}
-    <hr />
     <SettingsSection
       title="Bonds"
       current_values={{

--- a/src/routes/(demos)/color-bar/+page.md
+++ b/src/routes/(demos)/color-bar/+page.md
@@ -50,22 +50,19 @@ You can make fat and skinny bars:
 <br />
 ```
 
-`PeriodicTable.svelte` heatmap example with `ColorBar` inside `TableInset`
+`PeriodicTable.svelte` now automatically shows a `ColorBar` when `heatmap_values` is provided!
 
 ```svelte example code_above
 <script>
   import { element_data } from 'matterviz'
-  import { ColorBar, ColorScaleSelect } from 'matterviz/plot'
-  import { PeriodicTable, PropertySelect, TableInset } from 'matterviz/periodic-table'
+  import { ColorScaleSelect } from 'matterviz/plot'
+  import { PeriodicTable, PropertySelect } from 'matterviz/periodic-table'
 
   let color_scale = $state(`interpolateCividis`)
   let heatmap_key = $state(``)
   let heat_label = $state(``)
   let heatmap_values = $derived(
     heatmap_key ? element_data.map((el) => el[heatmap_key]) : [],
-  )
-  let heat_range = $derived(
-    heatmap_key ? [Math.min(...heatmap_values), Math.max(...heatmap_values)] : [0, 1],
   )
 </script>
 
@@ -78,22 +75,9 @@ You can make fat and skinny bars:
   {heatmap_values}
   style="margin: 2em auto 4em"
   bind:color_scale
-  color_scale_range={heat_range}
+  color_bar_title={heat_label}
   links="name"
->
-  {#snippet inset()}
-    <TableInset style="place-items: center; padding: 2em">
-      <ColorBar
-        {color_scale}
-        title={heat_label}
-        range={heat_range}
-        tick_labels={5}
-        tick_side="primary"
-        --cbar-width="calc(100% - 2em)"
-      />
-    </TableInset>
-  {/snippet}
-</PeriodicTable>
+/>
 
 <style>
   form {
@@ -104,6 +88,39 @@ You can make fat and skinny bars:
     margin: 2em auto;
   }
 </style>
+```
+
+For more control, you can also manually add a `ColorBar` inside a custom `TableInset` (which overrides the automatic color bar):
+
+```svelte example
+<script>
+  import { element_data } from 'matterviz'
+  import { ColorBar } from 'matterviz/plot'
+  import { PeriodicTable, TableInset } from 'matterviz/periodic-table'
+
+  const heatmap_values = element_data.map((el) => el.atomic_mass)
+  const heat_range = [Math.min(...heatmap_values), Math.max(...heatmap_values)]
+</script>
+
+<PeriodicTable
+  {heatmap_values}
+  style="margin: 2em auto"
+  color_scale="interpolateInferno"
+  color_scale_range={heat_range}
+>
+  {#snippet inset()}
+    <TableInset style="place-items: center; padding: 2em">
+      <ColorBar
+        color_scale="interpolateInferno"
+        title="Atomic Mass (u)"
+        range={heat_range}
+        tick_labels={5}
+        tick_side="primary"
+        --cbar-width="calc(100% - 2em)"
+      />
+    </TableInset>
+  {/snippet}
+</PeriodicTable>
 ```
 
 Example demonstrating `title_side` and `tick_side` interaction:

--- a/src/routes/(demos)/color-scales/+page.md
+++ b/src/routes/(demos)/color-scales/+page.md
@@ -41,10 +41,11 @@
       </section>
       <strong style="height: 25pt">
         {#if active_element?.name}
-          {active_element?.name}: {format_num(mp_elem_counts[active_element?.symbol])}
+          {@const elem_counts = data_name == `WBM` ? wbm_elem_counts : mp_elem_counts}
+          {active_element?.name}: {format_num(elem_counts[active_element?.symbol])}
           <!-- compute percent of total -->
-          {#if mp_elem_counts[active_element?.symbol] > 0}
-            ({format_num((mp_elem_counts[active_element?.symbol] / total) * 100)}%)
+          {#if elem_counts[active_element?.symbol] > 0}
+            ({format_num(elem_counts[active_element?.symbol] / total, `.2~%`)})
           {/if}
         {/if}
       </strong>

--- a/src/routes/(demos)/color-scales/+page.md
+++ b/src/routes/(demos)/color-scales/+page.md
@@ -2,23 +2,24 @@
 <script>
   import { ColorBar, ColorScaleSelect, PeriodicTable, TableInset } from 'matterviz'
   import { format_num } from 'matterviz/labels'
-  import { RadioButtons } from 'svelte-multiselect'
   import mp_elem_counts from './mp-element-counts.json'
   import wbm_elem_counts from './wbm-element-counts.json'
 
   let log_scale = $state(true)
-  let data = $state(`MP`)
+  let data_name = $state(`MP`)
   let color_scale = $derived(`interpolateViridis`)
   let heatmap_values = $derived(
-    Object.values(data == `WBM` ? wbm_elem_counts : mp_elem_counts),
+    Object.values(data_name == `WBM` ? wbm_elem_counts : mp_elem_counts),
   )
   let total = $derived(heatmap_values.reduce((a, b) => a + b, 0))
   let nice_range = $state([])
 </script>
 
-<h1>Color Scales</h1>
+<h1 style="text-align: center">Color Scales</h1>
 
-<h2>{data == 'MP' ? 'Materials Project' : 'WBM'} Element Occurrence Counts</h2>
+<h2 style="text-align: center">
+  {{ MP: `Materials Project` }[data_name] ?? data_name} Element Occurrence Counts
+</h2>
 
 <PeriodicTable
   {heatmap_values}
@@ -31,7 +32,9 @@
       <section>
         <span>
           Data set &ensp;
-          <RadioButtons options={[`MP`, `WBM`]} bind:selected={data} />
+          {#each [`MP`, `WBM`] as data_set}
+            <input type="radio" bind:group={data_name} value={data_set} /> {data_set}
+          {/each}
         </span>
         <span>Log color scale <input type="checkbox" bind:checked={log_scale} /></span>
         <ColorScaleSelect bind:value={color_scale} selected={[color_scale]} />

--- a/src/routes/(demos)/scatter-plot/+page.md
+++ b/src/routes/(demos)/scatter-plot/+page.md
@@ -1312,7 +1312,7 @@ This example shows how to place the color bar vertically on the right side of th
     x: Array(point_count).fill(0).map((_, idx) => (idx / point_count) * 90 + 5), // Range 5 to 95
     y: Array(point_count).fill(0).map(() => Math.random() * 90 + 5), // Range 5 to 95
     // Color value based on the y-coordinate
-    color_values: Array(point_count).fill(0).map((_, idx) => idx * 2), // Values from 0 to 98
+    color_values: Array(point_count).fill(0).map((_, idx) => idx * 2 + 1), // 1..99
     point_style: {
       radius: 6,
       stroke: `black`,

--- a/src/routes/(demos)/scatter-plot/+page.md
+++ b/src/routes/(demos)/scatter-plot/+page.md
@@ -1328,67 +1328,63 @@ This example shows how to place the color bar vertically on the right side of th
   let color_scale = $state({ type: `linear`, scheme: `interpolateCool` }) // Track which color scale type is active
 </script>
 
-<div>
-  <div
-    style="margin-bottom: 1em; display: flex; gap: 1em; flex-wrap: wrap; align-items: center"
-  >
-    <div>
-      <strong>Color Scale Type:</strong>
-      {#each ['linear', 'log'] as scale_type}
-        <label style="margin-left: 0.5em">
-          <input
-            type="radio"
-            name="scale_type"
-            value={scale_type}
-            bind:group={color_scale.type}
-          />
-          {scale_type}
-        </label>
-      {/each}
-    </div>
+<div
+  style="margin-bottom: 1em; display: flex; gap: 6pt; flex-wrap: wrap; align-items: center"
+>
+  <strong>Color Scale Type:</strong>
+  {#each [`linear`, `log`] as scale_type (scale_type)}
+    <label>
+      <input
+        type="radio"
+        name="scale_type"
+        value={scale_type}
+        bind:group={color_scale.type}
+      />
+      {scale_type}
+    </label>
+  {/each}
 
-    <ColorScaleSelect bind:value={color_scale.scheme} selected={[color_scale.scheme]} />
-  </div>
-
-  The color bar is positioned vertically to the right, outside the plot. The plot's right
-  padding is increased to prevent overlap. Use the controls above to change the color
-  scheme and scale type.
-
-  <ScatterPlot
-    series={[vertical_color_data]}
-    x_label="X Position"
-    y_label="Y Position"
-    x_lim={[0, 100]}
-    y_lim={[0, 100]}
-    x_format=".2"
-    y_format=".2"
-    markers="points"
-    {color_scale}
-    padding={plot_padding}
-    color_bar={{
-      title: `Color Bar Title (${color_scale.type})`,
-      orientation: `vertical`,
-      tick_side: `primary`,
-      wrapper_style: `
-        position: absolute;
-        /* Position outside the plot area using padding values */
-        right: 10px; /* Distance from the container's right edge */
-        top: ${plot_padding.t}px; /* Align with top padding */
-        /* Set height directly for the wrapper */
-        height: calc(100% - ${
-        plot_padding.t + plot_padding.b
-      }px); /* Fill vertical space */
-      `,
-      style: `width: 15px; height: 100%;`,
-    }}
-    style="height: 400px"
-  >
-    {#snippet tooltip({ x_formatted, y_formatted, metadata, color_value })}
-      Point ({x_formatted}, {y_formatted})<br />
-      Color value: {color_value?.toFixed(1)}
-    {/snippet}
-  </ScatterPlot>
+  <ColorScaleSelect bind:value={color_scale.scheme} selected={[color_scale.scheme]} />
 </div>
+
+The color bar is positioned vertically to the right, outside the plot. The plot's right
+padding is increased to prevent overlap. Use the controls above to change the color scheme
+and scale type.
+
+<ScatterPlot
+  series={[vertical_color_data]}
+  x_label="X Position"
+  y_label="Y Position"
+  x_lim={[0, 100]}
+  y_lim={[0, 100]}
+  x_format=".2"
+  y_format=".2"
+  markers="points"
+  {color_scale}
+  padding={plot_padding}
+  color_bar={{
+    title: `Color Bar Title (${color_scale.type})`,
+    orientation: `vertical`,
+    tick_side: `primary`,
+    wrapper_style: `
+      position: absolute;
+      /* Position outside the plot area using padding values */
+      right: 10px; /* Distance from the container's right edge */
+      top: ${plot_padding.t}px; /* Align with top padding */
+      /* Set height directly for the wrapper */
+      height: calc(100% - ${
+      plot_padding.t + plot_padding.b
+    }px); /* Fill vertical space */
+    `,
+    style: `width: 15px; height: 100%;`,
+  }}
+  style="height: 400px"
+>
+  {#snippet tooltip({ x_formatted, y_formatted, metadata, color_value })}
+    Point ({x_formatted}, {y_formatted})<br />
+    Color value: {color_value?.toFixed(1)}
+  {/snippet}
+</ScatterPlot>
 ```
 
 ## Line Clipping with Fixed Ranges


### PR DESCRIPTION
Closes #24.

- Uses a data-aware layout utility to place legends automatically in `BarPlot`, `Histogram`, and `ScatterPlot`.
- Adds single-series `bar_color` customization to `HistogramControls`.
- Automatically renders a configurable `ColorBar` for `PeriodicTable` heatmaps, with visibility, title, props, and manual-inset overrides; its range respects logarithmic and explicit color-scale settings.