### PR TITLE
Enhance interactivity in plotting components

### DIFF
--- a/src/lib/plot/BarPlot.svelte
+++ b/src/lib/plot/BarPlot.svelte
@@ -12,12 +12,8 @@
   import { find_best_legend_placement, PlotLegend } from '$lib/plot'
   import { format_value } from '$lib/plot/formatting'
   import { get_relative_coords } from '$lib/plot/interactions'
-  import {
-    create_scale,
-    generate_ticks,
-    get_nice_data_range,
-    type TicksOption,
-  } from '$lib/plot/scales'
+  import type { TicksOption } from '$lib/plot/scales'
+  import { create_scale, generate_ticks, get_nice_data_range } from '$lib/plot/scales'
   import type { ComponentProps, Snippet } from 'svelte'
   import type { HTMLAttributes } from 'svelte/elements'
   import BarPlotControls from './BarPlotControls.svelte'
@@ -303,17 +299,13 @@
     return { x, y, orient_x, orient_y, series_idx, bar_idx, metadata, label, color }
   }
 
-  function handle_bar_hover(
-    series_idx: number,
-    bar_idx: number,
-    color: string,
-    event: MouseEvent,
-  ) {
-    hovered = true
-    hover_info = get_bar_data(series_idx, bar_idx, color)
-    change(hover_info)
-    on_bar_hover?.({ ...hover_info, event })
-  }
+  const handle_bar_hover =
+    (series_idx: number, bar_idx: number, color: string) => (event: MouseEvent) => {
+      hovered = true
+      hover_info = get_bar_data(series_idx, bar_idx, color)
+      change(hover_info)
+      on_bar_hover?.({ ...hover_info, event })
+    }
 
   // Stack offsets (only for vertical stacked mode)
   let stacked_offsets = $derived.by(() => {
@@ -432,7 +424,7 @@
                     tabindex="0"
                     aria-label={`bar ${bar_idx + 1} of ${srs.label ?? `series`}`}
                     style:cursor={on_bar_click ? `pointer` : undefined}
-                    onmousemove={(evt) => handle_bar_hover(series_idx, bar_idx, color, evt)}
+                    onmousemove={handle_bar_hover(series_idx, bar_idx, color)}
                     onmouseleave={() => {
                       hover_info = null
                       change(null)
@@ -488,7 +480,7 @@
                     tabindex="0"
                     aria-label={`bar ${bar_idx + 1} of ${srs.label ?? `series`}`}
                     style:cursor={on_bar_click ? `pointer` : undefined}
-                    onmousemove={(evt) => handle_bar_hover(series_idx, bar_idx, color, evt)}
+                    onmousemove={handle_bar_hover(series_idx, bar_idx, color)}
                     onmouseleave={() => {
                       hover_info = null
                       change(null)

--- a/src/lib/plot/Histogram.svelte
+++ b/src/lib/plot/Histogram.svelte
@@ -53,7 +53,12 @@
     hovered?: boolean
     change?: (data: { value: number; count: number; property: string } | null) => void
     on_bar_click?: (
-      data: { value: number; count: number; property: string; event: MouseEvent },
+      data: {
+        value: number
+        count: number
+        property: string
+        event: MouseEvent | KeyboardEvent
+      },
     ) => void
     on_bar_hover?: (
       data:
@@ -417,6 +422,7 @@
             {@const bar_width = Math.max(1, Math.abs(scales.x(bin.x1!) - bar_x))}
             {@const bar_height = Math.max(0, (height - padding.b) - scales.y(bin.length))}
             {@const bar_y = scales.y(bin.length)}
+            {@const value = (bin.x0! + bin.x1!) / 2}
             {#if bar_height > 0}
               <rect
                 x={bar_x}
@@ -429,32 +435,18 @@
                 stroke-width={mode === `overlay` ? bar_stroke_width : 0}
                 role="button"
                 tabindex="0"
-                onmousemove={(evt) =>
-                handle_mouse_move(evt, (bin.x0! + bin.x1!) / 2, bin.length, label)}
+                onmousemove={(evt) => handle_mouse_move(evt, value, bin.length, label)}
                 onmouseleave={() => {
                   hover_info = null
                   change(null)
                   on_bar_hover?.(null)
                 }}
-                onclick={(evt) => {
-                  if (on_bar_click && bin.x0 !== undefined && bin.x1 !== undefined) {
-                    const value = (bin.x0 + bin.x1) / 2
-                    const count = bin.length
-                    on_bar_click({ value, count, property: label, event: evt })
-                  }
-                }}
-                onkeydown={(evt: KeyboardEvent) => {
-                  if (
-                    [`Enter`, ` `].includes(evt.key) && bin.x0 !== undefined &&
-                    bin.x1 !== undefined
-                  ) {
-                    evt.preventDefault()
-                    if (on_bar_click) {
-                      const value = (bin.x0 + bin.x1) / 2
-                      const count = bin.length
-                      const event = evt as unknown as MouseEvent
-                      on_bar_click({ value, count, property: label, event })
-                    }
+                onclick={(event) =>
+                on_bar_click?.({ value, count: bin.length, property: label, event })}
+                onkeydown={(event: KeyboardEvent) => {
+                  if ([`Enter`, ` `].includes(event.key)) {
+                    event.preventDefault()
+                    on_bar_click?.({ value, count: bin.length, property: label, event })
                   }
                 }}
                 style:cursor={on_bar_click ? `pointer` : undefined}

--- a/src/lib/plot/Histogram.svelte
+++ b/src/lib/plot/Histogram.svelte
@@ -90,7 +90,7 @@
     legend = { series_data: [] },
     bar_opacity = $bindable(0.7),
     bar_stroke_width = $bindable(1),
-    bar_color = $bindable(`#4682b4`),
+    bar_color = $bindable(`cornflowerblue`),
     selected_property = $bindable(``),
     mode = $bindable(`single`),
     show_zero_lines = $bindable(true),

--- a/src/lib/plot/ScatterPoint.svelte
+++ b/src/lib/plot/ScatterPoint.svelte
@@ -73,6 +73,7 @@
     fill="var(--point-fill-color, {style.fill ?? `black`})"
     class="marker"
     class:is-hovered={is_hovered && (hover.enabled ?? true)}
+    style:cursor={style.cursor}
   />
   {#if label.text}
     <text

--- a/src/lib/plot/index.ts
+++ b/src/lib/plot/index.ts
@@ -54,6 +54,7 @@ export interface PointStyle {
   symbol_type?: D3SymbolName
   symbol_size?: number | null // Optional override for marker size
   shape?: string // Add optional shape (string for flexibility)
+  cursor?: string // Cursor style for the point
 }
 
 export interface HoverStyle {

--- a/src/routes/(demos)/histogram/+page.md
+++ b/src/routes/(demos)/histogram/+page.md
@@ -10,11 +10,34 @@
   let bins = $state(50)
   let sample_size = $state(1000)
   let show_controls = $state(true)
+  let hover_info = $state('Hover over a bar to see details')
+  let click_info = $state('Click on a bar to select it')
 
   let data = $derived({
     y: generate_normal(sample_size, 50, 15),
     label: `Normal Distribution (μ=50, σ=15)`,
   })
+
+  function handle_bar_hover(data) {
+    if (data) {
+      const { value, count, property } = data
+      hover_info = `Hovering: ${property} - Value: ${
+        value.toFixed(1)
+      }, Count: ${count}, Percentage: ${(count / sample_size * 100).toFixed(1)}%`
+    } else {
+      hover_info = 'Hover over a bar to see details'
+    }
+  }
+
+  function handle_bar_click(data) {
+    const { value, count, property } = data
+    click_info = `Clicked: ${property} - Value: ${
+      value.toFixed(1)
+    }, Count: ${count}, Percentage: ${(count / sample_size * 100).toFixed(1)}%`
+  }
+
+  const info_style =
+    'margin: 1em 0; padding: 2pt 5pt; background-color: rgba(255, 255, 255, 0.1); border-radius: 4px'
 </script>
 
 <label>Bins: {bins}<input type="range" bind:value={bins} min="5" max="200" /></label>
@@ -27,6 +50,8 @@
   series={[data]}
   {bins}
   {show_controls}
+  on_bar_hover={handle_bar_hover}
+  on_bar_click={handle_bar_click}
   style="height: 400px"
 >
   {#snippet tooltip({ value, count })}
@@ -34,6 +59,9 @@
     %: {(count / sample_size * 100).toFixed(1)}%
   {/snippet}
 </Histogram>
+
+<div style={info_style}>{hover_info}</div>
+<div style={info_style}>{click_info}</div>
 ```
 
 ## Multiple Series Overlay

--- a/src/routes/(demos)/scatter-plot/+page.md
+++ b/src/routes/(demos)/scatter-plot/+page.md
@@ -36,6 +36,7 @@ A simple scatter plot showing different display modes (points, lines, or both). 
   let display_mode = $state('line+points')
   let clicked_point_info = $state('No point clicked yet.')
   let double_clicked_point_info = $state('No point double-clicked yet.')
+  let hovered_point_info = $state('No point hovered yet.')
 
   // It's good practice to type event handlers if you know the structure
   function handle_point_click({ point }) {
@@ -57,6 +58,21 @@ A simple scatter plot showing different display modes (points, lines, or both). 
     }', Point Index: ${point_idx}`
     if (metadata) {
       double_clicked_point_info += `, Metadata ID: ${metadata.id}`
+    }
+  }
+
+  function handle_point_hover({ point }) {
+    if (point) {
+      const { x, y, metadata, series_idx, point_idx } = point
+      hovered_point_info = `Hovering: Point (${x}, ${y}), Series: '${
+        metadata?.series_label ??
+          (series_idx === 0 ? basic_data.label : second_series.label)
+      }', Point Index: ${point_idx}`
+      if (metadata) {
+        hovered_point_info += `, Metadata ID: ${metadata.id}`
+      }
+    } else {
+      hovered_point_info = 'No point hovered yet.'
     }
   }
 
@@ -86,6 +102,7 @@ A simple scatter plot showing different display modes (points, lines, or both). 
   y_label="Y Value"
   markers={display_mode}
   point_events={{ onclick: handle_point_click, ondblclick: handle_point_double_click }}
+  on_point_hover={handle_point_hover}
   show_controls
   style="height: 300px"
 />
@@ -94,6 +111,9 @@ A simple scatter plot showing different display modes (points, lines, or both). 
 </div>
 <div {style}>
   {double_clicked_point_info}
+</div>
+<div {style}>
+  {hovered_point_info}
 </div>
 ```
 

--- a/src/routes/test/bar-plot/+page.svelte
+++ b/src/routes/test/bar-plot/+page.svelte
@@ -111,6 +111,20 @@
       visible: true,
     },
   ]
+
+  const handlers_series: BarSeries[] = [
+    {
+      x: [1, 2, 3, 4],
+      y: [12, 25, 18, 32],
+      label: `With Handlers`,
+      color: `#9467bd`,
+      bar_width: 0.6,
+      visible: true,
+    },
+  ]
+
+  let hover_msg = $state(`Hover over a bar`)
+  let click_msg = $state(`Click on a bar`)
 </script>
 
 <svelte:head>
@@ -222,5 +236,31 @@
       controls_toggle_props={{ class: `bar-controls-toggle` }}
       style="height: 300px"
     />
+  </div>
+</section>
+
+<section id="handlers-bar">
+  <h2>With Handlers</h2>
+  <BarPlot
+    series={handlers_series}
+    x_label="X"
+    y_label="Y"
+    on_bar_hover={(data) => {
+      if (data) {
+        hover_msg = `Hovering: bar ${data.bar_idx + 1} (x=${data.x}, y=${data.y})`
+      } else {
+        hover_msg = `Hover over a bar`
+      }
+    }}
+    on_bar_click={(data) => {
+      click_msg = `Clicked: bar ${data.bar_idx + 1} (x=${data.x}, y=${data.y})`
+    }}
+    show_controls
+    controls_toggle_props={{ class: `bar-controls-toggle` }}
+    style="height: 360px"
+  />
+  <div class="handler-info">
+    <p>{hover_msg}</p>
+    <p>{click_msg}</p>
   </div>
 </section>

--- a/tests/playwright/plot/bar-plot.test.ts
+++ b/tests/playwright/plot/bar-plot.test.ts
@@ -98,6 +98,55 @@ test.describe(`BarPlot Component Tests`, () => {
     await expect(tooltip).toBeVisible()
   })
 
+  test(`cursor is not pointer when no click handler provided`, async ({ page }) => {
+    const plot = page.locator(`#basic-bar .bar-plot`)
+    const bar = plot.locator(`svg rect`).first()
+    await expect(bar).toBeVisible()
+
+    // Check cursor is not pointer (no click handler)
+    const cursor = await bar.evaluate((el) => globalThis.getComputedStyle(el).cursor)
+    expect(cursor).not.toBe(`pointer`)
+  })
+
+  test(`on_bar_hover and on_bar_click handlers with pointer cursor`, async ({ page }) => {
+    const section = page.locator(`#handlers-bar`)
+    const plot = section.locator(`.bar-plot`)
+    await expect(plot).toBeVisible()
+
+    const bars = plot.locator(`svg rect[role="button"]`)
+    const bar_count = await bars.count()
+    expect(bar_count).toBeGreaterThan(0)
+
+    const first_bar = bars.first()
+
+    // Check cursor is pointer (click handler is defined)
+    const cursor = await first_bar.evaluate((el) =>
+      globalThis.getComputedStyle(el).cursor
+    )
+    expect(cursor).toBe(`pointer`)
+
+    const info = section.locator(`.handler-info`)
+    const hover_p = info.locator(`p`).first()
+    const click_p = info.locator(`p`).last()
+
+    // Initial state
+    await expect(hover_p).toContainText(`Hover over a bar`)
+    await expect(click_p).toContainText(`Click on a bar`)
+
+    // Test hover
+    await first_bar.hover()
+    await page.waitForTimeout(100)
+    await expect(hover_p).toContainText(`Hovering:`)
+
+    // Test click
+    await first_bar.click()
+    await expect(click_p).toContainText(`Clicked:`)
+
+    // Test hover clears on mouse leave
+    await page.mouse.move(0, 0)
+    await expect(hover_p).toContainText(`Hover over a bar`)
+  })
+
   test(`controls pane toggles grid and updates tick formats`, async ({ page }) => {
     const section = page.locator(`#basic-bar`)
     const plot = section.locator(`.bar-plot`)


### PR DESCRIPTION
- Adds `on_bar_click` and `on_bar_hover` to `BarPlot` and `Histogram`, plus `on_point_click` and `on_point_hover` to `ScatterPlot`.
- Passes the originating mouse or keyboard event to callbacks and emits `null` when hover ends.
- Supports Enter and Space activation for bars and shows pointer cursors only when click handlers are present.
- Exposes point cursor styling and standardizes scatter point and line defaults to `cornflowerblue`.