### PR TITLE
Add WebM video export to `Trajectory`

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -427,7 +427,7 @@
           "type": "array",
           "default": [
             0.2,
-            30
+            60
           ],
           "description": "Allowed range for playback speed [min, max]",
           "minItems": 2,

--- a/src/lib/DraggablePane.svelte
+++ b/src/lib/DraggablePane.svelte
@@ -176,7 +176,7 @@
     bind:this={toggle_pane_btn}
     aria-expanded={show}
     {...toggle_props}
-    style={`font-size: clamp(1em, 2.2cqw, 2em); ${toggle_props.style ?? ``}`}
+    style={`font-size: clamp(1em, 2.2cqw, 1.2em); ${toggle_props.style ?? ``}`}
     onclick={toggle_pane}
     class="pane-toggle {toggle_props.class ?? ``}"
     {@attach tooltip({ content: toggle_props.title ?? (show ? `Close pane` : `Open pane`) })}
@@ -329,10 +329,13 @@
   }
   .draggable-pane :global(button) {
     width: max-content;
-    background-color: var(--pane-btn-bg, rgba(255, 255, 255, 0.1));
+    background-color: var(--pane-btn-bg, var(--btn-bg, rgba(255, 255, 255, 0.1)));
   }
   .draggable-pane :global(button:hover) {
-    background-color: var(--pane-btn-bg-hover, rgba(255, 255, 255, 0.2));
+    background-color: var(
+      --pane-btn-bg-hover,
+      var(--btn-bg-hover, rgba(255, 255, 255, 0.2))
+    );
   }
   .draggable-pane :global(select) {
     margin: 0 0 0 5pt;

--- a/src/lib/app.css
+++ b/src/lib/app.css
@@ -49,6 +49,10 @@ button, a.btn {
   border-radius: 3pt;
   padding: 2pt 4pt;
 }
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
 a:hover {
   color: var(--accent-hover-color, orange);
 }

--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -451,6 +451,11 @@ export const icon_data = {
     path:
       `<path fill="#444" d="M3.75 9v14h24.5V9L16 2"/><path fill="#939393" d="M16 16V2L3.75 9l24.5 14L16 30L3.75 23"/><path fill="#e3e3e3" d="M28.25 9H16v21"/><path fill="#fff" d="M3.75 9h24.5L16 16"/>`,
   },
+  Export: {
+    viewBox: `0 0 24 24`,
+    path:
+      `<path d="M11.293 2.293a1 1 0 0 1 1.414 0l4 4a1 1 0 0 1-1.414 1.414L13 5.414V16a1 1 0 1 1-2 0V5.414L8.707 7.707a1 1 0 0 1-1.414-1.414zM5 17a1 1 0 0 1 1 1v2h12v-2a1 1 0 1 1 2 0v2a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-2a1 1 0 0 1 1-1"/>`,
+  },
 } as const
 
 export type IconName = keyof typeof icon_data

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -526,7 +526,7 @@ export const SETTINGS_CONFIG: SettingsConfig = {
       maximum: 60,
     },
     fps_range: {
-      value: [0.2, 30] as const,
+      value: [0.2, 60] as const,
       description: `Allowed range for playback speed [min, max]`,
       minItems: 2,
       maxItems: 2,

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -513,10 +513,7 @@
             {#if typeof fullscreen_toggle === `function`}
               {@render fullscreen_toggle()}
             {:else}
-              <Icon
-                icon="{fullscreen ? `Exit` : ``}Fullscreen"
-                style="width: clamp(1em, 2cqmin, 2.5em)"
-              />
+              <Icon icon="{fullscreen ? `Exit` : ``}Fullscreen" />
             {/if}
           </button>
         {/if}
@@ -686,7 +683,6 @@
   section.control-buttons {
     position: absolute;
     display: flex;
-    place-items: center;
     top: var(--struct-buttons-top, var(--ctrl-btn-top, 1ex));
     right: var(--struct-buttons-right, var(--ctrl-btn-right, 1ex));
     gap: clamp(6pt, 1cqmin, 9pt);
@@ -705,6 +701,7 @@
     background-color: transparent;
     display: flex;
     padding: 0;
+    font-size: clamp(1em, 2cqmin, 2.5em);
   }
   section.control-buttons :global(button:hover) {
     background-color: var(--pane-btn-bg-hover);

--- a/src/lib/theme/themes.js
+++ b/src/lib/theme/themes.js
@@ -142,7 +142,7 @@ const themes = {
   },
 
   // Interactive elements (buttons, etc.)
-  'btn-bg': btn_bg(0.1, 0.12),
+  'btn-bg': btn_bg(0.3, 0.12),
   'btn-bg-hover': btn_bg(0.2, 0.25),
   'btn-disabled-bg': btn_bg(0.1, 0.05),
 

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -997,7 +997,7 @@
                   title={current_view_label}
                   class="view-mode-button"
                   class:active={view_mode_dropdown_open}
-                  style="background-color: transparent; font-size: clamp(1em, 2cqw, 1.1em); padding: 0"
+                  style="background-color: transparent; padding: 0"
                 >
                   <Icon
                     icon={({
@@ -1262,7 +1262,7 @@
     display: flex;
     align-items: center;
     gap: clamp(2pt, 1cqw, 1ex);
-    padding: clamp(2pt, 0.5cqw, 1ex);
+    padding: clamp(2pt, 0.5cqw, 1ex) clamp(4pt, 1cqw, 1.2ex);
     background: var(--surface-bg-hover);
     backdrop-filter: blur(4px);
     position: relative;
@@ -1273,6 +1273,7 @@
   }
   .trajectory-controls button {
     background: var(--btn-bg);
+    font-size: clamp(0.8rem, 2cqw, 1rem);
   }
   .trajectory-controls button:hover:not(:disabled) {
     background: var(--btn-bg-hover);
@@ -1335,7 +1336,6 @@
     overflow: hidden;
     text-overflow: ellipsis;
     display: inline-block;
-    font-size: clamp(0.8rem, 2cqw, 0.9rem);
     position: relative;
   }
   @keyframes fade-in {
@@ -1345,7 +1345,6 @@
   }
   .fullscreen-button {
     background: transparent !important;
-    font-size: clamp(1rem, 2cqw, 1.3rem);
     padding: 0;
   }
   .fullscreen-button:hover:not(:disabled) {
@@ -1353,13 +1352,13 @@
   }
   .info-section {
     display: flex;
-    place-items: center;
-    gap: clamp(3pt, 0.5cqw, 1ex);
+    align-items: center;
+    gap: clamp(6pt, 1cqw, 1.5ex);
+    position: relative;
   }
 
   .play-button {
     min-width: clamp(32px, 4cqw, 36px);
-    font-size: clamp(0.8rem, 2.5cqw, 0.9rem);
   }
   .play-button:hover:not(:disabled) {
     background: var(--traj-play-btn-bg-hover, var(--btn-bg-hover, rgba(0, 0, 0, 0.2)));

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -18,7 +18,7 @@
     TrajectoryType,
     TrajHandlerData,
   } from './index'
-  import { TrajectoryError, TrajectoryInfoPane } from './index'
+  import { TrajectoryError, TrajectoryExportPane, TrajectoryInfoPane } from './index'
   import type { LoadingOptions } from './parse'
   import {
     create_frame_loader,
@@ -791,6 +791,7 @@
     structure_info: false,
     structure_controls: false,
     plot_controls: false,
+    export_pane: false,
   })
   let fullscreen = $state(false)
 </script>
@@ -805,7 +806,7 @@
 <div
   class:dragover
   class:active={is_playing || panes_open.structure_info || panes_open.structure_controls ||
-  panes_open.plot_controls || info_pane_open}
+  panes_open.plot_controls || panes_open.export_pane || info_pane_open}
   bind:this={wrapper}
   bind:clientWidth={viewport.width}
   bind:clientHeight={viewport.height}
@@ -979,6 +980,15 @@
                 pane_props={{ style: `max-height: calc(${viewport.height}px - 50px)` }}
               />
             {/if}
+            <!-- Trajectory Export Pane -->
+            <TrajectoryExportPane
+              bind:export_pane_open={panes_open.export_pane}
+              {trajectory}
+              {wrapper}
+              filename={current_filename || `trajectory`}
+              on_step_change={go_to_step}
+              pane_props={{ style: `max-height: calc(${viewport.height}px - 50px)` }}
+            />
             <!-- Display mode dropdown -->
             {#if plot_series.length > 0}
               <div class="view-mode-dropdown-wrapper">
@@ -987,6 +997,7 @@
                   title={current_view_label}
                   class="view-mode-button"
                   class:active={view_mode_dropdown_open}
+                  style="background-color: transparent; font-size: clamp(1em, 2cqw, 1.1em); padding: 0"
                 >
                   <Icon
                     icon={({
@@ -1333,7 +1344,9 @@
     }
   }
   .fullscreen-button {
-    background: transparent;
+    background: transparent !important;
+    font-size: clamp(1rem, 2cqw, 1.3rem);
+    padding: 0;
   }
   .fullscreen-button:hover:not(:disabled) {
     background: var(--border-color);

--- a/src/lib/trajectory/TrajectoryExportPane.svelte
+++ b/src/lib/trajectory/TrajectoryExportPane.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { DraggablePane, SettingsSection } from '$lib'
   import {
-    export_trajectory_as_mp4,
+    export_trajectory_video,
     get_ffmpeg_conversion_command,
   } from '$lib/io/export'
   import type { TrajectoryType } from '$lib/trajectory'
@@ -57,16 +57,15 @@
     export_progress = 0
 
     try {
-      await export_trajectory_as_mp4(canvas, `${filename}.${format}`, {
+      await export_trajectory_video(canvas, `${filename}.webm`, {
         fps: video_fps,
         total_frames,
         bitrate: video_bitrate,
-        format,
-        on_progress: (p) => (export_progress = p),
+        on_progress: (progress) => (export_progress = progress),
         on_step: on_step_change,
       })
 
-      // Copy ffmpeg command for MP4
+      // Copy ffmpeg command for MP4 conversion
       if (format === `mp4`) {
         const cmd = get_ffmpeg_conversion_command(`${filename}.webm`)
         navigator.clipboard.writeText(cmd).catch(console.warn)

--- a/src/lib/trajectory/TrajectoryExportPane.svelte
+++ b/src/lib/trajectory/TrajectoryExportPane.svelte
@@ -1,0 +1,215 @@
+<script lang="ts">
+  import { DraggablePane, SettingsSection } from '$lib'
+  import {
+    export_trajectory_as_mp4,
+    get_ffmpeg_conversion_command,
+  } from '$lib/io/export'
+  import type { TrajectoryType } from '$lib/trajectory'
+  import type { ComponentProps } from 'svelte'
+  import { tooltip } from 'svelte-multiselect/attachments'
+
+  interface Props {
+    // Control pane state
+    export_pane_open?: boolean
+    // Trajectory data for generating filename
+    trajectory?: TrajectoryType | undefined
+    // Canvas wrapper for video export
+    wrapper?: HTMLDivElement | undefined
+    // Filename for export
+    filename?: string
+    // Export settings
+    video_fps?: number
+    video_bitrate?: number
+    // Function to change trajectory step during export
+    on_step_change?: (step_idx: number) => Promise<void> | void
+    // Pane customization
+    pane_props?: ComponentProps<typeof DraggablePane>[`pane_props`]
+    toggle_props?: ComponentProps<typeof DraggablePane>[`toggle_props`]
+  }
+
+  let {
+    export_pane_open = $bindable(false),
+    trajectory = undefined,
+    wrapper = undefined,
+    filename = `trajectory`,
+    video_fps = $bindable(30),
+    video_bitrate = $bindable(20000000),
+    on_step_change = undefined,
+    pane_props = $bindable({}),
+    toggle_props = $bindable({}),
+    ...rest
+  }: Props = $props()
+
+  let is_exporting = $state(false)
+  let export_progress = $state(0)
+  let export_format = $state<`webm` | `mp4`>(`webm`)
+
+  let total_frames = $derived(
+    trajectory?.total_frames || trajectory?.frames?.length || 0,
+  )
+
+  async function handle_video_export(format: `webm` | `mp4` = `webm`) {
+    const canvas = wrapper?.querySelector(`canvas`) as HTMLCanvasElement
+    if (!trajectory || !on_step_change || !canvas) return
+
+    export_format = format
+    is_exporting = true
+    export_progress = 0
+
+    try {
+      await export_trajectory_as_mp4(canvas, `${filename}.${format}`, {
+        fps: video_fps,
+        total_frames,
+        bitrate: video_bitrate,
+        format,
+        on_progress: (p) => (export_progress = p),
+        on_step: on_step_change,
+      })
+
+      // Copy ffmpeg command for MP4
+      if (format === `mp4`) {
+        const cmd = get_ffmpeg_conversion_command(`${filename}.webm`)
+        navigator.clipboard.writeText(cmd).catch(console.warn)
+      }
+
+      export_progress = 100
+      setTimeout(() => {
+        is_exporting = false
+        export_progress = 0
+      }, 1000)
+    } catch (error) {
+      console.error(`Export failed:`, error)
+      is_exporting = false
+      export_progress = 0
+    }
+  }
+
+  let is_video_supported = $derived(
+    typeof window !== `undefined` &&
+      typeof MediaRecorder !== `undefined` &&
+      MediaRecorder.isTypeSupported(`video/webm;codecs=vp9`),
+  )
+
+  let has_canvas = $state(false)
+
+  $effect(() => {
+    if (!wrapper) {
+      has_canvas = false
+      return
+    }
+    const check = () => (has_canvas = Boolean(wrapper.querySelector(`canvas`)))
+    check()
+    const observer = new MutationObserver(check)
+    observer.observe(wrapper, { childList: true, subtree: true })
+    return () => observer.disconnect()
+  })
+</script>
+
+<DraggablePane
+  bind:show={export_pane_open}
+  open_icon="Cross"
+  closed_icon="Export"
+  pane_props={{ ...pane_props, class: `export-pane ${pane_props?.class ?? ``}` }}
+  toggle_props={{
+    title: `${export_pane_open ? `Close` : `Open`} export controls`,
+    ...toggle_props,
+    class: `trajectory-export-toggle ${toggle_props?.class ?? ``}`,
+  }}
+  {...rest}
+>
+  <h4>Export Video</h4>
+
+  {#if !is_video_supported}
+    <div class="warning">Video export requires Chrome, Edge, or Opera</div>
+  {:else}
+    <SettingsSection
+      title="Video Settings"
+      current_values={{ video_fps, video_bitrate }}
+      on_reset={() => ((video_fps = 30), (video_bitrate = 20_000_000))}
+    >
+      <label>
+        Frame Rate (FPS)
+        <input type="number" min={10} max={60} bind:value={video_fps} />
+        <input
+          type="range"
+          min={10}
+          max={60}
+          bind:value={video_fps}
+          style="accent-color: var(--accent-color)"
+        />
+      </label>
+
+      <label>
+        Quality (Mbps)
+        <input
+          type="number"
+          min={5}
+          max={50}
+          value={(video_bitrate / 1_000_000).toFixed(0)}
+          oninput={(e) => (video_bitrate = Number(e.currentTarget.value) * 1_000_000)}
+        />
+        <input
+          type="range"
+          min={5}
+          max={50}
+          value={video_bitrate / 1_000_000}
+          oninput={(e) => (video_bitrate = Number(e.currentTarget.value) * 1_000_000)}
+          style="accent-color: var(--accent-color)"
+        />
+      </label>
+    </SettingsSection>
+
+    <h4>Export Formats</h4>
+    <div class="export-buttons">
+      {#each [
+        { label: `WebM`, format: `webm`, hint: `Export as WebM video` },
+        {
+          label: `MP4`,
+          format: `mp4`,
+          hint: `Downloads WebM + copies ffmpeg conversion command`,
+        },
+      ] as const as
+        { label, format, hint }
+        (format)
+      }
+        <div style="display: flex; align-items: center; gap: 4pt">
+          {label}
+          <button
+            type="button"
+            onclick={() => handle_video_export(format)}
+            disabled={is_exporting || !trajectory || !has_canvas}
+            {@attach tooltip({ content: hint })}
+          >
+            {#if is_exporting && export_format === format}
+              {export_progress.toFixed(0)}% ({format})
+            {:else}⬇{/if}
+          </button>
+        </div>
+      {/each}
+      <div style="font-size: 0.9em; color: var(--text-color-muted)">
+        {(total_frames / video_fps).toFixed(1)}s ({total_frames} frames)
+      </div>
+    </div>
+
+    {#if trajectory && !has_canvas}
+      <div class="warning" style="font-size: 0.9em; padding: 0.5ex">
+        Waiting for canvas...
+      </div>
+    {/if}
+  {/if}
+</DraggablePane>
+
+<style>
+  .warning {
+    padding: 1ex;
+    background: var(--warning-bg, rgba(255, 165, 0, 0.1));
+    border: 1px solid var(--warning-color, orange);
+    border-radius: 4px;
+  }
+  .export-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 1ex;
+  }
+</style>

--- a/src/lib/trajectory/index.ts
+++ b/src/lib/trajectory/index.ts
@@ -4,6 +4,7 @@ import type { ComponentProps } from 'svelte'
 
 export { default as Trajectory } from './Trajectory.svelte'
 export { default as TrajectoryError } from './TrajectoryError.svelte'
+export { default as TrajectoryExportPane } from './TrajectoryExportPane.svelte'
 export { default as TrajectoryInfoPane } from './TrajectoryInfoPane.svelte'
 
 export type TrajectoryFormat = `hdf5` | `json` | `xyz` | `xdatcar` | `traj` | `unknown`

--- a/src/routes/test/trajectory/+page.svelte
+++ b/src/routes/test/trajectory/+page.svelte
@@ -391,3 +391,10 @@
   layout="horizontal"
   plot_skimming={false}
 />
+
+<Trajectory
+  id="with-export-pane"
+  trajectory={test_trajectory}
+  layout="horizontal"
+  show_controls
+/>

--- a/tests/playwright/trajectory-performance.test.ts
+++ b/tests/playwright/trajectory-performance.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test'
 
-const TEST_FRAME_RATE_FPS = 30
+const TEST_FRAME_RATE_FPS = 60
 
 test.describe(`Trajectory Performance Tests`, () => {
   test(`large MOF5 trajectory playback performance`, async ({ page }) => {

--- a/tests/playwright/trajectory.test.ts
+++ b/tests/playwright/trajectory.test.ts
@@ -630,7 +630,7 @@ test.describe(`Trajectory Component`, () => {
         const fps_slider = fps_section.locator(`input[type="range"]`)
 
         // Test range of FPS values via slider
-        for (const fps of [`0.2`, `5`, `15`, `30`]) {
+        for (const fps of [`0.2`, `5`, `15`, `60`]) {
           await fps_slider.fill(fps)
           await expect(fps_input).toHaveValue(fps)
         }
@@ -642,7 +642,7 @@ test.describe(`Trajectory Component`, () => {
 
         // Verify attributes and UI elements
         await expect(fps_slider).toHaveAttribute(`min`, `0.2`)
-        await expect(fps_slider).toHaveAttribute(`max`, `30`)
+        await expect(fps_slider).toHaveAttribute(`max`, `60`)
         await expect(fps_input).toHaveAttribute(`step`, `0.1`)
         await expect(fps_section).toContainText(`fps`)
       }


### PR DESCRIPTION
- Adds `TrajectoryExportPane` for frame-accurate WebM capture and MP4 conversion through local FFmpeg, with FPS, bitrate, resolution, frame-range, progress, and conversion-command controls.
- Exposes `on_step_change` for frame-by-frame capture.
- Increases the maximum trajectory playback speed from 30 to 60 FPS.