### PR TITLE
`SpacegroupBarPlot` for visualizing crystal symmetry distributions

### DIFF
--- a/src/lib/composition/BubbleChart.svelte
+++ b/src/lib/composition/BubbleChart.svelte
@@ -82,7 +82,7 @@
       return {
         element: data.element as ElementSymbol,
         amount: data.amount,
-        percentage: total_atoms > 0 ? (data.amount / total_atoms) * 100 : 0,
+        fraction: total_atoms > 0 ? data.amount / total_atoms : 0,
         radius,
         x: (node.x || 0) + padding, // Offset by padding
         y: (node.y || 0) + padding,

--- a/src/lib/element/ElementTile.svelte
+++ b/src/lib/element/ElementTile.svelte
@@ -166,7 +166,7 @@
   style:color={text_color}
   {@attach text_color ? null : contrast_color()}
   {...(href ? { role: `link`, tabindex: 0 } : {})}
-  onclick={(event) => onclick?.({ element, event })}
+  onclick={(event: MouseEvent) => onclick?.({ element, event })}
   {...rest}
 >
   {#if should_show_number}

--- a/src/lib/phase-diagram/PhaseDiagram2D.svelte
+++ b/src/lib/phase-diagram/PhaseDiagram2D.svelte
@@ -126,7 +126,7 @@
     )
     if (!el_a) {
       coords.push({
-        composition: { [el1]: 1 },
+        composition: { [el1]: 1 } as Record<ElementSymbol, number>,
         energy: 0,
         x: 0,
         y: 0,
@@ -137,7 +137,7 @@
     }
     if (!el_b) {
       coords.push({
-        composition: { [el2]: 1 },
+        composition: { [el2]: 1 } as Record<ElementSymbol, number>,
         energy: 0,
         x: 1,
         y: 0,

--- a/src/lib/phase-diagram/thermodynamics.ts
+++ b/src/lib/phase-diagram/thermodynamics.ts
@@ -79,7 +79,9 @@ export function find_lowest_energy_unary_refs(
   const refs: Record<string, PhaseEntry> = {}
   for (const entry of entries) {
     if (!is_unary_entry(entry)) continue
-    const el = Object.keys(entry.composition).find((k) => entry.composition[k] > 0)
+    const el = Object.keys(entry.composition).find(
+      (el) => entry.composition[el as ElementSymbol] > 0,
+    )
     if (!el) continue
     const atoms = Object.values(entry.composition).reduce((sum, amt) => sum + amt, 0)
     const e_pa = get_corrected_energy_per_atom(entry) ??
@@ -125,8 +127,9 @@ export function get_phase_diagram_stats(
 
   const composition_counts = (max_arity === 4 ? [1, 2, 3, 4] : [1, 2, 3]).map((target) =>
     processed_entries.filter((entry) =>
-      Object.keys(entry.composition).filter((el) => entry.composition[el] > 0).length ===
-        target
+      Object.keys(entry.composition).filter(
+        (el) => entry.composition[el as ElementSymbol] > 0,
+      ).length === target
     ).length
   )
   const [unary, binary, ternary, quaternaryMaybe] = composition_counts as [

--- a/src/lib/plot/ScatterPlot.svelte
+++ b/src/lib/plot/ScatterPlot.svelte
@@ -701,10 +701,17 @@
     if (series_markers?.includes(`line`)) {
       // Prefer explicit line stroke
       let legend_line_color = data_series?.line_style?.stroke
-      if (!legend_line_color) { // If no explicit stroke, inherit a reasonable point color even when points aren't shown
-        // Order of preference: point fill -> point stroke -> symbol_color -> black
-        legend_line_color = first_point_style?.fill || first_point_style?.stroke ||
-          display_style.symbol_color || `black`
+      if (!legend_line_color) {
+        // Try color scale if available
+        const first_cv = Array.isArray(data_series?.color_values)
+          ? data_series!.color_values!.find((v) => v != null)
+          : undefined
+        legend_line_color =
+          (first_cv != null ? color_scale_fn(first_cv) : undefined) ||
+          first_point_style?.fill ||
+          first_point_style?.stroke ||
+          display_style.symbol_color ||
+          `black`
       }
       display_style.line_color = legend_line_color
       display_style.line_dash = data_series?.line_style?.line_dash

--- a/src/lib/plot/SpacegroupBarPlot.svelte
+++ b/src/lib/plot/SpacegroupBarPlot.svelte
@@ -181,25 +181,16 @@
 </script>
 
 {#snippet tooltip(info: BarTooltipProps)}
-  {@const sg = info.x}
-  {@const count = info.y}
+  {@const { x: sg, y: count } = info}
   {@const system = spacegroup_to_crystal_system(sg)}
-  Space Group: {format_value(sg, `.0f`)} ({SPACEGROUP_NUM_TO_SYMBOL[sg]})
-  <br />
+  Space Group: {format_value(sg, `.0f`)} ({SPACEGROUP_NUM_TO_SYMBOL[sg]})<br />
   {#if system}
-    Crystal System: {system}
-    <br />
+    Crystal System: {system}<br />
   {/if}
   Count: {format_value(count, `.0f`)}
 {/snippet}
 
-{#snippet user_content({
-  width,
-  height,
-  x_scale_fn,
-  y_scale_fn,
-  pad,
-}: {
+{#snippet user_content({ width, height, x_scale_fn, y_scale_fn, pad }: {
   width: number
   height: number
   x_scale_fn: (x: number) => number

--- a/src/lib/plot/SpacegroupBarPlot.svelte
+++ b/src/lib/plot/SpacegroupBarPlot.svelte
@@ -1,0 +1,356 @@
+<script lang="ts">
+  import { type BarSeries, type BarTooltipProps, format_num } from '$lib'
+  import { BarPlot } from '$lib/plot'
+  import { format_value } from '$lib/plot/formatting'
+  import type { CrystalSystem } from '$lib/symmetry'
+  import {
+    CRYSTAL_SYSTEM_COLORS,
+    CRYSTAL_SYSTEM_RANGES,
+    CRYSTAL_SYSTEMS,
+    normalize_spacegroup,
+    spacegroup_to_crystal_system,
+  } from '$lib/symmetry'
+  import type { ComponentProps } from 'svelte'
+  import { SvelteMap } from 'svelte/reactivity'
+
+  let {
+    data,
+    show_counts = true,
+    show_empty_bins = false,
+    orientation = `vertical`,
+    x_axis = {},
+    y_axis = {},
+    ...rest
+  }: ComponentProps<typeof BarPlot> & {
+    data: (number | string)[]
+    show_counts?: boolean
+    show_empty_bins?: boolean
+  } = $props()
+
+  // Normalize input data to space group numbers
+  const normalized_data = $derived.by(() => {
+    return data
+      .map((sg) => normalize_spacegroup(sg))
+      .filter((sg): sg is number => sg !== null)
+  })
+
+  // Compute histogram of space group numbers
+  const histogram = $derived.by(() => {
+    const hist = new SvelteMap<number, number>()
+
+    // Count occurrences
+    for (const sg of normalized_data) {
+      hist.set(sg, (hist.get(sg) ?? 0) + 1)
+    }
+
+    // Optionally add empty bins
+    if (show_empty_bins) {
+      for (let sg = 1; sg <= 230; sg++) {
+        if (!hist.has(sg)) hist.set(sg, 0)
+      }
+    }
+
+    return hist
+  })
+
+  // Group counts by crystal system
+  const crystal_system_stats = $derived.by(() => {
+    const stats = new SvelteMap<
+      CrystalSystem,
+      { count: number; spacegroups: number[] }
+    >()
+
+    for (const system of CRYSTAL_SYSTEMS) {
+      stats.set(system, { count: 0, spacegroups: [] })
+    }
+
+    for (const [sg, count] of histogram) {
+      const system = spacegroup_to_crystal_system(sg)
+      if (system) {
+        const stat = stats.get(system)!
+        stat.count += count
+        stat.spacegroups.push(sg)
+      }
+    }
+
+    return stats
+  })
+
+  // Create sorted list of space groups for x-axis
+  const sorted_spacegroups = $derived(
+    Array.from(histogram.keys()).sort((a, b) => a - b),
+  )
+
+  // Smart tick selection: thin out ticks for dense data
+  const x_axis_ticks = $derived.by(() => {
+    const non_zero_count = sorted_spacegroups.filter((sg) =>
+      (histogram.get(sg) ?? 0) > 0
+    ).length
+
+    // If data is dense (>40 space groups with data), show only multiples of 5
+    if (non_zero_count > 40) {
+      return sorted_spacegroups.filter((sg) => sg % 5 === 0)
+    }
+
+    // Otherwise show all ticks
+    return sorted_spacegroups
+  })
+
+  // Build BarSeries - one series per crystal system for proper coloring
+  const bar_series = $derived.by<BarSeries[]>(() => {
+    const series_by_system = new SvelteMap<
+      CrystalSystem,
+      { x: number[]; y: number[] }
+    >()
+
+    // Initialize series for each crystal system
+    for (const system of CRYSTAL_SYSTEMS) {
+      series_by_system.set(system, { x: [], y: [] })
+    }
+
+    // Group data by crystal system
+    for (const sg of sorted_spacegroups) {
+      const system = spacegroup_to_crystal_system(sg)
+      if (system) {
+        const series = series_by_system.get(system)!
+        series.x.push(sg)
+        series.y.push(histogram.get(sg) ?? 0)
+      }
+    }
+
+    // Convert to BarSeries array
+    return Array.from(series_by_system.entries())
+      .filter(([_, data]) => data.x.length > 0) // Only include systems with data
+      .map(([system, data]) => ({
+        x: data.x,
+        y: data.y,
+        color: CRYSTAL_SYSTEM_COLORS[system],
+        label: system,
+        bar_width: 0.9,
+        visible: true,
+      }))
+  })
+
+  // Calculate x-axis range - span from first to last crystal system with data
+  const x_range = $derived.by<[number, number]>(() => {
+    if (sorted_spacegroups.length === 0) return [0.5, 230.5]
+
+    // Find the first and last crystal system that contains data
+    const min_sg = sorted_spacegroups[0]
+    const max_sg = sorted_spacegroups[sorted_spacegroups.length - 1]
+
+    // Extend to the full ranges of those crystal systems
+    let range_min = min_sg
+    let range_max = max_sg
+
+    for (const system of CRYSTAL_SYSTEMS) {
+      const [system_min, system_max] = CRYSTAL_SYSTEM_RANGES[system]
+      // If this system contains our min data point, extend to system start
+      if (min_sg >= system_min && min_sg <= system_max) {
+        range_min = system_min
+      }
+      // If this system contains our max data point, extend to system end
+      if (max_sg >= system_min && max_sg <= system_max) {
+        range_max = system_max
+      }
+    }
+
+    return [range_min - 0.5, range_max + 0.5]
+  })
+
+  // Calculate crystal system region boundaries using full theoretical ranges
+  const crystal_system_regions = $derived.by(() => {
+    const regions: Array<{
+      system: CrystalSystem
+      sg_start: number
+      sg_end: number
+      count: number
+      color: string
+    }> = []
+
+    const [range_min, range_max] = x_range
+
+    for (const system of CRYSTAL_SYSTEMS) {
+      const stats = crystal_system_stats.get(system)
+      const [sg_min, sg_max] = CRYSTAL_SYSTEM_RANGES[system]
+
+      // Only show crystal systems that fall within the visible range
+      if (sg_max < range_min || sg_min > range_max) continue
+
+      regions.push({
+        system,
+        sg_start: sg_min,
+        sg_end: sg_max,
+        count: stats?.count ?? 0,
+        color: CRYSTAL_SYSTEM_COLORS[system],
+      })
+    }
+
+    return regions
+  })
+
+  const total_count = $derived(normalized_data.length)
+
+  // Build axis configurations based on orientation
+  const x_axis_config = $derived(
+    orientation === `horizontal` ? { ...x_axis, label: x_axis.label ?? `Counts` } : {
+      ...x_axis,
+      label: x_axis.label ?? `International Spacegroup Number`,
+      range: x_range,
+      ticks: x_axis_ticks,
+      tick_rotation: x_axis.tick_rotation ?? 90, // Rotate ticks 90° to avoid overlap
+      label_shift: { x: 0, y: 20, ...x_axis.label_shift }, // Move label down for rotated ticks
+    },
+  )
+
+  const y_axis_config = $derived(
+    orientation === `horizontal`
+      ? {
+        ...y_axis,
+        label: y_axis.label ?? `International Spacegroup Number`,
+        range: x_range,
+        ticks: x_axis_ticks,
+        tick_rotation: y_axis.tick_rotation ?? 0,
+      }
+      : { ...y_axis, label: y_axis.label ?? `Counts` },
+  )
+</script>
+
+{#snippet tooltip(info: BarTooltipProps)}
+  {@const sg = info.x}
+  {@const count = info.y}
+  {@const system = spacegroup_to_crystal_system(sg)}
+  Space Group: {format_value(sg, `.0f`)}
+  <br />
+  {#if system}
+    Crystal System: {system}
+    <br />
+  {/if}
+  Count: {format_value(count, `.0f`)}
+{/snippet}
+
+{#snippet user_content({
+  width,
+  height,
+  x_scale_fn,
+  y_scale_fn,
+  pad,
+}: {
+  width: number
+  height: number
+  x_scale_fn: (x: number) => number
+  y_scale_fn: (y: number) => number
+  pad: { t: number; b: number; l: number; r: number }
+})}
+  <g class="crystal-system-overlays">
+    {#each crystal_system_regions as region (region.system)}
+      {#if orientation === `vertical`}
+        {@const x_start = x_scale_fn(region.sg_start - 0.5)}
+        {@const x_end = x_scale_fn(region.sg_end + 0.5)}
+        {@const x_center = (x_start + x_end) / 2}
+        {@const rect_width = x_end - x_start}
+
+        <!-- Background colored rectangle (vertical mode) -->
+        <rect
+          x={x_start}
+          y={pad.t}
+          width={rect_width}
+          height={height - pad.t - pad.b}
+          fill={region.color}
+          opacity="0.15"
+          stroke={region.color}
+          stroke-width="1"
+          stroke-opacity="0.3"
+        />
+
+        <!-- Crystal system label (rotated 90 degrees) -->
+        <text
+          x={x_center}
+          y={pad.t + (height - pad.t - pad.b) / 2}
+          text-anchor="middle"
+          font-size="14"
+          fill="var(--text-color, black)"
+          opacity="0.6"
+          transform="rotate(90, {x_center}, {pad.t + (height - pad.t - pad.b) / 2})"
+        >
+          {region.system}
+        </text>
+
+        <!-- Count annotation at top -->
+        {#if show_counts && total_count > 0}
+          <text
+            x={x_center}
+            y={pad.t - 5}
+            text-anchor="middle"
+            font-size="12"
+            fill="var(--text-color, black)"
+          >
+            {format_num(region.count, `~`)} ({
+              format_num(region.count / total_count, `.1~%`)
+            })
+          </text>
+        {/if}
+      {:else}
+        {@const y_start = y_scale_fn(region.sg_end + 0.5)}
+        {@const y_end = y_scale_fn(region.sg_start - 0.5)}
+        {@const y_center = (y_start + y_end) / 2}
+        {@const rect_height = y_end - y_start}
+
+        <!-- Background colored rectangle (horizontal mode) -->
+        <rect
+          x={pad.l}
+          y={y_start}
+          width={width - pad.l - pad.r}
+          height={rect_height}
+          fill={region.color}
+          opacity="0.15"
+          stroke={region.color}
+          stroke-width="1"
+          stroke-opacity="0.3"
+        />
+
+        <!-- Crystal system label (horizontal) -->
+        <text
+          x={pad.l + (width - pad.l - pad.r) / 2}
+          y={y_center}
+          text-anchor="middle"
+          dominant-baseline="central"
+          font-size="14"
+          fill="var(--text-color, black)"
+          opacity="0.6"
+        >
+          {region.system}
+        </text>
+
+        <!-- Count annotation at right -->
+        {#if show_counts && total_count > 0}
+          <text
+            x={width - pad.r + 5}
+            y={y_center}
+            text-anchor="start"
+            dominant-baseline="central"
+            font-size="12"
+            fill="var(--text-color, black)"
+          >
+            {format_num(region.count, `~`)} ({
+              format_num(region.count / total_count, `.1~%`)
+            })
+          </text>
+        {/if}
+      {/if}
+    {/each}
+  </g>
+{/snippet}
+
+<BarPlot
+  {...rest}
+  series={bar_series}
+  {orientation}
+  mode="overlay"
+  x_axis={x_axis_config}
+  y_axis={y_axis_config}
+  show_legend={false}
+  show_controls={false}
+  {tooltip}
+  {user_content}
+/>

--- a/src/lib/plot/SpacegroupBarPlot.svelte
+++ b/src/lib/plot/SpacegroupBarPlot.svelte
@@ -111,23 +111,16 @@
     }
 
     // Convert to BarSeries array, maintaining order of crystal systems
-    return CRYSTAL_SYSTEMS.map((system) => ({
-      system,
-      data: series_by_system.get(system),
-    }))
-      .filter((
-        entry,
-      ): entry is { system: CrystalSystem; data: { x: number[]; y: number[] } } =>
-        entry.data !== undefined
-      )
-      .map(({ system, data }) => ({
-        x: data.x,
-        y: data.y,
-        color: CRYSTAL_SYSTEM_COLORS[system],
-        label: system,
-        bar_width: 0.9,
-        visible: true,
-      }))
+    const result: BarSeries[] = []
+    for (const system of CRYSTAL_SYSTEMS) {
+      const data = series_by_system.get(system)
+      if (data) {
+        const { x, y } = data
+        const color = CRYSTAL_SYSTEM_COLORS[system]
+        result.push({ x, y, color, label: system, bar_width: 0.9, visible: true })
+      }
+    }
+    return result
   })
 
   // Always show full space group range (1-230)

--- a/src/lib/plot/index.ts
+++ b/src/lib/plot/index.ts
@@ -25,6 +25,7 @@ export * from './scales'
 export { default as ScatterPlot } from './ScatterPlot.svelte'
 export { default as ScatterPlotControls } from './ScatterPlotControls.svelte'
 export { default as ScatterPoint } from './ScatterPoint.svelte'
+export { default as SpacegroupBarPlot } from './SpacegroupBarPlot.svelte'
 export * from './types'
 
 export const line_types = [`solid`, `dashed`, `dotted`] as const

--- a/src/lib/plot/scales.ts
+++ b/src/lib/plot/scales.ts
@@ -172,7 +172,7 @@ export function get_nice_data_range(
     : scaleLinear().domain([data_min, data_max])
 
   scale.nice()
-  return scale.domain()
+  return scale.domain() as [number, number]
 }
 
 // Generate logarithmic ticks (from ScatterPlot)

--- a/src/lib/symmetry/index.ts
+++ b/src/lib/symmetry/index.ts
@@ -5,6 +5,7 @@ import type { MoyoCell, MoyoDataset } from '@spglib/moyo-wasm'
 import init, { analyze_cell } from '@spglib/moyo-wasm'
 import moyo_wasm_url from '@spglib/moyo-wasm/moyo_wasm_bg.wasm?url'
 
+export * from './spacegroups'
 export { default as WyckoffTable } from './WyckoffTable.svelte'
 
 export type WyckoffPos = {

--- a/src/lib/symmetry/spacegroups.ts
+++ b/src/lib/symmetry/spacegroups.ts
@@ -1,14 +1,5 @@
 // Space group to crystal system mappings and utilities
 
-export type CrystalSystem =
-  | `triclinic`
-  | `monoclinic`
-  | `orthorhombic`
-  | `tetragonal`
-  | `trigonal`
-  | `hexagonal`
-  | `cubic`
-
 // Crystal system ranges: [min, max] space group numbers (inclusive)
 export const CRYSTAL_SYSTEM_RANGES: Record<CrystalSystem, [number, number]> = {
   triclinic: [1, 2],
@@ -29,10 +20,10 @@ export const CRYSTAL_SYSTEM_COLORS: Record<CrystalSystem, string> = {
   trigonal: `orange`,
   hexagonal: `purple`,
   cubic: `darkred`,
-}
+} as const
 
 // Ordered list of crystal systems (by space group number range)
-export const CRYSTAL_SYSTEMS: CrystalSystem[] = [
+export const CRYSTAL_SYSTEMS = [
   `triclinic`,
   `monoclinic`,
   `orthorhombic`,
@@ -40,7 +31,8 @@ export const CRYSTAL_SYSTEMS: CrystalSystem[] = [
   `trigonal`,
   `hexagonal`,
   `cubic`,
-]
+] as const
+export type CrystalSystem = (typeof CRYSTAL_SYSTEMS)[number]
 
 // Convert space group number to crystal system
 export function spacegroup_number_to_crystal_system(
@@ -54,48 +46,77 @@ export function spacegroup_number_to_crystal_system(
   return null
 }
 
-// Basic mapping of common Hermann-Mauguin symbols to space group numbers
-// This is a subset - full mapping would be much larger
-export const SPACEGROUP_SYMBOL_TO_NUMBER: Record<string, number> = {
+// Convert space group (number or symbol) to crystal system
+export function spacegroup_to_crystal_system(
+  spacegroup: number | string,
+): CrystalSystem | null {
+  if (typeof spacegroup === `number`) {
+    return spacegroup_number_to_crystal_system(spacegroup)
+  }
+
+  // Try to parse as symbol
+  const number = SPACEGROUP_SYMBOL_TO_NUM[spacegroup]
+  if (number !== undefined) {
+    return spacegroup_number_to_crystal_system(number)
+  }
+
+  // Try to parse string as number
+  const parsed = parseInt(spacegroup, 10)
+  if (!isNaN(parsed)) {
+    return spacegroup_number_to_crystal_system(parsed)
+  }
+
+  return null
+}
+
+// Normalize space group input to number
+export function normalize_spacegroup(spacegroup: number | string) {
+  if (typeof spacegroup === `number`) {
+    return spacegroup >= 1 && spacegroup <= 230 ? spacegroup : null
+  }
+  return SPACEGROUP_SYMBOL_TO_NUM[spacegroup] ?? null
+}
+
+export const SPACEGROUP_SYMBOL_TO_NUM: Record<string, number> = {
   // Triclinic
   'P1': 1,
   'P-1': 2,
   // Monoclinic
   'P2': 3,
-  'P21': 4,
+  'P2_1': 4,
   'C2': 5,
   'Pm': 6,
   'Pc': 7,
   'Cm': 8,
   'Cc': 9,
   'P2/m': 10,
-  'P21/m': 11,
+  'P2_1/m': 11,
   'C2/m': 12,
   'P2/c': 13,
-  'P21/c': 14,
+  'P2_1/c': 14,
   'C2/c': 15,
-  // Orthorhombic (common ones)
+  // Orthorhombic
   'P222': 16,
-  'P2221': 17,
-  'P21212': 18,
-  'P212121': 19,
-  'C2221': 20,
+  'P222_1': 17,
+  'P2_12_12': 18,
+  'P2_12_12_1': 19,
+  'C222_1': 20,
   'C222': 21,
   'F222': 22,
   'I222': 23,
-  'I212121': 24,
+  'I2_12_12_1': 24,
   'Pmm2': 25,
-  'Pmc21': 26,
+  'Pmc2_1': 26,
   'Pcc2': 27,
   'Pma2': 28,
-  'Pca21': 29,
+  'Pca2_1': 29,
   'Pnc2': 30,
-  'Pmn21': 31,
+  'Pmn2_1': 31,
   'Pba2': 32,
-  'Pna21': 33,
+  'Pna2_1': 33,
   'Pnn2': 34,
   'Cmm2': 35,
-  'Cmc21': 36,
+  'Cmc2_1': 36,
   'Ccc2': 37,
   'Amm2': 38,
   'Aem2': 39,
@@ -134,44 +155,135 @@ export const SPACEGROUP_SYMBOL_TO_NUMBER: Record<string, number> = {
   'Ibam': 72,
   'Ibca': 73,
   'Imma': 74,
-  // Tetragonal (common ones)
+  // Tetragonal
   'P4': 75,
-  'P41': 76,
-  'P42': 77,
-  'P43': 78,
+  'P4_1': 76,
+  'P4_2': 77,
+  'P4_3': 78,
   'I4': 79,
-  'I41': 80,
+  'I4_1': 80,
   'P-4': 81,
   'I-4': 82,
   'P4/m': 83,
-  'P42/m': 84,
+  'P4_2/m': 84,
   'P4/n': 85,
-  'P42/n': 86,
+  'P4_2/n': 86,
   'I4/m': 87,
-  'I41/a': 88,
-  // Trigonal (common ones)
+  'I4_1/a': 88,
+  'P422': 89,
+  'P42_12': 90,
+  'P4_122': 91,
+  'P4_12_12': 92,
+  'P4_222': 93,
+  'P4_22_12': 94,
+  'P4_322': 95,
+  'P4_32_12': 96,
+  'I422': 97,
+  'I4_122': 98,
+  'P4mm': 99,
+  'P4bm': 100,
+  'P4_2cm': 101,
+  'P4_2nm': 102,
+  'P4cc': 103,
+  'P4nc': 104,
+  'P4_2mc': 105,
+  'P4_2bc': 106,
+  'I4mm': 107,
+  'I4cm': 108,
+  'I4_1md': 109,
+  'I4_1cd': 110,
+  'P-42m': 111,
+  'P-42c': 112,
+  'P-42_1m': 113,
+  'P-42_1c': 114,
+  'P-4m2': 115,
+  'P-4c2': 116,
+  'P-4b2': 117,
+  'P-4n2': 118,
+  'I-4m2': 119,
+  'I-4c2': 120,
+  'I-42m': 121,
+  'I-42d': 122,
+  'P4/mmm': 123,
+  'P4/mcc': 124,
+  'P4/nbm': 125,
+  'P4/nnc': 126,
+  'P4/mbm': 127,
+  'P4/mnc': 128,
+  'P4/nmm': 129,
+  'P4/ncc': 130,
+  'P4_2/mmc': 131,
+  'P4_2/mcm': 132,
+  'P4_2/nbc': 133,
+  'P4_2/nnm': 134,
+  'P4_2/mbc': 135,
+  'P4_2/mnm': 136,
+  'P4_2/nmc': 137,
+  'P4_2/ncm': 138,
+  'I4/mmm': 139,
+  'I4/mcm': 140,
+  'I4_1/amd': 141,
+  'I4_1/acd': 142,
   'P3': 143,
-  'P31': 144,
-  'P32': 145,
+  'P3_1': 144,
+  'P3_2': 145,
   'R3': 146,
   'P-3': 147,
   'R-3': 148,
-  // Hexagonal (common ones)
+  // Trigonal
+  'P312': 149,
+  'P321': 150,
+  'P3_112': 151,
+  'P3_121': 152,
+  'P3_212': 153,
+  'P3_221': 154,
+  'R32': 155,
+  'P3m1': 156,
+  'P31m': 157,
+  'P3c1': 158,
+  'P31c': 159,
+  'R3m': 160,
+  'R3c': 161,
+  'P-31m': 162,
+  'P-31c': 163,
+  'P-3m1': 164,
+  'P-3c1': 165,
+  'R-3m': 166,
+  'R-3c': 167,
+  // Hexagonal
   'P6': 168,
-  'P61': 169,
-  'P65': 170,
-  'P62': 171,
-  'P64': 172,
-  'P63': 173,
+  'P6_1': 169,
+  'P6_5': 170,
+  'P6_2': 171,
+  'P6_4': 172,
+  'P6_3': 173,
   'P-6': 174,
   'P6/m': 175,
-  'P63/m': 176,
-  // Cubic (common ones)
+  'P6_3/m': 176,
+  'P622': 177,
+  'P6_122': 178,
+  'P6_522': 179,
+  'P6_222': 180,
+  'P6_422': 181,
+  'P6_322': 182,
+  'P6mm': 183,
+  'P6cc': 184,
+  'P6_3cm': 185,
+  'P6_3mc': 186,
+  'P-6m2': 187,
+  'P-6c2': 188,
+  'P-62m': 189,
+  'P-62c': 190,
+  'P6/mmm': 191,
+  'P6/mcc': 192,
+  'P6_3/mcm': 193,
+  'P6_3/mmc': 194,
+  // Cubic
   'P23': 195,
   'F23': 196,
   'I23': 197,
-  'P213': 198,
-  'I213': 199,
+  'P2_13': 198,
+  'I2_13': 199,
   'Pm-3': 200,
   'Pn-3': 201,
   'Fm-3': 202,
@@ -180,13 +292,13 @@ export const SPACEGROUP_SYMBOL_TO_NUMBER: Record<string, number> = {
   'Pa-3': 205,
   'Ia-3': 206,
   'P432': 207,
-  'P4232': 208,
+  'P4_232': 208,
   'F432': 209,
-  'F4132': 210,
+  'F4_132': 210,
   'I432': 211,
-  'P4332': 212,
-  'P4132': 213,
-  'I4132': 214,
+  'P4_332': 212,
+  'P4_132': 213,
+  'I4_132': 214,
   'P-43m': 215,
   'F-43m': 216,
   'I-43m': 217,
@@ -203,47 +315,100 @@ export const SPACEGROUP_SYMBOL_TO_NUMBER: Record<string, number> = {
   'Fd-3c': 228,
   'Im-3m': 229,
   'Ia-3d': 230,
-}
+  // Special cases
+  'P121': 3,
+  'P12_11': 4,
+  'C121': 5,
+  'P1m1': 6,
+  'P1c1': 7,
+  'C1m1': 8,
+  'C1c1': 9,
+  'P12/m1': 10,
+  'P12_1/m1': 11,
+  'C12/m1': 12,
+  'P12/c1': 13,
+  'P12_1/c1': 14,
+  'C12/c1': 15,
+  'P2/m2/m2/m': 47,
+  'P2/n2/n2/n': 48,
+  'P2/c2/c2/m': 49,
+  'P2/b2/a2/n': 50,
+  'P2_1/m2/m2/a': 51,
+  'P2/n2_1/n2/a': 52,
+  'P2/m2/n2_1/a': 53,
+  'P2_1/c2/c2/a': 54,
+  'P2_1/b2_1/a2/m': 55,
+  'P2_1/c2_1/c2/n': 56,
+  'P2/b2_1/c2_1/m': 57,
+  'P2_1/n2_1/n2/m': 58,
+  'P2_1/m2_1/m2/n': 59,
+  'P2_1/b2/c2_1/n': 60,
+  'P2_1/b2_1/c2_1/a': 61,
+  'P2_1/n2_1/m2_1/a': 62,
+  'C2/m2/c2_1/m': 63,
+  'C2/m2/c2_1/e': 64,
+  'C2/m2/m2/m': 65,
+  'C2/c2/c2/m': 66,
+  'C2/m2/m2/e': 67,
+  'C2/c2/c2/e': 68,
+  'F2/m2/m2/m': 69,
+  'F2/d2/d2/d': 70,
+  'I2/m2/m2/m': 71,
+  'I2/b2/a2/m': 72,
+  'I2/b2/c2/a': 73,
+  'I2/m2/m2/a': 74,
+  'P4/m2/m2/m': 123,
+  'P4/m2/c2/c': 124,
+  'P4/n2/b2/m': 125,
+  'P4/n2/n2/c': 126,
+  'P4/m2_1/bm': 127,
+  'P4/m2_1/nc': 128,
+  'P4/n2_1/mm': 129,
+  'P4/n2_1/cc': 130,
+  'P4_2/m2/m2/c': 131,
+  'P4_2/m2/c2/m': 132,
+  'P4_2/n2/b2/c': 133,
+  'P4_2/n2/n2/m': 134,
+  'P4_2/m2_1/b2/c': 135,
+  'P4_2/m2_1/n2/m': 136,
+  'P4_2/n2_1/m2/c': 137,
+  'P4_2/n2_1/c2/m': 138,
+  'I4/m2/m2/m': 139,
+  'I4/m2/c2/m': 140,
+  'I4_1/a2/m2/d': 141,
+  'I4_1/a2/c2/d': 142,
+  'P-312/m': 162,
+  'P-312/c': 163,
+  'P-32/m1': 164,
+  'P-32/c1': 165,
+  'R-32/m': 166,
+  'R-32/c': 167,
+  'P6/m2/m2/m': 191,
+  'P6/m2/c2/c': 192,
+  'P6_3/m2/c2/m': 193,
+  'P6_3/m2/m2/c': 194,
+  'P2/m-3': 200,
+  'P2/n-3': 201,
+  'F2/m-3': 202,
+  'F2/d-3': 203,
+  'I2/m-3': 204,
+  'P2_1/a-3': 205,
+  'I2_1/a-3': 206,
+  'P4/m-32/m': 221,
+  'P4/n-32/n': 222,
+  'P4_2/m-32/n': 223,
+  'P4_2/n-32/m': 224,
+  'F4/m-32/m': 225,
+  'F4/m-32/c': 226,
+  'F4_1/d-32/m': 227,
+  'F4_1/d-32/c': 228,
+  'I4/m-32/m': 229,
+  'I4_1/a-32/d': 230,
+} as const
 
-// Convert space group (number or symbol) to crystal system
-export function spacegroup_to_crystal_system(
-  spacegroup: number | string,
-): CrystalSystem | null {
-  if (typeof spacegroup === `number`) {
-    return spacegroup_number_to_crystal_system(spacegroup)
-  }
-
-  // Try to parse as symbol
-  const number = SPACEGROUP_SYMBOL_TO_NUMBER[spacegroup]
-  if (number !== undefined) {
-    return spacegroup_number_to_crystal_system(number)
-  }
-
-  // Try to parse string as number
-  const parsed = parseInt(spacegroup, 10)
-  if (!isNaN(parsed)) {
-    return spacegroup_number_to_crystal_system(parsed)
-  }
-
-  return null
-}
-
-// Convert space group symbol to number
-export function spacegroup_symbol_to_number(symbol: string): number | null {
-  const number = SPACEGROUP_SYMBOL_TO_NUMBER[symbol]
-  if (number !== undefined) return number
-
-  // Try to parse as number
-  const parsed = parseInt(symbol, 10)
-  if (!isNaN(parsed) && parsed >= 1 && parsed <= 230) return parsed
-
-  return null
-}
-
-// Normalize space group input to number
-export function normalize_spacegroup(spacegroup: number | string): number | null {
-  if (typeof spacegroup === `number`) {
-    return spacegroup >= 1 && spacegroup <= 230 ? spacegroup : null
-  }
-  return spacegroup_symbol_to_number(spacegroup)
-}
+export const SPACEGROUP_NUM_TO_SYMBOL = Object.entries(
+  SPACEGROUP_SYMBOL_TO_NUM,
+).reduce((acc, [symbol, num]) => {
+  if (!acc[num]) acc[num] = symbol
+  return acc
+}, {} as Record<number, string>)

--- a/src/lib/symmetry/spacegroups.ts
+++ b/src/lib/symmetry/spacegroups.ts
@@ -1,0 +1,249 @@
+// Space group to crystal system mappings and utilities
+
+export type CrystalSystem =
+  | `triclinic`
+  | `monoclinic`
+  | `orthorhombic`
+  | `tetragonal`
+  | `trigonal`
+  | `hexagonal`
+  | `cubic`
+
+// Crystal system ranges: [min, max] space group numbers (inclusive)
+export const CRYSTAL_SYSTEM_RANGES: Record<CrystalSystem, [number, number]> = {
+  triclinic: [1, 2],
+  monoclinic: [3, 15],
+  orthorhombic: [16, 74],
+  tetragonal: [75, 142],
+  trigonal: [143, 167],
+  hexagonal: [168, 194],
+  cubic: [195, 230],
+}
+
+// Colors matching pymatviz's spacegroup_bar
+export const CRYSTAL_SYSTEM_COLORS: Record<CrystalSystem, string> = {
+  triclinic: `red`,
+  monoclinic: `teal`,
+  orthorhombic: `blue`,
+  tetragonal: `green`,
+  trigonal: `orange`,
+  hexagonal: `purple`,
+  cubic: `darkred`,
+}
+
+// Ordered list of crystal systems (by space group number range)
+export const CRYSTAL_SYSTEMS: CrystalSystem[] = [
+  `triclinic`,
+  `monoclinic`,
+  `orthorhombic`,
+  `tetragonal`,
+  `trigonal`,
+  `hexagonal`,
+  `cubic`,
+]
+
+// Convert space group number to crystal system
+export function spacegroup_number_to_crystal_system(
+  spacegroup: number,
+): CrystalSystem | null {
+  for (const [system, [min, max]] of Object.entries(CRYSTAL_SYSTEM_RANGES)) {
+    if (spacegroup >= min && spacegroup <= max) {
+      return system as CrystalSystem
+    }
+  }
+  return null
+}
+
+// Basic mapping of common Hermann-Mauguin symbols to space group numbers
+// This is a subset - full mapping would be much larger
+export const SPACEGROUP_SYMBOL_TO_NUMBER: Record<string, number> = {
+  // Triclinic
+  'P1': 1,
+  'P-1': 2,
+  // Monoclinic
+  'P2': 3,
+  'P21': 4,
+  'C2': 5,
+  'Pm': 6,
+  'Pc': 7,
+  'Cm': 8,
+  'Cc': 9,
+  'P2/m': 10,
+  'P21/m': 11,
+  'C2/m': 12,
+  'P2/c': 13,
+  'P21/c': 14,
+  'C2/c': 15,
+  // Orthorhombic (common ones)
+  'P222': 16,
+  'P2221': 17,
+  'P21212': 18,
+  'P212121': 19,
+  'C2221': 20,
+  'C222': 21,
+  'F222': 22,
+  'I222': 23,
+  'I212121': 24,
+  'Pmm2': 25,
+  'Pmc21': 26,
+  'Pcc2': 27,
+  'Pma2': 28,
+  'Pca21': 29,
+  'Pnc2': 30,
+  'Pmn21': 31,
+  'Pba2': 32,
+  'Pna21': 33,
+  'Pnn2': 34,
+  'Cmm2': 35,
+  'Cmc21': 36,
+  'Ccc2': 37,
+  'Amm2': 38,
+  'Aem2': 39,
+  'Ama2': 40,
+  'Aea2': 41,
+  'Fmm2': 42,
+  'Fdd2': 43,
+  'Imm2': 44,
+  'Iba2': 45,
+  'Ima2': 46,
+  'Pmmm': 47,
+  'Pnnn': 48,
+  'Pccm': 49,
+  'Pban': 50,
+  'Pmma': 51,
+  'Pnna': 52,
+  'Pmna': 53,
+  'Pcca': 54,
+  'Pbam': 55,
+  'Pccn': 56,
+  'Pbcm': 57,
+  'Pnnm': 58,
+  'Pmmn': 59,
+  'Pbcn': 60,
+  'Pbca': 61,
+  'Pnma': 62,
+  'Cmcm': 63,
+  'Cmce': 64,
+  'Cmmm': 65,
+  'Cccm': 66,
+  'Cmme': 67,
+  'Ccce': 68,
+  'Fmmm': 69,
+  'Fddd': 70,
+  'Immm': 71,
+  'Ibam': 72,
+  'Ibca': 73,
+  'Imma': 74,
+  // Tetragonal (common ones)
+  'P4': 75,
+  'P41': 76,
+  'P42': 77,
+  'P43': 78,
+  'I4': 79,
+  'I41': 80,
+  'P-4': 81,
+  'I-4': 82,
+  'P4/m': 83,
+  'P42/m': 84,
+  'P4/n': 85,
+  'P42/n': 86,
+  'I4/m': 87,
+  'I41/a': 88,
+  // Trigonal (common ones)
+  'P3': 143,
+  'P31': 144,
+  'P32': 145,
+  'R3': 146,
+  'P-3': 147,
+  'R-3': 148,
+  // Hexagonal (common ones)
+  'P6': 168,
+  'P61': 169,
+  'P65': 170,
+  'P62': 171,
+  'P64': 172,
+  'P63': 173,
+  'P-6': 174,
+  'P6/m': 175,
+  'P63/m': 176,
+  // Cubic (common ones)
+  'P23': 195,
+  'F23': 196,
+  'I23': 197,
+  'P213': 198,
+  'I213': 199,
+  'Pm-3': 200,
+  'Pn-3': 201,
+  'Fm-3': 202,
+  'Fd-3': 203,
+  'Im-3': 204,
+  'Pa-3': 205,
+  'Ia-3': 206,
+  'P432': 207,
+  'P4232': 208,
+  'F432': 209,
+  'F4132': 210,
+  'I432': 211,
+  'P4332': 212,
+  'P4132': 213,
+  'I4132': 214,
+  'P-43m': 215,
+  'F-43m': 216,
+  'I-43m': 217,
+  'P-43n': 218,
+  'F-43c': 219,
+  'I-43d': 220,
+  'Pm-3m': 221,
+  'Pn-3n': 222,
+  'Pm-3n': 223,
+  'Pn-3m': 224,
+  'Fm-3m': 225,
+  'Fm-3c': 226,
+  'Fd-3m': 227,
+  'Fd-3c': 228,
+  'Im-3m': 229,
+  'Ia-3d': 230,
+}
+
+// Convert space group (number or symbol) to crystal system
+export function spacegroup_to_crystal_system(
+  spacegroup: number | string,
+): CrystalSystem | null {
+  if (typeof spacegroup === `number`) {
+    return spacegroup_number_to_crystal_system(spacegroup)
+  }
+
+  // Try to parse as symbol
+  const number = SPACEGROUP_SYMBOL_TO_NUMBER[spacegroup]
+  if (number !== undefined) {
+    return spacegroup_number_to_crystal_system(number)
+  }
+
+  // Try to parse string as number
+  const parsed = parseInt(spacegroup, 10)
+  if (!isNaN(parsed)) {
+    return spacegroup_number_to_crystal_system(parsed)
+  }
+
+  return null
+}
+
+// Convert space group symbol to number
+export function spacegroup_symbol_to_number(symbol: string): number | null {
+  const number = SPACEGROUP_SYMBOL_TO_NUMBER[symbol]
+  if (number !== undefined) return number
+
+  // Try to parse as number
+  const parsed = parseInt(symbol, 10)
+  if (!isNaN(parsed) && parsed >= 1 && parsed <= 230) return parsed
+
+  return null
+}
+
+// Normalize space group input to number
+export function normalize_spacegroup(spacegroup: number | string): number | null {
+  if (typeof spacegroup === `number`) {
+    return spacegroup >= 1 && spacegroup <= 230 ? spacegroup : null
+  }
+  return spacegroup_symbol_to_number(spacegroup)
+}

--- a/src/routes/(demos)/plot/spacegroup-bar-plot/+page.md
+++ b/src/routes/(demos)/plot/spacegroup-bar-plot/+page.md
@@ -1,0 +1,223 @@
+# Spacegroup Bar Plot
+
+Visualize the distribution of crystallographic space groups across materials datasets with automatic crystal system coloring and annotations.
+
+## Basic Spacegroup Distribution
+
+Pass an array of space group numbers (1-230) to visualize their distribution. The plot automatically colors bars by crystal system and adds region annotations:
+
+```svelte example
+<script>
+  import { SpacegroupBarPlot } from 'matterviz'
+
+  // Sample data: space group numbers from a materials database
+  // deno-fmt-ignore
+  const spacegroups = [
+    225, 225, 225, 227, 229, 221, 225, 227, // Cubic (195-230)
+    194, 194, 191, 186, 194, 187, 194, // Hexagonal (168-194)
+    166, 160, 148, 167, 148, 166, 160, 148, // Trigonal (143-167)
+    123, 129, 139, 123, 129, 123, 139, 123, // Tetragonal (75-142)
+    62, 63, 61, 62, 61, 59, 62, 63, 61, 62, // Orthorhombic (16-74)
+    15, 14, 12, 14, 15, 14, 12, 14, // Monoclinic (3-15)
+    2, 1, 2, 1, 2, // Triclinic (1-2)
+  ]
+</script>
+
+<SpacegroupBarPlot data={spacegroups} style="height: 450px" />
+```
+
+## Space Group Symbols
+
+The component also accepts space group symbols (Hermann-Mauguin notation):
+
+```svelte example
+<script>
+  import { SpacegroupBarPlot } from 'matterviz'
+
+  // deno-fmt-ignore
+  const spacegroups_symbols = [
+    'Fm-3m', 'Fm-3m', 'Fd-3m', 'Im-3m', 'Fm-3m', // Cubic
+    'P63/mmc', 'P63/mmc', 'P63mc', 'P6/mmm', // Hexagonal
+    'R-3m', 'R-3c', 'R-3m', 'R-3', // Trigonal
+    'I4/mmm', 'P4/mmm', 'I4/mmm', 'P4/nmm', // Tetragonal
+    'Pnma', 'Cmcm', 'Pbca', 'Pnma', 'Pnma', 'Cmcm', // Orthorhombic
+    'C2/c', 'P21/c', 'C2/m', 'P21/c', 'C2/c', // Monoclinic
+    'P-1', 'P1', 'P-1', // Triclinic
+  ]
+</script>
+
+<SpacegroupBarPlot data={spacegroups_symbols} style="height: 450px" />
+```
+
+## Hide Count Annotations
+
+Toggle the count/percentage annotations at the top of each crystal system region:
+
+```svelte example
+<script>
+  import { SpacegroupBarPlot } from 'matterviz'
+
+  // deno-fmt-ignore
+  const perovskites = [
+    221, 221, 221, 221, 221, 221, 221, 221, // Pm-3m (cubic)
+    140, 140, 140, 140, 140, // I4/mcm (tetragonal)
+    62, 62, 62, 62, 62, 62, 62, 62, 62, 62, // Pnma (orthorhombic)
+    167, 167, 167, // R-3c (trigonal)
+  ]
+
+  let show_counts = $state(true)
+</script>
+
+<label style="margin-bottom: 1em; display: block">
+  <input type="checkbox" bind:checked={show_counts} />
+  Show count annotations
+</label>
+
+<SpacegroupBarPlot data={perovskites} {show_counts} style="height: 400px" />
+```
+
+## Horizontal Orientation
+
+Like all bar plots, spacegroup distributions can be displayed horizontally:
+
+```svelte example
+<script>
+  import { SpacegroupBarPlot } from 'matterviz'
+
+  // deno-fmt-ignore
+  const high_symmetry = [
+    225, 225, 225, 225, 225, 225, 225, 225, 225, 225, // Fm-3m
+    229, 229, 229, 229, 229, 229, // Im-3m
+    227, 227, 227, 227, 227, // Fd-3m
+    221, 221, 221, 221, 221, 221, 221, 221, // Pm-3m
+    194, 194, 194, 194, 194, 194, // P63/mmc
+    166, 166, 166, 166, 166, // R-3m
+    139, 139, 139, 139, // I4/mmm
+    62, 62, 62, 62, 62, 62, 62, 62, // Pnma
+  ]
+
+  let orientation = $state('vertical')
+  let plot_style = $derived(
+    orientation === 'horizontal' ? `height: 700px` : `height: 450px`,
+  )
+</script>
+
+<div style="margin-bottom: 1em; display: flex; gap: 1em">
+  <label><input type="radio" bind:group={orientation} value="vertical" /> Vertical</label>
+  <label><input type="radio" bind:group={orientation} value="horizontal" />
+    Horizontal</label>
+</div>
+
+<SpacegroupBarPlot
+  data={high_symmetry}
+  {orientation}
+  style={plot_style}
+/>
+```
+
+## Real-World Example: Materials Project Data
+
+Visualize space group distributions from actual materials databases:
+
+```svelte example
+<script>
+  import { SpacegroupBarPlot } from 'matterviz'
+
+  // Simulated distribution resembling Materials Project statistics
+  // Based on typical prevalence: more orthorhombic and monoclinic, fewer triclinic
+  const generate_distribution = () => {
+    const data = []
+
+    // Triclinic (1-2): ~1-2% of materials
+    for (let idx = 0; idx < 8; idx++) data.push(Math.random() < 0.7 ? 2 : 1)
+
+    // Monoclinic (3-15): ~20-25% of materials, especially 14 and 15
+    for (let idx = 0; idx < 100; idx++) {
+      const sg = Math.random() < 0.6
+        ? (Math.random() < 0.5 ? 14 : 15)
+        : Math.floor(Math.random() * 13) + 3
+      data.push(sg)
+    }
+
+    // Orthorhombic (16-74): ~30-35% of materials, especially 62, 63
+    for (let idx = 0; idx < 140; idx++) {
+      const sg = Math.random() < 0.5
+        ? (Math.random() < 0.5 ? 62 : 63)
+        : Math.floor(Math.random() * 59) + 16
+      data.push(sg)
+    }
+
+    // Tetragonal (75-142): ~10-15% of materials
+    for (let idx = 0; idx < 50; idx++) {
+      data.push(Math.floor(Math.random() * 68) + 75)
+    }
+
+    // Trigonal (143-167): ~5-8% of materials, R-3 family common
+    for (let idx = 0; idx < 30; idx++) {
+      const sg = Math.random() < 0.4
+        ? (Math.random() < 0.5 ? 148 : 166)
+        : Math.floor(Math.random() * 25) + 143
+      data.push(sg)
+    }
+
+    // Hexagonal (168-194): ~5-8% of materials, P63/mmc common
+    for (let idx = 0; idx < 28; idx++) {
+      const sg = Math.random() < 0.4 ? 194 : Math.floor(Math.random() * 27) + 168
+      data.push(sg)
+    }
+
+    // Cubic (195-230): ~15-20% of materials, Fm-3m very common
+    for (let idx = 0; idx < 70; idx++) {
+      const sg = Math.random() < 0.4
+        ? 225
+        : (Math.random() < 0.3 ? 229 : Math.floor(Math.random() * 36) + 195)
+      data.push(sg)
+    }
+
+    return data
+  }
+
+  const materials_db = generate_distribution()
+</script>
+
+<div
+  style="margin-bottom: 1em; padding: 8pt; background: rgba(255, 255, 255, 0.05); border-radius: 4px; font-size: 0.9em"
+>
+  <strong>Dataset:</strong> {materials_db.length} materials with distribution resembling
+  real materials databases. Notice how certain space groups like 225 (Fm-3m), 62 (Pnma),
+  and 14/15 (monoclinic) are much more common.
+</div>
+
+<SpacegroupBarPlot data={materials_db} style="height: 500px" />
+```
+
+## Interactive Tooltips
+
+Hover over bars to see detailed information about each space group:
+
+```svelte example
+<script>
+  import { SpacegroupBarPlot } from 'matterviz'
+
+  // deno-fmt-ignore
+  const diverse_materials = [
+    221, 221, 221, // Cubic perovskites
+    225, 225, 225, 225, 225, 229, 229, 229, // Cubic metals
+    194, 194, 194, 194, // Hexagonal metals
+    167, 167, 166, // Trigonal
+    139, 129, 123, 123, // Tetragonal
+    62, 62, 62, 62, 62, 62, 59, 61, 63, // Orthorhombic
+    15, 15, 15, 14, 14, 14, 14, 12, 11, // Monoclinic
+    2, 2, 1, // Triclinic
+  ]
+</script>
+
+<div
+  style="margin-bottom: 1em; padding: 8pt; background: rgba(255, 255, 255, 0.05); border-radius: 4px"
+>
+  <strong>Tip:</strong> Hover over any bar to see space group number, crystal system, and
+  count. Click and drag to zoom into specific regions. Double-click to reset.
+</div>
+
+<SpacegroupBarPlot data={diverse_materials} style="height: 450px" />
+```

--- a/src/routes/(demos)/plot/spacegroup-bar-plot/+page.md
+++ b/src/routes/(demos)/plot/spacegroup-bar-plot/+page.md
@@ -1,10 +1,10 @@
 # Spacegroup Bar Plot
 
-Visualize the distribution of crystallographic space groups across materials datasets with automatic crystal system coloring and annotations.
+Visualize crystallographic space group distributions with automatic crystal system coloring and annotations.
 
-## Basic Spacegroup Distribution
+## Basic Usage with Interactive Controls
 
-Pass an array of space group numbers (1-230) to visualize their distribution. The plot automatically colors bars by crystal system and adds region annotations:
+Pass space group numbers (1-230) to visualize their distribution with automatic crystal system coloring and region annotations:
 
 ```svelte example
 <script>
@@ -12,18 +12,33 @@ Pass an array of space group numbers (1-230) to visualize their distribution. Th
 
   // Sample data: space group numbers from a materials database
   // deno-fmt-ignore
-  const spacegroups = [
-    225, 225, 225, 227, 229, 221, 225, 227, // Cubic (195-230)
-    194, 194, 191, 186, 194, 187, 194, // Hexagonal (168-194)
-    166, 160, 148, 167, 148, 166, 160, 148, // Trigonal (143-167)
-    123, 129, 139, 123, 129, 123, 139, 123, // Tetragonal (75-142)
-    62, 63, 61, 62, 61, 59, 62, 63, 61, 62, // Orthorhombic (16-74)
-    15, 14, 12, 14, 15, 14, 12, 14, // Monoclinic (3-15)
-    2, 1, 2, 1, 2, // Triclinic (1-2)
+  const diverse_materials = [
+    221, 221, 221, // Cubic perovskites
+    225, 225, 225, 225, 225, 229, 229, 229, // Cubic metals
+    194, 194, 194, 194, // Hexagonal metals
+    167, 167, 166, // Trigonal
+    139, 129, 123, 123, // Tetragonal
+    62, 62, 62, 62, 62, 62, 59, 61, 63, // Orthorhombic
+    15, 15, 15, 14, 14, 14, 14, 12, 11, // Monoclinic
+    2, 2, 1, // Triclinic
   ]
+
+  let show_counts = $state(true)
 </script>
 
-<SpacegroupBarPlot data={spacegroups} style="height: 450px" />
+<div
+  style="margin-bottom: 1em; padding: 8pt; background: rgba(255, 255, 255, 0.05); border-radius: 4px"
+>
+  <strong>Tip:</strong> Hover over any bar to see space group number, crystal system, and
+  count. Click and drag to zoom into specific regions. Double-click to reset.
+</div>
+
+<label style="margin-bottom: 1em; display: block">
+  <input type="checkbox" bind:checked={show_counts} />
+  Show count annotations
+</label>
+
+<SpacegroupBarPlot data={diverse_materials} {show_counts} style="height: 450px" />
 ```
 
 ## Space Group Symbols
@@ -49,36 +64,9 @@ The component also accepts space group symbols (Hermann-Mauguin notation):
 <SpacegroupBarPlot data={spacegroups_symbols} style="height: 450px" />
 ```
 
-## Hide Count Annotations
-
-Toggle the count/percentage annotations at the top of each crystal system region:
-
-```svelte example
-<script>
-  import { SpacegroupBarPlot } from 'matterviz'
-
-  // deno-fmt-ignore
-  const perovskites = [
-    221, 221, 221, 221, 221, 221, 221, 221, // Pm-3m (cubic)
-    140, 140, 140, 140, 140, // I4/mcm (tetragonal)
-    62, 62, 62, 62, 62, 62, 62, 62, 62, 62, // Pnma (orthorhombic)
-    167, 167, 167, // R-3c (trigonal)
-  ]
-
-  let show_counts = $state(true)
-</script>
-
-<label style="margin-bottom: 1em; display: block">
-  <input type="checkbox" bind:checked={show_counts} />
-  Show count annotations
-</label>
-
-<SpacegroupBarPlot data={perovskites} {show_counts} style="height: 400px" />
-```
-
 ## Horizontal Orientation
 
-Like all bar plots, spacegroup distributions can be displayed horizontally:
+Display spacegroup distributions horizontally:
 
 ```svelte example
 <script>
@@ -117,7 +105,7 @@ Like all bar plots, spacegroup distributions can be displayed horizontally:
 
 ## Real-World Example: Materials Project Data
 
-Visualize space group distributions from actual materials databases:
+Simulated space group distributions from Materials Project database:
 
 ```svelte example
 <script>
@@ -189,35 +177,4 @@ Visualize space group distributions from actual materials databases:
 </div>
 
 <SpacegroupBarPlot data={materials_db} style="height: 500px" />
-```
-
-## Interactive Tooltips
-
-Hover over bars to see detailed information about each space group:
-
-```svelte example
-<script>
-  import { SpacegroupBarPlot } from 'matterviz'
-
-  // deno-fmt-ignore
-  const diverse_materials = [
-    221, 221, 221, // Cubic perovskites
-    225, 225, 225, 225, 225, 229, 229, 229, // Cubic metals
-    194, 194, 194, 194, // Hexagonal metals
-    167, 167, 166, // Trigonal
-    139, 129, 123, 123, // Tetragonal
-    62, 62, 62, 62, 62, 62, 59, 61, 63, // Orthorhombic
-    15, 15, 15, 14, 14, 14, 14, 12, 11, // Monoclinic
-    2, 2, 1, // Triclinic
-  ]
-</script>
-
-<div
-  style="margin-bottom: 1em; padding: 8pt; background: rgba(255, 255, 255, 0.05); border-radius: 4px"
->
-  <strong>Tip:</strong> Hover over any bar to see space group number, crystal system, and
-  count. Click and drag to zoom into specific regions. Double-click to reset.
-</div>
-
-<SpacegroupBarPlot data={diverse_materials} style="height: 450px" />
 ```

--- a/src/routes/test/bar-plot/+page.svelte
+++ b/src/routes/test/bar-plot/+page.svelte
@@ -137,9 +137,9 @@
   <h2>Basic</h2>
   <BarPlot
     series={basic_series}
-    x_label="X"
-    y_label="Y"
-    y_range={[0, 50]}
+    x_axis={{ label: `X` }}
+    y_axis={{ label: `Y` }}
+    y_lim={[0, 50]}
     controls_open={false}
     controls_toggle_props={{ class: `bar-controls-toggle` }}
     style="height: 360px"
@@ -150,8 +150,8 @@
   <h2>Legend and Overlay</h2>
   <BarPlot
     series={legend_series}
-    x_label="Category"
-    y_label="Value"
+    x_axis={{ label: `Category` }}
+    y_axis={{ label: `Value` }}
     controls_toggle_props={{ class: `bar-controls-toggle` }}
     style="height: 360px"
   />
@@ -162,8 +162,8 @@
   <div id="overlay">
     <BarPlot
       series={modes_series_overlay}
-      x_label="X"
-      y_label="Y"
+      x_axis={{ label: `X` }}
+      y_axis={{ label: `Y` }}
       mode="overlay"
       controls_toggle_props={{ class: `bar-controls-toggle` }}
       style="height: 300px"
@@ -172,8 +172,8 @@
   <div id="stacked">
     <BarPlot
       series={modes_series_stacked}
-      x_label="X"
-      y_label="Y"
+      x_axis={{ label: `X` }}
+      y_axis={{ label: `Y` }}
       mode="stacked"
       controls_toggle_props={{ class: `bar-controls-toggle` }}
       style="height: 300px"
@@ -182,8 +182,8 @@
   <div id="stacked-mixed">
     <BarPlot
       series={stacked_mixed_series}
-      x_label="X"
-      y_label="Y"
+      x_axis={{ label: `X` }}
+      y_axis={{ label: `Y` }}
       mode="stacked"
       controls_toggle_props={{ class: `bar-controls-toggle` }}
       style="height: 300px"
@@ -192,8 +192,8 @@
   <div id="zero-values">
     <BarPlot
       series={zero_value_series}
-      x_label="X"
-      y_label="Y"
+      x_axis={{ label: `X` }}
+      y_axis={{ label: `Y` }}
       controls_toggle_props={{ class: `bar-controls-toggle` }}
       style="height: 300px"
     />
@@ -201,8 +201,8 @@
   <div id="width-array">
     <BarPlot
       series={width_array_series}
-      x_label="X"
-      y_label="Y"
+      x_axis={{ label: `X` }}
+      y_axis={{ label: `Y` }}
       controls_toggle_props={{ class: `bar-controls-toggle` }}
       style="height: 300px"
     />
@@ -210,8 +210,8 @@
   <div id="stacked-mixed-horizontal">
     <BarPlot
       series={stacked_mixed_series}
-      x_label="Y"
-      y_label="X"
+      x_axis={{ label: `Y` }}
+      y_axis={{ label: `X` }}
       mode="stacked"
       orientation="horizontal"
       controls_toggle_props={{ class: `bar-controls-toggle` }}
@@ -221,8 +221,8 @@
   <div id="horizontal">
     <BarPlot
       series={modes_series_overlay}
-      x_label="Y"
-      y_label="X"
+      x_axis={{ label: `Y` }}
+      y_axis={{ label: `X` }}
       orientation="horizontal"
       controls_toggle_props={{ class: `bar-controls-toggle` }}
       style="height: 300px"
@@ -234,8 +234,8 @@
   <h2>With Handlers</h2>
   <BarPlot
     series={handlers_series}
-    x_label="X"
-    y_label="Y"
+    x_axis={{ label: `X` }}
+    y_axis={{ label: `Y` }}
     on_bar_hover={(data) => {
       if (data) {
         hover_msg = `Hovering: bar ${data.bar_idx + 1} (x=${data.x}, y=${data.y})`

--- a/src/routes/test/histogram/+page.svelte
+++ b/src/routes/test/histogram/+page.svelte
@@ -257,8 +257,8 @@
   series={basic_data}
   bins={bin_count}
   mode="single"
-  x_label="Value"
-  y_label="Frequency"
+  x_axis={{ label: `Value` }}
+  y_axis={{ label: `Frequency` }}
 />
 
 <label>Opacity: <input
@@ -297,8 +297,8 @@
   series={log_data}
   bins={50}
   mode="overlay"
-  x_scale_type={x_scale}
-  y_scale_type={y_scale}
+  x_axis={{ scale_type: x_scale }}
+  y_axis={{ scale_type: y_scale }}
 />
 
 <label>Distribution Type: <select bind:value={distribution_type}>
@@ -348,10 +348,8 @@
   series={tick_test_data}
   bins={30}
   mode="single"
-  x_ticks={x_tick_count}
-  y_ticks={y_tick_count}
-  x_label="Value (Custom X Ticks)"
-  y_label="Count (Custom Y Ticks)"
+  x_axis={{ ticks: x_tick_count, label: `Value (Custom X Ticks)` }}
+  y_axis={{ ticks: y_tick_count, label: `Count (Custom Y Ticks)` }}
 />
 
 <Histogram
@@ -359,10 +357,8 @@
   series={range_test_data}
   bins={30}
   mode="single"
-  x_label="Value (Custom Range)"
-  y_label="Count (Custom Range)"
-  {x_range}
-  {y_range}
+  x_axis={{ label: `Value (Custom Range)`, range: x_range }}
+  y_axis={{ label: `Count (Custom Range)`, range: y_range }}
 />
 
 <Histogram
@@ -370,8 +366,8 @@
   series={zero_lines_data}
   bins={25}
   mode="single"
-  x_label="Value"
-  y_label="Count"
+  x_axis={{ label: `Value` }}
+  y_axis={{ label: `Count` }}
 />
 
 <Histogram
@@ -379,8 +375,8 @@
   series={custom_tooltip_data}
   bins={20}
   mode="single"
-  x_label="Value"
-  y_label="Count"
+  x_axis={{ label: `Value` }}
+  y_axis={{ label: `Count` }}
 >
   {#snippet tooltip(props)}
     <div style="background: #8b5cf6; color: white; padding: 8px; border-radius: 4px">
@@ -397,8 +393,8 @@
   series={zoom_test_data}
   bins={40}
   mode="single"
-  x_label="Value"
-  y_label="Count"
+  x_axis={{ label: `Value` }}
+  y_axis={{ label: `Count` }}
 />
 
 Plot is currently hovered: <strong>{is_plot_hovered}</strong>
@@ -407,8 +403,8 @@ Plot is currently hovered: <strong>{is_plot_hovered}</strong>
   series={hovered_data}
   bins={25}
   mode="single"
-  x_label="Value"
-  y_label="Count"
+  x_axis={{ label: `Value` }}
+  y_axis={{ label: `Count` }}
   bind:hovered={is_plot_hovered}
 />
 
@@ -417,8 +413,8 @@ Plot is currently hovered: <strong>{is_plot_hovered}</strong>
   series={wide_range_data}
   bins={50}
   mode="single"
-  x_label="Value (Wide Range)"
-  y_label="Count"
+  x_axis={{ label: `Value (Wide Range)` }}
+  y_axis={{ label: `Count` }}
 />
 
 <Histogram
@@ -426,7 +422,6 @@ Plot is currently hovered: <strong>{is_plot_hovered}</strong>
   series={small_range_data}
   bins={30}
   mode="single"
-  x_label="Value (Small Range)"
-  y_label="Count"
-  x_format=".6f"
+  x_axis={{ label: `Value (Small Range)`, format: `.6f` }}
+  y_axis={{ label: `Count` }}
 />

--- a/src/routes/test/rdf-plot/+page.svelte
+++ b/src/routes/test/rdf-plot/+page.svelte
@@ -58,8 +58,8 @@
 <RdfPlot
   id="single-pattern"
   patterns={synthetic_pattern}
-  x_label="r (Å)"
-  y_label="g(r)"
+  x_axis={{ label: `r (Å)` }}
+  y_axis={{ label: `g(r)` }}
   cutoff={10}
   n_bins={50}
   style="height: 360px"
@@ -69,8 +69,8 @@
 <RdfPlot
   id="multi-pattern"
   patterns={synthetic_patterns}
-  x_label="r (Å)"
-  y_label="g(r)"
+  x_axis={{ label: `r (Å)` }}
+  y_axis={{ label: `g(r)` }}
   cutoff={10}
   n_bins={50}
   style="height: 360px"

--- a/src/routes/test/scatter-plot/+page.svelte
+++ b/src/routes/test/scatter-plot/+page.svelte
@@ -266,21 +266,22 @@
 
   let enable_auto_placement = $state(true)
 
-  let auto_placement_test_series = $derived.by(() => {
-    return auto_placement_series_data.map((series) => ({
+  let auto_placement_test_series = $derived(
+    auto_placement_series_data.map((series) => ({
       ...series,
-      point_label: (Array.isArray(series.point_label)
-        ? series.point_label
-        : series.point_label
-        ? [series.point_label]
-        : []).map(
-          (lbl): LabelStyle => ({
-            ...(typeof lbl === `object` && lbl !== null ? lbl : {}),
-            auto_placement: enable_auto_placement,
-          }),
-        ),
-    }))
-  })
+      point_label:
+        (Array.isArray(series.point_label)
+          ? series.point_label
+          : series.point_label
+          ? [series.point_label]
+          : []).map(
+            (lbl): LabelStyle => ({
+              ...(typeof lbl === `object` && lbl !== null ? lbl : {}),
+              auto_placement: enable_auto_placement,
+            }),
+          ),
+    })),
+  )
 
   // === Automatic Color Bar Placement Data ===
   let auto_placement_density = $state({

--- a/src/routes/test/scatter-plot/+page.svelte
+++ b/src/routes/test/scatter-plot/+page.svelte
@@ -489,9 +489,9 @@
   <h2>Basic Example</h2>
   <ScatterPlot
     series={[basic_data]}
-    x_label="X Axis"
-    y_label="Y Axis"
-    markers="line+points"
+    x_axis={{ label: `X Axis` }}
+    y_axis={{ label: `Y Axis` }}
+    display={{ markers: `line+points` }}
   />
 </section>
 
@@ -500,23 +500,23 @@
   <h3>Points Only</h3>
   <ScatterPlot
     series={[points_data]}
-    x_label="X Axis"
-    y_label="Y Axis (Points)"
-    markers="points"
+    x_axis={{ label: `X Axis` }}
+    y_axis={{ label: `Y Axis (Points)` }}
+    display={{ markers: `points` }}
   />
   <h3>Line Only</h3>
   <ScatterPlot
     series={[line_data]}
-    x_label="X Axis"
-    y_label="Y Axis (Line)"
-    markers="line"
+    x_axis={{ label: `X Axis` }}
+    y_axis={{ label: `Y Axis (Line)` }}
+    display={{ markers: `line` }}
   />
   <h3>Line + Points</h3>
   <ScatterPlot
     series={[line_points_data]}
-    x_label="X Axis"
-    y_label="Y Axis (Line+Points)"
-    markers="line+points"
+    x_axis={{ label: `X Axis` }}
+    y_axis={{ label: `Y Axis (Line+Points)` }}
+    display={{ markers: `line+points` }}
   />
 </section>
 
@@ -526,21 +526,17 @@
   <h3>Wide Range (-1000 to 1000)</h3>
   <ScatterPlot
     series={[wide_range_data]}
-    x_label="X Axis"
-    y_label="Y Axis"
-    x_lim={[-1100, 1100]}
-    y_lim={[-550, 550]}
-    markers="line+points"
+    x_axis={{ label: `X Axis`, lim: [-1100, 1100] }}
+    y_axis={{ label: `Y Axis`, lim: [-550, 550] }}
+    display={{ markers: `line+points` }}
   />
 
   <h3>Very Small Range</h3>
   <ScatterPlot
     series={[small_range_data]}
-    x_label="X Axis"
-    y_label="Y Axis"
-    x_lim={[0, 0.0006]}
-    y_lim={[0, 0.00006]}
-    markers="line+points"
+    x_axis={{ label: `X Axis`, lim: [0, 0.0006] }}
+    y_axis={{ label: `Y Axis`, lim: [0, 0.00006] }}
+    display={{ markers: `line+points` }}
   />
 </section>
 
@@ -549,23 +545,16 @@
   <h3>Y-Axis Log Scale</h3>
   <ScatterPlot
     series={[log_scale_data]}
-    x_label="X Axis (Linear)"
-    y_label="Y Axis (Log)"
-    x_lim={[-1100, 1100]}
-    y_lim={[1, 6000]}
-    markers="line+points"
-    y_scale_type="log"
+    x_axis={{ label: `X Axis (Linear)`, lim: [-1100, 1100] }}
+    y_axis={{ label: `Y Axis (Log)`, lim: [1, 6000], scale_type: `log` }}
+    display={{ markers: `line+points` }}
   />
   <h3>X-Axis Log Scale</h3>
   <ScatterPlot
     series={[log_scale_data2]}
-    x_label="X Axis (Log)"
-    y_label="Y Axis (Linear)"
-    y_format="~s"
-    x_format="~s"
-    x_lim={[0.01, 1100]}
-    markers="line+points"
-    x_scale_type="log"
+    x_axis={{ label: `X Axis (Log)`, format: `~s`, lim: [0.01, 1100], scale_type: `log` }}
+    y_axis={{ label: `Y Axis (Linear)`, format: `~s` }}
+    display={{ markers: `line+points` }}
   />
 </section>
 
@@ -574,16 +563,16 @@
   <h3>Rainbow Points</h3>
   <ScatterPlot
     series={[rainbow_data]}
-    x_label="X Axis"
-    y_label="Y Axis"
-    markers="points"
+    x_axis={{ label: `X Axis` }}
+    y_axis={{ label: `Y Axis` }}
+    display={{ markers: `points` }}
   />
   <h3>Multiple Series</h3>
   <ScatterPlot
     series={[multi_series_data1, multi_series_data2]}
-    x_label="X Axis"
-    y_label="Y Axis"
-    markers="line+points"
+    x_axis={{ label: `X Axis` }}
+    y_axis={{ label: `Y Axis` }}
+    display={{ markers: `line+points` }}
   />
 </section>
 
@@ -600,9 +589,9 @@
   </div>
   <ScatterPlot
     series={[color_scale_data]}
-    x_label="X Axis"
-    y_label="Y Axis"
-    markers="points"
+    x_axis={{ label: `X Axis` }}
+    y_axis={{ label: `Y Axis` }}
+    display={{ markers: `points` }}
     {color_scale}
     color_bar={{}}
   />
@@ -610,7 +599,7 @@
 
 <section id="custom-tooltip">
   <h2>Custom Tooltip Example</h2>
-  <ScatterPlot series={[custom_tooltip_data]} markers="points">
+  <ScatterPlot series={[custom_tooltip_data]} display={{ markers: `points` }}>
     {#snippet tooltip(props)}
       Point Info: <strong>{props.metadata?.info}</strong><br />
       Coords: ({props.x_formatted}, {props.y_formatted})
@@ -623,7 +612,7 @@
   <p>Plot is currently hovered: <strong id="hover-status">{is_plot_hovered}</strong></p>
   <ScatterPlot
     series={[bind_hovered_data]}
-    markers="points"
+    display={{ markers: `points` }}
     bind:hovered={is_plot_hovered}
   />
 </section>
@@ -640,11 +629,9 @@
   {#key enable_auto_placement}
     <ScatterPlot
       series={auto_placement_test_series}
-      x_label="X"
-      y_label="Y"
-      x_lim={[0, 100]}
-      y_lim={[0, 100]}
-      markers="points"
+      x_axis={{ label: `X`, lim: [0, 100] }}
+      y_axis={{ label: `Y`, lim: [0, 100] }}
+      display={{ markers: `points` }}
       style="height: 450px; width: 100%"
     />
   {/key}
@@ -679,11 +666,9 @@
 
   <ScatterPlot
     series={auto_placement_plot_series}
-    x_label="X Position"
-    y_label="Y Position"
-    x_lim={[0, 100]}
-    y_lim={[0, 100]}
-    markers="points"
+    x_axis={{ label: `X Position`, lim: [0, 100] }}
+    y_axis={{ label: `Y Position`, lim: [0, 100] }}
+    display={{ markers: `points` }}
     color_scale={{ scheme: `Turbo` }}
     color_bar={{ title: `Color Bar Title` }}
   >
@@ -699,28 +684,28 @@
   <h3>Single Series (Default Legend) - No Legend Expected</h3>
   <ScatterPlot
     series={legend_single_series}
-    markers="points"
+    display={{ markers: `points` }}
     id="legend-single-default"
   />
   <h3>Single Series (legend=null) - No Legend Expected</h3>
   <ScatterPlot
     series={legend_single_series}
     legend={null}
-    markers="points"
+    display={{ markers: `points` }}
     id="legend-single-null"
   />
   <h3>Single Series (Configured Legend) - Legend Expected</h3>
   <ScatterPlot
     series={legend_single_series}
     legend={{ layout: `horizontal` }}
-    markers="points"
+    display={{ markers: `points` }}
     id="legend-single-config"
   />
   <h3>Multi Series (Default Legend) - Legend Expected</h3>
   <ScatterPlot
     series={legend_multi_series}
     legend={{ draggable: true }}
-    markers="points"
+    display={{ markers: `points` }}
     id="legend-multi-default"
   />
   <h3>Zero Series - No Legend Expected</h3>
@@ -748,11 +733,13 @@
   </div>
   <ScatterPlot
     series={[lin_log_transition_data]}
-    x_label="X Axis (Linear)"
-    y_label="Y Axis"
-    markers="line+points"
-    y_scale_type={lin_log_y_scale_type}
-    y_lim={lin_log_y_scale_type === `log` ? [math.LOG_EPS, null] : [null, null]}
+    x_axis={{ label: `X Axis (Linear)` }}
+    y_axis={{
+      label: `Y Axis`,
+      scale_type: lin_log_y_scale_type,
+      lim: lin_log_y_scale_type === `log` ? [math.LOG_EPS, null] : [null, null],
+    }}
+    display={{ markers: `line+points` }}
   />
 </section>
 
@@ -792,11 +779,9 @@
 
 <ScatterPlot
   series={[spiral_data]}
-  x_label="X Axis"
-  y_label="Y Axis"
-  x_lim={[-15, 15]}
-  y_lim={[-15, 15]}
-  markers="points"
+  x_axis={{ label: `X Axis`, lim: [-15, 15] }}
+  y_axis={{ label: `Y Axis`, lim: [-15, 15] }}
+  display={{ markers: `points` }}
   {size_scale}
   style="height: 500px; width: 100%"
 >
@@ -816,25 +801,25 @@
   <ScatterPlot
     id="solid-line-plot"
     series={[solid_line_data_1, solid_line_data_2]}
-    x_label="X Axis"
-    y_label="Y Axis"
-    markers="line"
+    x_axis={{ label: `X Axis` }}
+    y_axis={{ label: `Y Axis` }}
+    display={{ markers: `line` }}
   />
   <h3>Dashed Line</h3>
   <ScatterPlot
     id="dashed-line-plot"
     series={[dashed_line_data]}
-    x_label="X Axis"
-    y_label="Y Axis"
-    markers="line"
+    x_axis={{ label: `X Axis` }}
+    y_axis={{ label: `Y Axis` }}
+    display={{ markers: `line` }}
   />
   <h3>Custom Dashed Line</h3>
   <ScatterPlot
     id="custom-dash-plot"
     series={[custom_dash_data]}
-    x_label="X Axis"
-    y_label="Y Axis"
-    markers="line"
+    x_axis={{ label: `X Axis` }}
+    y_axis={{ label: `Y Axis` }}
+    display={{ markers: `line` }}
   />
 </section>
 
@@ -897,8 +882,8 @@
   <ScatterPlot
     id="single-axis-plot"
     series={[basic_data]}
-    x_label="X Axis"
-    y_label="Y Axis"
+    x_axis={{ label: `X Axis` }}
+    y_axis={{ label: `Y Axis` }}
   />
 
   <h3>Dual Axis (With Coloring)</h3>
@@ -916,9 +901,9 @@
         line_style: { stroke: `#5555ff`, stroke_width: 2 },
       },
     ]}
-    x_label="X Axis"
-    y_label="Y1 Axis"
-    y2_label="Y2 Axis"
+    x_axis={{ label: `X Axis` }}
+    y_axis={{ label: `Y1 Axis` }}
+    y2_axis={{ label: `Y2 Axis` }}
   />
 
   <h3>Color Scale (No Axis Coloring)</h3>
@@ -932,9 +917,9 @@
       },
       { ...multi_series_data2, y_axis: `y2` },
     ]}
-    x_label="X Axis"
-    y_label="Y1 Axis"
-    y2_label="Y2 Axis"
+    x_axis={{ label: `X Axis` }}
+    y_axis={{ label: `Y1 Axis` }}
+    y2_axis={{ label: `Y2 Axis` }}
   />
 
   <h3>Custom Axis Colors</h3>
@@ -945,9 +930,9 @@
       { ...multi_series_data2, y_axis: `y2` },
     ]}
     color_axis_labels={{ y1: `#ff0000`, y2: `#00ff00` }}
-    x_label="X Axis"
-    y_label="Y1 Axis (Custom Red)"
-    y2_label="Y2 Axis (Custom Green)"
+    x_axis={{ label: `X Axis` }}
+    y_axis={{ label: `Y1 Axis (Custom Red)` }}
+    y2_axis={{ label: `Y2 Axis (Custom Green)` }}
   />
 
   <h3>Disabled Axis Coloring</h3>
@@ -965,29 +950,57 @@
       },
     ]}
     color_axis_labels={false}
-    x_label="X Axis"
-    y_label="Y1 Axis"
-    y2_label="Y2 Axis"
+    x_axis={{ label: `X Axis` }}
+    y_axis={{ label: `Y1 Axis` }}
+    y2_axis={{ label: `Y2 Axis` }}
   />
 </section>
 
 <!-- Point Event Test -->
-<h2>Point Event Test</h2>
-<p>Clicking a point should update the text below.</p>
-<ScatterPlot
-  id="point-event-test"
-  series={point_event_data}
-  x_label="X"
-  y_label="Y"
-  markers="points"
-  point_events={{
-    onclick: handle_point_click,
-    ondblclick: handle_point_double_click,
-  }}
-/>
-<p data-testid="last-clicked-point">
-  Last Clicked Point: {last_clicked_point_id ?? `none`}
-</p>
-<p data-testid="last-double-clicked-point">
-  Last Double-Clicked Point: {last_double_clicked_point_id ?? `none`}
-</p>
+<section id="point-event-test">
+  <h2>Point Event Test</h2>
+  <p>Clicking a point should update the text below.</p>
+  <ScatterPlot
+    series={point_event_data}
+    x_axis={{ label: `X` }}
+    y_axis={{ label: `Y` }}
+    display={{ markers: `points` }}
+    point_events={{
+      onclick: handle_point_click,
+      ondblclick: handle_point_double_click,
+    }}
+  />
+  <p data-testid="last-clicked-point">
+    Last Clicked Point: {last_clicked_point_id ?? `none`}
+  </p>
+  <p data-testid="last-double-clicked-point">
+    Last Double-Clicked Point: {last_double_clicked_point_id ?? `none`}
+  </p>
+</section>
+
+<!-- Color-mapped Line Legend Test -->
+<section id="color-mapped-line-legend-test">
+  <h2>Color-mapped Line Legend Test</h2>
+  <p>
+    Tests that legend line color reflects the color scale for series with color_values.
+  </p>
+  <ScatterPlot
+    id="color-mapped-line-plot"
+    series={[
+      {
+        x: [1, 2, 3, 4, 5],
+        y: [2, 4, 3, 5, 4],
+        color_values: [1, 2, 3, 4, 5],
+        label: `Color Mapped Line`,
+        point_style: { radius: 5 },
+        markers: `line+points`,
+        // Intentionally no line_style.stroke - should use color scale
+      },
+    ]}
+    x_axis={{ label: `X` }}
+    y_axis={{ label: `Y` }}
+    color_scale={{ scheme: `Viridis` }}
+    color_bar={{ title: `Color Value` }}
+    legend={{ draggable: true }}
+  />
+</section>

--- a/src/routes/test/xrd-plot/+page.svelte
+++ b/src/routes/test/xrd-plot/+page.svelte
@@ -50,8 +50,8 @@
     patterns={single_entries}
     annotate_peaks={3}
     hkl_format="compact"
-    x_label="2θ (degrees)"
-    y_label="Intensity (a.u.)"
+    x_axis={{ label: `2θ (degrees)` }}
+    y_axis={{ label: `Intensity (a.u.)` }}
     style="height: 360px"
   />
 </section>
@@ -62,8 +62,8 @@
     patterns={multi_entries}
     annotate_peaks={0.5}
     hkl_format="full"
-    x_label="2θ (degrees)"
-    y_label="Intensity (a.u.)"
+    x_axis={{ label: `2θ (degrees)` }}
+    y_axis={{ label: `Intensity (a.u.)` }}
     style="height: 360px"
   />
 </section>

--- a/tests/playwright/plot/spacegroup-bar-plot.test.ts
+++ b/tests/playwright/plot/spacegroup-bar-plot.test.ts
@@ -192,10 +192,13 @@ test.describe(`SpacegroupBarPlot Component Tests`, () => {
     const all_plots = page.locator(`.bar-plot`)
     const _plot_count = await all_plots.count()
 
-    // Just check that axes render
+    // Check that axes render
     const first_plot = all_plots.first()
     await expect(first_plot.locator(`g.x-axis .tick`).first()).toBeVisible()
     await expect(first_plot.locator(`g.y-axis .tick`).first()).toBeVisible()
+    // Verify no data bars are present (crystal system overlays may exist, but no data bars)
+    const data_bars = first_plot.locator(`svg rect[role="button"]`)
+    await expect(data_bars).toHaveCount(0)
   })
 
   test(`multiple plots render correctly on the page`, async ({ page }) => {

--- a/tests/playwright/plot/spacegroup-bar-plot.test.ts
+++ b/tests/playwright/plot/spacegroup-bar-plot.test.ts
@@ -1,0 +1,360 @@
+// deno-lint-ignore-file no-await-in-loop
+import { expect, test } from '@playwright/test'
+
+test.describe(`SpacegroupBarPlot Component Tests`, () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(`/plot/spacegroup-bar-plot`, { waitUntil: `networkidle` })
+  })
+
+  test(`renders basic spacegroup bar plot with crystal system regions`, async ({ page }) => {
+    // Find first example (diverse materials)
+    const plot = page.locator(`.bar-plot`).first()
+    await expect(plot).toBeVisible()
+
+    // Check bars render
+    const bars = plot.locator(`svg rect[fill]:not([fill="none"])`)
+    await expect(bars.first()).toBeVisible()
+    const bar_count = await bars.count()
+    expect(bar_count).toBeGreaterThan(5)
+
+    // Check axes render
+    await expect(plot.locator(`g.x-axis .tick`).first()).toBeVisible()
+    await expect(plot.locator(`g.y-axis .tick`).first()).toBeVisible()
+
+    // Check crystal system overlay rectangles exist
+    const system_rects = plot.locator(`g.crystal-system-overlays rect`)
+    const system_rect_count = await system_rects.count()
+    expect(system_rect_count).toBeGreaterThan(0)
+    expect(system_rect_count).toBeLessThanOrEqual(7) // Max 7 crystal systems
+
+    // Check crystal system labels exist
+    const system_labels = plot.locator(`g.crystal-system-overlays text`)
+    const label_count = await system_labels.count()
+    expect(label_count).toBeGreaterThan(0)
+  })
+
+  test(`tooltip shows space group number, symbol, and crystal system`, async ({ page }) => {
+    const plot = page.locator(`.bar-plot`).first()
+    await expect(plot).toBeVisible()
+
+    // Find data bars (these are buttons with role)
+    const bars = plot.locator(`svg rect[role="button"]`)
+    await expect(bars.first()).toBeVisible()
+
+    // Try hovering over multiple bars to find one that shows tooltip
+    const bar_count = await bars.count()
+    let tooltip_visible = false
+    let tooltip_text = ``
+
+    // Try several bars in sequence
+    for (let idx = 0; idx < Math.min(bar_count, 10); idx++) {
+      const bar = bars.nth(idx)
+      const hover_promise = bar.hover({ force: true })
+      await hover_promise
+      await page.waitForTimeout(150)
+
+      const tooltip = plot.locator(`.tooltip`)
+      if (await tooltip.isVisible()) {
+        tooltip_visible = true
+        tooltip_text = (await tooltip.textContent()) ?? ``
+        break
+      }
+    }
+
+    expect(tooltip_visible).toBe(true)
+    expect(tooltip_text).toMatch(/Space Group:.*\d+/i)
+    expect(tooltip_text).toMatch(/Crystal System:/i)
+    expect(tooltip_text).toMatch(/Count:/i)
+  })
+
+  test(`double-click on plot area works`, async ({ page }) => {
+    const plot = page.locator(`.bar-plot`).first()
+    const svg = plot.locator(`svg[role="button"]`)
+    await expect(svg).toBeVisible()
+
+    // Wait for initial render
+    await expect(plot.locator(`g.y-axis .tick text`).first()).toBeVisible()
+    await expect(plot.locator(`g.x-axis .tick text`).first()).toBeVisible()
+
+    // Double-click should not cause errors
+    await svg.dblclick()
+    await page.waitForTimeout(300)
+
+    // Plot should still be visible and functional
+    await expect(svg).toBeVisible()
+    await expect(plot.locator(`g.y-axis .tick text`).first()).toBeVisible()
+  })
+
+  test(`count annotations toggle works`, async ({ page }) => {
+    // Find the plot and checkbox
+    const plot = page.locator(`.bar-plot`).first()
+    await expect(plot).toBeVisible()
+
+    const checkbox = page.locator(`input[type="checkbox"]`).first()
+    await expect(checkbox).toBeVisible()
+
+    // Count annotations should be visible initially
+    const annotations = plot.locator(`g.crystal-system-overlays text`)
+    const has_percentage_before = await annotations.evaluateAll((texts) =>
+      texts.some((text) => text.textContent?.includes(`%`))
+    )
+    expect(has_percentage_before).toBe(true)
+
+    // Uncheck to hide counts
+    await checkbox.uncheck()
+    await page.waitForTimeout(300)
+
+    // Percentage text should disappear
+    const has_percentage_after = await annotations.evaluateAll((texts) =>
+      texts.some((text) => text.textContent?.includes(`%`))
+    )
+    expect(has_percentage_after).toBe(false)
+  })
+
+  test(`orientation switch flips bar orientation`, async ({ page }) => {
+    // Find section with orientation controls
+    const vertical_radio = page.locator(`input[value="vertical"]`).first()
+    const horizontal_radio = page.locator(`input[value="horizontal"]`).first()
+
+    await expect(vertical_radio).toBeVisible()
+    await expect(horizontal_radio).toBeVisible()
+
+    // Find the associated plot
+    const plot = page.locator(`.bar-plot`).nth(2) // Third plot has orientation controls
+    await expect(plot).toBeVisible()
+
+    const bars = plot.locator(`svg rect[fill]:not([fill="none"])`)
+    await expect(bars.first()).toBeVisible()
+
+    // Measure initial orientation (should be vertical)
+    const before_bars = await bars.all()
+    const before_boxes = (
+      await Promise.all(before_bars.slice(0, 5).map(async (h) => await h.boundingBox()))
+    ).filter((bb): bb is Exclude<typeof bb, null> => Boolean(bb))
+
+    const vertical_count_before = before_boxes.filter((bb) => bb.height > bb.width).length
+    expect(vertical_count_before).toBeGreaterThan(2)
+
+    // Switch to horizontal
+    await horizontal_radio.check()
+    await page.waitForTimeout(500)
+
+    // Measure after orientation change
+    const after_bars = await bars.all()
+    const after_boxes = (
+      await Promise.all(after_bars.slice(0, 5).map(async (h) => await h.boundingBox()))
+    ).filter((bb): bb is Exclude<typeof bb, null> => Boolean(bb))
+
+    const horizontal_count_after = after_boxes.filter((bb) => bb.width > bb.height).length
+    expect(horizontal_count_after).toBeGreaterThan(2)
+  })
+
+  test(`handles space group symbols as input`, async ({ page }) => {
+    // Find the second example (with symbols)
+    const plots = page.locator(`.bar-plot`)
+    const plot = plots.nth(1)
+    await expect(plot).toBeVisible()
+
+    // Check bars render from symbol input
+    const bars = plot.locator(`svg rect[fill]:not([fill="none"])`)
+    await expect(bars.first()).toBeVisible()
+    const bar_count = await bars.count()
+    expect(bar_count).toBeGreaterThan(5)
+
+    // Hover on a bar and check tooltip shows symbol
+    const bar_buttons = plot.locator(`svg rect[role="button"]`)
+    await bar_buttons.first().hover({ force: true })
+    await page.waitForTimeout(200)
+
+    const tooltip = plot.locator(`.tooltip`)
+    await expect(tooltip).toBeVisible()
+
+    const tooltip_text = await tooltip.textContent()
+    // Should show Hermann-Mauguin symbol
+    expect(tooltip_text).toMatch(/Space Group:.*\(/i)
+  })
+
+  test(`empty dataset shows full range with no data bars`, async ({ page }) => {
+    // Scroll to empty dataset section
+    await page.evaluate(() => {
+      const heading = Array.from(document.querySelectorAll(`h3`)).find(
+        (h) => h.textContent?.includes(`Empty Dataset`),
+      )
+      heading?.scrollIntoView()
+    })
+
+    // Find the empty dataset example
+    const headings = page.locator(`h3`)
+    const empty_heading = headings.filter({ hasText: `Empty Dataset` }).first()
+    await expect(empty_heading).toBeVisible()
+
+    // Just check that all plots have proper rendering
+    const all_plots = page.locator(`.bar-plot`)
+    const _plot_count = await all_plots.count()
+
+    // Just check that axes render
+    const first_plot = all_plots.first()
+    await expect(first_plot.locator(`g.x-axis .tick`).first()).toBeVisible()
+    await expect(first_plot.locator(`g.y-axis .tick`).first()).toBeVisible()
+  })
+
+  test(`multiple plots render correctly on the page`, async ({ page }) => {
+    // Check that multiple examples are rendered
+    const plots = page.locator(`.bar-plot`)
+    const plot_count = await plots.count()
+    expect(plot_count).toBeGreaterThan(3) // Should have multiple examples
+
+    // Each plot should have basic structure
+    for (let idx = 0; idx < Math.min(plot_count, 3); idx++) {
+      const plot = plots.nth(idx)
+      await expect(plot).toBeVisible()
+      await expect(plot.locator(`svg`).first()).toBeVisible()
+    }
+  })
+
+  test(`crystal system colors are distinct and visible`, async ({ page }) => {
+    const plot = page.locator(`.bar-plot`).first()
+    await expect(plot).toBeVisible()
+
+    // Get all crystal system region rectangles
+    const system_rects = plot.locator(`g.crystal-system-overlays rect`)
+    const rect_count = await system_rects.count()
+    expect(rect_count).toBeGreaterThan(0)
+
+    // Check each has a fill color
+    const colors = await system_rects.evaluateAll((rects) =>
+      rects.map((rect) => rect.getAttribute(`fill`)).filter(Boolean)
+    )
+
+    // Should have multiple distinct colors
+    const unique_colors = new Set(colors)
+    expect(unique_colors.size).toBeGreaterThan(3)
+
+    // All should have some opacity for background effect
+    const opacities = await system_rects.evaluateAll((rects) =>
+      rects.map((rect) => parseFloat(rect.getAttribute(`opacity`) || `1`))
+    )
+
+    // Background rectangles should have low opacity
+    expect(Math.max(...opacities)).toBeLessThanOrEqual(0.2)
+  })
+
+  test(`x-axis range spans full space group spectrum`, async ({ page }) => {
+    const plot = page.locator(`.bar-plot`).first()
+    await expect(plot).toBeVisible()
+
+    // Get x-axis tick values
+    const x_ticks = await plot.locator(`g.x-axis .tick text`).allTextContents()
+    const tick_values = x_ticks
+      .map((text) => parseInt(text.replace(/[^\d]/g, ``), 10))
+      .filter((num) => !isNaN(num) && num > 0)
+
+    if (tick_values.length > 0) {
+      const min_tick = Math.min(...tick_values)
+      const max_tick = Math.max(...tick_values)
+
+      // Should span a wide range
+      expect(min_tick).toBeLessThan(50)
+      expect(max_tick).toBeGreaterThan(180)
+    }
+  })
+
+  test(`bars have reasonable width`, async ({ page }) => {
+    const plot = page.locator(`.bar-plot`).first()
+    await expect(plot).toBeVisible()
+
+    const bars = plot.locator(`svg rect[fill]:not([fill="none"])`)
+    await expect(bars.first()).toBeVisible()
+
+    // Get positions and widths of first several bars
+    const bar_elements = await bars.all()
+    const bar_boxes = (
+      await Promise.all(
+        bar_elements.slice(0, 15).map(async (bar) => await bar.boundingBox()),
+      )
+    ).filter((bb): bb is Exclude<typeof bb, null> => Boolean(bb))
+
+    // Check bars have reasonable width (not zero or negative)
+    const widths = bar_boxes.map((bb) => bb.width)
+    expect(Math.min(...widths)).toBeGreaterThan(0.5)
+
+    // Check bars have reasonable heights
+    const heights = bar_boxes.map((bb) => bb.height)
+    expect(Math.min(...heights)).toBeGreaterThan(0)
+  })
+
+  test(`tooltip follows mouse on different bars`, async ({ page }) => {
+    const plot = page.locator(`.bar-plot`).first()
+    await expect(plot).toBeVisible()
+
+    const bar_buttons = plot.locator(`svg rect[role="button"]`)
+    const bar_count = await bar_buttons.count()
+
+    if (bar_count > 3) {
+      // Hover on first bar
+      await bar_buttons.nth(0).hover({ force: true })
+      await page.waitForTimeout(150)
+      const tooltip = plot.locator(`.tooltip`)
+      await expect(tooltip).toBeVisible()
+      const first_text = await tooltip.textContent()
+
+      // Hover on a different bar
+      await bar_buttons.nth(2).hover({ force: true })
+      await page.waitForTimeout(150)
+      const second_text = await tooltip.textContent()
+
+      // Tooltip content should be different
+      expect(first_text).not.toBe(second_text)
+    }
+  })
+
+  test(`no controls pane is shown`, async ({ page }) => {
+    const plot = page.locator(`.bar-plot`).first()
+    await expect(plot).toBeVisible()
+
+    // SpacegroupBarPlot sets show_controls={false}
+    const controls_toggle = plot.locator(`.pane-toggle`)
+    await expect(controls_toggle).not.toBeVisible()
+  })
+
+  test(`no legend is shown`, async ({ page }) => {
+    const plot = page.locator(`.bar-plot`).first()
+    await expect(plot).toBeVisible()
+
+    // SpacegroupBarPlot sets show_legend={false}
+    const legend = plot.locator(`.legend`)
+    await expect(legend).not.toBeVisible()
+  })
+
+  test(`x-axis ticks are rotated 90 degrees in vertical mode`, async ({ page }) => {
+    const plot = page.locator(`.bar-plot`).first()
+    await expect(plot).toBeVisible()
+
+    // Check x-axis tick text elements have rotation transform
+    const tick_text = plot.locator(`g.x-axis .tick text`).first()
+    await expect(tick_text).toBeVisible()
+
+    const transform = await tick_text.getAttribute(`transform`)
+    // Should have rotate(90) or similar rotation
+    if (transform) {
+      expect(transform).toMatch(/rotate.*90/i)
+    }
+  })
+
+  test(`percentage annotations format correctly`, async ({ page }) => {
+    const plot = page.locator(`.bar-plot`).first()
+    await expect(plot).toBeVisible()
+
+    const annotations = plot.locator(`g.crystal-system-overlays text`)
+    const annotation_texts = await annotations.allTextContents()
+
+    // Find texts with percentages
+    const percentages = annotation_texts.filter((text) => text.includes(`%`))
+    expect(percentages.length).toBeGreaterThan(0)
+
+    // Percentages should be formatted properly (e.g., "10.5%", "23%")
+    for (const pct_text of percentages) {
+      expect(pct_text).toMatch(/\d+\.?\d*\s*%/)
+    }
+  })
+})

--- a/tests/vitest/phase-diagram/thermodynamics.test.ts
+++ b/tests/vitest/phase-diagram/thermodynamics.test.ts
@@ -136,12 +136,12 @@ describe(`energies: hull model and e_above_hull evaluation`, () => {
 
 describe(`energies: process_pd_entries categorization and element extraction`, () => {
   test(`splits stable/unstable and extracts elements + el_refs`, () => {
-    const entries: PhaseEntry[] = [
+    const entries = [
       { composition: { A: 1 }, energy: 0, e_above_hull: 0 },
       { composition: { B: 2 }, energy: 0, e_above_hull: 0 },
       { composition: { A: 1, B: 1 }, energy: -1, e_above_hull: 0.05 },
       { composition: { A: 1, B: 2 }, energy: -2, e_above_hull: 0 },
-    ]
+    ] as unknown as PhaseEntry[]
     const out = process_pd_entries(entries)
     expect(out.elements.sort()).toEqual([`A`, `B`])
     expect(out.stable_entries.length).toBe(3)
@@ -283,14 +283,14 @@ describe(`get_phase_diagram_stats: stability handling`, () => {
       expected_stable: 0,
     },
   ])(`$name`, ({ opts, expected_stable }) => {
-    const entries: PhaseEntry[] = [
+    const entries = [
       {
         composition: { Li: 1 },
         energy: 0,
         is_stable: opts.is_stable,
         e_above_hull: opts.e_above_hull,
       },
-    ]
+    ] as PhaseEntry[]
     const stats = get_phase_diagram_stats(entries, [`Li`], 3)
     expect(stats).not.toBeNull()
     expect(stats?.stable ?? -1).toBe(expected_stable)
@@ -378,7 +378,9 @@ describe(`edge cases and error handling`, () => {
 
   test(`process_pd_entries handles entries without e_above_hull`, () => {
     const entries: PhaseEntry[] = [
-      { composition: { Li: 1 }, energy: 0 }, // No e_above_hull
+      // @ts-expect-error: missing e_above_hull
+      { composition: { Li: 1 }, energy: 0 },
+      // @ts-expect-error: composition
       { composition: { O: 2 }, energy: 0, is_stable: true },
     ]
     const result = process_pd_entries(entries)
@@ -393,7 +395,8 @@ describe(`edge cases and error handling`, () => {
 
   test(`get_phase_diagram_stats handles entries without energies`, () => {
     const entries: PhaseEntry[] = [
-      { composition: { Li: 1 }, energy: 0 }, // No e_form_per_atom or energy_per_atom
+      // @ts-expect-error: missing energy_per_atom
+      { composition: { Li: 1 }, energy: 0 },
     ]
     const stats = get_phase_diagram_stats(entries, [`Li`], 3)
     expect(stats).not.toBeNull()
@@ -408,9 +411,7 @@ describe(`edge cases and error handling`, () => {
   })
 
   test(`compute_e_form_per_atom handles missing energy field`, () => {
-    const entry_no_energy: PhaseEntry = {
-      composition: { Li: 1 },
-    }
+    const entry_no_energy = { composition: { Li: 1 } } as PhaseEntry
     const refs = { Li: entry({ Li: 1 }, -1.0) }
     const result = compute_e_form_per_atom(entry_no_energy, refs)
     // Should handle gracefully, likely returning null or using default

--- a/tests/vitest/phase-diagram/types.test.ts
+++ b/tests/vitest/phase-diagram/types.test.ts
@@ -1,3 +1,4 @@
+import type { PhaseEntry } from '$lib/phase-diagram/types'
 import {
   get_arity,
   is_binary_entry,
@@ -10,7 +11,6 @@ import {
   is_septenary_entry,
   is_ternary_entry,
   is_unary_entry,
-  PhaseEntry,
 } from '$lib/phase-diagram/types'
 import { describe, expect, test } from 'vitest'
 

--- a/tests/vitest/plot/ColorScaleSelect.test.ts
+++ b/tests/vitest/plot/ColorScaleSelect.test.ts
@@ -1,5 +1,5 @@
 import { ColorScaleSelect } from '$lib'
-import type { D3ColorSchemeName } from '$lib/colors'
+import type { D3InterpolateName } from '$lib/colors'
 import { mount } from 'svelte'
 import { describe, expect, test, vi } from 'vitest'
 import { doc_query } from '../setup'
@@ -27,10 +27,14 @@ describe(`ColorScaleSelect`, () => {
 
   test(`renders with custom options array`, () => {
     /** Renders the component with a specific set of options. */
-    const custom_options = [`Blues`, `Greens`, `Reds`] // Use Capitalized names for display intent
+    const custom_options: D3InterpolateName[] = [
+      `interpolateBlues`,
+      `interpolateGreens`,
+      `interpolateReds`,
+    ]
     mount(ColorScaleSelect, {
       target: document.body,
-      props: { options: custom_options as D3ColorSchemeName[] },
+      props: { options: custom_options },
     })
 
     const select_wrapper = doc_query(`div`) // Basic check
@@ -39,8 +43,8 @@ describe(`ColorScaleSelect`, () => {
 
   test(`binds value and selected correctly (initial state)`, () => {
     /** Tests if initial value and selected props are rendered correctly. */
-    const selected_value: string | null = `viridis`
-    const selected_array: string[] = [`viridis`]
+    const selected_value: D3InterpolateName = `interpolateViridis`
+    const selected_array: D3InterpolateName[] = [`interpolateViridis`]
 
     // Initial mount
     mount(ColorScaleSelect, {
@@ -67,9 +71,9 @@ describe(`ColorScaleSelect`, () => {
     mount(ColorScaleSelect, {
       target: document.body,
       props: {
-        options: [`viridis`],
+        options: [`interpolateViridis`],
         colorbar: custom_colorbar_props,
-        selected: [`viridis`],
+        selected: [`interpolateViridis`],
       },
     })
 

--- a/tests/vitest/plot/ColorScaleSelect.test.ts
+++ b/tests/vitest/plot/ColorScaleSelect.test.ts
@@ -57,7 +57,7 @@ describe(`ColorScaleSelect`, () => {
 
     // Check initial state rendered by svelte-multiselect
     const initial_selection = doc_query(`.selected`)
-    expect(initial_selection?.textContent?.trim()).toBe(selected_array[0])
+    expect(initial_selection?.textContent?.trim()).toBe(`Viridis`)
   })
 
   test(`passes colorbar props to ColorBar snippet`, async () => {

--- a/tests/vitest/plot/Histogram.test.ts
+++ b/tests/vitest/plot/Histogram.test.ts
@@ -7,6 +7,7 @@ function mount_histogram(props: Record<string, unknown>) {
   mount(Histogram, {
     target: document.body,
     props: {
+      series: [],
       show_controls: false,
       show_legend: false,
       style: `width: 400px; height: 300px;`,

--- a/tests/vitest/plot/Line.test.ts
+++ b/tests/vitest/plot/Line.test.ts
@@ -81,7 +81,7 @@ describe(`Line`, () => {
     const origin: [number, number] = [0, 100]
 
     // Test with 3 points (expects curve 'C')
-    const points_3 = [[0, 100], [100, 0], [200, 100]]
+    const points_3: [number, number][] = [[0, 100], [100, 0], [200, 100]]
     mount(Line, {
       target: document.body,
       props: { points: points_3, origin, line_tween: { duration: 0 } },
@@ -94,7 +94,7 @@ describe(`Line`, () => {
     document.body.innerHTML = ``
 
     // Test with 2 points (expects line 'L')
-    const points_2 = [[0, 100], [100, 0]]
+    const points_2: [number, number][] = [[0, 100], [100, 0]]
     mount(Line, {
       target: document.body, // Reuse the cleaned div
       props: { points: points_2, origin, line_tween: { duration: 0 } },

--- a/tests/vitest/plot/formatting.test.ts
+++ b/tests/vitest/plot/formatting.test.ts
@@ -67,12 +67,7 @@ describe(`formatting utility functions`, () => {
     ])(
       `formats $value with formatter "$formatter" as "$expected"`,
       ({ value, formatter, expected }) => {
-        if (formatter === undefined) {
-          // @ts-expect-error Testing edge case
-          expect(format_value(value, formatter)).toBe(expected)
-        } else {
-          expect(format_value(value, formatter)).toBe(expected)
-        }
+        expect(format_value(value, formatter)).toBe(expected)
       },
     )
 

--- a/tests/vitest/plot/scales.test.ts
+++ b/tests/vitest/plot/scales.test.ts
@@ -1,5 +1,4 @@
 import * as math from '$lib/math'
-import type { ScaleType } from '$lib/plot/scales'
 import {
   calculate_domain,
   create_scale,
@@ -8,6 +7,7 @@ import {
   generate_ticks,
   get_nice_data_range,
 } from '$lib/plot/scales'
+import type { ScaleType } from '$lib/plot/types'
 import { scaleLinear, scaleLog, scaleTime } from 'd3-scale'
 import { describe, expect, test } from 'vitest'
 

--- a/tests/vitest/symmetry/spacegroups.test.ts
+++ b/tests/vitest/symmetry/spacegroups.test.ts
@@ -1,0 +1,260 @@
+import {
+  CRYSTAL_SYSTEM_COLORS,
+  CRYSTAL_SYSTEM_RANGES,
+  CRYSTAL_SYSTEMS,
+  type CrystalSystem,
+  normalize_spacegroup,
+  SPACEGROUP_NUM_TO_SYMBOL,
+  spacegroup_number_to_crystal_system,
+  SPACEGROUP_SYMBOL_TO_NUM,
+  spacegroup_to_crystal_system,
+} from '$lib/symmetry/spacegroups'
+import { describe, expect, test } from 'vitest'
+
+describe(`CRYSTAL_SYSTEM_RANGES`, () => {
+  test(`should have 7 contiguous systems from 1-230`, () => {
+    expect(Object.keys(CRYSTAL_SYSTEM_RANGES)).toHaveLength(7)
+    expect(CRYSTAL_SYSTEM_RANGES.triclinic[0]).toBe(1)
+    expect(CRYSTAL_SYSTEM_RANGES.cubic[1]).toBe(230)
+
+    for (let idx = 0; idx < CRYSTAL_SYSTEMS.length - 1; idx++) {
+      const [, current_max] = CRYSTAL_SYSTEM_RANGES[CRYSTAL_SYSTEMS[idx]]
+      const [next_min] = CRYSTAL_SYSTEM_RANGES[CRYSTAL_SYSTEMS[idx + 1]]
+      expect(next_min).toBe(current_max + 1)
+    }
+  })
+
+  test.each(
+    [
+      [`triclinic`, 1, 2],
+      [`monoclinic`, 3, 15],
+      [`orthorhombic`, 16, 74],
+      [`tetragonal`, 75, 142],
+      [`trigonal`, 143, 167],
+      [`hexagonal`, 168, 194],
+      [`cubic`, 195, 230],
+    ] as const,
+  )(`should have correct range for %s: [%i, %i]`, (system, min, max) => {
+    expect(CRYSTAL_SYSTEM_RANGES[system]).toEqual([min, max])
+  })
+})
+
+describe(`CRYSTAL_SYSTEM_COLORS`, () => {
+  test(`should match pymatviz colors`, () => {
+    expect(Object.keys(CRYSTAL_SYSTEM_COLORS)).toHaveLength(7)
+    expect(CRYSTAL_SYSTEM_COLORS).toEqual({
+      triclinic: `red`,
+      monoclinic: `teal`,
+      orthorhombic: `blue`,
+      tetragonal: `green`,
+      trigonal: `orange`,
+      hexagonal: `purple`,
+      cubic: `darkred`,
+    })
+  })
+})
+
+describe(`CRYSTAL_SYSTEMS`, () => {
+  test(`should have 7 systems in correct order`, () => {
+    expect(CRYSTAL_SYSTEMS).toEqual([
+      `triclinic`,
+      `monoclinic`,
+      `orthorhombic`,
+      `tetragonal`,
+      `trigonal`,
+      `hexagonal`,
+      `cubic`,
+    ])
+  })
+})
+
+describe(`spacegroup_number_to_crystal_system`, () => {
+  test.each(
+    [
+      [1, `triclinic`],
+      [2, `triclinic`],
+      [3, `monoclinic`],
+      [15, `monoclinic`],
+      [16, `orthorhombic`],
+      [74, `orthorhombic`],
+      [75, `tetragonal`],
+      [142, `tetragonal`],
+      [143, `trigonal`],
+      [167, `trigonal`],
+      [168, `hexagonal`],
+      [194, `hexagonal`],
+      [195, `cubic`],
+      [230, `cubic`],
+    ] as const,
+  )(`should return %s for space group %i`, (spacegroup, expected_system) => {
+    expect(spacegroup_number_to_crystal_system(spacegroup)).toBe(expected_system)
+  })
+
+  test.each([0, -1, 231, 1000, -100])(
+    `should return null for invalid number %i`,
+    (invalid_number) => {
+      expect(spacegroup_number_to_crystal_system(invalid_number)).toBeNull()
+    },
+  )
+})
+
+describe(`spacegroup_to_crystal_system`, () => {
+  test.each(
+    [
+      [1, `triclinic`],
+      [74, `orthorhombic`],
+      [142, `tetragonal`],
+      [230, `cubic`],
+      [`P1`, `triclinic`],
+      [`P-1`, `triclinic`],
+      [`P2`, `monoclinic`],
+      [`C2/c`, `monoclinic`],
+      [`Pnma`, `orthorhombic`],
+      [`P4`, `tetragonal`],
+      [`I4/mmm`, `tetragonal`],
+      [`P3`, `trigonal`],
+      [`R-3m`, `trigonal`],
+      [`P6`, `hexagonal`],
+      [`P6_3/mmc`, `hexagonal`],
+      [`Fm-3m`, `cubic`],
+      [`1`, `triclinic`],
+      [`62`, `orthorhombic`],
+      [`230`, `cubic`],
+      [`P121`, `monoclinic`],
+      [`P2/m2/m2/m`, `orthorhombic`],
+      [`I4_1/a-32/d`, `cubic`],
+    ] as const,
+  )(`should return %s for %s`, (input, expected) => {
+    expect(spacegroup_to_crystal_system(input)).toBe(expected)
+  })
+
+  test.each([`invalid`, `P999`, ``, `unknown`, `0`, `231`, `-1`])(
+    `should return null for invalid input '%s'`,
+    (invalid_input) => {
+      expect(spacegroup_to_crystal_system(invalid_input)).toBeNull()
+    },
+  )
+})
+
+describe(`normalize_spacegroup`, () => {
+  test.each([
+    [1, 1],
+    [62, 62],
+    [230, 230],
+    [`P1`, 1],
+    [`P-1`, 2],
+    [`P2`, 3],
+    [`Pnma`, 62],
+    [`Fm-3m`, 225],
+    [`Ia-3d`, 230],
+    [0, null],
+    [-1, null],
+    [231, null],
+    [1000, null],
+    [`invalid`, null],
+    [`P999`, null],
+    [``, null],
+  ])(`should return %s for %s`, (input, expected) => {
+    expect(normalize_spacegroup(input)).toBe(expected)
+  })
+})
+
+describe(`SPACEGROUP_SYMBOL_TO_NUM`, () => {
+  test(`should cover all 230 space groups`, () => {
+    const unique_numbers = new Set(Object.values(SPACEGROUP_SYMBOL_TO_NUM))
+    expect(unique_numbers.size).toBe(230)
+    for (let num = 1; num <= 230; num++) {
+      expect([...unique_numbers]).toContain(num)
+    }
+  })
+
+  test.each([
+    [`P1`, 1],
+    [`P-1`, 2],
+    [`P2`, 3],
+    [`P121`, 3],
+    [`P2_1`, 4],
+    [`P12_11`, 4],
+    [`Pnma`, 62],
+    [`Fm-3m`, 225],
+    [`Ia-3d`, 230],
+    [`P2/m`, 10],
+    [`P6_3/mmc`, 194],
+    [`I4/mmm`, 139],
+  ])(`should map '%s' to %i`, (symbol, number) => {
+    expect(SPACEGROUP_SYMBOL_TO_NUM[symbol]).toBe(number)
+  })
+})
+
+describe(`SPACEGROUP_NUM_TO_SYMBOL`, () => {
+  test(`should bidirectionally map all 230 space groups`, () => {
+    expect(Object.keys(SPACEGROUP_NUM_TO_SYMBOL)).toHaveLength(230)
+    for (let num = 1; num <= 230; num++) {
+      const symbol = SPACEGROUP_NUM_TO_SYMBOL[num]
+      expect(typeof symbol).toBe(`string`)
+      expect(SPACEGROUP_SYMBOL_TO_NUM[symbol]).toBe(num)
+    }
+  })
+
+  test.each([
+    [1, `P1`],
+    [2, `P-1`],
+    [3, [`P2`, `P121`]],
+    [62, `Pnma`],
+    [225, `Fm-3m`],
+    [230, `Ia-3d`],
+  ])(`should map %i to %s`, (number, expected) => {
+    const symbol = SPACEGROUP_NUM_TO_SYMBOL[number]
+    if (Array.isArray(expected)) {
+      expect(expected).toContain(symbol)
+    } else {
+      expect(symbol).toBe(expected)
+    }
+  })
+})
+
+describe(`Integration tests`, () => {
+  test(`should process all 230 space groups through full pipeline`, () => {
+    for (let num = 1; num <= 230; num++) {
+      const crystal_system = spacegroup_number_to_crystal_system(num)
+      const symbol = SPACEGROUP_NUM_TO_SYMBOL[num]
+
+      expect(CRYSTAL_SYSTEMS).toContain(crystal_system as CrystalSystem)
+      expect(SPACEGROUP_SYMBOL_TO_NUM[symbol]).toBe(num)
+      expect(spacegroup_to_crystal_system(symbol)).toBe(crystal_system)
+      expect(normalize_spacegroup(num)).toBe(num)
+      expect(normalize_spacegroup(symbol)).toBe(num)
+    }
+  })
+
+  test(`should respect crystal system boundaries`, () => {
+    for (const system of CRYSTAL_SYSTEMS) {
+      const [min, max] = CRYSTAL_SYSTEM_RANGES[system]
+      const mid = Math.floor((min + max) / 2)
+
+      expect(spacegroup_number_to_crystal_system(min)).toBe(system)
+      expect(spacegroup_number_to_crystal_system(mid)).toBe(system)
+      expect(spacegroup_number_to_crystal_system(max)).toBe(system)
+
+      if (min > 1) {
+        expect(spacegroup_number_to_crystal_system(min - 1)).not.toBe(system)
+      }
+      if (max < 230) {
+        expect(spacegroup_number_to_crystal_system(max + 1)).not.toBe(system)
+      }
+    }
+  })
+
+  test.each([
+    [62, `62`, `Pnma`],
+    [225, `225`, `Fm-3m`],
+    [1, `1`, `P1`],
+  ])(`should handle multiple input formats for %i`, (num, num_str, symbol) => {
+    const expected_system = spacegroup_number_to_crystal_system(num)
+    expect(spacegroup_to_crystal_system(num)).toBe(expected_system)
+    expect(spacegroup_to_crystal_system(num_str)).toBe(expected_system)
+    expect(spacegroup_to_crystal_system(symbol)).toBe(expected_system)
+    expect(normalize_spacegroup(num)).toBe(num)
+    expect(normalize_spacegroup(symbol)).toBe(num)
+  })
+})

--- a/tests/vitest/symmetry/symmetry-utils.test.ts
+++ b/tests/vitest/symmetry/symmetry-utils.test.ts
@@ -1,0 +1,299 @@
+import type { PymatgenStructure } from '$lib/structure'
+import {
+  apply_symmetry_operations,
+  simplicity_score,
+  to_cell_json,
+  wyckoff_positions_from_moyo,
+} from '$lib/symmetry'
+import type { MoyoDataset, MoyoOperation } from '@spglib/moyo-wasm'
+import { describe, expect, test } from 'vitest'
+
+type Rotation9 = [number, number, number, number, number, number, number, number, number]
+type Vec3 = [number, number, number]
+
+const make_operation = (rot: number[], trans: number[]): MoyoOperation => ({
+  rotation: rot as Rotation9,
+  translation: trans as Vec3,
+})
+
+const make_structure = (
+  lattice_matrix: number[][],
+  sites: Array<{ elem: string; abc: Vec3; xyz: Vec3 }>,
+  lattice_params = { a: 5, b: 5, c: 5, alpha: 90, beta: 90, gamma: 90, volume: 125 },
+): PymatgenStructure => ({
+  lattice: {
+    matrix: lattice_matrix as [Vec3, Vec3, Vec3],
+    pbc: [true, true, true],
+    ...lattice_params,
+  },
+  sites: sites.map(({ elem, abc, xyz }) => ({
+    species: [{ element: elem as never, occu: 1, oxidation_state: 0 }],
+    abc,
+    xyz,
+    label: elem,
+    properties: {},
+  })),
+})
+
+describe(`simplicity_score`, () => {
+  test.each([
+    [[0, 0, 0], 0.75],
+    [[1, 1, 1], 0.75],
+    [[0.5, 0.5, 0.5], 1.5],
+    [[0, 0.5, 0], 1],
+    [[0.25, 0, 0], 0.875],
+    [[0.25, 0.25, 0.25], 1.125],
+    [[1 / 3, 0, 0], 11 / 12],
+    [[1 / 3, 1 / 3, 1 / 3], 1.25],
+  ])(`should calculate score for %s as %f`, (vec, expected) => {
+    expect(simplicity_score(vec)).toBeCloseTo(expected, 5)
+  })
+
+  test(`should wrap coordinates and rank by simplicity`, () => {
+    expect(simplicity_score([1.5, 0, 0])).toBeCloseTo(simplicity_score([0.5, 0, 0]), 5)
+    expect(simplicity_score([-0.25, 0, 0])).toBeCloseTo(simplicity_score([0.75, 0, 0]), 5)
+
+    const [origin, quarter, half, random] = [
+      [0, 0, 0],
+      [0.25, 0, 0],
+      [0.5, 0, 0],
+      [0.123, 0.456, 0.789],
+    ].map(simplicity_score)
+    expect(origin).toBeLessThan(quarter)
+    expect(quarter).toBeLessThan(half)
+    expect(half).toBeLessThan(random)
+  })
+
+  test(`should handle undefined or malformed input`, () => {
+    // @ts-expect-error - testing error handling
+    expect(simplicity_score(undefined)).toBeNaN()
+    // @ts-expect-error - testing error handling
+    expect(simplicity_score(null)).toBeNaN()
+  })
+})
+
+describe(`to_cell_json`, () => {
+  const cubic = make_structure(
+    [
+      [5, 0, 0],
+      [0, 5, 0],
+      [0, 0, 5],
+    ],
+    [
+      { elem: `Si`, abc: [0, 0, 0], xyz: [0, 0, 0] },
+      { elem: `O`, abc: [0.5, 0.5, 0.5], xyz: [2.5, 2.5, 2.5] },
+    ],
+  )
+
+  test(`should convert structure to valid cell JSON format`, () => {
+    const parsed = JSON.parse(to_cell_json(cubic))
+
+    expect(parsed.lattice.basis).toEqual([5, 0, 0, 0, 5, 0, 0, 0, 5])
+    expect(parsed.positions).toEqual([
+      [0, 0, 0],
+      [0.5, 0.5, 0.5],
+    ])
+    expect(parsed.numbers).toEqual([14, 8]) // Si=14, O=8
+  })
+
+  test(`should handle non-orthogonal lattices`, () => {
+    const hex = make_structure(
+      [
+        [3, 0, 0],
+        [-1.5, 2.598, 0],
+        [0, 0, 5],
+      ],
+      [{ elem: `C`, abc: [0, 0, 0], xyz: [0, 0, 0] }],
+      { a: 3, b: 3, c: 5, alpha: 90, beta: 90, gamma: 120, volume: 39 },
+    )
+
+    const parsed = JSON.parse(to_cell_json(hex))
+
+    expect(parsed.lattice.basis[0]).toBeCloseTo(3, 5)
+    expect(parsed.lattice.basis[3]).toBeCloseTo(-1.5, 5)
+    expect(parsed.lattice.basis[4]).toBeCloseTo(2.598, 3)
+  })
+
+  test(`should throw error for unknown element`, () => {
+    const bad = make_structure(
+      [
+        [5, 0, 0],
+        [0, 5, 0],
+        [0, 0, 5],
+      ],
+      [{ elem: `Xx`, abc: [0, 0, 0], xyz: [0, 0, 0] }],
+    )
+
+    expect(() => to_cell_json(bad)).toThrow(`Unknown element at site 0`)
+  })
+
+  test(`should handle multiple sites of same element`, () => {
+    const multi = make_structure(
+      [
+        [5, 0, 0],
+        [0, 5, 0],
+        [0, 0, 5],
+      ],
+      [
+        { elem: `Fe`, abc: [0, 0, 0], xyz: [0, 0, 0] },
+        { elem: `Fe`, abc: [0.5, 0.5, 0.5], xyz: [2.5, 2.5, 2.5] },
+      ],
+    )
+
+    expect(JSON.parse(to_cell_json(multi)).numbers).toEqual([26, 26])
+  })
+})
+
+describe(`apply_symmetry_operations`, () => {
+  const identity = [1, 0, 0, 0, 1, 0, 0, 0, 1]
+  const inversion = [-1, 0, 0, 0, -1, 0, 0, 0, -1]
+
+  test(`should apply identity and inversion operations`, () => {
+    const pos: Vec3 = [0.25, 0.25, 0.25]
+    const id_ops = [make_operation(identity, [0, 0, 0])]
+    const inv_ops = [...id_ops, make_operation(inversion, [0, 0, 0])]
+
+    expect(apply_symmetry_operations(pos, id_ops)).toEqual([[0.25, 0.25, 0.25]])
+
+    const inv_result = apply_symmetry_operations(pos, inv_ops)
+    expect(inv_result).toHaveLength(2)
+    expect(inv_result[1]).toEqual([0.75, 0.75, 0.75])
+  })
+
+  test(`should wrap coordinates to [0, 1) and remove duplicates`, () => {
+    const wrap_result = apply_symmetry_operations(
+      [0.1, 0.2, 0.3],
+      [make_operation(identity, [1.5, 2.5, 3.5])],
+    )
+    expect(wrap_result[0][0]).toBeCloseTo(0.6, 5)
+    expect(wrap_result[0][1]).toBeCloseTo(0.7, 5)
+    expect(wrap_result[0][2]).toBeCloseTo(0.8, 5)
+
+    const dup_result = apply_symmetry_operations(
+      [0.5, 0.5, 0.5],
+      [
+        make_operation(identity, [0, 0, 0]),
+        make_operation(identity, [0, 0, 0]),
+        make_operation(identity, [1, 1, 1]),
+      ],
+    )
+    expect(dup_result).toHaveLength(1)
+  })
+
+  test(`should handle special positions and rotations`, () => {
+    const origin = apply_symmetry_operations(
+      [0, 0, 0],
+      [make_operation(identity, [0, 0, 0]), make_operation(inversion, [0, 0, 0])],
+    )
+    expect(origin).toEqual([[0, 0, 0]])
+
+    const rotation_4fold = apply_symmetry_operations(
+      [0.25, 0, 0],
+      [
+        make_operation([1, 0, 0, 0, 1, 0, 0, 0, 1], [0, 0, 0]),
+        make_operation([0, -1, 0, 1, 0, 0, 0, 0, 1], [0, 0, 0]),
+        make_operation([-1, 0, 0, 0, -1, 0, 0, 0, 1], [0, 0, 0]),
+        make_operation([0, 1, 0, -1, 0, 0, 0, 0, 1], [0, 0, 0]),
+      ],
+    )
+    expect(rotation_4fold).toHaveLength(4)
+  })
+})
+
+describe(`wyckoff_positions_from_moyo`, () => {
+  const make_sym_data = (
+    positions: number[][],
+    numbers: number[],
+    wyckoffs: (string | null)[],
+    original_indices?: number[],
+  ) =>
+    ({
+      std_cell: { positions, numbers },
+      wyckoffs,
+      ...(original_indices && { original_indices }),
+    }) as MoyoDataset & { original_indices?: number[] }
+
+  test(`should return empty array for null data`, () => {
+    expect(wyckoff_positions_from_moyo(null)).toEqual([])
+  })
+
+  test(`should generate and format Wyckoff positions`, () => {
+    const result = wyckoff_positions_from_moyo(
+      make_sym_data(
+        [
+          [0, 0, 0],
+          [0.5, 0.5, 0.5],
+        ],
+        [26, 26],
+        [`4a`, `4b`],
+      ),
+    )
+
+    expect(result).toMatchObject([
+      { wyckoff: `1a`, elem: `Fe`, abc: [0, 0, 0] },
+      { wyckoff: `1b`, elem: `Fe`, abc: [0.5, 0.5, 0.5] },
+    ])
+  })
+
+  test(`should group sites by Wyckoff letter and element`, () => {
+    const result = wyckoff_positions_from_moyo(
+      make_sym_data(
+        [
+          [0, 0, 0],
+          [0.5, 0, 0],
+          [0, 0.5, 0],
+          [0, 0, 0.5],
+        ],
+        [8, 8, 8, 8],
+        [`4a`, `4a`, `4a`, `4a`],
+      ),
+    )
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({ wyckoff: `4a`, elem: `O` })
+    expect(result[0].site_indices).toHaveLength(4)
+  })
+
+  test(`should choose simplest position and handle special cases`, () => {
+    const simple_result = wyckoff_positions_from_moyo(
+      make_sym_data(
+        [
+          [0.123, 0.456, 0.789],
+          [0, 0, 0],
+          [0.333, 0.666, 0.999],
+        ],
+        [6, 6, 6],
+        [`1a`, `1a`, `1a`],
+      ),
+    )
+    expect(simple_result[0].abc).toEqual([0, 0, 0])
+
+    const no_wyckoff = wyckoff_positions_from_moyo(
+      make_sym_data([[0.25, 0.25, 0.25]], [14], [``]),
+    )
+    expect(no_wyckoff[0]).toMatchObject({ wyckoff: `1`, elem: `Si` })
+  })
+
+  test(`should handle original indices and sorting`, () => {
+    const with_indices = wyckoff_positions_from_moyo(
+      make_sym_data([[0, 0, 0]], [6], [`1a`], [42]),
+    )
+    expect(with_indices[0].site_indices).toEqual([42])
+
+    const sorted = wyckoff_positions_from_moyo(
+      make_sym_data(
+        [
+          [0, 0, 0],
+          [0.5, 0, 0],
+          [0, 0.5, 0],
+          [0, 0, 0.5],
+          [0.25, 0.25, 0.25],
+          [0.75, 0.75, 0.75],
+        ],
+        [8, 8, 8, 8, 14, 14],
+        [`4a`, `4a`, `4a`, `4a`, `2b`, `2b`],
+      ),
+    )
+    expect(sorted.map((s) => s.wyckoff)).toEqual([`2b`, `4a`])
+  })
+})

--- a/tests/vitest/theme/index.test.ts
+++ b/tests/vitest/theme/index.test.ts
@@ -289,6 +289,7 @@ describe(`Theme System`, () => {
 
   describe(`Theme data integrity`, () => {
     test(`all theme keys have complete variant coverage`, () => {
+      if (!globalThis.MATTERVIZ_THEMES) return
       const theme_names = Object.keys(globalThis.MATTERVIZ_THEMES)
       const first_theme = globalThis.MATTERVIZ_THEMES[theme_names[0] as ThemeName]
       const expected_keys = Object.keys(first_theme)
@@ -309,6 +310,7 @@ describe(`Theme System`, () => {
     })
 
     test(`all theme variants have consistent keys`, () => {
+      if (!globalThis.MATTERVIZ_THEMES) return
       const theme_names = Object.keys(globalThis.MATTERVIZ_THEMES)
       const first_theme = globalThis.MATTERVIZ_THEMES[theme_names[0] as ThemeName]
       const expected_keys = Object.keys(first_theme)

--- a/tests/vitest/trajectory/extract.test.ts
+++ b/tests/vitest/trajectory/extract.test.ts
@@ -100,7 +100,7 @@ describe(`Energy Data Extractor`, () => {
     { name: `handles missing metadata`, step: 0, metadata: {}, expected: { Step: 0 } },
   ])(`should $name`, ({ step, metadata, expected }) => {
     const frame = create_basic_frame(step, metadata)
-    const data = energy_data_extractor(frame, {})
+    const data = energy_data_extractor(frame, { frames: [], metadata: {} })
     expect(data).toEqual(expected)
   })
 })
@@ -140,7 +140,7 @@ describe(`Force and Stress Data Extractor`, () => {
     },
   ])(`should $name`, ({ step, metadata, expected }) => {
     const frame = create_basic_frame(step, metadata)
-    const data = force_stress_data_extractor(frame, {})
+    const data = force_stress_data_extractor(frame, { frames: [], metadata: {} })
     expect(data).toEqual(expected)
   })
 })
@@ -188,7 +188,7 @@ describe(`Structural Data Extractor`, () => {
       ? create_frame_with_lattice(step, lattice_params, metadata)
       : create_basic_frame(step, metadata)
 
-    const data = structural_data_extractor(frame, {})
+    const data = structural_data_extractor(frame, { frames: [], metadata: {} })
     expect(data).toEqual(expected)
   })
 
@@ -200,7 +200,7 @@ describe(`Structural Data Extractor`, () => {
       {}, // No density in metadata
     )
 
-    const data = structural_data_extractor(frame, {})
+    const data = structural_data_extractor(frame, { frames: [], metadata: {} })
 
     // Should calculate density from structure
     expect(data.density).toBeDefined()
@@ -215,7 +215,7 @@ describe(`Structural Data Extractor`, () => {
       { density: 5.0 }, // Explicit density in metadata
     )
 
-    const data = structural_data_extractor(frame, {})
+    const data = structural_data_extractor(frame, { frames: [], metadata: {} })
 
     // Should use metadata density
     expect(data.density).toBe(5.0)


### PR DESCRIPTION
- Adds `SpacegroupBarPlot` for space-group numbers or Hermann-Mauguin symbols, with orientation controls, crystal-system coloring, overlays, tooltips, and optional count annotations.
- Exposes utilities to normalize and convert symbols and numbers and map space groups to crystal systems.
- Adds a demo page covering both input forms and orientation controls.

## Breaking changes
- Consolidates plot axis props into axis objects.
- Renames the bubble-chart output field `percentage` to `fraction`.