### PR TITLE
Add `grouped` mode to `BarPlot` + interactivity improvements

### DIFF
--- a/src/lib/DraggablePane.svelte
+++ b/src/lib/DraggablePane.svelte
@@ -176,6 +176,7 @@
     bind:this={toggle_pane_btn}
     aria-expanded={show}
     {...toggle_props}
+    style={`font-size: clamp(1em, 2.2cqw, 2em); ${toggle_props.style ?? ``}`}
     onclick={toggle_pane}
     class="pane-toggle {toggle_props.class ?? ``}"
     {@attach tooltip({ content: toggle_props.title ?? (show ? `Close pane` : `Open pane`) })}

--- a/src/lib/Nav.svelte
+++ b/src/lib/Nav.svelte
@@ -120,6 +120,9 @@
     return page?.url.pathname.startsWith(path) ? `page` : undefined
   }
 
+  const is_child_current = (sub_routes: string[]) =>
+    sub_routes.some((child_path) => is_current(child_path) === `page`)
+
   function format_label(text: string, remove_parent = false) {
     const custom_label = labels?.[text]
     if (custom_label) return { label: custom_label, style: `` }
@@ -172,11 +175,14 @@
       {#if sub_routes}
         <!-- Dropdown menu item -->
         {@const parent = format_label(label)}
+        {@const child_is_active = is_child_current(sub_routes)}
         <div
           class="dropdown-wrapper"
+          class:active={child_is_active}
           role="button"
           tabindex="0"
           data-href={href}
+          aria-current={child_is_active ? `true` : undefined}
           aria-expanded={hovered_dropdown === href}
           aria-haspopup="true"
           onmouseenter={() => !is_touch_device && (hovered_dropdown = href)}
@@ -261,6 +267,7 @@
   nav {
     position: relative;
     margin: -0.75em auto 1.25em;
+    --nav-border-radius: 6pt;
   }
   .menu-content {
     display: flex;
@@ -270,27 +277,29 @@
     padding: 0.5em;
   }
   .menu-content > a,
-  .dropdown-wrapper {
+  .dropdown-trigger {
     line-height: 1.3;
     padding: 1pt 5pt;
-    border-radius: 2pt;
+    border-radius: var(--nav-border-radius);
     text-decoration: none;
     color: inherit;
     transition: background-color 0.2s;
   }
   .menu-content > a:hover,
-  .dropdown-wrapper:hover {
+  .dropdown-wrapper:hover .dropdown-trigger {
     background-color: var(--nav-link-bg-hover);
   }
   .menu-content > a[aria-current='page'] {
     color: var(--nav-link-active-color);
-    background-color: var(--nav-link-bg-hover, rgba(128, 128, 128, 0.24));
   }
 
   /* Dropdown styles */
   .dropdown-wrapper {
     position: relative;
     cursor: pointer;
+  }
+  .dropdown-wrapper.active > .dropdown-trigger {
+    color: var(--nav-link-active-color);
   }
   .dropdown-wrapper::after {
     content: '';
@@ -315,7 +324,7 @@
     background-color: var(--nav-dropdown-bg, var(--surface-bg, var(--bg-color, #ffffff)));
     border: 1px solid
       var(--nav-dropdown-border-color, var(--border-color, rgba(128, 128, 128, 0.25)));
-    border-radius: var(--nav-dropdown-border-radius, 6pt);
+    border-radius: var(--nav-border-radius, 6pt);
     box-shadow: var(--nav-dropdown-shadow, 0 2px 8px rgba(0, 0, 0, 0.15));
     padding: var(--nav-dropdown-padding, 2pt 3pt);
     display: none;
@@ -328,7 +337,7 @@
   }
   .dropdown-menu a {
     padding: var(--nav-dropdown-link-padding, 1pt 4pt);
-    border-radius: var(--nav-dropdown-link-border-radius, 4pt);
+    border-radius: var(--nav-border-radius);
     text-decoration: none;
     color: inherit;
     white-space: nowrap;

--- a/src/lib/plot/BarPlot.svelte
+++ b/src/lib/plot/BarPlot.svelte
@@ -336,7 +336,9 @@
 
     return visible_series.flatMap((srs) => {
       const is_line = srs.render_mode === `line`
-      const series_offsets = stacked_offsets[visible_series.indexOf(srs)] ?? []
+      // Use original series index to look up stacked_offsets
+      const series_idx = series.indexOf(srs)
+      const series_offsets = stacked_offsets[series_idx] ?? []
       return srs.x.map((x_val, bar_idx) => {
         const y_val = srs.y[bar_idx]
         const base = !is_line && mode === `stacked`
@@ -790,7 +792,7 @@
 
     {#if show_controls}
       <BarPlotControls
-        toggle_props={{ style: `font-size: clamp(1em, 2.1cqw, 2em)`, ...controls_toggle_props }}
+        toggle_props={controls_toggle_props}
         bind:show_controls
         bind:controls_open
         bind:orientation
@@ -823,7 +825,6 @@
     container-type: size;
     z-index: var(--barplot-z-index, auto);
     border-radius: var(--border-radius, 4px);
-    container-type: size;
   }
   .bar-plot.dragover {
     border: var(--barplot-dragover-border, var(--dragover-border));

--- a/src/lib/plot/BarPlot.svelte
+++ b/src/lib/plot/BarPlot.svelte
@@ -42,6 +42,7 @@
     show_zero_lines?: boolean
     legend?: LegendConfig | null
     padding?: Sides
+    default_bar_color?: string
     tooltip?: Snippet<[BarTooltipProps]>
     hovered?: boolean
     change?: (data: BarTooltipProps | null) => void
@@ -77,6 +78,7 @@
     show_zero_lines = $bindable(true),
     legend = {},
     padding = { t: 10, b: 60, l: 60, r: 30 },
+    default_bar_color = `var(--bar-color, #4682b4)`,
     tooltip,
     hovered = $bindable(false),
     change = () => {},
@@ -294,8 +296,14 @@
       label: srs.label ?? `Series ${idx + 1}`,
       visible: srs.visible ?? true,
       display_style: srs.render_mode === `line`
-        ? { line_color: srs.color ?? `black`, line_dash: srs.line_style?.line_dash }
-        : { symbol_type: `Square` as const, symbol_color: srs.color ?? `black` },
+        ? {
+          line_color: srs.color ?? default_bar_color,
+          line_dash: srs.line_style?.line_dash,
+        }
+        : {
+          symbol_type: `Square` as const,
+          symbol_color: srs.color ?? default_bar_color,
+        },
     }))
   )
 
@@ -470,7 +478,7 @@
             >
               {#if is_line}
                 <!-- Render as line -->
-                {@const color = srs.color ?? `var(--bar-color, #4682b4)`}
+                {@const color = srs.color ?? default_bar_color}
                 {@const stroke_width = srs.line_style?.stroke_width ?? 2}
                 {@const line_dash = srs.line_style?.line_dash ?? `none`}
                 {@const points = srs.x.map((x_val, idx) => {
@@ -556,7 +564,7 @@
                   {@const base = mode === `stacked`
             ? (stacked_offsets[series_idx]?.[bar_idx] ?? 0)
             : 0}
-                  {@const color = srs.color ?? `var(--bar-color, #4682b4)`}
+                  {@const color = srs.color ?? default_bar_color}
                   {@const bar_width_val = Array.isArray(srs.bar_width)
             ? (srs.bar_width[bar_idx] ?? 0.5)
             : (srs.bar_width ?? 0.5)}

--- a/src/lib/plot/BarPlot.svelte
+++ b/src/lib/plot/BarPlot.svelte
@@ -16,6 +16,7 @@
   import { create_scale, generate_ticks, get_nice_data_range } from '$lib/plot/scales'
   import type { ComponentProps, Snippet } from 'svelte'
   import type { HTMLAttributes } from 'svelte/elements'
+  import { SvelteMap } from 'svelte/reactivity'
   import BarPlotControls from './BarPlotControls.svelte'
 
   interface Props extends HTMLAttributes<HTMLDivElement> {
@@ -90,16 +91,47 @@
 
   let [width, height] = $state([0, 0])
   let svg_element: SVGElement | null = $state(null)
+  let clip_path_id = `chart-clip-${Math.random().toString(36).slice(2)}`
 
   // Compute auto ranges from visible series
   let visible_series = $derived(series.filter((s) => s?.visible ?? true))
 
   let auto_ranges = $derived.by(() => {
-    const all_points = visible_series.flatMap((s) =>
+    let all_points = visible_series.flatMap((s) =>
       s.x.map((x_val, idx) => ({ x: x_val, y: s.y[idx] }))
     )
+
+    // In stacked mode, calculate stacked totals for accurate range
+    if (mode === `stacked`) {
+      const stacked_totals = new SvelteMap<number, { pos: number; neg: number }>()
+
+      // Only include visible bar series (not lines) in stacking
+      visible_series
+        .filter((srs) => srs.render_mode !== `line`)
+        .forEach((srs) =>
+          srs.x.forEach((x_val, idx) => {
+            const y_val = srs.y[idx] ?? 0
+            const totals = stacked_totals.get(x_val) ?? { pos: 0, neg: 0 }
+            if (y_val >= 0) totals.pos += y_val
+            else totals.neg += y_val
+            stacked_totals.set(x_val, totals)
+          })
+        )
+
+      // Replace points with stacked totals + line series (which don't stack)
+      all_points = [
+        ...Array.from(stacked_totals).flatMap(([x_val, { pos, neg }]) => [
+          ...(pos > 0 ? [{ x: x_val, y: pos }] : []),
+          ...(neg < 0 ? [{ x: x_val, y: neg }] : []),
+        ]),
+        ...visible_series
+          .filter((srs) => srs.render_mode === `line`)
+          .flatMap((srs) => srs.x.map((x_val, idx) => ({ x: x_val, y: srs.y[idx] }))),
+      ]
+    }
+
     if (!all_points.length) {
-      return { x: [0, 1] as [number, number], y: [0, 1] as [number, number] }
+      return { x: [0, 1], y: [0, 1] }
     }
     // Compute data-driven ranges first (categories from x, magnitudes from y)
     const x_range = get_nice_data_range(
@@ -110,7 +142,7 @@
       range_padding,
       x_format?.startsWith(`%`) || false,
     )
-    const y_range = get_nice_data_range(
+    let y_range = get_nice_data_range(
       all_points,
       (p) => p.y,
       y_lim,
@@ -119,6 +151,23 @@
       false,
     )
 
+    // For bar plots, ensure the value axis starts at 0 unless there are negative values
+    // This prevents bars from starting at arbitrary values
+    const has_negative = all_points.some((p) => p.y < 0)
+    const has_positive = all_points.some((p) => p.y > 0)
+
+    // Only adjust if no explicit y_lim is set
+    if (!y_lim?.[0] && !y_lim?.[1]) {
+      if (has_positive && !has_negative) {
+        // All positive/zero values: always start from 0
+        y_range = [0, y_range[1]]
+      } else if (has_negative && !has_positive) {
+        // All negative values: end at 0
+        y_range = [y_range[0], 0]
+      }
+      // Mixed positive/negative: keep natural range (will include 0)
+    }
+
     // Map data ranges to axis ranges depending on orientation
     return orientation === `horizontal`
       ? ({ x: y_range, y: x_range })
@@ -126,9 +175,12 @@
   })
 
   // Initialize and current ranges
-  let ranges = $state({
-    initial: { x: [0, 1] as [number, number], y: [0, 1] as [number, number] },
-    current: { x: [0, 1] as [number, number], y: [0, 1] as [number, number] },
+  let ranges = $state<{
+    initial: { x: [number, number]; y: [number, number] }
+    current: { x: [number, number]; y: [number, number] }
+  }>({
+    initial: { x: [0, 1], y: [0, 1] },
+    current: { x: [0, 1], y: [0, 1] },
   })
 
   $effect(() => { // handle x|y_range changes
@@ -146,12 +198,48 @@
     }
   })
 
-  // Layout helpers
-  const pad = $derived({ t: 20, b: 60, l: 60, r: 20, ...padding })
+  // Measure text width helper
+  let measurement_canvas: HTMLCanvasElement | null = null
+  function measure_text_width(
+    text: string,
+    font: string = `12px sans-serif`,
+  ): number {
+    if (typeof document === `undefined`) return 0
+    if (!measurement_canvas) {
+      measurement_canvas = document.createElement(`canvas`)
+    }
+    const ctx = measurement_canvas.getContext(`2d`)
+    if (!ctx) return 0
+    ctx.font = font
+    return ctx.measureText(text).width
+  }
+
+  // Layout helpers with dynamic padding based on tick label sizes
+  // Use $state to break circular dependency with ticks
+  let pad = $state({ t: 20, b: 60, l: 60, r: 20, ...padding })
+
+  // Update padding when format or ticks change, but prevent infinite loop
+  $effect(() => {
+    const base_pad = { t: 20, b: 60, l: 60, r: 20, ...padding }
+
+    if (!width || !height || !ticks.x.length || !ticks.y.length) {
+      if (JSON.stringify(pad) !== JSON.stringify(base_pad)) pad = base_pad
+      return
+    }
+
+    // Measure y-axis tick labels
+    const max_y_tick_width = Math.max(
+      0,
+      ...ticks.y.map((tick) =>
+        measure_text_width(format_value(tick, y_format), `12px sans-serif`)
+      ),
+    )
+    const new_pad = { ...base_pad, l: Math.max(base_pad.l, max_y_tick_width + 45) }
+
+    if (JSON.stringify(pad) !== JSON.stringify(new_pad)) pad = new_pad
+  })
   const chart_width = $derived(Math.max(1, width - pad.l - pad.r))
-  // Ensure enough headroom for tallest label above bars (~14px). Add 8px extra buffer.
-  const extra_top = $derived(14 + 8)
-  const chart_height = $derived(Math.max(1, height - (pad.t + extra_top) - pad.b))
+  const chart_height = $derived(Math.max(1, height - pad.t - pad.b))
 
   // Scales (linear only for now)
   let scales = $derived({
@@ -174,13 +262,11 @@
   })
 
   // Zoom drag state
-  let drag_state = $state<
-    {
-      start: { x: number; y: number } | null
-      current: { x: number; y: number } | null
-      bounds: DOMRect | null
-    }
-  >({ start: null, current: null, bounds: null })
+  let drag_state = $state<{
+    start: { x: number; y: number } | null
+    current: { x: number; y: number } | null
+    bounds: DOMRect | null
+  }>({ start: null, current: null, bounds: null })
   const on_window_mouse_move = (evt: MouseEvent) => {
     if (!drag_state.start || !drag_state.bounds) return
     drag_state.current = {
@@ -225,14 +311,16 @@
   }
 
   // Legend data and handlers
-  let legend_data = $derived.by<LegendItem[]>(() => {
-    return series.map((srs, idx) => ({
+  let legend_data = $derived.by<LegendItem[]>(() =>
+    series.map((srs, idx) => ({
       series_idx: idx,
       label: srs.label ?? `Series ${idx + 1}`,
       visible: srs.visible ?? true,
-      display_style: { line_color: srs.color ?? `black` },
+      display_style: srs.render_mode === `line`
+        ? { line_color: srs.color ?? `black`, line_dash: srs.line_style?.line_dash }
+        : { symbol_type: `Square` as const, symbol_color: srs.color ?? `black` },
     }))
-  })
+  )
 
   function toggle_series_visibility(series_idx: number) {
     if (series_idx >= 0 && series_idx < series.length) {
@@ -242,59 +330,57 @@
     }
   }
 
-  // Collect bar positions for legend placement
+  // Collect bar and line positions for legend placement
   let bar_points_for_placement = $derived.by(() => {
     if (!width || !height || !visible_series.length) return []
 
-    const points: { x: number; y: number }[] = []
-
-    for (const srs of visible_series) {
-      for (let bar_idx = 0; bar_idx < srs.x.length; bar_idx++) {
-        const x_val = srs.x[bar_idx]
+    return visible_series.flatMap((srs) => {
+      const is_line = srs.render_mode === `line`
+      const series_offsets = stacked_offsets[visible_series.indexOf(srs)] ?? []
+      return srs.x.map((x_val, bar_idx) => {
         const y_val = srs.y[bar_idx]
-
-        if (orientation === `vertical`) {
-          const bar_x = scales.x(x_val)
-          const bar_y = scales.y(y_val)
-          if (isFinite(bar_x) && isFinite(bar_y)) points.push({ x: bar_x, y: bar_y })
-        } else {
-          const bar_x = scales.x(y_val)
-          const bar_y = scales.y(x_val)
-          if (isFinite(bar_x) && isFinite(bar_y)) points.push({ x: bar_x, y: bar_y })
-        }
-      }
-    }
-    return points
+        const base = !is_line && mode === `stacked`
+          ? (series_offsets[bar_idx] ?? 0)
+          : 0
+        const [bar_x, bar_y] = orientation === `vertical`
+          ? [scales.x(x_val), scales.y(base + y_val)]
+          : [scales.x(base + y_val), scales.y(x_val)]
+        return { x: bar_x, y: bar_y }
+      }).filter((p) => isFinite(p.x) && isFinite(p.y))
+    })
   })
 
   // Calculate best legend placement
-  let legend_placement = $derived.by(() => {
-    const should_place = (series?.length ?? 0) > 1
-
-    if (!should_place || !width || !height) return null
-
-    return find_best_legend_placement(bar_points_for_placement, {
-      plot_width: chart_width,
-      plot_height: chart_height,
-      padding: { t: pad.t, b: pad.b, l: pad.l, r: pad.r },
-      margin: 10,
-      legend_size: { width: 120, height: 60 },
-    })
-  })
+  let legend_placement = $derived.by(() =>
+    series.length > 1 && width && height
+      ? find_best_legend_placement(bar_points_for_placement, {
+        plot_width: chart_width,
+        plot_height: chart_height,
+        padding: pad,
+        margin: 10,
+        legend_size: { width: 120, height: 60 },
+      })
+      : null
+  )
 
   // Tooltip state
   let hover_info = $state<BarTooltipProps | null>(null)
 
   function get_bar_data(series_idx: number, bar_idx: number, color: string) {
     const srs = series[series_idx]
-    const x = srs.x[bar_idx]
-    const y = srs.y[bar_idx]
-    const label = srs.labels?.[bar_idx] ?? null
-    const metadata = Array.isArray(srs.metadata)
-      ? (srs.metadata[bar_idx] as Record<string, unknown> | undefined)
-      : (srs.metadata as Record<string, unknown> | undefined)
+    const [x, y] = [srs.x[bar_idx], srs.y[bar_idx]]
     const [orient_x, orient_y] = orientation === `horizontal` ? [y, x] : [x, y]
-    return { x, y, orient_x, orient_y, series_idx, bar_idx, metadata, label, color }
+    return {
+      x,
+      y,
+      orient_x,
+      orient_y,
+      series_idx,
+      bar_idx,
+      label: srs.labels?.[bar_idx] ?? null,
+      metadata: Array.isArray(srs.metadata) ? srs.metadata[bar_idx] : srs.metadata,
+      color,
+    }
   }
 
   const handle_bar_hover =
@@ -305,34 +391,36 @@
       on_bar_hover?.({ ...hover_info, event })
     }
 
-  // Stack offsets (only for vertical stacked mode)
+  // Stack offsets (only for bar series in stacked mode)
   let stacked_offsets = $derived.by(() => {
     if (mode !== `stacked`) return [] as number[][]
-    // Compute base offsets per series/bar index.
-    // Only visible series contribute; negatives and positives stack separately.
     const max_len = Math.max(0, ...series.map((s) => s.y.length))
-    const offsets: number[][] = series.map(() =>
-      Array.from({ length: max_len }, () => 0)
-    )
+    const offsets = series.map(() => Array.from({ length: max_len }, () => 0))
     const pos_acc = Array.from({ length: max_len }, () => 0)
     const neg_acc = Array.from({ length: max_len }, () => 0)
 
-    for (let series_idx = 0; series_idx < series.length; series_idx++) {
-      const srs = series[series_idx]
-      const is_visible = srs?.visible ?? true
-      if (!is_visible) continue
+    series.forEach((srs, series_idx) => {
+      if (!(srs?.visible ?? true) || srs.render_mode === `line`) return
       for (let bar_idx = 0; bar_idx < max_len; bar_idx++) {
         const y_val = srs.y[bar_idx] ?? 0
-        if (y_val >= 0) {
-          offsets[series_idx][bar_idx] = pos_acc[bar_idx]
-          pos_acc[bar_idx] += y_val
-        } else {
-          offsets[series_idx][bar_idx] = neg_acc[bar_idx]
-          neg_acc[bar_idx] += y_val
-        }
+        const acc = y_val >= 0 ? pos_acc : neg_acc
+        offsets[series_idx][bar_idx] = acc[bar_idx]
+        acc[bar_idx] += y_val
       }
-    }
+    })
     return offsets
+  })
+
+  // Calculate group positions for grouped mode (side-by-side bars)
+  let group_info = $derived.by(() => {
+    if (mode !== `grouped`) return { bar_series_count: 0, bar_series_indices: [] }
+    const bar_series_indices = series
+      .map((
+        srs,
+        idx,
+      ) => ((srs?.visible ?? true) && srs.render_mode !== `line` ? idx : -1))
+      .filter((idx) => idx >= 0)
+    return { bar_series_count: bar_series_indices.length, bar_series_indices }
   })
 </script>
 
@@ -358,11 +446,20 @@
       tabindex="0"
       aria-label="Interactive bar plot with zoom and tooltip"
     >
-      <!-- Zero lines -->
-      {#if show_zero_lines}
-        {#if ranges.current.x[0] <= 0 && ranges.current.x[1] >= 0}
+      <!-- Define clip path for chart area -->
+      <defs>
+        <clipPath id={clip_path_id}>
+          <rect x={pad.l} y={pad.t} width={chart_width} height={chart_height} />
+        </clipPath>
+      </defs>
+
+      <!-- Clipped content: zero lines, bars, and lines -->
+      <g clip-path="url(#{clip_path_id})">
+        <!-- Zero lines -->
+        {#if show_zero_lines}
           {@const zx = scales.x(0)}
-          {#if isFinite(zx)}
+          {@const zy = scales.y(0)}
+          {#if ranges.current.x[0] <= 0 && ranges.current.x[1] >= 0 && isFinite(zx)}
             <line
               x1={zx}
               x2={zx}
@@ -372,10 +469,7 @@
               stroke-width="0.5"
             />
           {/if}
-        {/if}
-        {#if ranges.current.y[0] < 0 && ranges.current.y[1] > 0}
-          {@const zy = scales.y(0)}
-          {#if isFinite(zy)}
+          {#if ranges.current.y[0] < 0 && ranges.current.y[1] > 0 && isFinite(zy)}
             <line
               x1={pad.l}
               x2={width - pad.r}
@@ -386,44 +480,76 @@
             />
           {/if}
         {/if}
-      {/if}
 
-      <!-- Bars -->
-      {#each series as srs, series_idx (series_idx)}
-        {#if srs?.visible ?? true}
-          <g class="bar-series" data-series-idx={series_idx}>
-            {#each srs.x as x_val, bar_idx (bar_idx)}
-              {@const y_val = srs.y[bar_idx]}
-              {@const base = mode === `stacked`
-          ? (stacked_offsets[series_idx]?.[bar_idx] ?? 0)
-          : 0}
-              {@const color = srs.color ?? `var(--bar-color, #4682b4)`}
-              {#if orientation === `vertical`}
-                {@const half = (Array.isArray(srs.bar_width)
-          ? (srs.bar_width[bar_idx] ?? 0.5)
-          : (srs.bar_width ?? 0.5)) / 2}
-                {@const x0v = scales.x(x_val - half)}
-                {@const x1v = scales.x(x_val + half)}
-                {@const y0v = scales.y(base)}
-                {@const y1v = scales.y(base + y_val)}
-                {@const rect_x = Math.min(x0v, x1v)}
-                {@const rect_y = Math.min(y0v, y1v)}
-                {@const rect_w = Math.max(1, Math.abs(x1v - x0v))}
-                {@const rect_h = Math.max(0, Math.abs(y1v - y0v))}
-                {#if rect_h > 0}
-                  <rect
-                    x={rect_x}
-                    y={rect_y}
-                    width={rect_w}
-                    height={rect_h}
+        <!-- Bars and Lines -->
+        {#each series as srs, series_idx (series_idx)}
+          {#if srs?.visible ?? true}
+            {@const is_line = srs.render_mode === `line`}
+            <g
+              class={is_line ? `line-series` : `bar-series`}
+              data-series-idx={series_idx}
+            >
+              {#if is_line}
+                <!-- Render as line -->
+                {@const color = srs.color ?? `var(--bar-color, #4682b4)`}
+                {@const stroke_width = srs.line_style?.stroke_width ?? 2}
+                {@const line_dash = srs.line_style?.line_dash ?? `none`}
+                {@const points = srs.x.map((x_val, idx) => {
+            const y_val = srs.y[idx]
+            // Lines don't stack - they show absolute values (useful for totals/trends)
+            const plot_x = orientation === `vertical`
+              ? scales.x(x_val)
+              : scales.x(y_val)
+            const plot_y = orientation === `vertical`
+              ? scales.y(y_val)
+              : scales.y(x_val)
+            return { x: plot_x, y: plot_y, idx }
+          }).filter((p) => isFinite(p.x) && isFinite(p.y))}
+                {#if points.length > 1}
+                  <polyline
+                    points={points.map((p) => `${p.x},${p.y}`).join(` `)}
+                    fill="none"
+                    stroke={color}
+                    stroke-width={stroke_width}
+                    stroke-dasharray={line_dash}
+                    stroke-linejoin="round"
+                    stroke-linecap="round"
+                  />
+                {/if}
+                <!-- Add invisible wider line for easier hovering -->
+                {#if points.length > 1 && (on_bar_hover || on_bar_click)}
+                  <polyline
+                    points={points.map((p) => `${p.x},${p.y}`).join(` `)}
+                    fill="none"
+                    stroke="transparent"
+                    stroke-width={Math.max(10, stroke_width * 3)}
+                    stroke-linejoin="round"
+                    stroke-linecap="round"
+                    style:cursor={on_bar_click ? `pointer` : undefined}
+                  />
+                {/if}
+                <!-- Render hover circles at each data point -->
+                {#each points as point (point.idx)}
+                  {@const bar_idx = point.idx}
+                  <circle
+                    cx={point.x}
+                    cy={point.y}
+                    r="4"
                     fill={color}
-                    opacity={mode === `overlay` ? 0.85 : 1}
+                    opacity="0"
                     role="button"
                     tabindex="0"
-                    aria-label={`bar ${bar_idx + 1} of ${srs.label ?? `series`}`}
+                    aria-label={`point ${bar_idx + 1} of ${srs.label ?? `series`}`}
                     style:cursor={on_bar_click ? `pointer` : undefined}
+                    onmouseenter={(evt) => {
+                      // Show the circle on hover
+                      const circle_el = evt.currentTarget as SVGCircleElement
+                      if (circle_el) circle_el.setAttribute(`opacity`, `1`)
+                    }}
                     onmousemove={handle_bar_hover(series_idx, bar_idx, color)}
-                    onmouseleave={() => {
+                    onmouseleave={(evt) => {
+                      const circle_el = evt.currentTarget as SVGCircleElement
+                      if (circle_el) circle_el.setAttribute(`opacity`, `0`)
                       hover_info = null
                       change(null)
                       on_bar_hover?.(null)
@@ -443,78 +569,93 @@
                       }
                     }}
                   />
-                  {#if srs.labels?.[bar_idx]}
-                    <text
-                      x={(x0v + x1v) / 2}
-                      y={Math.max(0, Math.min(y0v, y1v) - 6)}
-                      text-anchor="middle"
-                      class="bar-label"
-                    >
-                      {srs.labels[bar_idx]}
-                    </text>
-                  {/if}
-                {/if}
+                {/each}
               {:else}
-                {@const half_h = (Array.isArray(srs.bar_width)
-          ? (srs.bar_width[bar_idx] ?? 0.5)
-          : (srs.bar_width ?? 0.5)) / 2}
-                {@const y0h = scales.y(x_val - half_h)}
-                {@const y1h = scales.y(x_val + half_h)}
-                {@const x0h = scales.x(base)}
-                {@const x1h = scales.x(base + y_val)}
-                {@const rect_xh = Math.min(x0h, x1h)}
-                {@const rect_yh = Math.min(y0h, y1h)}
-                {@const rect_wh = Math.max(1, Math.abs(x1h - x0h))}
-                {@const rect_hh = Math.max(0, Math.abs(y1h - y0h))}
-                {#if rect_wh > 0}
-                  <rect
-                    x={rect_xh}
-                    y={rect_yh}
-                    width={rect_wh}
-                    height={rect_hh}
-                    fill={color}
-                    opacity={mode === `overlay` ? 0.85 : 1}
-                    role="button"
-                    tabindex="0"
-                    aria-label={`bar ${bar_idx + 1} of ${srs.label ?? `series`}`}
-                    style:cursor={on_bar_click ? `pointer` : undefined}
-                    onmousemove={handle_bar_hover(series_idx, bar_idx, color)}
-                    onmouseleave={() => {
-                      hover_info = null
-                      change(null)
-                      on_bar_hover?.(null)
-                    }}
-                    onclick={(evt) =>
-                    on_bar_click?.({
-                      ...get_bar_data(series_idx, bar_idx, color),
-                      event: evt,
-                    })}
-                    onkeydown={(evt) => {
-                      if (evt.key === `Enter` || evt.key === ` `) {
-                        evt.preventDefault()
-                        on_bar_click?.({
-                          ...get_bar_data(series_idx, bar_idx, color),
-                          event: evt,
-                        })
-                      }
-                    }}
-                  />
-                  {#if srs.labels?.[bar_idx]}
-                    <text
-                      x={Math.max(x0h, x1h) + 4}
-                      y={(y0h + y1h) / 2}
-                      dominant-baseline="central"
-                      class="bar-label"
-                    >
-                      {srs.labels[bar_idx]}
-                    </text>
+                <!-- Render as bars -->
+                {#each srs.x as x_val, bar_idx (bar_idx)}
+                  {@const y_val = srs.y[bar_idx]}
+                  {@const base = mode === `stacked`
+            ? (stacked_offsets[series_idx]?.[bar_idx] ?? 0)
+            : 0}
+                  {@const color = srs.color ?? `var(--bar-color, #4682b4)`}
+                  {@const bar_width_val = Array.isArray(srs.bar_width)
+            ? (srs.bar_width[bar_idx] ?? 0.5)
+            : (srs.bar_width ?? 0.5)}
+                  {@const half = mode === `grouped` && group_info.bar_series_count > 1
+            ? bar_width_val / (2 * group_info.bar_series_count)
+            : bar_width_val / 2}
+                  {@const group_offset = mode === `grouped` && group_info.bar_series_count > 1
+            ? ((pos = group_info.bar_series_indices.indexOf(series_idx)) =>
+              (pos - (group_info.bar_series_count - 1) / 2) *
+              (bar_width_val / group_info.bar_series_count))()
+            : 0}
+                  {@const is_vertical = orientation === `vertical`}
+                  {@const cat_val = x_val}
+                  {@const val = y_val}
+                  {@const [cat_scale, val_scale] = is_vertical
+            ? [scales.x, scales.y]
+            : [scales.y, scales.x]}
+                  {@const c0 = cat_scale(cat_val + group_offset - half)}
+                  {@const c1 = cat_scale(cat_val + group_offset + half)}
+                  {@const v0 = val_scale(base)}
+                  {@const v1 = val_scale(base + val)}
+                  {@const [rect_x, rect_y] = is_vertical
+            ? [Math.min(c0, c1), Math.min(v0, v1)]
+            : [Math.min(v0, v1), Math.min(c0, c1)]}
+                  {@const [rect_w, rect_h] = is_vertical
+            ? [Math.max(1, Math.abs(c1 - c0)), Math.max(0, Math.abs(v1 - v0))]
+            : [Math.max(1, Math.abs(v1 - v0)), Math.max(0, Math.abs(c1 - c0))]}
+                  {#if (is_vertical ? rect_h : rect_w) > 0}
+                    <rect
+                      x={rect_x}
+                      y={rect_y}
+                      width={rect_w}
+                      height={rect_h}
+                      fill={color}
+                      opacity={mode === `overlay` ? 0.6 : 1}
+                      role="button"
+                      tabindex="0"
+                      aria-label={`bar ${bar_idx + 1} of ${srs.label ?? `series`}`}
+                      style:cursor={on_bar_click ? `pointer` : undefined}
+                      onmousemove={handle_bar_hover(series_idx, bar_idx, color)}
+                      onmouseleave={() => {
+                        hover_info = null
+                        change(null)
+                        on_bar_hover?.(null)
+                      }}
+                      onclick={(evt) =>
+                      on_bar_click?.({
+                        ...get_bar_data(series_idx, bar_idx, color),
+                        event: evt,
+                      })}
+                      onkeydown={(evt) => {
+                        if (evt.key === `Enter` || evt.key === ` `) {
+                          evt.preventDefault()
+                          on_bar_click?.({
+                            ...get_bar_data(series_idx, bar_idx, color),
+                            event: evt,
+                          })
+                        }
+                      }}
+                    />
+                    {#if srs.labels?.[bar_idx]}
+                      <text
+                        x={is_vertical ? (c0 + c1) / 2 : Math.max(v0, v1) + 4}
+                        y={is_vertical ? Math.max(0, Math.min(v0, v1) - 6) : (c0 + c1) / 2}
+                        text-anchor={is_vertical ? `middle` : undefined}
+                        dominant-baseline={is_vertical ? undefined : `central`}
+                        class="bar-label"
+                      >
+                        {srs.labels[bar_idx]}
+                      </text>
+                    {/if}
                   {/if}
-                {/if}
+                {/each}
               {/if}
-            {/each}
-          </g>
-        {/if}
-      {/each}
+            </g>
+          {/if}
+        {/each}
+      </g>
 
       <!-- Zoom rectangle -->
       {#if drag_state.start && drag_state.current}
@@ -553,14 +694,16 @@
             </g>
           {/if}
         {/each}
-        <text
-          x={pad.l + chart_width / 2 + (x_label_shift.x ?? 0)}
-          y={height - (pad.b / 2) + (x_label_shift.y ?? 0)}
-          text-anchor="middle"
-          fill="var(--text-color)"
-        >
-          {x_label}
-        </text>
+        {#if x_label}
+          <text
+            x={pad.l + chart_width / 2 + (x_label_shift.x ?? 0)}
+            y={height - (pad.b / 3) + (x_label_shift.y ?? 0)}
+            text-anchor="middle"
+            fill="var(--text-color)"
+          >
+            {x_label}
+          </text>
+        {/if}
       </g>
 
       <!-- Y-axis -->
@@ -596,20 +739,31 @@
             </g>
           {/if}
         {/each}
-        <text
-          x={15 + (y_label_shift.x ?? 0)}
-          y={pad.t + chart_height / 2 + (y_label_shift.y ?? 0)}
-          text-anchor="middle"
-          fill="var(--text-color)"
-          transform="rotate(-90, {15 + (y_label_shift.x ?? 0)}, {pad.t + chart_height / 2 + (y_label_shift.y ?? 0)})"
-        >
-          {y_label}
-        </text>
+        {#if y_label}
+          {@const max_y_tick_width = Math.max(
+          0,
+          ...ticks.y.map((tick) =>
+            measure_text_width(format_value(tick, y_format), `12px sans-serif`)
+          ),
+        )}
+          {@const y_label_x = Math.max(15, pad.l - max_y_tick_width - 35) +
+          (y_label_shift.x ?? 0)}
+          {@const y_label_y = pad.t + chart_height / 2 + (y_label_shift.y ?? 0)}
+          <text
+            x={y_label_x}
+            y={y_label_y}
+            text-anchor="middle"
+            fill="var(--text-color)"
+            transform="rotate(-90, {y_label_x}, {y_label_y})"
+          >
+            {y_label}
+          </text>
+        {/if}
       </g>
     </svg>
 
     <!-- Legend -->
-    {#if (series?.length ?? 0) > 1 && legend_placement}
+    {#if legend_placement}
       <PlotLegend
         {...legend}
         series_data={legend_data}
@@ -636,7 +790,7 @@
 
     {#if show_controls}
       <BarPlotControls
-        toggle_props={controls_toggle_props}
+        toggle_props={{ style: `font-size: clamp(1em, 2.1cqw, 2em)`, ...controls_toggle_props }}
         bind:show_controls
         bind:controls_open
         bind:orientation
@@ -649,17 +803,15 @@
         bind:y_format
         bind:x_range
         bind:y_range
-        auto_x_range={auto_ranges.x}
-        auto_y_range={auto_ranges.y}
+        auto_x_range={auto_ranges.x as [number, number]}
+        auto_y_range={auto_ranges.y as [number, number]}
         {plot_controls}
       />
     {/if}
   {/if}
 
-  <!-- User-provided children (e.g., for custom absolutely-positioned overlays) -->
-  {#if children}
-    {@render children()}
-  {/if}
+  <!-- User-provided children (e.g. for custom absolutely-positioned overlays) -->
+  {@render children?.()}
 </div>
 
 <style>
@@ -671,6 +823,7 @@
     container-type: size;
     z-index: var(--barplot-z-index, auto);
     border-radius: var(--border-radius, 4px);
+    container-type: size;
   }
   .bar-plot.dragover {
     border: var(--barplot-dragover-border, var(--dragover-border));

--- a/src/lib/plot/BarPlotControls.svelte
+++ b/src/lib/plot/BarPlotControls.svelte
@@ -162,6 +162,7 @@
           <select bind:value={mode} id="mode-select">
             <option value="overlay">Overlay</option>
             <option value="stacked">Stacked</option>
+            <option value="grouped">Grouped (Side-by-Side)</option>
           </select>
         </label>
       </SettingsSection>

--- a/src/lib/plot/PlotLegend.svelte
+++ b/src/lib/plot/PlotLegend.svelte
@@ -197,6 +197,7 @@
     border-radius: var(--plot-legend-border-radius, 3px);
     font-size: var(--plot-legend-font-size, 0.8em);
     max-width: var(--plot-legend-max-width);
+    width: fit-content;
     z-index: var(--plot-legend-z-index, 2);
     box-sizing: border-box;
   }

--- a/src/lib/plot/ScatterPlot.svelte
+++ b/src/lib/plot/ScatterPlot.svelte
@@ -61,7 +61,7 @@
     y_lim?: [number | null, number | null]
     x_range?: [number | null, number | null] // Explicit ranges for x and y axes. Null pins a side to auto.
     y_range?: [number | null, number | null] // Use null on one side to auto that bound.
-    current_x_value?: number | null // Current x value to highlight on the x-axis (e.g., current frame)
+    current_x_value?: number | null // Current x value to highlight on the x-axis (e.g. current frame)
     // Right y-axis configuration
     y2_lim?: [number | null, number | null]
     y2_range?: [number | null, number | null]
@@ -103,7 +103,7 @@
     }
     size_scale?: {
       type?: ScaleType // Type of scale for size mapping
-      radius_range?: [number, number] // Min/max point radius in pixels (auto detected if not provided, e.g., [2, 10])
+      radius_range?: [number, number] // Min/max point radius in pixels (auto detected if not provided, e.g. [2, 10])
       value_range?: [number, number] // Min/max for size scaling (auto detected if not provided)
     }
     // Props for the ColorBar component, plus an optional 'margin' used for plot corner distance when auto placing
@@ -120,7 +120,7 @@
     legend?: LegendConfig | null // Configuration for the legend
     point_tween?: LocalTweenedOptions<XyObj>
     line_tween?: LocalTweenedOptions<string>
-    range_padding?: number // Factor to pad auto-detected ranges *before* nicing (e.g., 0.05 = 5%)
+    range_padding?: number // Factor to pad auto-detected ranges *before* nicing (e.g. 0.05 = 5%)
     point_events?: Record<
       string,
       (payload: { point: InternalPoint; event: Event }) => void
@@ -951,7 +951,7 @@
         Math.max(start_data_y_val, end_data_y_val),
       ]
 
-      // Check for minuscule zoom box (e.g., accidental click)
+      // Check for minuscule zoom box (e.g. accidental click)
       const min_zoom_size = 5 // Minimum pixels to trigger zoom
       const dx = Math.abs(drag_start_coords.x - drag_current_coords.x)
       const dy = Math.abs(drag_start_coords.y - drag_current_coords.y)
@@ -1921,10 +1921,8 @@
     {/if}
   {/if}
 
-  <!-- User-provided children (e.g., for custom absolutely-positioned overlays) -->
-  {#if children}
-    {@render children()}
-  {/if}
+  <!-- User-provided children (e.g. for custom absolutely-positioned overlays) -->
+  {@render children?.()}
 </div>
 
 <style>

--- a/src/lib/plot/ScatterPlot.svelte
+++ b/src/lib/plot/ScatterPlot.svelte
@@ -208,7 +208,7 @@
     point_events,
     on_point_click,
     on_point_hover,
-    show_controls = false,
+    show_controls = true,
     controls_open = $bindable(false),
     plot_controls,
     // Style control props
@@ -344,7 +344,7 @@
   // Update padding when format or ticks change, but prevent infinite loop
   $effect(() => {
     const base_pad = { ...default_padding, ...padding }
-    const new_pad = width && height && y_tick_values.length
+    const new_pad = width && height && (y_tick_values.length || y2_tick_values.length)
       ? calc_auto_padding({
         base_padding: base_pad,
         y_ticks: y_tick_values,

--- a/src/lib/plot/index.ts
+++ b/src/lib/plot/index.ts
@@ -255,7 +255,7 @@ export type UserContentProps = {
 }
 
 export type Orientation = `vertical` | `horizontal`
-export type BarMode = `overlay` | `stacked`
+export type BarMode = `overlay` | `stacked` | `grouped`
 
 export interface BarSeries {
   x: readonly number[]
@@ -266,4 +266,9 @@ export interface BarSeries {
   visible?: boolean
   metadata?: Record<string, unknown>[] | Record<string, unknown>
   labels?: readonly (string | null | undefined)[]
+  render_mode?: `bar` | `line` // Render as bars (default) or as a line
+  line_style?: {
+    stroke_width?: number
+    line_dash?: string
+  }
 }

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -1098,7 +1098,6 @@
             markers="line"
             x_format=".3~s"
             x_ticks={step_label_positions}
-            show_controls
             bind:controls_open={panes_open.plot_controls}
             padding={{ t: 20, b: 60, l: 100, r: has_y2_series ? 100 : 20 }}
             range_padding={0}

--- a/src/routes/(demos)/plot/bar-plot/+page.md
+++ b/src/routes/(demos)/plot/bar-plot/+page.md
@@ -306,7 +306,6 @@ Bar plots handle negative values automatically and display zero lines for refere
   series={formation_energies}
   x_label="Compound"
   y_label="Formation Energy (eV/atom)"
-  show_zero_lines
   style="height: 400px"
 />
 ```

--- a/src/routes/(demos)/plot/bar-plot/+page.md
+++ b/src/routes/(demos)/plot/bar-plot/+page.md
@@ -1,0 +1,427 @@
+# Bar Plot
+
+## Crystal Structure Analysis
+
+A simple bar plot showing lattice parameters across different crystal systems. Use the controls (gear icon) to toggle orientation, modes, and grid display:
+
+```svelte example
+<script>
+  import { BarPlot } from 'matterviz'
+
+  const lattice_params = [
+    {
+      x: [1, 2, 3, 4, 5, 6, 7],
+      y: [3.52, 4.05, 5.43, 6.08, 3.89, 4.95, 5.65],
+      label: `Lattice Parameter a (Å)`,
+      color: `#4c6ef5`,
+      labels: [`Diamond`, `NaCl`, `Si`, `GaAs`, `GaN`, `ZnO`, `CdTe`],
+    },
+  ]
+</script>
+
+<BarPlot
+  series={lattice_params}
+  x_label="Crystal System"
+  y_label="Lattice Parameter (Å)"
+  style="height: 400px"
+/>
+```
+
+## Mode Comparison: Band Gap Measurements
+
+Compare overlay, stacked, and grouped (side-by-side) modes using band gap data from different measurement techniques. Click legend items to toggle series visibility:
+
+```svelte example
+<script>
+  import { BarPlot } from 'matterviz'
+
+  const band_gaps = [
+    {
+      x: [1, 2, 3, 4, 5],
+      y: [1.12, 1.43, 2.26, 3.4, 5.47],
+      label: `Optical Absorption`,
+      color: `#4c6ef5`,
+    },
+    {
+      x: [1, 2, 3, 4, 5],
+      y: [0.95, 1.25, 1.85, 2.98, 4.82],
+      label: `Photoluminescence`,
+      color: `#ff6b6b`,
+    },
+    {
+      x: [1, 2, 3, 4, 5],
+      y: [1.28, 1.62, 2.58, 3.75, 6.15],
+      label: `DFT Calculation`,
+      color: `#51cf66`,
+    },
+  ]
+
+  let mode = $state(`grouped`)
+</script>
+
+<div style="margin-bottom: 1em; display: flex; gap: 1em">
+  <label><input type="radio" bind:group={mode} value="overlay" /> Overlay</label>
+  <label><input type="radio" bind:group={mode} value="stacked" /> Stacked (Sum)</label>
+  <label><input type="radio" bind:group={mode} value="grouped" /> Grouped
+    (Side-by-Side)</label>
+</div>
+
+<BarPlot
+  series={band_gaps}
+  {mode}
+  x_label="Material (1=Si, 2=GaAs, 3=GaN, 4=ZnO, 5=Diamond)"
+  y_label="Band Gap (eV)"
+  style="height: 400px"
+/>
+```
+
+## Reaction Kinetics with Temperature Profile
+
+Combine bars and lines to show product formation alongside process parameters. Lines render as absolute values (perfect for trends/targets):
+
+```svelte example
+<script>
+  import { BarPlot } from 'matterviz'
+
+  const reaction_data = [
+    {
+      x: [0, 10, 20, 30, 40, 50, 60],
+      y: [0, 12, 28, 45, 58, 67, 72],
+      label: `Product A (mol)`,
+      color: `#4c6ef5`,
+    },
+    {
+      x: [0, 10, 20, 30, 40, 50, 60],
+      y: [0, 8, 19, 32, 41, 48, 52],
+      label: `Product B (mol)`,
+      color: `#51cf66`,
+    },
+    {
+      x: [0, 10, 20, 30, 40, 50, 60],
+      y: [25, 80, 120, 140, 145, 142, 138],
+      label: `Temperature (°C)`,
+      color: `#ff6b6b`,
+      render_mode: `line`,
+      line_style: {
+        stroke_width: 3,
+        line_dash: `5,5`,
+      },
+    },
+    {
+      x: [0, 10, 20, 30, 40, 50, 60],
+      y: [0, 20, 47, 77, 99, 115, 124],
+      label: `Total Yield`,
+      color: `#ffd43b`,
+      render_mode: `line`,
+      line_style: {
+        stroke_width: 3,
+      },
+    },
+  ]
+</script>
+
+<BarPlot
+  series={reaction_data}
+  mode="stacked"
+  x_label="Time (minutes)"
+  y_label="Amount / Temperature"
+  style="height: 450px"
+/>
+```
+
+## Element Abundance in Earth's Crust
+
+Horizontal bar charts work well for categorical data with long labels:
+
+```svelte example
+<script>
+  import { BarPlot } from 'matterviz'
+
+  const abundances = [
+    {
+      x: [1, 2, 3, 4, 5, 6, 7, 8],
+      y: [461000, 277200, 82300, 50000, 41500, 26000, 23600, 20900],
+      label: `Abundance (ppm)`,
+      color: `#845ef7`,
+      labels: [
+        `Oxygen`,
+        `Silicon`,
+        `Aluminum`,
+        `Iron`,
+        `Calcium`,
+        `Sodium`,
+        `Magnesium`,
+        `Potassium`,
+      ],
+    },
+  ]
+
+  let orientation = $state(`horizontal`)
+</script>
+
+<label style="margin-bottom: 1em; display: block">
+  <input
+    type="checkbox"
+    checked={orientation === `horizontal`}
+    onchange={(evt) => (orientation = evt.target.checked ? `horizontal` : `vertical`)}
+  />
+  Horizontal Orientation
+</label>
+
+<BarPlot
+  series={abundances}
+  {orientation}
+  x_label="Abundance (ppm)"
+  y_label="Element"
+  x_format="~s"
+  y_format="~s"
+  style="height: 400px"
+/>
+```
+
+## Phase Stability with Interactive Tooltips
+
+Add rich interactivity with custom tooltips, hover effects, and click handlers:
+
+```svelte example
+<script>
+  import { BarPlot } from 'matterviz'
+
+  const phase_stability = [
+    {
+      x: [1, 2, 3, 4, 5],
+      y: [85, 92, 78, 95, 88],
+      label: `α-phase`,
+      color: `#5c7cfa`,
+      metadata: [
+        { phase: `α-phase`, temp: `300K`, structure: `FCC`, stability: `High` },
+        { phase: `α-phase`, temp: `500K`, structure: `FCC`, stability: `Very High` },
+        { phase: `α-phase`, temp: `700K`, structure: `FCC`, stability: `Medium` },
+        { phase: `α-phase`, temp: `900K`, structure: `FCC`, stability: `Very High` },
+        { phase: `α-phase`, temp: `1100K`, structure: `FCC`, stability: `High` },
+      ],
+    },
+    {
+      x: [1, 2, 3, 4, 5],
+      y: [70, 75, 88, 82, 90],
+      label: `β-phase`,
+      color: `#ff6b6b`,
+      metadata: [
+        { phase: `β-phase`, temp: `300K`, structure: `BCC`, stability: `Medium` },
+        { phase: `β-phase`, temp: `500K`, structure: `BCC`, stability: `Medium` },
+        { phase: `β-phase`, temp: `700K`, structure: `BCC`, stability: `High` },
+        { phase: `β-phase`, temp: `900K`, structure: `BCC`, stability: `High` },
+        { phase: `β-phase`, temp: `1100K`, structure: `BCC`, stability: `Very High` },
+      ],
+    },
+  ]
+
+  let clicked_info = $state(`Click a bar to see phase details`)
+  let hovered_info = $state(`Hover over a bar`)
+
+  function handle_click(data) {
+    const { metadata, y } = data
+    clicked_info =
+      `${metadata.phase} at ${metadata.temp}: ${metadata.structure} structure, ${y}% stable (${metadata.stability})`
+  }
+
+  function handle_hover(data) {
+    if (data) {
+      const { metadata, y } = data
+      hovered_info = `${metadata.phase} at ${metadata.temp}: ${y}% stability`
+    } else {
+      hovered_info = `Hover over a bar`
+    }
+  }
+
+  const info_style =
+    `margin: 1em 0; padding: 4pt 8pt; background: rgba(255,255,255,0.1); border-radius: 4px; font-size: 0.9em`
+</script>
+
+<BarPlot
+  series={phase_stability}
+  mode="grouped"
+  x_label="Temperature Point"
+  y_label="Stability (%)"
+  on_bar_click={handle_click}
+  on_bar_hover={handle_hover}
+  style="height: 400px"
+>
+  {#snippet tooltip({ metadata, y })}
+    <div style="font-weight: 600">{metadata.phase}</div>
+    <div>Temp: {metadata.temp}</div>
+    <div>Structure: {metadata.structure}</div>
+    <div>Stability: {y}% ({metadata.stability})</div>
+  {/snippet}
+</BarPlot>
+
+<div style={info_style}>
+  <strong>Clicked:</strong> {clicked_info}
+</div>
+<div style={info_style}>
+  <strong>Hovered:</strong> {hovered_info}
+</div>
+```
+
+## Formation Energy Diagram
+
+Bar plots handle negative values automatically and display zero lines for reference:
+
+```svelte example
+<script>
+  import { BarPlot } from 'matterviz'
+
+  const formation_energies = [
+    {
+      x: [1, 2, 3, 4, 5, 6, 7, 8],
+      y: [-2.45, 1.28, -1.82, 0.95, -3.12, 2.01, -0.67, -1.93],
+      label: `Formation Energy`,
+      color: `#4c6ef5`,
+      labels: [
+        `TiO₂`,
+        `CuO`,
+        `Al₂O₃`,
+        `Fe₂O₃`,
+        `MgO`,
+        `ZnO`,
+        `NiO`,
+        `FeO`,
+      ],
+    },
+    {
+      x: [1, 2, 3, 4, 5, 6, 7, 8],
+      y: [-2.0, -2.0, -2.0, -2.0, -2.0, -2.0, -2.0, -2.0],
+      label: `Stability Threshold`,
+      color: `#51cf66`,
+      render_mode: `line`,
+      line_style: {
+        stroke_width: 2,
+        line_dash: `8,4`,
+      },
+    },
+  ]
+</script>
+
+<BarPlot
+  series={formation_energies}
+  x_label="Compound"
+  y_label="Formation Energy (eV/atom)"
+  show_zero_lines
+  style="height: 400px"
+/>
+```
+
+## Material Properties Over Time
+
+Custom formatting, tick control, and axis configuration for publication-quality plots:
+
+```svelte example
+<script>
+  import { BarPlot } from 'matterviz'
+
+  const yearly_discoveries = [
+    {
+      x: [1990, 1995, 2000, 2005, 2010, 2015, 2020],
+      y: [120000, 185000, 275000, 420000, 680000, 1050000, 1600000],
+      label: `Materials in Database`,
+      color: `#4c6ef5`,
+    },
+    {
+      x: [1990, 1995, 2000, 2005, 2010, 2015, 2020],
+      y: [80000, 150000, 250000, 400000, 650000, 1000000, 1500000],
+      label: `Target Growth`,
+      color: `#ff6b6b`,
+      render_mode: `line`,
+      line_style: {
+        stroke_width: 3,
+        line_dash: `6,3`,
+      },
+    },
+  ]
+
+  let x_format = $state(`d`)
+  let y_format = $state(`.2s`)
+  let x_ticks = $state(7)
+  let y_ticks = $state(6)
+</script>
+
+<div style="display: flex; gap: 2em; margin-bottom: 1em; flex-wrap: wrap">
+  <label>
+    X Format:
+    <select bind:value={x_format}>
+      <option value="d">Integer (2020)</option>
+      <option value=".0f">Float (2020.0)</option>
+    </select>
+  </label>
+  <label>
+    Y Format:
+    <select bind:value={y_format}>
+      <option value=".2s">Short (1.6M)</option>
+      <option value=",.0f">Full (1,600,000)</option>
+      <option value=".3s">Precise (1.60M)</option>
+    </select>
+  </label>
+  <label>
+    X Ticks: {x_ticks}
+    <input type="range" bind:value={x_ticks} min="3" max="10" style="width: 100px">
+  </label>
+  <label>
+    Y Ticks: {y_ticks}
+    <input type="range" bind:value={y_ticks} min="3" max="10" style="width: 100px">
+  </label>
+</div>
+
+<BarPlot
+  series={yearly_discoveries}
+  {x_format}
+  {y_format}
+  {x_ticks}
+  {y_ticks}
+  x_label="Year"
+  y_label="Number of Materials"
+  style="height: 400px"
+/>
+```
+
+## Spectroscopy Data with Zoom
+
+Interactive zoom and pan for exploring large datasets. Click and drag to zoom, double-click to reset:
+
+```svelte example
+<script>
+  import { BarPlot } from 'matterviz'
+
+  const spectroscopy = [
+    {
+      x: [200, 250, 300, 350, 400, 450, 500, 550, 600, 650, 700, 750, 800],
+      y: [0.05, 0.12, 0.28, 0.65, 1.45, 2.8, 4.2, 3.5, 2.1, 0.95, 0.38, 0.15, 0.06],
+      label: `Absorption Spectrum`,
+      color: `#4c6ef5`,
+    },
+    {
+      x: [200, 250, 300, 350, 400, 450, 500, 550, 600, 650, 700, 750, 800],
+      y: [0.02, 0.08, 0.22, 0.58, 1.35, 2.65, 4.0, 3.3, 1.95, 0.85, 0.32, 0.12, 0.05],
+      label: `Theoretical Fit`,
+      color: `#ff6b6b`,
+      render_mode: `line`,
+      line_style: {
+        stroke_width: 2,
+      },
+    },
+  ]
+</script>
+
+<div
+  style="margin-bottom: 1em; padding: 8pt; background: rgba(255, 255, 255, 0.05); border-radius: 4px"
+>
+  <strong>Instructions:</strong> Click and drag to zoom into a wavelength region.
+  Double-click to reset the view. Use the controls to adjust display.
+</div>
+
+<BarPlot
+  series={spectroscopy}
+  x_label="Wavelength (nm)"
+  y_label="Absorption Coefficient"
+  style="height: 450px"
+/>
+```

--- a/src/routes/(demos)/plot/histogram/+page.md
+++ b/src/routes/(demos)/plot/histogram/+page.md
@@ -118,7 +118,6 @@ Y: {#each [`linear`, `log`] as scale}<label><input type="radio" bind:group={y_sc
   y_scale_type={y_scale}
   x_grid={show_grid}
   y_grid={show_grid}
-  show_controls
   style="height: 450px; margin-block: 1em;"
 >
   {#snippet tooltip({ value, count, property })}
@@ -191,7 +190,6 @@ Y: {#each [`linear`, `log`] as scale (scale)}
   y_label="Frequency ({y_scale} scale)"
   x_format="~s"
   y_format={y_scale === `log` ? `~s` : `d`}
-  show_controls
   style="height: 450px; margin-block: 1em"
 >
   {#snippet tooltip({ value, count, property })}
@@ -281,7 +279,6 @@ Y: {#each [`linear`, `log`] as scale (scale)}
   x_label={selected === `age` ? `Age (years)` : selected === `discrete` ? `Rating` : `Value`}
   y_label="Count"
   x_format={selected === `discrete` ? `.1f` : `.0f`}
-  show_controls
   show_legend={mode === `overlay`}
   style="height: 450px; margin-block: 1em"
 >
@@ -342,7 +339,6 @@ Y: {#each [`linear`, `log`] as scale (scale)}
   bins={show_overlay ? 25 : bin_counts[1]}
   mode={show_overlay ? `overlay` : `single`}
   bar_opacity={opacity}
-  show_controls
   show_legend={show_overlay}
   style="height: 450px; margin-block: 1em;"
 >
@@ -401,7 +397,6 @@ Y: {#each [`linear`, `log`] as scale (scale)}
   y_label={y_format === `percentage` ? `Percentage` : `Count`}
   x_format={x_formats[x_format]}
   y_format={y_format === `percentage` ? `.1%` : y_formats[y_format]}
-  show_controls
   style="height: 450px; border: 2px solid {color_schemes[color_scheme][0]}; border-radius: 8px;"
 >
   {#snippet tooltip({ value, count, property })}
@@ -491,7 +486,6 @@ points, {bins} bins, {mode} mode
   series={series_data}
   {mode}
   {bins}
-  show_controls
   show_legend={mode === `overlay`}
   style="height: 450px; margin-block: 1em"
 >

--- a/src/routes/(demos)/plot/scatter-plot/+page.md
+++ b/src/routes/(demos)/plot/scatter-plot/+page.md
@@ -1384,15 +1384,11 @@ and scale type.
     tick_side: `primary`,
     wrapper_style: `
       position: absolute;
-      /* Position outside the plot area using padding values */
-      right: 10px; /* Distance from the container's right edge */
-      top: ${plot_padding.t}px; /* Align with top padding */
-      /* Set height directly for the wrapper */
-      height: calc(100% - ${
-      plot_padding.t + plot_padding.b
-    }px); /* Fill vertical space */
+      right: 10px;
+      top: ${plot_padding.t}px;
+      height: calc(100% - ${plot_padding.t + plot_padding.b}px);
     `,
-    style: `width: 15px; height: 100%;`,
+    bar_style: `width: 15px; height: 100%;`,
   }}
   style="height: 400px"
 >
@@ -1405,7 +1401,7 @@ and scale type.
 
 ## Line Clipping with Fixed Ranges
 
-This example demonstrates how lines are clipped when they extend beyond the fixed `x_lim` and `y_lim` provided to the `ScatterPlot`. Observe how the lines originating and ending outside the plot area are correctly cut off at the plot boundaries on all four sides (top, bottom, left, right). This verifies the `clipPath` functionality.
+This example demonstrates how lines are clipped when they extend beyond the fixed `x_lim` and `y_lim` provided to the `ScatterPlot`. Lines originating and ending outside the plot area are cut off at the plot boundaries on all four sides (top, bottom, left, right). This verifies the `clipPath` functionality.
 
 ```svelte example
 <script>
@@ -1505,11 +1501,5 @@ This example demonstrates how lines are clipped when they extend beyond the fixe
   y_label="Y Axis (Fixed Range)"
   markers="line"
   style="height: 400px"
-  show_zero_lines
-  padding={{ l: 150 }}
-  legend={{
-    wrapper_style:
-      `position: absolute; right: 0; transform: translateX(100%); max-width: 400px;`,
-  }}
 />
 ```

--- a/src/routes/(demos)/plot/scatter-plot/+page.md
+++ b/src/routes/(demos)/plot/scatter-plot/+page.md
@@ -103,7 +103,6 @@ A simple scatter plot showing different display modes (points, lines, or both). 
   markers={display_mode}
   point_events={{ onclick: handle_point_click, ondblclick: handle_point_double_click }}
   on_point_hover={handle_point_hover}
-  show_controls
   style="height: 300px"
 />
 <div {style}>
@@ -1009,7 +1008,6 @@ This example combines multiple features including different display modes, custo
     y_label={axis_labels.y}
     markers={display_mode}
     change={(point) => (hovered_point = point)}
-    show_controls
     style="height: 400px;"
     legend={null}
   >

--- a/src/routes/test/bar-plot/+page.svelte
+++ b/src/routes/test/bar-plot/+page.svelte
@@ -140,7 +140,6 @@
     x_label="X"
     y_label="Y"
     y_range={[0, 50]}
-    show_controls
     controls_open={false}
     controls_toggle_props={{ class: `bar-controls-toggle` }}
     style="height: 360px"
@@ -153,7 +152,6 @@
     series={legend_series}
     x_label="Category"
     y_label="Value"
-    show_controls
     controls_toggle_props={{ class: `bar-controls-toggle` }}
     style="height: 360px"
   />
@@ -167,7 +165,6 @@
       x_label="X"
       y_label="Y"
       mode="overlay"
-      show_controls
       controls_toggle_props={{ class: `bar-controls-toggle` }}
       style="height: 300px"
     />
@@ -178,7 +175,6 @@
       x_label="X"
       y_label="Y"
       mode="stacked"
-      show_controls
       controls_toggle_props={{ class: `bar-controls-toggle` }}
       style="height: 300px"
     />
@@ -189,7 +185,6 @@
       x_label="X"
       y_label="Y"
       mode="stacked"
-      show_controls
       controls_toggle_props={{ class: `bar-controls-toggle` }}
       style="height: 300px"
     />
@@ -199,7 +194,6 @@
       series={zero_value_series}
       x_label="X"
       y_label="Y"
-      show_controls
       controls_toggle_props={{ class: `bar-controls-toggle` }}
       style="height: 300px"
     />
@@ -209,7 +203,6 @@
       series={width_array_series}
       x_label="X"
       y_label="Y"
-      show_controls
       controls_toggle_props={{ class: `bar-controls-toggle` }}
       style="height: 300px"
     />
@@ -221,7 +214,6 @@
       y_label="X"
       mode="stacked"
       orientation="horizontal"
-      show_controls
       controls_toggle_props={{ class: `bar-controls-toggle` }}
       style="height: 300px"
     />
@@ -232,7 +224,6 @@
       x_label="Y"
       y_label="X"
       orientation="horizontal"
-      show_controls
       controls_toggle_props={{ class: `bar-controls-toggle` }}
       style="height: 300px"
     />
@@ -255,7 +246,6 @@
     on_bar_click={(data) => {
       click_msg = `Clicked: bar ${data.bar_idx + 1} (x=${data.x}, y=${data.y})`
     }}
-    show_controls
     controls_toggle_props={{ class: `bar-controls-toggle` }}
     style="height: 360px"
   />

--- a/src/routes/test/histogram/+page.svelte
+++ b/src/routes/test/histogram/+page.svelte
@@ -372,7 +372,6 @@
   mode="single"
   x_label="Value"
   y_label="Count"
-  show_zero_lines
 />
 
 <Histogram

--- a/src/routes/test/histogram/+page.svelte
+++ b/src/routes/test/histogram/+page.svelte
@@ -259,7 +259,6 @@
   mode="single"
   x_label="Value"
   y_label="Frequency"
-  show_controls
 />
 
 <label>Opacity: <input
@@ -285,7 +284,6 @@
   bins={30}
   mode="overlay"
   show_legend
-  show_controls
 />
 
 <label>X-axis: <input type="radio" name="x-scale" value="linear" bind:group={x_scale} />
@@ -301,7 +299,6 @@
   mode="overlay"
   x_scale_type={x_scale}
   y_scale_type={y_scale}
-  show_controls
 />
 
 <label>Distribution Type: <select bind:value={distribution_type}>
@@ -355,7 +352,6 @@
   y_ticks={y_tick_count}
   x_label="Value (Custom X Ticks)"
   y_label="Count (Custom Y Ticks)"
-  show_controls
 />
 
 <Histogram
@@ -367,7 +363,6 @@
   y_label="Count (Custom Range)"
   {x_range}
   {y_range}
-  show_controls
 />
 
 <Histogram
@@ -378,7 +373,6 @@
   x_label="Value"
   y_label="Count"
   show_zero_lines
-  show_controls
 />
 
 <Histogram
@@ -388,7 +382,6 @@
   mode="single"
   x_label="Value"
   y_label="Count"
-  show_controls
 >
   {#snippet tooltip(props)}
     <div style="background: #8b5cf6; color: white; padding: 8px; border-radius: 4px">
@@ -407,7 +400,6 @@
   mode="single"
   x_label="Value"
   y_label="Count"
-  show_controls
 />
 
 Plot is currently hovered: <strong>{is_plot_hovered}</strong>
@@ -419,7 +411,6 @@ Plot is currently hovered: <strong>{is_plot_hovered}</strong>
   x_label="Value"
   y_label="Count"
   bind:hovered={is_plot_hovered}
-  show_controls
 />
 
 <Histogram
@@ -429,7 +420,6 @@ Plot is currently hovered: <strong>{is_plot_hovered}</strong>
   mode="single"
   x_label="Value (Wide Range)"
   y_label="Count"
-  show_controls
 />
 
 <Histogram
@@ -440,5 +430,4 @@ Plot is currently hovered: <strong>{is_plot_hovered}</strong>
   x_label="Value (Small Range)"
   y_label="Count"
   x_format=".6f"
-  show_controls
 />

--- a/src/routes/test/scatter-plot/+page.svelte
+++ b/src/routes/test/scatter-plot/+page.svelte
@@ -491,7 +491,6 @@
     x_label="X Axis"
     y_label="Y Axis"
     markers="line+points"
-    show_controls
   />
 </section>
 
@@ -720,7 +719,6 @@
   <ScatterPlot
     series={legend_multi_series}
     legend={{ draggable: true }}
-    show_controls
     markers="points"
     id="legend-multi-default"
   />

--- a/src/routes/test/trajectory/+page.svelte
+++ b/src/routes/test/trajectory/+page.svelte
@@ -215,7 +215,6 @@
   bind:trajectory={loaded_trajectory}
   bind:current_step_idx={current_step}
   allow_file_drop
-  show_controls
   step_labels={3}
 />
 
@@ -225,7 +224,6 @@
   id="vertical-layout"
   trajectory={test_trajectory}
   layout="vertical"
-  show_controls
   step_labels={[-1]}
 />
 
@@ -322,7 +320,6 @@
   id="single-frame"
   trajectory={single_frame_trajectory}
   layout="horizontal"
-  show_controls
 />
 
 <Trajectory
@@ -393,5 +390,4 @@
   trajectory={test_trajectory}
   layout="horizontal"
   plot_skimming={false}
-  show_controls
 />

--- a/tests/vitest/Nav.test.ts
+++ b/tests/vitest/Nav.test.ts
@@ -493,4 +493,54 @@ describe(`Nav`, () => {
     expect(burger.getAttribute(`aria-expanded`)).toBe(`false`)
     expect(menu.classList.contains(`visible`)).toBe(false)
   })
+
+  test.each([
+    [`/parent/child1`, `/parent`, true],
+    [`/parent/child2`, `/parent`, true],
+    [`/parent`, `/parent`, true],
+    [`/other-route`, `/parent`, false],
+    [`/`, `/parent`, false],
+  ])(
+    `dropdown active when child is current: pathname=%s parent=%s -> active=%s`,
+    (pathname, parent_href, should_be_active) => {
+      const mock_page = { url: { pathname } } as Page
+      mount(Nav, {
+        target: document.body,
+        props: {
+          routes: [[parent_href, [
+            parent_href,
+            `${parent_href}/child1`,
+            `${parent_href}/child2`,
+          ]]],
+          page: mock_page,
+        },
+      })
+
+      const dropdown = doc_query(`.dropdown-wrapper`)
+      expect(dropdown.classList.contains(`active`)).toBe(should_be_active)
+      expect(dropdown.getAttribute(`aria-current`)).toBe(
+        should_be_active ? `true` : null,
+      )
+    },
+  )
+
+  test(`only active dropdown gets highlighted, not others`, () => {
+    const mock_page = { url: { pathname: `/parent1/child` } } as Page
+    mount(Nav, {
+      target: document.body,
+      props: {
+        routes: [
+          [`/parent1`, [`/parent1`, `/parent1/child`]],
+          [`/parent2`, [`/parent2`, `/parent2/child`]],
+        ],
+        page: mock_page,
+      },
+    })
+
+    const [dropdown1, dropdown2] = Array.from(
+      document.querySelectorAll(`.dropdown-wrapper`),
+    )
+    expect(dropdown1.classList.contains(`active`)).toBe(true)
+    expect(dropdown2.classList.contains(`active`)).toBe(false)
+  })
 })

--- a/tests/vitest/plot/BarPlot.test.ts
+++ b/tests/vitest/plot/BarPlot.test.ts
@@ -1,9 +1,9 @@
 import { BarPlot } from '$lib'
-import type { BarSeries } from '$lib/plot'
+import type { BarMode, BarSeries, BarTooltipProps, Orientation } from '$lib/plot'
 import { mount } from 'svelte'
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 
-const basic_series: BarSeries = {
+const basic: BarSeries = {
   x: [1, 2, 3, 4, 5],
   y: [10, 20, 15, 25, 18],
   label: `Test Series`,
@@ -11,36 +11,167 @@ const basic_series: BarSeries = {
 }
 
 describe(`BarPlot`, () => {
-  test.each([
-    [{ series: [basic_series], x_label: `Category`, y_label: `Value` }, `basic`],
-    [{ series: [], orientation: `vertical` as const }, `empty`],
-    [{ series: [{ ...basic_series, labels: [`A`, `B`, `C`, `D`, `E`] }] }, `labels`],
-    [
-      {
-        series: [{ x: [1, 2, 3], y: [-5, 0, 5] }],
-        x_grid: true,
-        y_grid: true,
-        show_zero_lines: true,
-      },
-      `grid+zero`,
-    ],
-  ])(`renders %s`, (props, _desc) => {
+  test.each<{ series: BarSeries[]; [key: string]: unknown }>([
+    { series: [basic], x_label: `Category`, y_label: `Value` },
+    { series: [], orientation: `vertical` },
+    { series: [{ ...basic, labels: [`A`, `B`, `C`, `D`, `E`] }] },
+    { series: [{ x: [1, 2, 3], y: [-5, 0, 5] }], x_grid: true, show_zero_lines: true },
+    { series: [{ x: [1, 2, 3, 4], y: [-10, -20, -15, -25] }] }, // all negative
+    { series: [basic], x_lim: [2, 4], y_lim: [10, 25] },
+    { series: [basic], x_format: `.0f`, y_format: `.2f` },
+    { series: [basic], x_ticks: 10, y_ticks: -3 },
+    { series: [basic], range_padding: 0.1 },
+    { series: [basic], padding: { t: 20, b: 80, l: 100, r: 40 } },
+    { series: [basic], show_controls: false },
+    { series: [basic], controls_open: true },
+    { series: [basic], x_range: [0, 10], y_range: [0, 50] },
+    { series: [basic], legend: null },
+    {
+      series: [basic],
+      x_grid: { stroke: `blue`, 'stroke-width': 2 },
+      y_grid: { stroke: `red` },
+    },
+    {
+      series: [basic],
+      x_label: `X`,
+      y_label: `Y`,
+      x_label_shift: { x: 10 },
+      y_label_shift: { y: 10 },
+    },
+    { series: [{ x: [1, 2, 3, 4], y: [-10, 5, -15, 20] }], show_zero_lines: false },
+    { series: [{ ...basic, bar_width: 0.8 }] },
+    { series: [{ ...basic, bar_width: [0.3, 0.5, 0.7, 0.9, 0.4] }] },
+    {
+      series: [{
+        ...basic,
+        metadata: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }],
+      }],
+    },
+    { series: [{ ...basic, metadata: { dataset: `Test`, units: `kg` } }] },
+    {
+      series: [
+        basic,
+        { ...basic, color: `orangered`, visible: false },
+        { ...basic, color: `green` },
+      ],
+    },
+    {
+      series: [basic, { ...basic, color: `orangered`, label: `S2` }],
+      legend: { title: `Test` },
+    },
+  ])(`renders various configs`, (props) => {
     mount(BarPlot, { target: document.body, props })
   })
 
-  test.each(
-    [
-      [`vertical`, `overlay`],
-      [`horizontal`, `overlay`],
-      [`vertical`, `stacked`],
-    ] as const,
-  )(`orientation=%s mode=%s`, (orientation, mode) => {
+  test.each<[Orientation, BarMode]>([
+    [`vertical`, `overlay`],
+    [`horizontal`, `overlay`],
+    [`vertical`, `stacked`],
+    [`vertical`, `grouped`],
+    [`horizontal`, `grouped`],
+    [`horizontal`, `stacked`],
+  ])(`orientation=%s mode=%s`, (orientation, mode) => {
     mount(BarPlot, {
       target: document.body,
       props: {
-        series: [basic_series, { ...basic_series, color: `orangered` }],
+        series: [basic, { ...basic, color: `orangered` }],
         orientation,
         mode,
+      },
+    })
+  })
+
+  test.each<[BarMode, BarSeries[]]>([
+    [`overlay`, [{ x: [1, 2, 3, 4], y: [-10, -5, 15, 20] }, {
+      x: [1, 2, 3, 4],
+      y: [5, -8, 12, -3],
+    }]],
+    [`stacked`, [{ x: [1, 2, 3, 4], y: [10, -5, 15, 20] }, {
+      x: [1, 2, 3, 4],
+      y: [-5, 10, -8, 5],
+    }]],
+    [
+      `grouped`,
+      [
+        basic,
+        { ...basic, color: `orangered`, label: `S2` },
+        { ...basic, color: `green`, label: `S3` },
+      ],
+    ],
+  ])(`%s mode with negative/multiple series`, (mode, series) => {
+    mount(BarPlot, { target: document.body, props: { series, mode } })
+  })
+
+  test.each([
+    { render_mode: `line` as const, color: `red`, label: `Line` },
+    { render_mode: `line` as const, line_style: { stroke_width: 4, line_dash: `10,5` } },
+  ])(`line series`, (series_props) => {
+    mount(BarPlot, {
+      target: document.body,
+      props: {
+        series: [{ x: [1, 2, 3, 4, 5], y: [10, 20, 15, 25, 18], ...series_props }],
+      },
+    })
+  })
+
+  test(`mixed bar and line series`, () => {
+    mount(BarPlot, {
+      target: document.body,
+      props: {
+        series: [
+          basic,
+          {
+            x: [1, 2, 3, 4, 5],
+            y: [12, 18, 20, 22, 16],
+            render_mode: `line` as const,
+            line_style: { stroke_width: 3, line_dash: `5,5` },
+          },
+        ],
+        mode: `stacked`,
+      },
+    })
+  })
+
+  test(`stacked mode with interleaved hidden series`, () => {
+    // Regression test: stacked_offsets lookup should use original series index
+    mount(BarPlot, {
+      target: document.body,
+      props: {
+        series: [
+          { x: [1, 2, 3], y: [10, 20, 15], color: `red`, visible: true },
+          { x: [1, 2, 3], y: [5, 10, 8], color: `blue`, visible: false }, // hidden
+          { x: [1, 2, 3], y: [8, 12, 10], color: `green`, visible: true },
+        ],
+        mode: `stacked`,
+      },
+    })
+  })
+
+  test(`event callbacks`, () => {
+    const [change_fn, hover_fn, click_fn] = [vi.fn(), vi.fn(), vi.fn()]
+    mount(BarPlot, {
+      target: document.body,
+      props: {
+        series: [basic],
+        change: change_fn,
+        on_bar_hover: hover_fn,
+        on_bar_click: click_fn,
+      },
+    })
+  })
+
+  test(`custom tooltip snippet`, () => {
+    mount(BarPlot, {
+      target: document.body,
+      props: {
+        series: [basic],
+        tooltip: (data: BarTooltipProps) => {
+          const div_el = document.createElement(`div`)
+          div_el.className = `custom-tooltip`
+          div_el.textContent = `x: ${data.x}, y: ${data.y}`
+          document.body.appendChild(div_el)
+        },
+        hovered: true,
       },
     })
   })
@@ -50,7 +181,7 @@ describe(`BarPlot`, () => {
     mount(BarPlot, {
       target: document.body,
       props: {
-        series: [basic_series],
+        series: [basic],
         children: () => {
           called = true
           const div_el = document.createElement(`div`)

--- a/tests/vitest/plot/layout.test.ts
+++ b/tests/vitest/plot/layout.test.ts
@@ -1,6 +1,6 @@
 import {
   constrain_tooltip_position,
-  find_best_legend_placement,
+  find_best_plot_area,
   get_chart_dimensions,
 } from '$lib/plot/layout'
 import { describe, expect, it, test } from 'vitest'
@@ -327,7 +327,7 @@ describe(`layout utility functions`, () => {
     })
   })
 
-  describe(`find_best_legend_placement`, () => {
+  describe(`find_best_plot_area`, () => {
     const base_config = {
       plot_width: 400,
       plot_height: 300,
@@ -337,7 +337,7 @@ describe(`layout utility functions`, () => {
     }
 
     it(`should place legend in top-left corner when no points exist`, () => {
-      const result = find_best_legend_placement([], base_config)
+      const result = find_best_plot_area([], base_config)
 
       expect(result.position).toBe(`top-left`)
       expect(result.x).toBeGreaterThan(0)
@@ -351,7 +351,7 @@ describe(`layout utility functions`, () => {
         y: base_config.padding.t + 50,
       }))
 
-      const result = find_best_legend_placement(points, base_config)
+      const result = find_best_plot_area(points, base_config)
 
       // Should NOT be top-left since that's crowded
       expect(result.position).not.toBe(`top-left`)
@@ -366,7 +366,7 @@ describe(`layout utility functions`, () => {
         },
       ]
 
-      const result = find_best_legend_placement(points, base_config)
+      const result = find_best_plot_area(points, base_config)
 
       // Should be one of the four corners
       const corners = [`top-left`, `top-right`, `bottom-left`, `bottom-right`]
@@ -386,7 +386,7 @@ describe(`layout utility functions`, () => {
         })),
       ]
 
-      const result = find_best_legend_placement(points, base_config)
+      const result = find_best_plot_area(points, base_config)
 
       // Should prefer top-left or bottom-left (both have 0 points)
       expect([`top-left`, `bottom-left`]).toContain(result.position)
@@ -394,7 +394,7 @@ describe(`layout utility functions`, () => {
 
     it(`should respect margin settings`, () => {
       const config_with_margin = { ...base_config, margin: 20 }
-      const result = find_best_legend_placement([], config_with_margin)
+      const result = find_best_plot_area([], config_with_margin)
 
       // Top-left corner with margin
       expect(result.x).toBe(base_config.padding.l + 20)
@@ -402,7 +402,7 @@ describe(`layout utility functions`, () => {
     })
 
     it(`should calculate correct coordinates within plot area`, () => {
-      const result = find_best_legend_placement([], base_config)
+      const result = find_best_plot_area([], base_config)
 
       // Should be within plot area boundaries
       expect(result.x).toBeGreaterThanOrEqual(base_config.padding.l)
@@ -416,7 +416,7 @@ describe(`layout utility functions`, () => {
     })
 
     it(`should always return a transform string`, () => {
-      const result = find_best_legend_placement([], base_config)
+      const result = find_best_plot_area([], base_config)
 
       expect(typeof result.transform).toBe(`string`)
     })


### PR DESCRIPTION
- Adds `grouped` mode to `BarPlot` for side-by-side bars.
- Allows series to render as bars or lines with per-series line styles.
- Computes stacked ranges from separate positive and negative totals, excludes line series from stacking, and pins the automatic baseline to zero for one-sided data.
- Measures tick labels for dynamic padding, clips content to the plot area, and improves legend placement.
- Adds type-aware legend styling, per-point line hover visuals, larger hover targets, and smoother zoom and drag behavior.