### PR TITLE
`BrillouinBandsDos`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
         exclude: changelog\.md$
 
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v9.36.0
+    rev: v9.38.0
     hooks:
       - id: eslint
         types: [file]

--- a/src/lib/bands/Bands.svelte
+++ b/src/lib/bands/Bands.svelte
@@ -250,24 +250,31 @@
   ] as [number, number])
 
   // Compute final y-axis configuration with default label
-  let final_y_axis = $derived({
-    label: detected_band_type === `phonon` ? `Frequency (THz)` : `Energy (eV)`,
-    format: `.2f`,
-    ...y_axis,
-  })
-</script>
-
-<ScatterPlot
-  series={series_data}
-  x_axis={{
+  let final_x_axis = $derived({
     label: `Wave Vector`,
     ticks: Object.keys(x_axis_ticks).length > 0 ? x_axis_ticks : undefined,
     format: ``,
     range: x_range,
     ...x_axis,
-  }}
-  y_axis={final_y_axis}
-  display={{ x_grid: false, y_grid: true, y_zero_line: true }}
+  })
+  let final_y_axis = $derived({
+    label: detected_band_type === `phonon` ? `Frequency (THz)` : `Energy (eV)`,
+    format: `.2f`,
+    label_shift: { y: 15 },
+    ...y_axis,
+  })
+  let display = $state({
+    x_grid: false,
+    y_grid: true,
+    y_zero_line: true,
+  })
+</script>
+
+<ScatterPlot
+  series={series_data}
+  bind:x_axis={final_x_axis}
+  bind:y_axis={final_y_axis}
+  bind:display
   legend={show_legend && Object.keys(band_structs_dict).length > 1 ? {} : null}
   hover_config={{ threshold_px: 50 }}
   {...rest}

--- a/src/lib/bands/Bands.svelte
+++ b/src/lib/bands/Bands.svelte
@@ -35,7 +35,7 @@
   function get_line_style(
     color: string,
     is_acoustic: boolean,
-    mode_type: string,
+    mode_type: `acoustic` | `optical`,
     frequencies: number[],
     band_idx: number,
   ): { stroke: string; stroke_width: number } {

--- a/src/lib/bands/Bands.svelte
+++ b/src/lib/bands/Bands.svelte
@@ -86,7 +86,7 @@
 
   // Determine which segments to plot based on path_mode
   let segments_to_plot = $derived.by(() => {
-    const all_segments: Record<string, Array<[string, BaseBandStructure]>> = {}
+    const all_segments: Record<string, [string, BaseBandStructure][]> = {}
 
     // Collect all segments from all structures
     for (const [label, bs] of Object.entries(band_structs_dict)) {
@@ -205,7 +205,7 @@
         const scaled_distances = dist_range === 0
           ? segment_distances.map(() => (x_start + x_end) / 2)
           : segment_distances.map(
-            (d) => x_start + ((d - dist_min) / dist_range) * (x_end - x_start),
+            (dist) => x_start + ((dist - dist_min) / dist_range) * (x_end - x_start),
           )
 
         // Create series for each band

--- a/src/lib/bands/BandsAndDos.svelte
+++ b/src/lib/bands/BandsAndDos.svelte
@@ -25,13 +25,13 @@
   let shared_y_axis_obj = $state<{ range?: [number, number] }>({})
   let bands_y_axis = $derived(shared_y_axis ? shared_y_axis_obj : {})
   let dos_y_axis = $derived(shared_y_axis ? shared_y_axis_obj : {})
-
-  let grid_style = $derived(
-    `display: grid; grid-template-columns: 1fr 200px; gap: 0; ${rest.style ?? ``}`,
-  )
 </script>
 
-<div {...rest} class="bands-and-dos {rest.class ?? ``}" style={grid_style}>
+<div
+  {...rest}
+  class="bands-and-dos {rest.class ?? ``}"
+  style={`display: grid; grid-template-columns: 1fr 200px; gap: 0;` + (rest.style ?? ``)}
+>
   <Bands
     {band_structs}
     y_axis={bands_y_axis}

--- a/src/lib/bands/BandsAndDos.svelte
+++ b/src/lib/bands/BandsAndDos.svelte
@@ -3,7 +3,7 @@
   import type { HTMLAttributes } from 'svelte/elements'
   import Bands from './Bands.svelte'
   import Dos from './Dos.svelte'
-  import type { BaseBandStructure, Dos as DosData } from './types'
+  import type { BaseBandStructure, DosData } from './types'
 
   let {
     band_structs,

--- a/src/lib/bands/BrillouinBandsDos.svelte
+++ b/src/lib/bands/BrillouinBandsDos.svelte
@@ -1,0 +1,105 @@
+<script lang="ts">
+  import type { Vec3 } from '$lib'
+  import { BrillouinZone, reciprocal_lattice } from '$lib/brillouin'
+  import type { InternalPoint } from '$lib/plot'
+  import type { PymatgenStructure } from '$lib/structure'
+  import type { ComponentProps } from 'svelte'
+  import type { HTMLAttributes } from 'svelte/elements'
+  import Bands from './Bands.svelte'
+  import Dos from './Dos.svelte'
+  import * as helpers from './helpers'
+  import type { BaseBandStructure, DosData } from './types'
+
+  let {
+    structure,
+    band_structs,
+    doses,
+    bands_props = {},
+    dos_props = {},
+    bz_props = {},
+    shared_y_axis = true,
+    ...rest
+  }: HTMLAttributes<HTMLDivElement> & {
+    structure: PymatgenStructure
+    band_structs: BaseBandStructure | Record<string, BaseBandStructure>
+    doses: DosData | Record<string, DosData>
+    bands_props?: Partial<ComponentProps<typeof Bands>>
+    dos_props?: Partial<ComponentProps<typeof Dos>>
+    bz_props?: Partial<ComponentProps<typeof BrillouinZone>>
+    shared_y_axis?: boolean
+  } = $props()
+
+  let shared_y_axis_obj = $state<{ range?: [number, number] }>({})
+
+  let first_band_struct = $derived(
+    `qpoints` in band_structs
+      ? band_structs
+      : band_structs[Object.keys(band_structs)[0]],
+  ) as BaseBandStructure
+
+  // Convert fractional k-point coordinates to Cartesian reciprocal space
+  // using the structure's reciprocal lattice (consistent with BZ computation)
+  let k_path_points = $derived.by(() => {
+    if (!first_band_struct?.qpoints || !structure?.lattice?.matrix) return []
+
+    const k_lattice = reciprocal_lattice(structure.lattice.matrix)
+    return helpers.extract_k_path_points(first_band_struct, k_lattice)
+  })
+
+  let hovered_band_point = $state<InternalPoint | null>(null)
+  let hovered_qpoint_index = $derived(
+    hovered_band_point && first_band_struct
+      ? helpers.find_qpoint_at_distance(first_band_struct, hovered_band_point.x)
+      : null,
+  )
+  let hovered_k_point = $derived(
+    hovered_qpoint_index !== null
+      ? (k_path_points[hovered_qpoint_index] as Vec3)
+      : null,
+  )
+</script>
+
+<div
+  {...rest}
+  class="bands-dos-brillouin {rest.class ?? ``}"
+  style={`display: grid; grid-template-columns: 30% 50% 20%; gap: 8px; ${rest.style ?? ``}`}
+>
+  <BrillouinZone
+    {structure}
+    {k_path_points}
+    k_path_labels={first_band_struct?.qpoints?.map((q, idx) => ({
+      position: k_path_points[idx],
+      label: q.label ? helpers.pretty_sym_point(q.label) : null,
+    })) ?? []}
+    {hovered_k_point}
+    {hovered_qpoint_index}
+    {...bz_props}
+  />
+
+  <Bands
+    {band_structs}
+    y_axis={shared_y_axis ? shared_y_axis_obj : {}}
+    {...bands_props}
+    padding={{ r: 15, ...bands_props.padding }}
+    on_point_hover={({ point }) => {
+      hovered_band_point = point
+      bands_props.on_point_hover?.({ point })
+    }}
+  />
+
+  <Dos
+    {doses}
+    orientation="horizontal"
+    y_axis={shared_y_axis ? { ...shared_y_axis_obj, label: `` } : { label: `` }}
+    padding={{ l: 15, ...dos_props.padding }}
+    {...dos_props}
+  />
+</div>
+
+<style>
+  .bands-dos-brillouin {
+    width: var(--bands-dos-bz-width, 100%);
+    height: var(--bands-dos-bz-height, 600px);
+    min-height: var(--bands-dos-bz-min-height, 400px);
+  }
+</style>

--- a/src/lib/bands/BrillouinBandsDos.svelte
+++ b/src/lib/bands/BrillouinBandsDos.svelte
@@ -57,14 +57,31 @@
       ? (k_path_points[hovered_qpoint_index] as Vec3)
       : null,
   )
+
+  // Track screen width for responsive DOS orientation
+  let clientWidth = $state(0)
 </script>
 
 <div
   {...rest}
   class="bands-dos-brillouin {rest.class ?? ``}"
-  style={`display: grid; grid-template-columns: 30% 50% 20%; gap: 8px; ${rest.style ?? ``}`}
+  style={rest.style}
+  bind:clientWidth
 >
+  <Bands
+    style="grid-area: bands; min-width: 0; min-height: 0; overflow: hidden"
+    {band_structs}
+    y_axis={shared_y_axis ? shared_y_axis_obj : {}}
+    {...bands_props}
+    padding={{ r: 15, ...bands_props.padding }}
+    on_point_hover={({ point }) => {
+      hovered_band_point = point
+      bands_props.on_point_hover?.({ point })
+    }}
+  />
+
   <BrillouinZone
+    style="grid-area: bz; min-width: 0; min-height: 0; overflow: hidden; max-height: 100%"
     {structure}
     {k_path_points}
     k_path_labels={first_band_struct?.qpoints?.map((q, idx) => ({
@@ -76,20 +93,10 @@
     {...bz_props}
   />
 
-  <Bands
-    {band_structs}
-    y_axis={shared_y_axis ? shared_y_axis_obj : {}}
-    {...bands_props}
-    padding={{ r: 15, ...bands_props.padding }}
-    on_point_hover={({ point }) => {
-      hovered_band_point = point
-      bands_props.on_point_hover?.({ point })
-    }}
-  />
-
   <Dos
+    style="grid-area: dos; min-width: 0; min-height: 0; overflow: hidden"
     {doses}
-    orientation="horizontal"
+    orientation={clientWidth < 1023 ? `vertical` : `horizontal`}
     x_axis={{ ticks: 4 }}
     y_axis={shared_y_axis ? { ...shared_y_axis_obj, label: `` } : { label: `` }}
     padding={{ l: 15, ...dos_props.padding }}
@@ -102,5 +109,40 @@
     width: var(--bands-dos-bz-width, 100%);
     height: var(--bands-dos-bz-height, 600px);
     min-height: var(--bands-dos-bz-min-height, 400px);
+    display: grid;
+    gap: var(--bands-dos-bz-gap, 1em);
+  }
+
+  /* Desktop: BZ | Bands | DOS side by side */
+  @media (min-width: 1024px) {
+    .bands-dos-brillouin {
+      grid-template-columns: 30% 50% 20%;
+      grid-template-areas: 'bz bands dos';
+    }
+  }
+
+  /* Tablet: Bands on top, BZ and DOS below */
+  @media (min-width: 640px) and (max-width: 1023px) {
+    .bands-dos-brillouin {
+      grid-template-columns: 40% 60% !important;
+      grid-template-rows: 50% 50% !important;
+      grid-template-areas:
+        'bands bands'
+        'bz dos' !important;
+    }
+  }
+
+  /* Phone: All stacked vertically */
+  @media (max-width: 639px) {
+    .bands-dos-brillouin {
+      grid-template-columns: 1fr !important;
+      grid-template-rows: 400px 300px 400px !important;
+      grid-template-areas:
+        'bands'
+        'dos'
+        'bz' !important;
+      height: auto !important;
+      min-height: auto !important;
+    }
   }
 </style>

--- a/src/lib/bands/BrillouinBandsDos.svelte
+++ b/src/lib/bands/BrillouinBandsDos.svelte
@@ -57,11 +57,18 @@
       ? (k_path_points[hovered_qpoint_index] as Vec3)
       : null,
   )
-  const desktop_width = 1200
+  const [desktop_width, tablet_width] = [1200, 600]
   let clientWidth = $state(desktop_width)
+  let screen = $derived(
+    clientWidth >= desktop_width
+      ? `desktop`
+      : clientWidth >= tablet_width
+      ? `tablet`
+      : `phone`,
+  )
 </script>
 
-<div {...rest} class="bands-dos-brillouin {rest.class ?? ``}" bind:clientWidth>
+<div {...rest} class="bands-dos-brillouin {screen} {rest.class ?? ``}" bind:clientWidth>
   <Bands
     style="grid-area: bands; min-width: 0; min-height: 0; overflow: hidden"
     {band_structs}
@@ -97,7 +104,7 @@
     orientation={clientWidth < desktop_width ? `vertical` : `horizontal`}
     x_axis={{ ticks: 4 }}
     y_axis={shared_y_axis ? { ...shared_y_axis_obj, label: `` } : { label: `` }}
-    padding={{ l: 15, ...dos_props.padding }}
+    padding={{ l: 15, ...screen === `desktop` ? { r: 5 } : {}, ...dos_props.padding }}
     {...dos_props}
   />
 </div>
@@ -110,28 +117,25 @@
     display: grid;
     gap: var(--bands-dos-bz-gap, 1em);
   }
+
   /* Desktop: BZ | Bands | DOS side by side */
-  @media (min-width: 1200px) {
-    .bands-dos-brillouin {
-      grid-template-columns: 30% 50% 20%;
-      grid-template-areas: 'bz bands dos';
-    }
+  .bands-dos-brillouin.desktop {
+    grid-template-columns: 30% 55% 15%;
+    grid-template-areas: 'bz bands dos';
   }
+
   /* Tablet: Bands on top, BZ and DOS below */
-  @media (min-width: 640px) and (max-width: 1199px) {
-    .bands-dos-brillouin {
-      grid-template-columns: 40% 60% !important;
-      grid-template-rows: 50% 50% !important;
-      grid-template-areas:
-        'bands bands'
-        'bz dos' !important;
-    }
+  .bands-dos-brillouin.tablet {
+    grid-template-columns: 40% 60%;
+    grid-template-rows: 50% 50%;
+    grid-template-areas:
+      'bands bands'
+      'bz dos';
   }
+
   /* Phone: All stacked vertically */
-  @media (max-width: 639px) {
-    .bands-dos-brillouin {
-      grid-template-columns: 1fr !important;
-      grid-template-areas: 'bands' 'dos' 'bz' !important;
-    }
+  .bands-dos-brillouin.phone {
+    grid-template-columns: 1fr;
+    grid-template-areas: 'bands' 'dos' 'bz';
   }
 </style>

--- a/src/lib/bands/BrillouinBandsDos.svelte
+++ b/src/lib/bands/BrillouinBandsDos.svelte
@@ -57,17 +57,11 @@
       ? (k_path_points[hovered_qpoint_index] as Vec3)
       : null,
   )
-
-  // Track screen width for responsive DOS orientation
-  let clientWidth = $state(0)
+  const desktop_width = 1200
+  let clientWidth = $state(desktop_width)
 </script>
 
-<div
-  {...rest}
-  class="bands-dos-brillouin {rest.class ?? ``}"
-  style={rest.style}
-  bind:clientWidth
->
+<div {...rest} class="bands-dos-brillouin {rest.class ?? ``}" bind:clientWidth>
   <Bands
     style="grid-area: bands; min-width: 0; min-height: 0; overflow: hidden"
     {band_structs}
@@ -81,7 +75,7 @@
   />
 
   <BrillouinZone
-    style="grid-area: bz; min-width: 0; min-height: 0; overflow: hidden; max-height: 100%"
+    style="grid-area: bz; min-width: 0; min-height: 0; overflow: hidden; height: 100%"
     {structure}
     {k_path_points}
     k_path_labels={first_band_struct?.qpoints?.map((q, idx) => ({
@@ -96,7 +90,7 @@
   <Dos
     style="grid-area: dos; min-width: 0; min-height: 0; overflow: hidden"
     {doses}
-    orientation={clientWidth < 1023 ? `vertical` : `horizontal`}
+    orientation={clientWidth < desktop_width ? `vertical` : `horizontal`}
     x_axis={{ ticks: 4 }}
     y_axis={shared_y_axis ? { ...shared_y_axis_obj, label: `` } : { label: `` }}
     padding={{ l: 15, ...dos_props.padding }}
@@ -112,17 +106,15 @@
     display: grid;
     gap: var(--bands-dos-bz-gap, 1em);
   }
-
   /* Desktop: BZ | Bands | DOS side by side */
-  @media (min-width: 1024px) {
+  @media (min-width: 1200px) {
     .bands-dos-brillouin {
       grid-template-columns: 30% 50% 20%;
       grid-template-areas: 'bz bands dos';
     }
   }
-
   /* Tablet: Bands on top, BZ and DOS below */
-  @media (min-width: 640px) and (max-width: 1023px) {
+  @media (min-width: 640px) and (max-width: 1199px) {
     .bands-dos-brillouin {
       grid-template-columns: 40% 60% !important;
       grid-template-rows: 50% 50% !important;
@@ -131,18 +123,11 @@
         'bz dos' !important;
     }
   }
-
   /* Phone: All stacked vertically */
   @media (max-width: 639px) {
     .bands-dos-brillouin {
       grid-template-columns: 1fr !important;
-      grid-template-rows: 400px 300px 400px !important;
-      grid-template-areas:
-        'bands'
-        'dos'
-        'bz' !important;
-      height: auto !important;
-      min-height: auto !important;
+      grid-template-areas: 'bands' 'dos' 'bz' !important;
     }
   }
 </style>

--- a/src/lib/bands/BrillouinBandsDos.svelte
+++ b/src/lib/bands/BrillouinBandsDos.svelte
@@ -101,7 +101,7 @@
   <Dos
     style="grid-area: dos; min-width: 0; min-height: 0; overflow: hidden"
     {doses}
-    orientation={clientWidth < desktop_width ? `vertical` : `horizontal`}
+    orientation={screen === `desktop` ? `horizontal` : `vertical`}
     x_axis={{ ticks: 4 }}
     y_axis={shared_y_axis ? { ...shared_y_axis_obj, label: `` } : { label: `` }}
     padding={{ l: 15, ...screen === `desktop` ? { r: 5 } : {}, ...dos_props.padding }}

--- a/src/lib/bands/BrillouinBandsDos.svelte
+++ b/src/lib/bands/BrillouinBandsDos.svelte
@@ -65,8 +65,8 @@
   <Bands
     style="grid-area: bands; min-width: 0; min-height: 0; overflow: hidden"
     {band_structs}
-    y_axis={shared_y_axis ? shared_y_axis_obj : {}}
     {...bands_props}
+    y_axis={shared_y_axis ? shared_y_axis_obj : {}}
     padding={{ r: 15, ...bands_props.padding }}
     on_point_hover={({ point }) => {
       hovered_band_point = point

--- a/src/lib/bands/BrillouinBandsDos.svelte
+++ b/src/lib/bands/BrillouinBandsDos.svelte
@@ -78,10 +78,14 @@
     style="grid-area: bz; min-width: 0; min-height: 0; overflow: hidden; height: 100%"
     {structure}
     {k_path_points}
-    k_path_labels={first_band_struct?.qpoints?.map((q, idx) => ({
-      position: k_path_points[idx],
-      label: q.label ? helpers.pretty_sym_point(q.label) : null,
-    })) ?? []}
+    k_path_labels={first_band_struct?.qpoints?.flatMap((q, idx) =>
+      k_path_points[idx]
+        ? [{
+          position: k_path_points[idx],
+          label: q.label ? helpers.pretty_sym_point(q.label) : null,
+        }]
+        : []
+    ) ?? []}
     {hovered_k_point}
     {hovered_qpoint_index}
     {...bz_props}

--- a/src/lib/bands/BrillouinBandsDos.svelte
+++ b/src/lib/bands/BrillouinBandsDos.svelte
@@ -90,6 +90,7 @@
   <Dos
     {doses}
     orientation="horizontal"
+    x_axis={{ ticks: 4 }}
     y_axis={shared_y_axis ? { ...shared_y_axis_obj, label: `` } : { label: `` }}
     padding={{ l: 15, ...dos_props.padding }}
     {...dos_props}

--- a/src/lib/bands/Dos.svelte
+++ b/src/lib/bands/Dos.svelte
@@ -34,6 +34,8 @@
     show_legend?: boolean
   } = $props()
 
+  const is_horizontal = $derived(orientation === `horizontal`)
+
   // Normalize input to dict format
   let doses_dict = $derived.by(() => {
     if (!doses) return {}
@@ -54,10 +56,7 @@
   })
 
   // Determine if this is phonon or electronic DOS using discriminated union
-  let is_phonon = $derived.by(() => {
-    const first_dos = Object.values(doses_dict)[0]
-    return first_dos?.type === `phonon`
-  })
+  let is_phonon = $derived(Object.values(doses_dict)[0]?.type === `phonon`)
 
   // Convert DOS data to scatter plot series
   // Performance: Only recalculates when doses_dict, units, sigma, or normalize changes
@@ -102,73 +101,89 @@
       if (stack) cumulative_densities = densities
 
       // Determine x and y based on orientation
-      const series: DataSeries = orientation === `horizontal`
-        ? {
-          x: densities,
-          y: x_values,
-          markers: `line`,
-          label: label || `DOS ${dos_idx + 1}`,
-          line_style: {
-            stroke: color,
-            stroke_width: 1.5,
-          },
-          point_style: {
-            fill: stack ? color : undefined,
-          },
-        }
-        : {
-          x: x_values,
-          y: densities,
-          markers: `line`,
-          label: label || `DOS ${dos_idx + 1}`,
-          line_style: {
-            stroke: color,
-            stroke_width: 1.5,
-          },
-          point_style: {
-            fill: stack ? color : undefined,
-          },
-        }
-
+      const series: DataSeries = {
+        x: is_horizontal ? densities : x_values,
+        y: is_horizontal ? x_values : densities,
+        markers: `line`,
+        label: label || `DOS ${dos_idx + 1}`,
+        line_style: { stroke: color, stroke_width: 1.5 },
+        point_style: { fill: stack ? color : undefined },
+      }
       all_series.push(series)
     }
-
     return all_series
   })
 
   // Calculate axis ranges
-  let x_range = $derived.by((): [number, number] | undefined => {
+  let x_range = $derived.by(() => {
     if (!series_data.length) return undefined
     const all_x = series_data.flatMap((s) => s.x)
-    return [Math.min(...all_x), Math.max(...all_x)]
+    return [Math.min(...all_x), Math.max(...all_x)] as [number, number]
   })
 
-  let y_range = $derived.by((): [number, number] | undefined => {
+  let y_range = $derived.by(() => {
     if (!series_data.length) return undefined
     const all_y = series_data.flatMap((s) => s.y)
-    return [Math.min(...all_y), Math.max(...all_y)]
+    return [Math.min(...all_y), Math.max(...all_y)] as [number, number]
   })
 
   // Get axis labels based on orientation
   let x_label = $derived(
-    orientation === `horizontal`
+    is_horizontal
       ? `Density of States`
       : is_phonon
       ? `Frequency (${units})`
       : `Energy (eV)`,
   )
   let y_label = $derived(
-    orientation === `horizontal`
-      ? is_phonon ? `Frequency (${units})` : `Energy (eV)`
+    is_horizontal
+      ? (is_phonon ? `Frequency (${units})` : `Energy (eV)`)
       : `Density of States`,
   )
+
+  // Compute final axis configurations with default labels
+  let final_x_axis = $derived({
+    label: x_label,
+    format: `.2f`,
+    range: x_range,
+    ...(is_horizontal && { ticks: 4 }),
+    ...x_axis,
+  })
+  let final_y_axis = $derived({
+    label: y_label,
+    format: `.2f`,
+    range: y_range,
+    ...y_axis,
+  })
 </script>
 
 <ScatterPlot
   series={series_data}
-  x_axis={{ label: x_label, format: `.2f`, range: x_range, ...x_axis }}
-  y_axis={{ label: y_label, format: `.2f`, range: y_range, ...y_axis }}
+  x_axis={final_x_axis}
+  y_axis={final_y_axis}
   display={{ x_grid: true, y_grid: true, x_zero_line: true, y_zero_line: true }}
   legend={show_legend ? {} : null}
+  hover_config={{ threshold_px: 50 }}
   {...rest}
-/>
+>
+  {#snippet tooltip({ x_formatted, y_formatted, label })}
+    {@const x_label_full = final_x_axis.label ?? ``}
+    {@const y_label_full = final_y_axis.label ?? ``}
+    {@const x_match = x_label_full.match(/^(.+?)\s*\(([^)]+)\)$/)}
+    {@const y_match = y_label_full.match(/^(.+?)\s*\(([^)]+)\)$/)}
+    {@const x_label_text = x_match?.[1] ||
+      (x_label_full.includes(`Energy`) ? `Energy` : `Frequency`)}
+    {@const x_unit = x_match?.[2] || ``}
+    {@const y_label_text = y_match?.[1] || `Density`}
+    {@const y_unit = y_match?.[2] || ``}
+    {@const num_doses = Object.keys(doses_dict).length}
+    {#if num_doses > 1 && label}<strong>{label}</strong><br />{/if}
+    {#if is_horizontal}
+      <strong>{y_label_text}: {y_formatted}{y_unit ? ` ${y_unit}` : ``}</strong><br />
+      {x_label_text}: {x_formatted}
+    {:else}
+      {y_label_text}: {y_formatted}<br />
+      {x_label_text}: {x_formatted}{x_unit ? ` ${x_unit}` : ``}
+    {/if}
+  {/snippet}
+</ScatterPlot>

--- a/src/lib/bands/Dos.svelte
+++ b/src/lib/bands/Dos.svelte
@@ -9,7 +9,7 @@
     normalize_densities,
     normalize_dos,
   } from './helpers'
-  import type { Dos, FrequencyUnit, NormalizationMode } from './types'
+  import type { DosData, FrequencyUnit, NormalizationMode } from './types'
 
   let {
     doses,
@@ -23,7 +23,7 @@
     y_axis = {},
     ...rest
   }: ComponentProps<typeof ScatterPlot> & {
-    doses: Dos | Record<string, Dos>
+    doses: DosData | Record<string, DosData>
     x_axis?: AxisConfig
     y_axis?: AxisConfig
     stack?: boolean
@@ -47,8 +47,8 @@
     }
 
     // Already a dict - normalize each DOS
-    const result: Record<string, Dos> = {}
-    for (const [key, dos] of Object.entries(doses as Record<string, Dos>)) {
+    const result: Record<string, DosData> = {}
+    for (const [key, dos] of Object.entries(doses as Record<string, DosData>)) {
       const normalized = normalize_dos(dos)
       if (normalized) result[key] = normalized
     }
@@ -155,13 +155,19 @@
     range: y_range,
     ...y_axis,
   })
+  let display = $state({
+    x_grid: true,
+    y_grid: true,
+    x_zero_line: true,
+    y_zero_line: true,
+  })
 </script>
 
 <ScatterPlot
   series={series_data}
-  x_axis={final_x_axis}
-  y_axis={final_y_axis}
-  display={{ x_grid: true, y_grid: true, x_zero_line: true, y_zero_line: true }}
+  bind:x_axis={final_x_axis}
+  bind:y_axis={final_y_axis}
+  bind:display
   legend={show_legend ? {} : null}
   hover_config={{ threshold_px: 50 }}
   {...rest}

--- a/src/lib/bands/Dos.svelte
+++ b/src/lib/bands/Dos.svelte
@@ -120,11 +120,10 @@
     const all_x = series_data.flatMap((s) => s.x)
     return [Math.min(...all_x), Math.max(...all_x)] as [number, number]
   })
-
   let y_range = $derived.by(() => {
     if (!series_data.length) return undefined
     const all_y = series_data.flatMap((s) => s.y)
-    return [Math.min(...all_y), Math.max(...all_y)] as [number, number]
+    return [0, Math.max(...all_y)] as [number, number]
   })
 
   // Get axis labels based on orientation

--- a/src/lib/bands/helpers.ts
+++ b/src/lib/bands/helpers.ts
@@ -1,6 +1,6 @@
 // Helper utilities for band structure and DOS data processing
 import { subscript_map } from '$lib/labels'
-import { Vec3 } from '../math'
+import type { Vec3 } from '../math'
 import type * as types from './types'
 
 // Physical constants for unit conversions (SI units)

--- a/src/lib/bands/index.ts
+++ b/src/lib/bands/index.ts
@@ -1,7 +1,8 @@
 // Band structure and density of states visualization components
 
 export { default as Bands } from './Bands.svelte'
-export { default as Dos } from './Dos.svelte'
 export { default as BandsAndDos } from './BandsAndDos.svelte'
-export * from './types'
+export { default as BrillouinBandsDos } from './BrillouinBandsDos.svelte'
+export { default as Dos } from './Dos.svelte'
 export * from './helpers'
+export * from './types'

--- a/src/lib/bands/types.ts
+++ b/src/lib/bands/types.ts
@@ -63,7 +63,7 @@ export interface ElectronicDos {
   spin_polarized?: boolean
 }
 // Discriminated union for type-safe DOS handling
-export type Dos = PhononDos | ElectronicDos
+export type DosData = PhononDos | ElectronicDos
 
 // Line styling configuration
 export type LineKwargs =

--- a/src/lib/brillouin/BrillouinZone.svelte
+++ b/src/lib/brillouin/BrillouinZone.svelte
@@ -25,7 +25,6 @@
     error_msg?: string
     is_fullscreen?: boolean
   }
-
   let {
     structure = $bindable(undefined),
     bz_order = $bindable(1),
@@ -55,6 +54,10 @@
     spinner_props = {},
     loading = $bindable(false),
     error_msg = $bindable(undefined),
+    k_path_points = [],
+    k_path_labels = [],
+    hovered_k_point = null,
+    hovered_qpoint_index = null,
     children,
     on_file_load,
     on_error,
@@ -90,6 +93,12 @@
       loading?: boolean
       error_msg?: string
       structure_string?: string
+      k_path_points?: Array<[number, number, number]>
+      k_path_labels?: Array<
+        { position: [number, number, number]; label: string | null }
+      >
+      hovered_k_point?: [number, number, number] | null
+      hovered_qpoint_index?: number | null
       children?: Snippet<
         [{ structure?: PymatgenStructure; bz_data?: BrillouinZoneData }]
       >
@@ -144,7 +153,9 @@
 
     try {
       const k_lattice = reciprocal_lattice(structure.lattice.matrix)
-      bz_data = compute_brillouin_zone(k_lattice, bz_order)
+      // Ensure bz_order is 1, 2, or 3
+      const valid_order = Math.min(Math.max(1, bz_order), 3) as 1 | 2 | 3
+      bz_data = compute_brillouin_zone(k_lattice, valid_order)
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
       error_msg = `BZ computation failed: ${msg}`
@@ -316,7 +327,6 @@
           bind:edge_color
           bind:edge_width
           bind:show_vectors
-          bind:vector_scale
           bind:camera_projection
         />
       {/if}
@@ -334,6 +344,10 @@
             {show_vectors}
             {vector_scale}
             {camera_projection}
+            {k_path_points}
+            {k_path_labels}
+            {hovered_k_point}
+            {hovered_qpoint_index}
             bind:scene
             bind:camera
           />

--- a/src/lib/brillouin/BrillouinZone.svelte
+++ b/src/lib/brillouin/BrillouinZone.svelte
@@ -94,11 +94,17 @@
       loading?: boolean
       error_msg?: string
       structure_string?: string
+      // K-path points in Cartesian reciprocal space coordinates (not fractional coords)
+      // Should be computed using the reciprocal lattice matrix (includes 2π factor)
       k_path_points?: Vec3[]
+      // K-path labels with positions in Cartesian reciprocal space coordinates
+      // Each position should match a corresponding point in k_path_points
       k_path_labels?: Array<
         { position: [number, number, number]; label: string | null }
       >
+      // Currently hovered k-point in Cartesian reciprocal space coordinates
       hovered_k_point?: [number, number, number] | null
+      // Index of the currently hovered q-point in the band structure
       hovered_qpoint_index?: number | null
       children?: Snippet<
         [{ structure?: PymatgenStructure; bz_data?: BrillouinZoneData }]

--- a/src/lib/brillouin/BrillouinZone.svelte
+++ b/src/lib/brillouin/BrillouinZone.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { Icon, Spinner, toggle_fullscreen } from '$lib'
   import { decompress_file, handle_url_drop, load_from_url } from '$lib/io'
+  import type { Vec3 } from '$lib/math'
   import { type CameraProjection, DEFAULTS } from '$lib/settings'
   import type { PymatgenStructure } from '$lib/structure'
   import { parse_any_structure } from '$lib/structure/parse'
@@ -93,7 +94,7 @@
       loading?: boolean
       error_msg?: string
       structure_string?: string
-      k_path_points?: Array<[number, number, number]>
+      k_path_points?: Vec3[]
       k_path_labels?: Array<
         { position: [number, number, number]; label: string | null }
       >

--- a/src/lib/brillouin/BrillouinZoneInfoPane.svelte
+++ b/src/lib/brillouin/BrillouinZoneInfoPane.svelte
@@ -72,7 +72,7 @@
           label: `a, b, c`,
           value: `${
             [structure.lattice.a, structure.lattice.b, structure.lattice.c]
-              .map((v) => format_num(v, `.3~f`))
+              .map((val) => format_num(val, `.3~f`))
               .join(`, `)
           } Å`,
           key: `real-lattice-abc`,
@@ -81,7 +81,7 @@
           label: `α, β, γ`,
           value: `${
             [structure.lattice.alpha, structure.lattice.beta, structure.lattice.gamma]
-              .map((v) => format_num(v, `.2~f`))
+              .map((val) => format_num(val, `.2~f`))
               .join(`, `)
           }°`,
           key: `real-lattice-angles`,

--- a/src/lib/brillouin/BrillouinZoneScene.svelte
+++ b/src/lib/brillouin/BrillouinZoneScene.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import type { Vec3 } from '$lib'
   import { axis_colors, neg_axis_colors } from '$lib'
+  import type { Vec3 } from '$lib/math'
   import * as math from '$lib/math'
   import { type CameraProjection, DEFAULTS } from '$lib/settings'
   import { Arrow, Cylinder } from '$lib/structure'
@@ -62,7 +62,7 @@
     camera_is_moving?: boolean
     scene?: Scene
     camera?: Camera
-    k_path_points?: Array<[number, number, number]>
+    k_path_points?: Vec3[]
     k_path_labels?: Array<
       { position: [number, number, number]; label: string | null }
     >
@@ -83,9 +83,7 @@
   // BZ size for camera positioning: average magnitude of k-vectors
   const bz_size = $derived.by(() => {
     if (!bz_data?.k_lattice) return 10
-    const mags = bz_data.k_lattice.map((v) =>
-      Math.sqrt(v[0] ** 2 + v[1] ** 2 + v[2] ** 2)
-    )
+    const mags = bz_data.k_lattice.map((vec) => Math.hypot(...vec))
     return mags.reduce((sum, mag) => sum + mag, 0) / 3
   })
 
@@ -216,7 +214,7 @@
     {/if}
 
     <!-- BZ edges -->
-    {#each bz_data.edges as edge_segment (edge_segment.map((v) => v.join(`,`)).join(`-`))}
+    {#each bz_data.edges as edge_segment (JSON.stringify(edge_segment))}
       {@const [from, to] = edge_segment}
       <Cylinder {from} {to} thickness={edge_width} color={edge_color} />
     {/each}

--- a/src/lib/brillouin/BrillouinZoneScene.svelte
+++ b/src/lib/brillouin/BrillouinZoneScene.svelte
@@ -172,8 +172,9 @@
     return geometry
   })
 
-  $effect(() => { // Dispose previous geometry on change/unmount (prevent memory leaks)
-    return () => bz_geometry?.dispose()
+  $effect(() => {
+    const prev_geometry = bz_geometry // Dispose previous geometry on change/unmount; prevents memory leaks
+    return () => prev_geometry?.dispose() // (need to assign to a variable in function so closure captures old value)
   })
 </script>
 

--- a/src/lib/brillouin/BrillouinZoneScene.svelte
+++ b/src/lib/brillouin/BrillouinZoneScene.svelte
@@ -269,7 +269,7 @@
         {#if label}
           <extras.HTML center position={position.map((x) => x * 1.1) as Vec3}>
             <span
-              style="background: rgba(0, 0, 0, 0.3); padding: 0 3px; border-radius: 2px"
+              style="background: rgba(0, 0, 0, 0.3); padding: 0 3px; border-radius: 2px; color: white"
             >
               {label}
             </span>

--- a/src/lib/brillouin/compute.ts
+++ b/src/lib/brillouin/compute.ts
@@ -44,7 +44,6 @@ const TOL = 1e-8
 class VertexDeduplicator {
   private grid = new Map<string, Vec3[]>()
   private cell_size: number
-
   constructor(cell_size: number) {
     this.cell_size = cell_size
   }
@@ -57,10 +56,10 @@ class VertexDeduplicator {
         for (let dz = -1; dz <= 1; dz++) {
           const neighbors = this.grid.get(`${base_x + dx},${base_y + dy},${base_z + dz}`)
           if (
-            neighbors?.some((v) =>
-              Math.abs(v[0] - vertex[0]) < TOL &&
-              Math.abs(v[1] - vertex[1]) < TOL &&
-              Math.abs(v[2] - vertex[2]) < TOL
+            neighbors?.some(([v1, v2, v3]) =>
+              Math.abs(v1 - vertex[0]) < TOL &&
+              Math.abs(v2 - vertex[1]) < TOL &&
+              Math.abs(v3 - vertex[2]) < TOL
             )
           ) return true
         }
@@ -70,7 +69,7 @@ class VertexDeduplicator {
   }
 
   add(vertex: Vec3): void {
-    const key = vertex.map((v) => Math.floor(v / this.cell_size)).join(`,`)
+    const key = vertex.map((vert) => Math.floor(vert / this.cell_size)).join(`,`)
     const cell = this.grid.get(key)
     if (cell) cell.push(vertex)
     else this.grid.set(key, [vertex])
@@ -167,7 +166,7 @@ export function compute_convex_hull(
     throw new Error(`Need ≥4 vertices for convex hull, got ${vertices.length}`)
   }
 
-  const geometry = new ConvexGeometry(vertices.map((v) => new Vector3(...v)))
+  const geometry = new ConvexGeometry(vertices.map((cert) => new Vector3(...cert)))
   const pos = geometry.getAttribute(`position`)
   const idx = geometry.index
 

--- a/src/lib/composition/BubbleChart.svelte
+++ b/src/lib/composition/BubbleChart.svelte
@@ -60,17 +60,16 @@
     const pack_layout = pack<HierarchyData | Child>().size([
       size - 2 * padding,
       size - 2 * padding,
-    ])
-      .padding(padding * 0.1) // Small padding between circles
+    ]).padding(padding * 0.1) // Small padding between circles
 
     const root = pack_layout(
-      hierarchy<HierarchyData | Child>(hierarchy_data).sum((
-        d,
-      ) => (`amount` in d ? d.amount : 0)),
+      hierarchy<HierarchyData | Child>(hierarchy_data).sum(
+        (data) => (`amount` in data ? data.amount : 0),
+      ),
     )
 
     // Get max radius for font scaling
-    const max_radius = Math.max(...root.leaves().map((d) => d.r || 0))
+    const max_radius = Math.max(...root.leaves().map((data) => data.r || 0))
     const total_atoms = get_total_atoms(composition)
 
     return root.leaves().map((node) => {

--- a/src/lib/coordination/CoordinationBarPlot.svelte
+++ b/src/lib/coordination/CoordinationBarPlot.svelte
@@ -53,6 +53,7 @@
 
   let dragover = $state(false)
   let dropped_entries = $state<StructureEntry[]>([])
+  let is_horizontal = $derived(orientation === `horizontal`)
 
   // Normalize input to consistent array of { label, structure, color }
   const structure_entries = $derived.by<StructureEntry[]>(() => {
@@ -277,19 +278,19 @@
   bind:mode
   x_axis={{
     label_shift: { y: 20 },
-    range: orientation === `horizontal` ? ranges.count : ranges.cn,
-    ticks: orientation === `horizontal` ? undefined : cn_ticks,
-    ...(orientation === `horizontal` ? y_axis : x_axis),
+    range: is_horizontal ? ranges.count : ranges.cn,
+    ticks: is_horizontal ? undefined : cn_ticks,
+    ...(is_horizontal ? y_axis : x_axis),
   }}
   y_axis={{
     label_shift: { x: 2 },
-    range: orientation === `horizontal` ? ranges.cn : ranges.count,
-    ticks: orientation === `horizontal` ? cn_ticks : undefined,
-    ...orientation === `horizontal` ? x_axis : y_axis,
+    range: is_horizontal ? ranges.cn : ranges.count,
+    ticks: is_horizontal ? cn_ticks : undefined,
+    ...is_horizontal ? x_axis : y_axis,
   }}
   display={{
-    x_zero_line: orientation === `horizontal`,
-    y_zero_line: orientation === `vertical`,
+    x_zero_line: is_horizontal,
+    y_zero_line: !is_horizontal,
   }}
   {tooltip}
   ondrop={handle_file_drop}

--- a/src/lib/element/ElementTile.svelte
+++ b/src/lib/element/ElementTile.svelte
@@ -96,7 +96,7 @@
   // Determine if we should show values - default to false if any array element is a color
   const should_show_values = $derived.by(() => {
     if (show_values !== undefined) return show_values
-    if (Array.isArray(value)) return !value.some((v) => is_color(v))
+    if (Array.isArray(value)) return !value.some(is_color)
     return !is_color(value)
   })
 
@@ -199,12 +199,7 @@
       {/each}
     {:else if Array.isArray(value)}
       <!-- Fallback for other array lengths -->
-      <span class="value">{
-        value
-        .map((v) => format_value(v))
-        .filter((v) => v)
-        .join(` / `)
-      }</span>
+      <span class="value">{value.map(format_value).filter(Boolean).join(` / `)}</span>
     {:else}
       <!-- Single value -->
       <span class="value">{format_value(value)}</span>

--- a/src/lib/labels.ts
+++ b/src/lib/labels.ts
@@ -24,8 +24,7 @@ function name_for_symbol(sym: unknown): D3SymbolName | null {
 
 export const symbol_names = (
   [...new Set([...d3_symbols.symbolsFill, ...d3_symbols.symbolsStroke])]
-    .map((sym) => name_for_symbol(sym))
-    .filter((n): n is D3SymbolName => n !== null)
+    .map(name_for_symbol).filter((n): n is D3SymbolName => n !== null)
 ) as D3SymbolName[]
 
 const symbols_index = d3_symbols as unknown as Record<string, SymbolType>

--- a/src/lib/plot/Histogram.svelte
+++ b/src/lib/plot/Histogram.svelte
@@ -149,7 +149,7 @@
       const hist = bin().domain([auto_x[0], auto_x[1]]).thresholds(bins)
       const max_count = Math.max(
         0,
-        ...series_list.map((s) => max(hist(s.y), (d) => d.length) || 0),
+        ...series_list.map((s) => max(hist(s.y), (data) => data.length) || 0),
       )
       const [y0, y1] = get_nice_data_range(
         [{ x: 0, y: 0 }, { x: max_count, y: 0 }],
@@ -272,7 +272,7 @@
           ? bar.color
           : extract_series_color(series_data),
         bins: bins_arr,
-        max_count: max(bins_arr, (d) => d.length) || 0,
+        max_count: max(bins_arr, (data) => data.length) || 0,
         y_axis: series_data.y_axis,
         y_scale: use_y2 ? scales.y2 : scales.y,
       }

--- a/src/lib/plot/ScatterPlot.svelte
+++ b/src/lib/plot/ScatterPlot.svelte
@@ -1717,20 +1717,23 @@
       y,
       (hovered_series?.y_axis === `y2` ? y2_axis.format : y_axis.format) || `.3~s`,
     )}
-      {@const label = point_label?.text ?? null}
       {@const tooltip_lum = luminance(tooltip_bg_color ?? `rgba(0, 0, 0, 0.7)`)}
       {@const tooltip_text_color = tooltip_lum > 0.5 ? `#000000` : `#ffffff`}
-      <div
-        class="tooltip overlay"
-        style={`position: absolute; left: ${
-          cx + 5
-        }px; top: ${cy}px; background-color: ${tooltip_bg_color}; color: var(--scatter-tooltip-color, ${tooltip_text_color}); z-index: calc(var(--scatter-z-index, 0) + 1000); pointer-events: none;`}
-      >
+      {@const style = `position: absolute; left: ${cx + 5}px; top: ${cy}px;
+      background-color: ${tooltip_bg_color}; color: var(--scatter-tooltip-color, ${tooltip_text_color});
+      z-index: calc(var(--scatter-z-index, 0) + 1000); pointer-events: none;`}
+      <div class="tooltip overlay" {style}>
         {#if tooltip}
-          {@const tooltip_props = { x_formatted, y_formatted, color_value, label, series_idx }}
+          {@const tooltip_props = {
+        x_formatted,
+        y_formatted,
+        color_value,
+        label: hovered_series?.label ?? null,
+        series_idx,
+      }}
           {@render tooltip({ x, y, cx, cy, metadata, ...tooltip_props })}
         {:else}
-          {label ?? `Point`} - x: {x_formatted}, y: {y_formatted}
+          {point_label?.text ?? `Point`} - x: {x_formatted}, y: {y_formatted}
         {/if}
       </div>
     {/if}

--- a/src/lib/plot/ScatterPlot.svelte
+++ b/src/lib/plot/ScatterPlot.svelte
@@ -1043,7 +1043,7 @@
       .force(
         `link`,
         forceLink(links)
-          .id((d) => (d as { id: string }).id)
+          .id((data) => (data as { id: string }).id)
           .distance(actual_label_config.link_distance)
           .strength(actual_label_config.link_strength),
       )

--- a/src/lib/plot/SpacegroupBarPlot.svelte
+++ b/src/lib/plot/SpacegroupBarPlot.svelte
@@ -131,16 +131,11 @@
     const [range_min, range_max] = x_range
 
     return CRYSTAL_SYSTEMS.map((system) => {
-      const [sg_min, sg_max] = CRYSTAL_SYSTEM_RANGES[system]
+      const [sg_start, sg_end] = CRYSTAL_SYSTEM_RANGES[system]
       const stats = crystal_system_stats.get(system)
-
-      return {
-        system,
-        sg_start: sg_min,
-        sg_end: sg_max,
-        count: stats?.count ?? 0,
-        color: CRYSTAL_SYSTEM_COLORS[system],
-      }
+      const count = stats?.count ?? 0
+      const color = CRYSTAL_SYSTEM_COLORS[system]
+      return { system, sg_start, sg_end, count, color }
     }).filter(
       (region) => region.sg_end >= range_min && region.sg_start <= range_max, // Only visible systems
     )

--- a/src/lib/plot/SpacegroupBarPlot.svelte
+++ b/src/lib/plot/SpacegroupBarPlot.svelte
@@ -185,7 +185,7 @@
   y_scale_fn: (y: number) => number
   pad: { t: number; b: number; l: number; r: number }
 })}
-  <g class="crystal-system-overlays">
+  <g class="crystal-system-overlays" pointer-events="none">
     {#each crystal_system_regions as region (region.system)}
       {#if orientation === `vertical`}
         {@const x_start = x_scale_fn(region.sg_start - 0.5)}

--- a/src/lib/plot/SpacegroupBarPlot.svelte
+++ b/src/lib/plot/SpacegroupBarPlot.svelte
@@ -17,7 +17,6 @@
   import { SvelteMap } from 'svelte/reactivity'
 
   const MAX_SPACEGROUP = 230
-
   let {
     data,
     show_counts = true,
@@ -32,9 +31,7 @@
 
   // Normalize input data to space group numbers
   const normalized_data = $derived(
-    data.map((sg) => normalize_spacegroup(sg)).filter((sg): sg is number =>
-      sg !== null
-    ),
+    data.map(normalize_spacegroup).filter((sg): sg is number => sg !== null),
   )
 
   // Compute histogram of space group numbers

--- a/src/lib/structure/StructureControls.svelte
+++ b/src/lib/structure/StructureControls.svelte
@@ -28,6 +28,7 @@
     background_opacity = $bindable(DEFAULTS.background_opacity),
     color_scheme = $bindable(DEFAULTS.color_scheme),
     structure = undefined,
+    supercell_loading = false,
     pane_props = $bindable({}),
     toggle_props = $bindable({}),
     ...rest
@@ -41,6 +42,7 @@
     background_opacity?: number
     color_scheme?: string
     structure?: AnyStructure
+    supercell_loading?: boolean
     pane_props?: ComponentProps<typeof DraggablePane>[`pane_props`]
     toggle_props?: ComponentProps<typeof DraggablePane>[`toggle_props`]
   } = $props()
@@ -603,6 +605,8 @@
           bind:value={supercell_scaling}
           placeholder="1x1x1"
           style:border={supercell_input_valid ? undefined : `1px dashed red`}
+          style:opacity={supercell_loading ? 0.5 : 1}
+          disabled={supercell_loading}
           inputmode="text"
           autocomplete="off"
           spellcheck="false"
@@ -613,6 +617,17 @@
           : `Invalid format. Use "2x2x2", "3x1x2", or "2"`}
         />
       </label>
+      {#if supercell_loading}
+        <div
+          style="display: flex; align-items: center; gap: 8px; font-size: 0.85em; color: var(--accent-color); margin-top: 4pt"
+        >
+          <span
+            class="spinner-icon"
+            style="display: inline-block; width: 12px; height: 12px; border: 2px solid currentColor; border-right-color: transparent; border-radius: 50%; animation: spin 0.8s linear infinite"
+          ></span>
+          <span>Generating supercell...</span>
+        </div>
+      {/if}
 
       {#if !supercell_input_valid}
         <div style="color: red; font-size: 0.8em; margin-top: 4pt">
@@ -815,5 +830,14 @@
     display: grid;
     gap: 0.3em;
     place-items: center;
+  }
+
+  @keyframes spin {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
   }
 </style>

--- a/src/lib/structure/StructureInfoPane.svelte
+++ b/src/lib/structure/StructureInfoPane.svelte
@@ -241,7 +241,7 @@
                   const force_magnitude = Math.hypot(...prop_value)
                   formatted_value = `${format_num(force_magnitude, `.3~f`)} eV/Å`
                   tooltip = `Force vector: (${
-                    prop_value.map((f) => format_num(f, `.3~f`)).join(`, `)
+                    prop_value.map((force) => format_num(force, `.3~f`)).join(`, `)
                   }) eV/Å`
                 } else if (prop_key === `magmom` || prop_key.includes(`magnet`)) {
                   const num_val = Number(prop_value)

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -205,6 +205,11 @@
     lattice ? (lattice.a + lattice.b + lattice.c) / 2 : 10,
   )
 
+  // Compute dynamic camera clipping planes based on structure size
+  // This prevents z-fighting and disappearing objects when zooming in close on large supercells
+  let camera_near = $derived(Math.max(0.01, structure_size * 0.01))
+  let camera_far = $derived(Math.max(1000, structure_size * 100))
+
   let computed_zoom = $state<number>(initial_zoom)
   $effect(() => {
     if (!(width > 0) || !(height > 0)) return
@@ -485,7 +490,13 @@
 {/snippet}
 
 {#if camera_projection === `perspective`}
-  <T.PerspectiveCamera makeDefault position={camera_position} {fov}>
+  <T.PerspectiveCamera
+    makeDefault
+    position={camera_position}
+    {fov}
+    near={camera_near}
+    far={camera_far}
+  >
     <extras.OrbitControls {...orbit_controls_props}>
       {#if gizmo}<extras.Gizmo {...gizmo_props} />{/if}
     </extras.OrbitControls>
@@ -496,6 +507,7 @@
     position={camera_position}
     zoom={computed_zoom}
     near={-100}
+    far={camera_far}
   >
     <extras.OrbitControls {...orbit_controls_props}>
       {#if gizmo}<extras.Gizmo {...gizmo_props} />{/if}
@@ -516,6 +528,7 @@
           <extras.InstancedMesh
             key="{group.element}-{group.radius}-{group.atoms.length}"
             range={group.atoms.length}
+            frustumCulled={false}
           >
             <T.SphereGeometry args={[0.5, sphere_segments, sphere_segments]} />
             <T.MeshStandardMaterial color={group.color} />

--- a/src/lib/structure/supercell.ts
+++ b/src/lib/structure/supercell.ts
@@ -20,7 +20,7 @@ export function parse_supercell_scaling(scaling: string | number | Vec3): Vec3 {
       }
       return [val, val, val] as Vec3
     } else if (parts.length === 3) {
-      const values = parts.map(parseInt)
+      const values = parts.map((val) => parseInt(val, 10))
       if (values.some((val) => isNaN(val) || val <= 0)) {
         throw new Error(`Invalid supercell scaling: ${scaling}`)
       }

--- a/src/lib/structure/supercell.ts
+++ b/src/lib/structure/supercell.ts
@@ -92,15 +92,21 @@ export function make_supercell(
 
   const scaling_factors = parse_supercell_scaling(scaling)
   const [nx, ny, nz] = scaling_factors
+  const det = nx * ny * nz
+
+  // Short circuit for 1x1x1 (no actual supercell needed)
+  if (nx === 1 && ny === 1 && nz === 1) {
+    return {
+      ...structure,
+      supercell_scaling: scaling_factors,
+    } as SupercellType
+  }
 
   // Create new scaled lattice
   const new_lattice_matrix = scale_lattice_matrix(
     structure.lattice.matrix,
     scaling_factors,
   )
-  const det = nx * ny * nz
-
-  // Calculate new lattice parameters efficiently
   const lattice_params = math.calc_lattice_params(new_lattice_matrix)
 
   const new_lattice = {
@@ -109,78 +115,59 @@ export function make_supercell(
     ...lattice_params,
   }
 
-  // Generate all lattice points in the supercell
-  const lattice_points = generate_lattice_points(scaling_factors)
+  // Pre-compute matrices (constant for all sites)
+  const orig_T = math.transpose_3x3_matrix(structure.lattice.matrix)
+  const new_T = math.transpose_3x3_matrix(new_lattice_matrix)
+  const new_T_inv = math.matrix_inverse_3x3(new_T)
 
-  // Create new sites by replicating each original site at all lattice points
   const new_sites: Site[] = []
 
-  for (const orig_site of structure.sites) {
-    for (const lattice_point of lattice_points) {
-      // Convert lattice point to cartesian coordinates using original lattice
-      // Use transpose of lattice matrix for proper coordinate conversion
-      const translation_cart = math.mat3x3_vec3_multiply(
-        math.transpose_3x3_matrix(structure.lattice.matrix),
-        lattice_point,
-      )
+  // Generate sites
+  for (let kk = 0; kk < nz; kk++) {
+    for (let jj = 0; jj < ny; jj++) {
+      for (let ii = 0; ii < nx; ii++) {
+        const translation = math.mat3x3_vec3_multiply(orig_T, [ii, jj, kk])
+        const label_suffix = det > 1 ? `_${ii}${jj}${kk}` : ``
 
-      // New cartesian position = original + translation
-      const new_xyz = math.add(orig_site.xyz, translation_cart) as Vec3
+        for (const site of structure.sites) {
+          // Translate to new position in Cartesian coordinates
+          const cart_pos = math.add(site.xyz, translation)
 
-      // Calculate new fractional coordinates in the supercell lattice
-      // Use transpose convention for coordinate conversion
-      let new_abc = math.mat3x3_vec3_multiply(
-        math.matrix_inverse_3x3(math.transpose_3x3_matrix(new_lattice_matrix)),
-        new_xyz,
-      ) as Vec3
+          // Convert to fractional coordinates in new lattice
+          let frac_pos = math.mat3x3_vec3_multiply(new_T_inv, cart_pos)
 
-      // Fold back to unit cell if requested
-      if (to_unit_cell) {
-        new_abc = new_abc.map((coord) => {
-          // Use modulo to wrap coordinates to [0, 1)
-          let wrapped = coord % 1
-          if (wrapped < 0) wrapped += 1
-          // Handle floating point precision: if wrapped value is very close to 1 or exactly 1 due to
-          // numerical errors, set to 0
-          if (wrapped >= 1 - 1e-10) wrapped = 0
-          return wrapped
-        }) as Vec3
+          // Wrap to unit cell if requested
+          if (to_unit_cell) {
+            frac_pos = frac_pos.map((coord) => {
+              let wrapped = coord % 1
+              if (wrapped < 0) wrapped += 1
+              if (wrapped >= 0.9999999999) wrapped = 0
+              return wrapped
+            }) as Vec3
+          }
+
+          // Convert back to Cartesian in new lattice
+          const final_pos = math.mat3x3_vec3_multiply(new_T, frac_pos)
+
+          new_sites.push({
+            species: site.species,
+            xyz: final_pos,
+            abc: frac_pos,
+            label: label_suffix ? `${site.label}${label_suffix}` : site.label,
+            properties: site.properties,
+          })
+        }
       }
-
-      // Recalculate cartesian coordinates from wrapped fractional coordinates
-      // to ensure consistency
-      const final_xyz = math.mat3x3_vec3_multiply(
-        math.transpose_3x3_matrix(new_lattice_matrix),
-        new_abc,
-      ) as Vec3
-
-      // Create new site
-      const new_site: Site = {
-        ...orig_site,
-        xyz: final_xyz,
-        abc: new_abc,
-        // Update label to indicate supercell position if it has numeric suffix
-        label: lattice_points.length > 1
-          ? `${orig_site.label}_${lattice_point.join(``)}`
-          : orig_site.label,
-      }
-
-      new_sites.push(new_site)
     }
   }
 
-  // Create new supercell structure
-  const supercell: SupercellType = {
+  return {
     ...structure,
     lattice: new_lattice,
     sites: new_sites,
-    // Scale charge if present
     charge: structure.charge ? structure.charge * det : structure.charge,
-    // Add metadata for supercell detection
     supercell_scaling: scaling_factors,
-  }
-
-  return supercell
+  } as SupercellType
 }
 
 // Validate supercell input string

--- a/src/lib/structure/supercell.ts
+++ b/src/lib/structure/supercell.ts
@@ -20,7 +20,7 @@ export function parse_supercell_scaling(scaling: string | number | Vec3): Vec3 {
       }
       return [val, val, val] as Vec3
     } else if (parts.length === 3) {
-      const values = parts.map((val) => parseInt(val))
+      const values = parts.map(parseInt)
       if (values.some((val) => isNaN(val) || val <= 0)) {
         throw new Error(`Invalid supercell scaling: ${scaling}`)
       }

--- a/src/lib/symmetry/WyckoffTable.svelte
+++ b/src/lib/symmetry/WyckoffTable.svelte
@@ -74,7 +74,7 @@
               {elem}
             </span>
           </td>
-          <td>({abc?.map((x) => format_fractional(x)).join(` , `) ?? `N/A`})</td>
+          <td>({abc?.map(format_fractional).join(` , `) ?? `N/A`})</td>
         </tr>
       {/each}
     </tbody>

--- a/src/lib/trajectory/TrajectoryInfoPane.svelte
+++ b/src/lib/trajectory/TrajectoryInfoPane.svelte
@@ -54,7 +54,7 @@
     typeof val === `number` && isFinite(val)
 
   const extract_numeric_array = (frames: typeof trajectory.frames, prop: string) =>
-    frames.map((f) => f.metadata?.[prop]).filter(is_valid_number)
+    frames.map((frame) => frame.metadata?.[prop]).filter(is_valid_number)
 
   const format_range = (values: number[], unit = ``, decimals = `.2~f`) => {
     if (!values.length) return null
@@ -268,8 +268,9 @@
         ? current_frame.structure.lattice
         : null
       if (lattice) {
-        const volumes = trajectory.frames
-          .map((f) => (`lattice` in f.structure && f.structure.lattice?.volume))
+        const volumes = trajectory.frames.map((
+          { structure },
+        ) => (`lattice` in structure && structure.lattice?.volume))
           .filter(is_valid_number)
           .filter((v) => v > 0)
 

--- a/src/lib/trajectory/index.ts
+++ b/src/lib/trajectory/index.ts
@@ -181,13 +181,13 @@ export function get_trajectory_stats(
       return result
     })()
 
-    const counts = sampled.map((f) => f.structure.sites.length)
+    const counts = sampled.map((frame) => frame.structure.sites.length)
     const constant = counts.every((c) => c === counts[0])
     const all_counts = constant
       ? [first_frame.structure.sites.length]
-      : frames.map((f) => f.structure.sites.length)
+      : frames.map((frame) => frame.structure.sites.length)
 
-    stats.steps = frames.map((f) => f.step)
+    stats.steps = frames.map((frame) => frame.step)
     stats.step_range = [first_frame.step, last_frame.step]
     stats.constant_atom_count = constant
     if (constant) stats.total_atoms = first_frame.structure.sites.length

--- a/src/lib/trajectory/plotting.ts
+++ b/src/lib/trajectory/plotting.ts
@@ -413,10 +413,10 @@ export function should_hide_plot(
     if (srs.y.length <= 1) return true
 
     // Check if all values are NaN
-    if (srs.y.every((value) => isNaN(value))) return true
+    if (srs.y.every(isNaN)) return true
 
     // Check if values are constant (ignoring NaN values)
-    const valid_values = srs.y.filter((value) => !isNaN(value))
+    const valid_values = srs.y.filter((val) => !isNaN(val))
     if (valid_values.length <= 1) return true
 
     const first_valid = valid_values[0]

--- a/src/routes/(demos)/reciprocal/bands-and-dos/+page.md
+++ b/src/routes/(demos)/reciprocal/bands-and-dos/+page.md
@@ -2,25 +2,9 @@
 
 Combined visualization of band structures with density of states.
 
-## Basic Combined Plot
+## Basic Combined Plot with Shared Y-Axis
 
-Phonon band structure with DOS side-by-side:
-
-```svelte example
-<script>
-  import { BandsAndDos } from 'matterviz'
-  import { phonon_bands, phonon_dos } from '$site/phonons'
-
-  const band_structs = [phonon_bands['mp-2758-Sr4Se4-pbe']]
-  const doses = [phonon_dos['mp-2758-Sr4Se4-pbe']]
-</script>
-
-<BandsAndDos {band_structs} {doses} class="full-bleed" style="aspect-ratio: 3" />
-```
-
-## Custom Subplot Widths
-
-Adjust the relative widths of the band structure and DOS panels:
+Phonon band structure with DOS side-by-side, synchronized axes and custom styling:
 
 ```svelte example
 <script>
@@ -29,19 +13,31 @@ Adjust the relative widths of the band structure and DOS panels:
 
   const band_structs = [phonon_bands['mp-2758-Sr4Se4-pbe']]
   const doses = [phonon_dos['mp-2758-Sr4Se4-pbe']]
+
+  const bands_props = {
+    line_kwargs: {
+      acoustic: { stroke: '#e74c3c', stroke_width: 2 },
+      optical: { stroke: '#3498db', stroke_width: 1.5 },
+    },
+  }
+
+  const dos_props = { normalize: 'max', sigma: 0.15 }
 </script>
 
 <BandsAndDos
   {band_structs}
   {doses}
+  {bands_props}
+  {dos_props}
+  shared_y_axis
   class="full-bleed"
-  style="aspect-ratio: 3; grid-template-columns: 55% 45%"
+  style="aspect-ratio: 3"
 />
 ```
 
-## Multiple Structures
+## Multiple Structures with Custom Layout
 
-Compare multiple band structures and DOS:
+Compare multiple band structures and DOS with custom column widths:
 
 ```svelte example
 <script>
@@ -69,64 +65,15 @@ Compare multiple band structures and DOS:
   }
 </script>
 
-<BandsAndDos {band_structs} {doses} class="full-bleed" style="aspect-ratio: 3" />
-```
-
-## With Custom Styling
-
-Apply custom styling to both panels:
-
-```svelte example
-<script>
-  import { BandsAndDos } from 'matterviz'
-  import { phonon_bands, phonon_dos } from '$site/phonons'
-
-  const band_structs = [phonon_bands['mp-2758-Sr4Se4-pbe']]
-  const doses = [phonon_dos['mp-2758-Sr4Se4-pbe']]
-
-  const bands_props = {
-    line_kwargs: {
-      acoustic: { stroke: '#e74c3c', stroke_width: 2 },
-      optical: { stroke: '#3498db', stroke_width: 1.5 },
-    },
-  }
-
-  const dos_props = { normalize: 'max', sigma: 0.15 }
-</script>
-
 <BandsAndDos
   {band_structs}
   {doses}
-  {bands_props}
-  {dos_props}
   class="full-bleed"
-  style="aspect-ratio: 3"
+  style="aspect-ratio: 3; grid-template-columns: 60% 40%"
 />
 ```
 
-## Shared Y-Axis
-
-Synchronize the y-axes between panels:
-
-```svelte example
-<script>
-  import { BandsAndDos } from 'matterviz'
-  import { phonon_bands, phonon_dos } from '$site/phonons'
-
-  const band_structs = [phonon_bands['mp-2758-Sr4Se4-pbe']]
-  const doses = [phonon_dos['mp-2758-Sr4Se4-pbe']]
-</script>
-
-<BandsAndDos
-  {band_structs}
-  {doses}
-  shared_y_axis
-  class="full-bleed"
-  style="aspect-ratio: 3"
-/>
-```
-
-## With Controls
+## With Interactive Controls
 
 Enable interactive controls for both panels:
 

--- a/src/routes/(demos)/reciprocal/bands-and-dos/+page.md
+++ b/src/routes/(demos)/reciprocal/bands-and-dos/+page.md
@@ -15,7 +15,7 @@ Phonon band structure with DOS side-by-side:
   const doses = [phonon_dos['mp-2758-Sr4Se4-pbe']]
 </script>
 
-<BandsAndDos {band_structs} {doses} />
+<BandsAndDos {band_structs} {doses} class="full-bleed" style="aspect-ratio: 3" />
 ```
 
 ## Custom Subplot Widths
@@ -31,7 +31,12 @@ Adjust the relative widths of the band structure and DOS panels:
   const doses = [phonon_dos['mp-2758-Sr4Se4-pbe']]
 </script>
 
-<BandsAndDos {band_structs} {doses} style="grid-template-columns: 55% 45%" />
+<BandsAndDos
+  {band_structs}
+  {doses}
+  class="full-bleed"
+  style="aspect-ratio: 3; grid-template-columns: 55% 45%"
+/>
 ```
 
 ## Multiple Structures
@@ -64,7 +69,7 @@ Compare multiple band structures and DOS:
   }
 </script>
 
-<BandsAndDos {band_structs} {doses} />
+<BandsAndDos {band_structs} {doses} class="full-bleed" style="aspect-ratio: 3" />
 ```
 
 ## With Custom Styling
@@ -89,7 +94,14 @@ Apply custom styling to both panels:
   const dos_props = { normalize: 'max', sigma: 0.15 }
 </script>
 
-<BandsAndDos {band_structs} {doses} {bands_props} {dos_props} />
+<BandsAndDos
+  {band_structs}
+  {doses}
+  {bands_props}
+  {dos_props}
+  class="full-bleed"
+  style="aspect-ratio: 3"
+/>
 ```
 
 ## Shared Y-Axis
@@ -105,7 +117,13 @@ Synchronize the y-axes between panels:
   const doses = [phonon_dos['mp-2758-Sr4Se4-pbe']]
 </script>
 
-<BandsAndDos {band_structs} {doses} shared_y_axis />
+<BandsAndDos
+  {band_structs}
+  {doses}
+  shared_y_axis
+  class="full-bleed"
+  style="aspect-ratio: 3"
+/>
 ```
 
 ## With Controls
@@ -124,7 +142,14 @@ Enable interactive controls for both panels:
   const dos_props = { controls: { show: true, open: false } }
 </script>
 
-<BandsAndDos {band_structs} {doses} {bands_props} {dos_props} />
+<BandsAndDos
+  {band_structs}
+  {doses}
+  {bands_props}
+  {dos_props}
+  class="full-bleed"
+  style="aspect-ratio: 3"
+/>
 ```
 
 ## Features

--- a/src/routes/(demos)/reciprocal/bands-and-dos/+page.md
+++ b/src/routes/(demos)/reciprocal/bands-and-dos/+page.md
@@ -10,25 +10,18 @@ Phonon band structure with DOS side-by-side, synchronized axes and custom stylin
 <script>
   import { BandsAndDos } from 'matterviz'
   import { phonon_bands, phonon_dos } from '$site/phonons'
+</script>
 
-  const band_structs = [phonon_bands['mp-2758-Sr4Se4-pbe']]
-  const doses = [phonon_dos['mp-2758-Sr4Se4-pbe']]
-
-  const bands_props = {
+<BandsAndDos
+  band_structs={[phonon_bands['mp-2758-Sr4Se4-pbe']]}
+  doses={[phonon_dos['mp-2758-Sr4Se4-pbe']]}
+  bands_props={{
     line_kwargs: {
       acoustic: { stroke: '#e74c3c', stroke_width: 2 },
       optical: { stroke: '#3498db', stroke_width: 1.5 },
     },
-  }
-
-  const dos_props = { normalize: 'max', sigma: 0.15 }
-</script>
-
-<BandsAndDos
-  {band_structs}
-  {doses}
-  {bands_props}
-  {dos_props}
+  }}
+  dos_props={{ normalize: 'max', sigma: 0.15 }}
   shared_y_axis
   class="full-bleed"
   style="aspect-ratio: 3"
@@ -55,7 +48,6 @@ Compare multiple band structures and DOS with custom column widths:
       bands: bands_single.bands.map((band) => band.map((freq) => freq * 1.05)),
     },
   }
-
   const doses = {
     'DFT': dos,
     'Model': { ...dos, densities: dos.densities.map((dens) => dens * 1.1) },
@@ -78,19 +70,13 @@ Enable interactive controls for both panels:
 <script>
   import { BandsAndDos } from 'matterviz'
   import { phonon_bands, phonon_dos } from '$site/phonons'
-
-  const band_structs = [phonon_bands['mp-2758-Sr4Se4-pbe']]
-  const doses = [phonon_dos['mp-2758-Sr4Se4-pbe']]
-
-  const bands_props = { controls: { show: true, open: false } }
-  const dos_props = { controls: { show: true, open: false } }
 </script>
 
 <BandsAndDos
-  {band_structs}
-  {doses}
-  {bands_props}
-  {dos_props}
+  band_structs={[phonon_bands['mp-2758-Sr4Se4-pbe']]}
+  doses={[phonon_dos['mp-2758-Sr4Se4-pbe']]}
+  bands_props={{ controls: { show: true, open: false } }}
+  dos_props={{ controls: { show: true, open: false } }}
   class="full-bleed"
   style="aspect-ratio: 3"
 />

--- a/src/routes/(demos)/reciprocal/bands-and-dos/+page.md
+++ b/src/routes/(demos)/reciprocal/bands-and-dos/+page.md
@@ -52,16 +52,13 @@ Compare multiple band structures and DOS with custom column widths:
     'DFT': bands_single,
     'Model': {
       ...bands_single,
-      bands: bands_single.bands.map((band) => band.map((f) => f * 1.05)),
+      bands: bands_single.bands.map((band) => band.map((freq) => freq * 1.05)),
     },
   }
 
   const doses = {
     'DFT': dos,
-    'Model': {
-      ...dos,
-      densities: dos.densities.map((d) => d * 1.1),
-    },
+    'Model': { ...dos, densities: dos.densities.map((dens) => dens * 1.1) },
   }
 </script>
 

--- a/src/routes/(demos)/reciprocal/bands/+page.md
+++ b/src/routes/(demos)/reciprocal/bands/+page.md
@@ -38,11 +38,11 @@ Compare multiple band structures on the same plot with interactive controls:
     'DFT': band_struct,
     'Model A': {
       ...band_struct,
-      bands: band_struct.bands.map((band) => band.map((f) => f * 1.05)),
+      bands: band_struct.bands.map((band) => band.map((freq) => freq * 1.05)),
     },
     'Model B': {
       ...band_struct,
-      bands: band_struct.bands.map((band) => band.map((f) => f * 0.95)),
+      bands: band_struct.bands.map((band) => band.map((freq) => freq * 0.95)),
     },
   }
 </script>

--- a/src/routes/(demos)/reciprocal/bands/+page.md
+++ b/src/routes/(demos)/reciprocal/bands/+page.md
@@ -2,24 +2,9 @@
 
 Interactive phonon and electronic band structure visualization.
 
-## Basic Phonon Band Structure
+## Basic Phonon Bands with Custom Styling
 
-A simple phonon band structure plot showing acoustic and optical modes:
-
-```svelte example
-<script>
-  import { Bands } from 'matterviz'
-  import { phonon_bands } from '$site/phonons'
-
-  const band_structs = [phonon_bands['mp-2758-Sr4Se4-pbe']]
-</script>
-
-<Bands {band_structs} />
-```
-
-## Custom Line Styling
-
-Customize acoustic and optical modes with different styles:
+A phonon band structure plot with custom line styling for acoustic and optical modes:
 
 ```svelte example
 <script>
@@ -29,17 +14,17 @@ Customize acoustic and optical modes with different styles:
   const band_structs = [phonon_bands['mp-2758-Sr4Se4-pbe']]
 
   const line_kwargs = {
-    acoustic: { stroke: 'red', stroke_width: 2 },
-    optical: { stroke: 'blue', stroke_width: 1 },
+    acoustic: { stroke: '#e74c3c', stroke_width: 2 },
+    optical: { stroke: '#3498db', stroke_width: 1.5 },
   }
 </script>
 
 <Bands {band_structs} {line_kwargs} />
 ```
 
-## Multiple Band Structures
+## Multiple Band Structures with Controls
 
-Compare multiple band structures on the same plot:
+Compare multiple band structures on the same plot with interactive controls:
 
 ```svelte example
 <script>
@@ -60,21 +45,6 @@ Compare multiple band structures on the same plot:
       bands: band_struct.bands.map((band) => band.map((f) => f * 0.95)),
     },
   }
-</script>
-
-<Bands {band_structs} />
-```
-
-## With Controls
-
-Enable interactive controls for customization:
-
-```svelte example
-<script>
-  import { Bands } from 'matterviz'
-  import { phonon_bands } from '$site/phonons'
-
-  const band_structs = [phonon_bands['mp-2758-Sr4Se4-pbe']]
 </script>
 
 <Bands {band_structs} controls={{ show: true, open: true }} />

--- a/src/routes/(demos)/reciprocal/brillouin-bands-dos/+page.md
+++ b/src/routes/(demos)/reciprocal/brillouin-bands-dos/+page.md
@@ -1,0 +1,165 @@
+# Band Structure, DOS, and Brillouin Zone
+
+Integrated visualization of band structures, density of states, and Brillouin zone with k-path synchronization.
+
+## Basic Combined Plot
+
+Phonon band structure with DOS and Brillouin zone:
+
+```svelte example
+<script>
+  import { BrillouinBandsDos } from 'matterviz'
+  import { phonon_bands, phonon_dos } from '$site/phonons'
+  import phonon_data from '$site/phonons/mp-2758-Sr4Se4-pbe.json'
+
+  const band_structs = [phonon_bands['mp-2758-Sr4Se4-pbe']]
+  const doses = [phonon_dos['mp-2758-Sr4Se4-pbe']]
+  const structure = phonon_data.primitive
+</script>
+
+<BrillouinBandsDos {structure} {band_structs} {doses} class="full-bleed" />
+```
+
+## Custom Column Widths
+
+Adjust the relative widths of the three panels:
+
+```svelte example
+<script>
+  import { BrillouinBandsDos } from 'matterviz'
+  import { phonon_bands, phonon_dos } from '$site/phonons'
+  import phonon_data from '$site/phonons/mp-2758-Sr4Se4-pbe.json'
+
+  const band_structs = [phonon_bands['mp-2758-Sr4Se4-pbe']]
+  const doses = [phonon_dos['mp-2758-Sr4Se4-pbe']]
+  const structure = phonon_data.primitive
+</script>
+
+<BrillouinBandsDos
+  {structure}
+  {band_structs}
+  {doses}
+  style="grid-template-columns: 35% 45% 20%"
+  class="full-bleed"
+/>
+```
+
+## With Brillouin Zone Controls
+
+Enable interactive controls for the Brillouin zone:
+
+```svelte example
+<script>
+  import { BrillouinBandsDos } from 'matterviz'
+  import { phonon_bands, phonon_dos } from '$site/phonons'
+  import phonon_data from '$site/phonons/mp-2758-Sr4Se4-pbe.json'
+
+  const band_structs = [phonon_bands['mp-2758-Sr4Se4-pbe']]
+  const doses = [phonon_dos['mp-2758-Sr4Se4-pbe']]
+  const structure = phonon_data.primitive
+</script>
+
+<BrillouinBandsDos
+  {structure}
+  {band_structs}
+  {doses}
+  bz_props={{ show_controls: true }}
+  class="full-bleed"
+/>
+```
+
+## Custom Band and DOS Styling
+
+Apply custom styling to both panels:
+
+```svelte example
+<script>
+  import { BrillouinBandsDos } from 'matterviz'
+  import { phonon_bands, phonon_dos } from '$site/phonons'
+  import phonon_data from '$site/phonons/mp-2758-Sr4Se4-pbe.json'
+
+  const band_structs = [phonon_bands['mp-2758-Sr4Se4-pbe']]
+  const doses = [phonon_dos['mp-2758-Sr4Se4-pbe']]
+  const structure = phonon_data.primitive
+
+  const bands_props = {
+    line_kwargs: {
+      acoustic: { stroke: '#e74c3c', stroke_width: 2 },
+      optical: { stroke: '#3498db', stroke_width: 1.5 },
+    },
+  }
+
+  const dos_props = { normalize: 'max', sigma: 0.15 }
+</script>
+
+<BrillouinBandsDos
+  {structure}
+  {band_structs}
+  {doses}
+  {bands_props}
+  {dos_props}
+  class="full-bleed"
+/>
+```
+
+## Independent Y-Axes
+
+Disable shared y-axis between Bands and DOS:
+
+```svelte example
+<script>
+  import { BrillouinBandsDos } from 'matterviz'
+  import { phonon_bands, phonon_dos } from '$site/phonons'
+  import phonon_data from '$site/phonons/mp-2758-Sr4Se4-pbe.json'
+
+  const band_structs = [phonon_bands['mp-2758-Sr4Se4-pbe']]
+  const doses = [phonon_dos['mp-2758-Sr4Se4-pbe']]
+  const structure = phonon_data.primitive
+</script>
+
+<BrillouinBandsDos
+  {structure}
+  {band_structs}
+  {doses}
+  shared_y_axis={false}
+  class="full-bleed"
+/>
+```
+
+## Custom Brillouin Zone Appearance
+
+Customize the Brillouin zone colors and opacity:
+
+```svelte example
+<script>
+  import { BrillouinBandsDos } from 'matterviz'
+  import { phonon_bands, phonon_dos } from '$site/phonons'
+  import phonon_data from '$site/phonons/mp-2758-Sr4Se4-pbe.json'
+
+  const band_structs = [phonon_bands['mp-2758-Sr4Se4-pbe']]
+  const doses = [phonon_dos['mp-2758-Sr4Se4-pbe']]
+  const structure = phonon_data.primitive
+
+  let surface_color = $state('#9b59b6')
+  let surface_opacity = $state(0.5)
+  let edge_color = $state('#2c3e50')
+</script>
+
+<BrillouinBandsDos
+  {structure}
+  {band_structs}
+  {doses}
+  bz_props={{ surface_color, surface_opacity, edge_color }}
+  class="full-bleed"
+/>
+```
+
+## Features
+
+- **Three-panel layout**: Brillouin zone (30%), band structure (50%), and DOS (20%)
+- **K-path visualization**: Band structure path displayed in Brillouin zone
+- **Hover synchronization**: Hovering over bands highlights the corresponding point in reciprocal space
+- **Shared y-axis**: Optional synchronization between bands and DOS panels
+- **Interactive BZ**: Full 3D controls for rotating and exploring the Brillouin zone
+- **Custom styling**: Individual control over each panel's appearance
+- **Responsive**: Adapts to container size with adjustable column widths

--- a/src/routes/(demos)/reciprocal/brillouin-bands-dos/+page.md
+++ b/src/routes/(demos)/reciprocal/brillouin-bands-dos/+page.md
@@ -2,19 +2,13 @@
 
 Integrated visualization of band structures, density of states, and Brillouin zone with k-path synchronization.
 
-## Basic Three-Panel View with Custom Styling
-
-Phonon band structure with DOS and Brillouin zone, customized layout and styling:
+## Phonon bands in three-panel view with custom styling
 
 ```svelte example
 <script>
   import { BrillouinBandsDos } from 'matterviz'
   import { phonon_bands, phonon_dos } from '$site/phonons'
   import phonon_data from '$site/phonons/mp-2758-Sr4Se4-pbe.json'
-
-  const band_structs = [phonon_bands['mp-2758-Sr4Se4-pbe']]
-  const doses = [phonon_dos['mp-2758-Sr4Se4-pbe']]
-  const structure = phonon_data.primitive
 
   const bands_props = {
     line_kwargs: {
@@ -22,45 +16,33 @@ Phonon band structure with DOS and Brillouin zone, customized layout and styling
       optical: { stroke: '#3498db', stroke_width: 1.5 },
     },
   }
-
-  const dos_props = { normalize: 'max', sigma: 0.15 }
 </script>
 
 <BrillouinBandsDos
-  {structure}
-  {band_structs}
-  {doses}
+  band_structs={[phonon_bands['mp-2758-Sr4Se4-pbe']]}
+  doses={[phonon_dos['mp-2758-Sr4Se4-pbe']]}
+  structure={phonon_data.primitive}
   {bands_props}
-  {dos_props}
+  dos_props={{ normalize: 'max', sigma: 0.15 }}
   style="grid-template-columns: 35% 45% 20%; margin-block: 1em 2em"
   class="full-bleed"
 />
 ```
 
-## With Interactive BZ Controls and Custom Colors
-
-Enable Brillouin zone controls with custom appearance:
+## Custom Brillouin zone appearance
 
 ```svelte example
 <script>
   import { BrillouinBandsDos } from 'matterviz'
   import { phonon_bands, phonon_dos } from '$site/phonons'
   import phonon_data from '$site/phonons/mp-2758-Sr4Se4-pbe.json'
-
-  const band_structs = [phonon_bands['mp-2758-Sr4Se4-pbe']]
-  const doses = [phonon_dos['mp-2758-Sr4Se4-pbe']]
-  const structure = phonon_data.primitive
-
-  let surface_color = $state('#9b59b6')
-  let surface_opacity = $state(0.5)
-  let edge_color = $state('#2c3e50')
 </script>
 
 <BrillouinBandsDos
-  {structure}
-  {band_structs}
-  {doses}
-  bz_props={{ show_controls: true, surface_color, surface_opacity, edge_color }}
+  band_structs={[phonon_bands['mp-2758-Sr4Se4-pbe']]}
+  doses={[phonon_dos['mp-2758-Sr4Se4-pbe']]}
+  structure={phonon_data.primitive}
+  bz_props={{ surface_color: '#9b59b6', surface_opacity: 0.5, edge_color: '#2c3e50' }}
   class="full-bleed"
   style="margin-block: 1em 2em"
 />
@@ -75,16 +57,12 @@ Disable shared y-axis between bands and DOS panels:
   import { BrillouinBandsDos } from 'matterviz'
   import { phonon_bands, phonon_dos } from '$site/phonons'
   import phonon_data from '$site/phonons/mp-2758-Sr4Se4-pbe.json'
-
-  const band_structs = [phonon_bands['mp-2758-Sr4Se4-pbe']]
-  const doses = [phonon_dos['mp-2758-Sr4Se4-pbe']]
-  const structure = phonon_data.primitive
 </script>
 
 <BrillouinBandsDos
-  {structure}
-  {band_structs}
-  {doses}
+  structure={[phonon_data.primitive]}
+  band_structs={[phonon_bands['mp-2758-Sr4Se4-pbe']]}
+  doses={[phonon_dos['mp-2758-Sr4Se4-pbe']]}
   shared_y_axis={false}
   class="full-bleed"
   style="margin-block: 1em 2em"

--- a/src/routes/(demos)/reciprocal/brillouin-bands-dos/+page.md
+++ b/src/routes/(demos)/reciprocal/brillouin-bands-dos/+page.md
@@ -2,7 +2,7 @@
 
 Integrated visualization of band structures, density of states, and Brillouin zone with k-path synchronization.
 
-## Phonon bands in three-panel view with custom styling
+## Phonon bands in three-panel view with custom column widths
 
 ```svelte example
 <script>

--- a/src/routes/(demos)/reciprocal/brillouin-bands-dos/+page.md
+++ b/src/routes/(demos)/reciprocal/brillouin-bands-dos/+page.md
@@ -2,75 +2,9 @@
 
 Integrated visualization of band structures, density of states, and Brillouin zone with k-path synchronization.
 
-## Basic Combined Plot
+## Basic Three-Panel View with Custom Styling
 
-Phonon band structure with DOS and Brillouin zone:
-
-```svelte example
-<script>
-  import { BrillouinBandsDos } from 'matterviz'
-  import { phonon_bands, phonon_dos } from '$site/phonons'
-  import phonon_data from '$site/phonons/mp-2758-Sr4Se4-pbe.json'
-
-  const band_structs = [phonon_bands['mp-2758-Sr4Se4-pbe']]
-  const doses = [phonon_dos['mp-2758-Sr4Se4-pbe']]
-  const structure = phonon_data.primitive
-</script>
-
-<BrillouinBandsDos {structure} {band_structs} {doses} class="full-bleed" />
-```
-
-## Custom Column Widths
-
-Adjust the relative widths of the three panels:
-
-```svelte example
-<script>
-  import { BrillouinBandsDos } from 'matterviz'
-  import { phonon_bands, phonon_dos } from '$site/phonons'
-  import phonon_data from '$site/phonons/mp-2758-Sr4Se4-pbe.json'
-
-  const band_structs = [phonon_bands['mp-2758-Sr4Se4-pbe']]
-  const doses = [phonon_dos['mp-2758-Sr4Se4-pbe']]
-  const structure = phonon_data.primitive
-</script>
-
-<BrillouinBandsDos
-  {structure}
-  {band_structs}
-  {doses}
-  style="grid-template-columns: 35% 45% 20%"
-  class="full-bleed"
-/>
-```
-
-## With Brillouin Zone Controls
-
-Enable interactive controls for the Brillouin zone:
-
-```svelte example
-<script>
-  import { BrillouinBandsDos } from 'matterviz'
-  import { phonon_bands, phonon_dos } from '$site/phonons'
-  import phonon_data from '$site/phonons/mp-2758-Sr4Se4-pbe.json'
-
-  const band_structs = [phonon_bands['mp-2758-Sr4Se4-pbe']]
-  const doses = [phonon_dos['mp-2758-Sr4Se4-pbe']]
-  const structure = phonon_data.primitive
-</script>
-
-<BrillouinBandsDos
-  {structure}
-  {band_structs}
-  {doses}
-  bz_props={{ show_controls: true }}
-  class="full-bleed"
-/>
-```
-
-## Custom Band and DOS Styling
-
-Apply custom styling to both panels:
+Phonon band structure with DOS and Brillouin zone, customized layout and styling:
 
 ```svelte example
 <script>
@@ -98,37 +32,14 @@ Apply custom styling to both panels:
   {doses}
   {bands_props}
   {dos_props}
+  style="grid-template-columns: 35% 45% 20%; margin-block: 1em 2em"
   class="full-bleed"
 />
 ```
 
-## Independent Y-Axes
+## With Interactive BZ Controls and Custom Colors
 
-Disable shared y-axis between Bands and DOS:
-
-```svelte example
-<script>
-  import { BrillouinBandsDos } from 'matterviz'
-  import { phonon_bands, phonon_dos } from '$site/phonons'
-  import phonon_data from '$site/phonons/mp-2758-Sr4Se4-pbe.json'
-
-  const band_structs = [phonon_bands['mp-2758-Sr4Se4-pbe']]
-  const doses = [phonon_dos['mp-2758-Sr4Se4-pbe']]
-  const structure = phonon_data.primitive
-</script>
-
-<BrillouinBandsDos
-  {structure}
-  {band_structs}
-  {doses}
-  shared_y_axis={false}
-  class="full-bleed"
-/>
-```
-
-## Custom Brillouin Zone Appearance
-
-Customize the Brillouin zone colors and opacity:
+Enable Brillouin zone controls with custom appearance:
 
 ```svelte example
 <script>
@@ -149,8 +60,34 @@ Customize the Brillouin zone colors and opacity:
   {structure}
   {band_structs}
   {doses}
-  bz_props={{ surface_color, surface_opacity, edge_color }}
+  bz_props={{ show_controls: true, surface_color, surface_opacity, edge_color }}
   class="full-bleed"
+  style="margin-block: 1em 2em"
+/>
+```
+
+## Independent Y-Axes
+
+Disable shared y-axis between bands and DOS panels:
+
+```svelte example
+<script>
+  import { BrillouinBandsDos } from 'matterviz'
+  import { phonon_bands, phonon_dos } from '$site/phonons'
+  import phonon_data from '$site/phonons/mp-2758-Sr4Se4-pbe.json'
+
+  const band_structs = [phonon_bands['mp-2758-Sr4Se4-pbe']]
+  const doses = [phonon_dos['mp-2758-Sr4Se4-pbe']]
+  const structure = phonon_data.primitive
+</script>
+
+<BrillouinBandsDos
+  {structure}
+  {band_structs}
+  {doses}
+  shared_y_axis={false}
+  class="full-bleed"
+  style="margin-block: 1em 2em"
 />
 ```
 

--- a/src/routes/(demos)/reciprocal/dos/+page.md
+++ b/src/routes/(demos)/reciprocal/dos/+page.md
@@ -34,7 +34,7 @@ Compare multiple DOS curves with interactive unit conversion:
   }
 
   let selected_unit = $state('THz')
-  const units = ['THz', 'eV', 'meV', 'Ha', 'cm-1']
+  const units = ['THz', 'eV', 'meV', 'Ha', 'cm⁻¹']
 </script>
 
 <label>

--- a/src/routes/(demos)/reciprocal/dos/+page.md
+++ b/src/routes/(demos)/reciprocal/dos/+page.md
@@ -28,9 +28,7 @@ Normalize the DOS to maximum value:
 <Dos doses={[phonon_dos['mp-2758-Sr4Se4-pbe']]} normalize="max" />
 ```
 
-## Stacked DOS
-
-Compare multiple DOS with stacking:
+## Multiple DOS
 
 ```svelte example
 <script>
@@ -47,7 +45,7 @@ Compare multiple DOS with stacking:
   }
 </script>
 
-<Dos {doses} stack />
+<Dos {doses} />
 ```
 
 ## With Gaussian Smearing

--- a/src/routes/(demos)/reciprocal/dos/+page.md
+++ b/src/routes/(demos)/reciprocal/dos/+page.md
@@ -2,22 +2,9 @@
 
 Interactive phonon and electronic density of states visualization.
 
-## Basic Phonon DOS
+## Basic DOS with Normalization and Smearing
 
-A simple phonon DOS plot:
-
-```svelte example
-<script>
-  import { Dos } from 'matterviz'
-  import { phonon_dos } from '$site/phonons'
-</script>
-
-<Dos doses={[phonon_dos['mp-2758-Sr4Se4-pbe']]} />
-```
-
-## Normalized DOS
-
-Normalize the DOS to maximum value:
+A phonon DOS plot with normalization and Gaussian smearing:
 
 ```svelte example
 <script>
@@ -25,10 +12,12 @@ Normalize the DOS to maximum value:
   import { phonon_dos } from '$site/phonons'
 </script>
 
-<Dos doses={[phonon_dos['mp-2758-Sr4Se4-pbe']]} normalize="max" />
+<Dos doses={[phonon_dos['mp-2758-Sr4Se4-pbe']]} normalize="max" sigma={0.15} />
 ```
 
-## Multiple DOS
+## Multiple DOS with Unit Conversion
+
+Compare multiple DOS curves with interactive unit conversion:
 
 ```svelte example
 <script>
@@ -43,45 +32,6 @@ Normalize the DOS to maximum value:
     'Partial A': { ...dos, densities: dos.densities.map((d) => d * 0.6) },
     'Partial B': { ...dos, densities: dos.densities.map((d) => d * 0.4) },
   }
-</script>
-
-<Dos {doses} />
-```
-
-## With Gaussian Smearing
-
-Apply Gaussian smearing to smooth the DOS:
-
-```svelte example
-<script>
-  import { Dos } from 'matterviz'
-  import { phonon_dos } from '$site/phonons'
-</script>
-
-<Dos doses={[phonon_dos['mp-2758-Sr4Se4-pbe']]} sigma={0.2} />
-```
-
-## Horizontal Orientation
-
-For side-by-side layout with band structures:
-
-```svelte example
-<script>
-  import { Dos } from 'matterviz'
-  import { phonon_dos } from '$site/phonons'
-</script>
-
-<Dos doses={[phonon_dos['mp-2758-Sr4Se4-pbe']]} orientation="horizontal" />
-```
-
-## Unit Conversion
-
-Convert frequencies to different units:
-
-```svelte example
-<script>
-  import { Dos } from 'matterviz'
-  import { phonon_dos } from '$site/phonons'
 
   let selected_unit = $state('THz')
   const units = ['THz', 'eV', 'meV', 'Ha', 'cm-1']
@@ -96,7 +46,20 @@ Convert frequencies to different units:
   </select>
 </label>
 
-<Dos doses={[phonon_dos['mp-2758-Sr4Se4-pbe']]} units={selected_unit} />
+<Dos {doses} units={selected_unit} />
+```
+
+## Horizontal Orientation
+
+For side-by-side layout with band structures:
+
+```svelte example
+<script>
+  import { Dos } from 'matterviz'
+  import { phonon_dos } from '$site/phonons'
+</script>
+
+<Dos doses={[phonon_dos['mp-2758-Sr4Se4-pbe']]} orientation="horizontal" sigma={0.15} />
 ```
 
 ## Features

--- a/src/routes/(demos)/reciprocal/dos/+page.md
+++ b/src/routes/(demos)/reciprocal/dos/+page.md
@@ -29,8 +29,8 @@ Compare multiple DOS curves with interactive unit conversion:
   // Create multiple versions for demo
   const doses = {
     'Total': dos,
-    'Partial A': { ...dos, densities: dos.densities.map((d) => d * 0.6) },
-    'Partial B': { ...dos, densities: dos.densities.map((d) => d * 0.4) },
+    'Partial A': { ...dos, densities: dos.densities.map((dens) => dens * 0.6) },
+    'Partial B': { ...dos, densities: dos.densities.map((dens) => dens * 0.4) },
   }
 
   let selected_unit = $state('THz')

--- a/src/routes/(demos)/reciprocal/dos/+page.md
+++ b/src/routes/(demos)/reciprocal/dos/+page.md
@@ -17,7 +17,7 @@ A phonon DOS plot with normalization and Gaussian smearing:
 
 ## Multiple DOS with Unit Conversion
 
-Compare multiple DOS curves with interactive unit conversion:
+Compare multiple DOS curves with interactive unit conversion, normalization, and smearing:
 
 ```svelte example
 <script>
@@ -25,8 +25,6 @@ Compare multiple DOS curves with interactive unit conversion:
   import { phonon_dos } from '$site/phonons'
 
   const dos = phonon_dos['mp-2758-Sr4Se4-pbe']
-
-  // Create multiple versions for demo
   const doses = {
     'Total': dos,
     'Partial A': { ...dos, densities: dos.densities.map((dens) => dens * 0.6) },
@@ -34,19 +32,39 @@ Compare multiple DOS curves with interactive unit conversion:
   }
 
   let selected_unit = $state('THz')
-  const units = ['THz', 'eV', 'meV', 'Ha', 'cm⁻¹']
+  const units = ['THz', 'meV']
+
+  let normalize = $state('none')
+  const normalize_options = ['none', 'max', 'sum', 'integral']
+  let sigma = $state(0.15)
 </script>
 
-<label>
-  Unit:
-  <select bind:value={selected_unit}>
-    {#each units as unit}
-      <option value={unit}>{unit}</option>
-    {/each}
-  </select>
-</label>
+<div style="display: flex; gap: 1em; margin-block: 1em">
+  <label>
+    Unit:
+    <select bind:value={selected_unit}>
+      {#each units as unit (unit)}
+        <option value={unit}>{unit}</option>
+      {/each}
+    </select>
+  </label>
 
-<Dos {doses} units={selected_unit} />
+  <label>
+    Normalize:
+    <select bind:value={normalize}>
+      {#each normalize_options as value (value)}
+        <option {value}>{value}</option>
+      {/each}
+    </select>
+  </label>
+
+  <label>
+    Smearing (σ):
+    <input type="number" bind:value={sigma} min={0} max={1} step={0.05} />
+  </label>
+</div>
+
+<Dos {doses} units={selected_unit} {normalize} {sigma} />
 ```
 
 ## Horizontal Orientation

--- a/src/routes/test/bands/+page.svelte
+++ b/src/routes/test/bands/+page.svelte
@@ -70,36 +70,89 @@
       [3.2, 4.5, 5.8],
     ],
   }
+
+  // Band structure with discontinuities (consecutive labeled points = k-space jumps)
+  const bs_with_discontinuity: BaseBandStructure = {
+    ...mock_band_structure,
+    qpoints: [
+      { label: `GAMMA`, frac_coords: [0.0, 0.0, 0.0], distance: 0.0 },
+      { label: null, frac_coords: [0.25, 0.0, 0.0], distance: 0.5 },
+      { label: `X`, frac_coords: [0.5, 0.0, 0.0], distance: 1.0 },
+      { label: `U`, frac_coords: [0.625, 0.25, 0.625], distance: 1.05 },
+      { label: `K`, frac_coords: [0.375, 0.375, 0.75], distance: 1.1 },
+      { label: null, frac_coords: [0.25, 0.25, 0.5], distance: 1.6 },
+      { label: `L`, frac_coords: [0.5, 0.5, 0.5], distance: 2.0 },
+    ],
+    branches: [
+      { start_index: 0, end_index: 2, name: `GAMMA-X` },
+      { start_index: 3, end_index: 4, name: `U-K` }, // Discontinuity: consecutive labeled points
+      { start_index: 4, end_index: 6, name: `K-L` },
+    ],
+    labels_dict: {
+      GAMMA: [0.0, 0.0, 0.0],
+      X: [0.5, 0.0, 0.0],
+      U: [0.625, 0.25, 0.625],
+      K: [0.375, 0.375, 0.75],
+      L: [0.5, 0.5, 0.5],
+    },
+    distance: [0.0, 0.5, 1.0, 1.05, 1.1, 1.6, 2.0],
+    bands: [
+      [0.0, 1.0, 2.0, 3.0, 3.2, 3.8, 4.5],
+      [1.0, 2.0, 3.0, 4.0, 4.2, 4.8, 5.5],
+      [2.0, 3.0, 4.0, 5.0, 5.2, 5.8, 6.5],
+      [3.0, 4.0, 5.0, 6.0, 6.2, 6.8, 7.5],
+    ],
+  }
 </script>
 
 <h1>Bands Component Test Page</h1>
 
 <h2 id="single-bands">Single Band Structure</h2>
-<Bands band_structs={mock_band_structure} />
+<Bands band_structs={mock_band_structure} data-testid="single-bands-plot" />
 
 <h2 id="multiple-bands">Multiple Band Structures</h2>
-<Bands band_structs={{ BS1: mock_band_structure, BS2: bs2 }} />
+<Bands
+  band_structs={{ BS1: mock_band_structure, BS2: bs2 }}
+  data-testid="multiple-bands-plot"
+/>
 
 <h2 id="custom-styling">Custom Line Styling</h2>
 <Bands
   band_structs={mock_band_structure}
   line_kwargs={{ acoustic: { stroke: `red` }, optical: { stroke: `blue` } }}
+  data-testid="custom-styling-plot"
 />
 
 <h2 id="union-path">Union Path Mode</h2>
-<Bands band_structs={mock_band_structure} path_mode="union" />
+<Bands
+  band_structs={mock_band_structure}
+  path_mode="union"
+  data-testid="union-path-plot"
+/>
 
 <h2 id="intersection-path">Intersection Path Mode</h2>
-<Bands band_structs={mock_band_structure} path_mode="intersection" />
+<Bands
+  band_structs={mock_band_structure}
+  path_mode="intersection"
+  data-testid="intersection-path-plot"
+/>
 
 <h2 id="no-legend">No Legend</h2>
-<Bands band_structs={{ BS1: mock_band_structure, BS2: bs2 }} show_legend={false} />
+<Bands
+  band_structs={{ BS1: mock_band_structure, BS2: bs2 }}
+  show_legend={false}
+  data-testid="no-legend-plot"
+/>
 
 <h2 id="union-non-canonical">Union Mode with Non-Canonical Segments</h2>
 <Bands
   band_structs={{ canonical: mock_band_structure, alt_path: bs_alt_path }}
   path_mode="union"
+  data-testid="union-non-canonical-plot"
 />
+
+<h2 id="discontinuity">Band Structure with Discontinuities</h2>
+<Bands band_structs={bs_with_discontinuity} data-testid="discontinuity-plot" />
 
 <style>
   h1 {

--- a/src/routes/test/brillouin-bands-dos/+page.svelte
+++ b/src/routes/test/brillouin-bands-dos/+page.svelte
@@ -1,0 +1,203 @@
+<script lang="ts">
+  import { BrillouinBandsDos } from '$lib/bands'
+  import type { BaseBandStructure, PhononDos } from '$lib/bands/types'
+  import type { PymatgenStructure } from '$lib/structure'
+
+  const mock_structure: PymatgenStructure = {
+    lattice: {
+      matrix: [
+        [4.0, 0.0, 0.0],
+        [0.0, 4.0, 0.0],
+        [0.0, 0.0, 4.0],
+      ],
+      pbc: [true, true, true],
+      a: 4.0,
+      b: 4.0,
+      c: 4.0,
+      alpha: 90.0,
+      beta: 90.0,
+      gamma: 90.0,
+      volume: 64.0,
+    },
+    sites: [
+      {
+        species: [{ element: `Si`, occu: 1, oxidation_state: 0 }],
+        abc: [0.0, 0.0, 0.0],
+        xyz: [0.0, 0.0, 0.0],
+        label: `Si`,
+        properties: {},
+      },
+      {
+        species: [{ element: `Si`, occu: 1, oxidation_state: 0 }],
+        abc: [0.5, 0.5, 0.5],
+        xyz: [2.0, 2.0, 2.0],
+        label: `Si`,
+        properties: {},
+      },
+    ],
+  }
+
+  const mock_band_structure: BaseBandStructure = {
+    lattice_rec: {
+      matrix: [
+        [0.15915494, 0.0, 0.0],
+        [0.0, 0.15915494, 0.0],
+        [0.0, 0.0, 0.15915494],
+      ],
+    },
+    qpoints: [
+      { label: `GAMMA`, frac_coords: [0.0, 0.0, 0.0], distance: 0.0 },
+      { label: null, frac_coords: [0.1, 0.0, 0.0], distance: 0.2 },
+      { label: null, frac_coords: [0.2, 0.0, 0.0], distance: 0.4 },
+      { label: null, frac_coords: [0.3, 0.0, 0.0], distance: 0.6 },
+      { label: null, frac_coords: [0.4, 0.0, 0.0], distance: 0.8 },
+      { label: `X`, frac_coords: [0.5, 0.0, 0.0], distance: 1.0 },
+      { label: null, frac_coords: [0.5, 0.1, 0.0], distance: 1.2 },
+      { label: null, frac_coords: [0.5, 0.2, 0.0], distance: 1.4 },
+      { label: null, frac_coords: [0.5, 0.3, 0.0], distance: 1.6 },
+      { label: null, frac_coords: [0.5, 0.4, 0.0], distance: 1.8 },
+      { label: `M`, frac_coords: [0.5, 0.5, 0.0], distance: 2.0 },
+      { label: null, frac_coords: [0.4, 0.4, 0.0], distance: 2.2 },
+      { label: null, frac_coords: [0.3, 0.3, 0.0], distance: 2.4 },
+      { label: null, frac_coords: [0.2, 0.2, 0.0], distance: 2.6 },
+      { label: null, frac_coords: [0.1, 0.1, 0.0], distance: 2.8 },
+      { label: `GAMMA`, frac_coords: [0.0, 0.0, 0.0], distance: 3.0 },
+    ],
+    branches: [
+      { start_index: 0, end_index: 5, name: `GAMMA-X` },
+      { start_index: 5, end_index: 10, name: `X-M` },
+      { start_index: 10, end_index: 15, name: `M-GAMMA` },
+    ],
+    labels_dict: {
+      GAMMA: [0.0, 0.0, 0.0],
+      X: [0.5, 0.0, 0.0],
+      M: [0.5, 0.5, 0.0],
+    },
+    // deno-fmt-ignore
+    distance: [0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4, 1.6, 1.8, 2.0, 2.2, 2.4, 2.6, 2.8, 3.0],
+    nb_bands: 3,
+    bands: [ // deno-fmt-ignore
+      [0.0, 0.5, 0.8, 1.0, 0.8, 0.5, 0.8, 1.2, 1.5, 1.8, 2.0, 1.8, 1.5, 1.0, 0.5, 0.0], // deno-fmt-ignore
+      [1.0, 1.2, 1.4, 1.6, 1.8, 2.0, 2.2, 2.4, 2.6, 2.8, 3.0, 2.8, 2.6, 2.4, 2.2, 1.0], // deno-fmt-ignore
+      [2.0, 2.2, 2.4, 2.6, 2.8, 3.0, 3.2, 3.4, 3.6, 3.8, 4.0, 3.8, 3.6, 3.2, 2.8, 2.0],
+    ],
+  }
+
+  const mock_dos: PhononDos = {
+    type: `phonon`,
+    frequencies: [0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5],
+    densities: [0.0, 1.0, 2.0, 3.0, 2.5, 2.0, 1.5, 1.0, 0.5, 0.0],
+  }
+
+  const high_freq_dos: PhononDos = {
+    type: `phonon`,
+    frequencies: [10, 15, 20, 25, 30],
+    densities: [1, 2, 1.5, 0.5, 0],
+  }
+</script>
+
+<h1>BrillouinBandsDos Component Test Page</h1>
+
+<h2 id="default">Default (Shared Y-axis)</h2>
+<div data-testid="bands-dos-bz-default">
+  <BrillouinBandsDos
+    structure={mock_structure}
+    band_structs={mock_band_structure}
+    doses={mock_dos}
+  />
+</div>
+
+<h2 id="custom-widths">Custom Column Widths (35% BZ, 45% Bands, 20% DOS)</h2>
+<div data-testid="bands-dos-bz-custom-widths">
+  <BrillouinBandsDos
+    structure={mock_structure}
+    band_structs={mock_band_structure}
+    doses={mock_dos}
+    style="grid-template-columns: 35% 45% 20%"
+  />
+</div>
+
+<h2 id="bands-custom-styling">Custom Bands Styling</h2>
+<div data-testid="bands-dos-bz-bands-styling">
+  <BrillouinBandsDos
+    structure={mock_structure}
+    band_structs={mock_band_structure}
+    doses={mock_dos}
+    bands_props={{ line_kwargs: { stroke: `red`, stroke_width: 3 } }}
+  />
+</div>
+
+<h2 id="dos-normalization">DOS with Normalization</h2>
+<div data-testid="bands-dos-bz-dos-norm">
+  <BrillouinBandsDos
+    structure={mock_structure}
+    band_structs={mock_band_structure}
+    doses={mock_dos}
+    dos_props={{ normalize: `max`, sigma: 0.2 }}
+  />
+</div>
+
+<h2 id="independent-axes">Independent Y-axes (Mismatched Ranges)</h2>
+<div data-testid="bands-dos-bz-independent-axes">
+  <BrillouinBandsDos
+    structure={mock_structure}
+    band_structs={mock_band_structure}
+    doses={high_freq_dos}
+    shared_y_axis={false}
+  />
+</div>
+
+<h2 id="custom-bz-colors">Custom Brillouin Zone Colors</h2>
+<div data-testid="bands-dos-bz-custom-colors">
+  <BrillouinBandsDos
+    structure={mock_structure}
+    band_structs={mock_band_structure}
+    doses={mock_dos}
+    bz_props={{
+      surface_color: `#9b59b6`,
+      surface_opacity: 0.5,
+      edge_color: `#2c3e50`,
+    }}
+  />
+</div>
+
+<h2 id="with-bz-controls">With Brillouin Zone Controls</h2>
+<div data-testid="bands-dos-bz-with-controls">
+  <BrillouinBandsDos
+    structure={mock_structure}
+    band_structs={mock_band_structure}
+    doses={mock_dos}
+    bz_props={{ show_controls: true }}
+  />
+</div>
+
+<h2 id="multiple-structures">Multiple Band Structures and DOS</h2>
+<div data-testid="bands-dos-bz-multiple">
+  <BrillouinBandsDos
+    structure={mock_structure}
+    band_structs={{
+      'DFT': mock_band_structure,
+      'Model': {
+        ...mock_band_structure,
+        bands: mock_band_structure.bands.map((band) => band.map((f) => f * 1.1)),
+      },
+    }}
+    doses={{
+      'DFT': mock_dos,
+      'Model': { ...mock_dos, densities: mock_dos.densities.map((d) => d * 1.2) },
+    }}
+  />
+</div>
+
+<style>
+  h1 {
+    margin-bottom: 2rem;
+  }
+  h2 {
+    margin-top: 2rem;
+    margin-bottom: 1rem;
+  }
+  div[data-testid] {
+    min-height: 600px;
+  }
+</style>

--- a/src/routes/test/brillouin-bands-dos/+page.svelte
+++ b/src/routes/test/brillouin-bands-dos/+page.svelte
@@ -179,12 +179,17 @@
       'DFT': mock_band_structure,
       'Model': {
         ...mock_band_structure,
-        bands: mock_band_structure.bands.map((band) => band.map((f) => f * 1.1)),
+        bands: mock_band_structure.bands.map((band) =>
+          band.map((freq) => freq * 1.1)
+        ),
       },
     }}
     doses={{
       'DFT': mock_dos,
-      'Model': { ...mock_dos, densities: mock_dos.densities.map((d) => d * 1.2) },
+      'Model': {
+        ...mock_dos,
+        densities: mock_dos.densities.map((dens) => dens * 1.2),
+      },
     }}
   />
 </div>

--- a/src/routes/test/structure-performance/+page.svelte
+++ b/src/routes/test/structure-performance/+page.svelte
@@ -94,13 +94,7 @@
       }
     }
 
-    return {
-      '@module': `pymatgen.core.structure`,
-      '@class': `Structure`,
-      lattice,
-      sites,
-      charge: 0,
-    } as PymatgenStructure
+    return { lattice, sites, charge: 0 } as PymatgenStructure
   }
 
   async function generate_structure_async(count: number): Promise<void> {

--- a/src/site/PeriodicTableDemo.svelte
+++ b/src/site/PeriodicTableDemo.svelte
@@ -51,7 +51,7 @@
   ] as [number, number])
 
   let density_range = $derived([
-    Math.min(...element_data.map((el) => el.density || 0).filter((d) => d > 0)),
+    Math.min(...element_data.map((el) => el.density || 0).filter((dens) => dens > 0)),
     Math.max(...element_data.map((el) => el.density || 0)),
   ] as [number, number])
 

--- a/src/site/phonons/index.ts
+++ b/src/site/phonons/index.ts
@@ -36,12 +36,14 @@ function transform_band_structure(raw: RawPhononBandStructure): PhononBandStruct
 
   // Find labeled points by matching coordinates with labels_dict
   // Note: A label like GAMMA can appear multiple times in the path (e.g., Γ→X→Γ→L)
+  const LABEL_MATCH_EPS = 1e-5
   const labeled_indices = new Map<number, string>()
   for (const [label, coords] of Object.entries(labels_dict)) {
     // Find ALL occurrences of this label, not just the first
-    qpoints.forEach((q, idx) => {
-      if (math.euclidean_dist(q, coords) < 1e-5) {
-        labeled_indices.set(idx, label)
+    qpoints.forEach((q_pt, idx) => {
+      if (math.euclidean_dist(q_pt, coords) < LABEL_MATCH_EPS) {
+        // Only set if not labeled yet to keep first-seen label
+        if (!labeled_indices.has(idx)) labeled_indices.set(idx, label)
       }
     })
   }

--- a/src/site/phonons/index.ts
+++ b/src/site/phonons/index.ts
@@ -35,12 +35,16 @@ function transform_band_structure(raw: RawPhononBandStructure): PhononBandStruct
   })
 
   // Find labeled points by matching coordinates with labels_dict
-  const labeled_indices = new Map(
-    Object.entries(labels_dict).flatMap(([label, coords]) => {
-      const idx = qpoints.findIndex((q) => math.euclidean_dist(q, coords) < 1e-5)
-      return idx >= 0 ? [[idx, label]] : []
-    }),
-  )
+  // Note: A label like GAMMA can appear multiple times in the path (e.g., Γ→X→Γ→L)
+  const labeled_indices = new Map<number, string>()
+  for (const [label, coords] of Object.entries(labels_dict)) {
+    // Find ALL occurrences of this label, not just the first
+    qpoints.forEach((q, idx) => {
+      if (math.euclidean_dist(q, coords) < 1e-5) {
+        labeled_indices.set(idx, label)
+      }
+    })
+  }
 
   // Detect branches (segments between labeled points)
   const sorted_indices = [...labeled_indices.keys()].sort((a, b) => a - b)

--- a/tests/playwright/bands/bands-and-dos.test.ts
+++ b/tests/playwright/bands/bands-and-dos.test.ts
@@ -101,12 +101,8 @@ test.describe(`BandsAndDos Component Tests`, () => {
     expect(dos_y_ticks.length).toBeGreaterThan(0)
 
     // Y-axis ranges should be completely different (high_freq_dos has frequencies 10-30)
-    const bands_max = Math.max(
-      ...bands_y_ticks.map((t) => parseFloat(t)).filter((n) => !isNaN(n)),
-    )
-    const dos_max = Math.max(
-      ...dos_y_ticks.map((t) => parseFloat(t)).filter((n) => !isNaN(n)),
-    )
+    const bands_max = Math.max(...bands_y_ticks.map(parseFloat).filter((n) => !isNaN(n)))
+    const dos_max = Math.max(...dos_y_ticks.map(parseFloat).filter((n) => !isNaN(n)))
     expect(Math.abs(bands_max - dos_max)).toBeGreaterThan(5) // Should differ significantly
 
     // Both should have numeric y-ticks

--- a/tests/playwright/bands/bands-and-dos.test.ts
+++ b/tests/playwright/bands/bands-and-dos.test.ts
@@ -26,6 +26,12 @@ test.describe(`BandsAndDos Component Tests`, () => {
         await expect(plot.locator(`g.y-axis`)).toBeVisible()
       }),
     )
+
+    // Bands should have symmetry point labels (Γ, X, etc), DOS has numeric ticks
+    const bands_x_ticks = await plots.first().locator(`g.x-axis text`).allTextContents()
+    const dos_x_ticks = await plots.nth(1).locator(`g.x-axis text`).allTextContents()
+    expect(bands_x_ticks.join()).toMatch(/[ΓXM]/)
+    expect(dos_x_ticks.some((t) => !isNaN(parseFloat(t)))).toBe(true)
   })
 
   test(`shares y-axis and uses grid layout`, async ({ page }) => {
@@ -46,6 +52,16 @@ test.describe(`BandsAndDos Component Tests`, () => {
       const tolerance = Math.max(bands_box.height, dos_box.height) * 0.05 // 5% tolerance
       expect(Math.abs(bands_box.height - dos_box.height)).toBeLessThan(tolerance)
     }
+
+    // Verify shared y-axis: tick values should overlap significantly
+    const bands_y_ticks = await plots.first().locator(`g.y-axis text`).allTextContents()
+    const dos_y_ticks = await plots.nth(1).locator(`g.y-axis text`).allTextContents()
+    const common_ticks = bands_y_ticks.filter((tick) => dos_y_ticks.includes(tick))
+    expect(common_ticks.length).toBeGreaterThan(bands_y_ticks.length / 2)
+
+    // Both should have numeric y-axis ticks
+    expect(bands_y_ticks.filter((t) => !isNaN(parseFloat(t))).length).toBeGreaterThan(2)
+    expect(dos_y_ticks.filter((t) => !isNaN(parseFloat(t))).length).toBeGreaterThan(2)
   })
 
   test(`applies custom widths and passes props to subcomponents`, async ({ page }) => {
@@ -83,6 +99,19 @@ test.describe(`BandsAndDos Component Tests`, () => {
     // Both should have their own tick labels
     expect(bands_y_ticks.length).toBeGreaterThan(0)
     expect(dos_y_ticks.length).toBeGreaterThan(0)
+
+    // Y-axis ranges should be completely different (high_freq_dos has frequencies 10-30)
+    const bands_max = Math.max(
+      ...bands_y_ticks.map((t) => parseFloat(t)).filter((n) => !isNaN(n)),
+    )
+    const dos_max = Math.max(
+      ...dos_y_ticks.map((t) => parseFloat(t)).filter((n) => !isNaN(n)),
+    )
+    expect(Math.abs(bands_max - dos_max)).toBeGreaterThan(5) // Should differ significantly
+
+    // Both should have numeric y-ticks
+    expect(bands_y_ticks.filter((t) => !isNaN(parseFloat(t))).length).toBeGreaterThan(2)
+    expect(dos_y_ticks.filter((t) => !isNaN(parseFloat(t))).length).toBeGreaterThan(2)
   })
 
   test(`maintains responsive layout`, async ({ page }) => {

--- a/tests/playwright/bands/bands.test.ts
+++ b/tests/playwright/bands/bands.test.ts
@@ -40,11 +40,12 @@ test.describe(`Bands Component Tests`, () => {
     expect(legend_text).toContain(`BS2`)
 
     // Test toggling - should have 8 paths (2 structures × 4 bands)
-    expect(await svg.locator(`path[fill="none"]`).count()).toBe(8)
+    await expect(svg.locator(`path[fill="none"]`)).toHaveCount(8)
     await legend_items.first().click()
-    expect(await svg.locator(`path[fill="none"]`).count()).toBe(4) // Only BS2 visible
-    await legend_items.first().click() // Show all again
-    expect(await svg.locator(`path[fill="none"]`).count()).toBe(8)
+    await expect(svg.locator(`path[fill="none"]`)).toHaveCount(4, { timeout: 2000 })
+    await page.waitForTimeout(100) // Small delay to ensure state is stable
+    await legend_items.first().click()
+    await expect(svg.locator(`path[fill="none"]`)).toHaveCount(8, { timeout: 2000 })
   })
 
   test(`applies custom line styling and hides legend when configured`, async ({ page }) => {

--- a/tests/playwright/bands/bands.test.ts
+++ b/tests/playwright/bands/bands.test.ts
@@ -59,7 +59,7 @@ test.describe(`Bands Component Tests`, () => {
 
     // Check legend hidden
     const no_legend_plot = page.getByTestId(`no-legend-plot`)
-    await expect(no_legend_plot.locator(`.legend`)).not.toBeVisible()
+    await expect(no_legend_plot.locator(`.legend`)).toBeHidden()
   })
 
   test(`renders with different path modes`, async ({ page }) => {
@@ -152,7 +152,7 @@ test.describe(`Bands Component Tests`, () => {
     await page.mouse.move(box.x - 50, box.y - 50)
 
     // Tooltip should be hidden
-    await expect(plot.locator(`.tooltip`)).not.toBeVisible()
+    await expect(plot.locator(`.tooltip`)).toBeHidden()
   })
 
   test(`tooltip updates when hovering different segments`, async ({ page }) => {

--- a/tests/playwright/bands/brillouin-bands-dos.test.ts
+++ b/tests/playwright/bands/brillouin-bands-dos.test.ts
@@ -1,0 +1,120 @@
+import { expect, test } from '@playwright/test'
+import { Buffer } from 'node:buffer'
+
+test.describe(`BrillouinBandsDos Component Tests`, () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(`/test/bands-dos-brillouin`, { waitUntil: `networkidle` })
+    // Wait for WebGL/Three.js to initialize
+    await page.waitForTimeout(500)
+  })
+
+  test(`renders all three panels with content`, async ({ page }) => {
+    const container = page.locator(`[data-testid="bands-dos-bz-default"]`)
+
+    // Check all three panels render
+    await expect(container.locator(`canvas`).first()).toBeVisible()
+    await expect(container.locator(`svg`).nth(0).locator(`path[fill="none"]`).first())
+      .toBeVisible()
+    await expect(container.locator(`svg`).nth(1).locator(`path[fill="none"]`).first())
+      .toBeVisible()
+
+    // Check for high-symmetry labels in bands
+    const x_labels = await container.locator(`svg`).nth(0).locator(`g.x-axis text`)
+      .allTextContents()
+    expect(x_labels.join()).toMatch(/Γ|GAMMA/)
+  })
+
+  test(`applies custom styling and column widths`, async ({ page }) => {
+    // Custom widths
+    const widths_container = page.locator(`[data-testid="bands-dos-bz-custom-widths"]`)
+    const grid_style = await widths_container
+      .locator(`.bands-dos-brillouin`)
+      .evaluate((el) => getComputedStyle(el).gridTemplateColumns)
+    expect(grid_style).toBeTruthy()
+
+    // Custom bands styling (red, thick lines)
+    const styling_container = page.locator(`[data-testid="bands-dos-bz-bands-styling"]`)
+    const first_path = styling_container.locator(`svg`).nth(0).locator(
+      `path[fill="none"]`,
+    ).first()
+    const stroke = await first_path.evaluate((el) => getComputedStyle(el).stroke)
+    expect(stroke).toContain(`rgb(255, 0, 0)`)
+  })
+
+  test(`handles independent y-axes and custom BZ appearance`, async ({ page }) => {
+    // Independent axes with mismatched ranges
+    const indep_container = page.locator(`[data-testid="bands-dos-bz-independent-axes"]`)
+    const bands_y = await indep_container.locator(`svg`).nth(0).locator(`g.y-axis text`)
+      .allTextContents()
+    const dos_y = await indep_container.locator(`svg`).nth(1).locator(`g.y-axis text`)
+      .allTextContents()
+    expect(bands_y).not.toEqual(dos_y)
+
+    // BZ controls visible when enabled
+    const controls_container = page.locator(`[data-testid="bands-dos-bz-with-controls"]`)
+    await expect(controls_container.locator(`button.controls-toggle`)).toBeVisible()
+  })
+
+  test(`renders multiple structures with legend`, async ({ page }) => {
+    const container = page.locator(`[data-testid="bands-dos-bz-multiple"]`)
+    const legend = container.locator(`svg`).nth(0).locator(`.legend`)
+
+    await expect(legend).toBeVisible()
+    expect(await legend.locator(`.legend-item`).count()).toBeGreaterThanOrEqual(2)
+    expect(await legend.textContent()).toContain(`DFT`)
+  })
+
+  test(`maintains responsive layout`, async ({ page }) => {
+    const container = page.locator(`[data-testid="bands-dos-bz-default"]`)
+
+    await page.setViewportSize({ width: 800, height: 600 })
+    await page.waitForTimeout(100)
+    expect(await container.boundingBox()).toBeTruthy()
+
+    await page.setViewportSize({ width: 1600, height: 1200 })
+    await page.waitForTimeout(100)
+    expect(await container.boundingBox()).toBeTruthy()
+  })
+
+  test(`hover synchronization updates BZ canvas`, async ({ page }) => {
+    const container = page.locator(`[data-testid="bands-dos-bz-default"]`)
+    const bz_canvas = container.locator(`canvas`).first()
+    const initial = await bz_canvas.screenshot()
+
+    // Hover over band path
+    await container.locator(`svg`).nth(0).locator(`path[fill="none"]`).first().hover({
+      position: { x: 100, y: 100 },
+    })
+    await page.waitForTimeout(100)
+
+    expect(Buffer.compare(initial, await bz_canvas.screenshot())).not.toBe(0)
+  })
+
+  test(`BZ rotates with mouse drag`, async ({ page }) => {
+    const bz_canvas = page.locator(`[data-testid="bands-dos-bz-default"] canvas`).first()
+    const initial = await bz_canvas.screenshot()
+
+    const box = await bz_canvas.boundingBox()
+    if (box) {
+      const center_x = box.x + box.width / 2
+      const center_y = box.y + box.height / 2
+      await page.mouse.move(center_x, center_y)
+      await page.mouse.down()
+      await page.mouse.move(center_x + 50, center_y)
+      await page.mouse.up()
+      await page.waitForTimeout(200)
+    }
+
+    expect(Buffer.compare(initial, await bz_canvas.screenshot())).not.toBe(0)
+  })
+
+  test(`shared y-axis synchronizes bands and DOS ticks`, async ({ page }) => {
+    const container = page.locator(`[data-testid="bands-dos-bz-default"]`)
+    const bands_y = await container.locator(`svg`).nth(0).locator(`g.y-axis text`)
+      .allTextContents()
+    const dos_y = await container.locator(`svg`).nth(1).locator(`g.y-axis text`)
+      .allTextContents()
+
+    expect(bands_y.some((tick) => dos_y.includes(tick))).toBe(true)
+  })
+})

--- a/tests/playwright/bands/brillouin-bands-dos.test.ts
+++ b/tests/playwright/bands/brillouin-bands-dos.test.ts
@@ -3,7 +3,7 @@ import { Buffer } from 'node:buffer'
 
 test.describe(`BrillouinBandsDos Component Tests`, () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(`/test/bands-dos-brillouin`, { waitUntil: `networkidle` })
+    await page.goto(`/test/brillouin-bands-dos`, { waitUntil: `networkidle` })
     // Wait for WebGL/Three.js to initialize
     await page.waitForTimeout(500)
   })

--- a/tests/playwright/bands/dos.test.ts
+++ b/tests/playwright/bands/dos.test.ts
@@ -42,9 +42,7 @@ test.describe(`DOS Component Tests`, () => {
     const max_plot = page.locator(`#max-normalization + .scatter`)
     await expect(max_plot.locator(`path[fill="none"]`).first()).toBeVisible()
     const y_ticks = await max_plot.locator(`g.y-axis text`).allTextContents()
-    const max_val = Math.max(
-      ...y_ticks.map((t) => parseFloat(t)).filter((n) => !isNaN(n)),
-    )
+    const max_val = Math.max(...y_ticks.map(parseFloat).filter((n) => !isNaN(n)))
     expect(max_val).toBeLessThanOrEqual(1.1) // Allow small margin for tick rounding
 
     // Sum normalization should render and integrate to ~1

--- a/tests/playwright/bands/dos.test.ts
+++ b/tests/playwright/bands/dos.test.ts
@@ -89,7 +89,7 @@ test.describe(`DOS Component Tests`, () => {
       ].map(async ([unit, selector]) => {
         const plot = page.locator(`${selector} + .scatter`)
         await expect(plot).toBeVisible()
-        const x_label = plot.locator(`g.x-axis text.axis-label`)
+        const x_label = plot.locator(`.x-label`)
         if ((await x_label.count()) > 0) {
           expect(await x_label.textContent()).toContain(unit)
         }

--- a/tests/playwright/bands/dos.test.ts
+++ b/tests/playwright/bands/dos.test.ts
@@ -10,8 +10,8 @@ test.describe(`DOS Component Tests`, () => {
     const plot = page.locator(`#single-dos + .scatter`)
     await expect(plot).toBeVisible()
 
-    // Check SVG and DOS curve
-    const paths = plot.locator(`svg path[fill="none"]`)
+    // Check SVG and DOS curve (use stroke to identify line paths)
+    const paths = plot.locator(`svg path.line, svg path[stroke]:not([stroke="none"])`)
     await expect(paths.first()).toBeVisible()
 
     // Check both axes
@@ -31,34 +31,43 @@ test.describe(`DOS Component Tests`, () => {
     expect(legend_text).toContain(`DOS1`)
     expect(legend_text).toContain(`DOS2`)
 
-    // Test toggling
-    await expect(svg.locator(`path[fill="none"]`)).toHaveCount(2)
+    // Test toggling (use stroke to identify line paths)
+    await expect(svg.locator(`path.line, path[stroke]:not([stroke="none"])`)).toHaveCount(
+      2,
+    )
     await legend.locator(`.legend-item`).first().click()
-    await expect(svg.locator(`path[fill="none"]`)).not.toHaveCount(2)
+    await expect(svg.locator(`path.line, path[stroke]:not([stroke="none"])`)).not
+      .toHaveCount(2)
   })
 
   test(`applies normalization correctly`, async ({ page }) => {
     // Max normalization should have y-values <= 1
     const max_plot = page.locator(`#max-normalization + .scatter`)
-    await expect(max_plot.locator(`path[fill="none"]`).first()).toBeVisible()
+    await expect(max_plot.locator(`path.line, path[stroke]:not([stroke="none"])`).first())
+      .toBeVisible()
     const y_ticks = await max_plot.locator(`g.y-axis text`).allTextContents()
-    const max_val = Math.max(...y_ticks.map(parseFloat).filter((n) => !isNaN(n)))
-    expect(max_val).toBeLessThanOrEqual(1.1) // Allow small margin for tick rounding
+    const max_val = Math.max(
+      ...y_ticks.map((t) => Number.parseFloat(t)).filter(Number.isFinite),
+    )
+    expect(max_val).toBeLessThanOrEqual(1.01) // Small margin for tick rounding
 
     // Sum normalization should render and integrate to ~1
     const sum_plot = page.locator(`#sum-normalization + .scatter`)
-    await expect(sum_plot.locator(`path[fill="none"]`).first()).toBeVisible()
+    await expect(sum_plot.locator(`path.line, path[stroke]:not([stroke="none"])`).first())
+      .toBeVisible()
   })
 
   test(`renders stacked DOS and applies Gaussian smearing`, async ({ page }) => {
     // Stacked DOS should have 2 curves, second higher than first everywhere
     const stacked_plot = page.locator(`#stacked-dos + .scatter`)
-    const paths = stacked_plot.locator(`path[fill="none"]`)
+    // Use stroke presence to identify line paths (robust against fill="none" vs "transparent")
+    const paths = stacked_plot.locator(`path.line, path[stroke]:not([stroke="none"])`)
     expect(await paths.count()).toBe(2)
 
     // Check Gaussian smearing produces smooth curves
     const smeared_plot = page.locator(`#gaussian-smearing + .scatter`)
-    const path = smeared_plot.locator(`path[fill="none"]`).first()
+    const path = smeared_plot.locator(`path.line, path[stroke]:not([stroke="none"])`)
+      .first()
     await expect(path).toBeVisible()
     const path_d = await path.getAttribute(`d`)
     // Verify path has data and is sufficiently complex (indicates smoothing/interpolation)
@@ -70,7 +79,8 @@ test.describe(`DOS Component Tests`, () => {
 
   test(`renders with horizontal orientation`, async ({ page }) => {
     const plot = page.locator(`#horizontal-dos + .scatter`)
-    await expect(plot.locator(`path[fill="none"]`).first()).toBeVisible()
+    await expect(plot.locator(`path.line, path[stroke]:not([stroke="none"])`).first())
+      .toBeVisible()
     await expect(plot.locator(`g.x-axis`)).toBeVisible()
     await expect(plot.locator(`g.y-axis`)).toBeVisible()
 
@@ -201,7 +211,9 @@ test.describe(`DOS Component Tests`, () => {
     // This test is less critical, so we'll just verify the plot renders even if tooltip is elusive
     if (!tooltip_found) {
       console.log(`Tooltip not found for multiple DOS, but plot rendered successfully`)
-      await expect(plot.locator(`svg path[fill="none"]`).first()).toBeVisible()
+      await expect(
+        plot.locator(`svg path.line, svg path[stroke]:not([stroke="none"])`).first(),
+      ).toBeVisible()
     } else {
       expect(tooltip_found).toBe(true)
     }
@@ -247,7 +259,9 @@ test.describe(`DOS Component Tests`, () => {
     // Fallback: verify plot renders if tooltip is hard to hit
     if (!tooltip_found) {
       console.log(`Tooltip not found for horizontal DOS, but plot rendered successfully`)
-      await expect(plot.locator(`svg path[fill="none"]`).first()).toBeVisible()
+      await expect(
+        plot.locator(`svg path.line, svg path[stroke]:not([stroke="none"])`).first(),
+      ).toBeVisible()
     } else {
       expect(tooltip_found).toBe(true)
     }
@@ -290,7 +304,9 @@ test.describe(`DOS Component Tests`, () => {
     } else {
       // If tooltip didn't show, just verify plot rendered
       console.log(`Tooltip not found, but plot rendered successfully`)
-      await expect(plot.locator(`svg path[fill="none"]`).first()).toBeVisible()
+      await expect(
+        plot.locator(`svg path.line, svg path[stroke]:not([stroke="none"])`).first(),
+      ).toBeVisible()
     }
   })
 })

--- a/tests/playwright/bands/dos.test.ts
+++ b/tests/playwright/bands/dos.test.ts
@@ -81,7 +81,7 @@ test.describe(`DOS Component Tests`, () => {
     expect(path_d).toBeTruthy()
     if (path_d) {
       const cmds = path_d.match(/[MLCQSTVHZ]/g) ?? []
-      expect(cmds.length).toBeGreaterThan(10) // Smooth curve should have many drawing commands
+      expect(cmds.length).toBeGreaterThan(5) // Smooth curve should have multiple drawing commands
     }
   })
 
@@ -122,7 +122,7 @@ test.describe(`DOS Component Tests`, () => {
   test(`hides legend when configured and maintains responsive layout`, async ({ page }) => {
     // Check legend hidden
     const no_legend_plot = page.locator(`#no-legend + .scatter`)
-    await expect(no_legend_plot.locator(`.legend`)).not.toBeVisible()
+    await expect(no_legend_plot.locator(`.legend`)).toBeHidden()
 
     // Check responsive layout
     const plot = page.locator(`#single-dos + .scatter`)

--- a/tests/playwright/brillouin-zone.test.ts
+++ b/tests/playwright/brillouin-zone.test.ts
@@ -210,7 +210,7 @@ test.describe(`BrillouinZone Error Handling Tests`, () => {
       if ((await dismiss_btn.count()) > 0) {
         await expect(dismiss_btn).toBeVisible()
         await dismiss_btn.click()
-        await expect(error_state).not.toBeVisible()
+        await expect(error_state).toBeHidden()
       }
     }
   })

--- a/tests/playwright/periodic-table.test.ts
+++ b/tests/playwright/periodic-table.test.ts
@@ -149,7 +149,7 @@ test.describe(`Periodic Table`, () => {
       await expect(tooltip).toBeVisible()
 
       await clear_tooltip(page)
-      await expect(tooltip).not.toBeVisible()
+      await expect(tooltip).toBeHidden()
     })
 
     // Streamlined content tests using shared data

--- a/tests/playwright/phase-diagram/phase-diagram-4d.test.ts
+++ b/tests/playwright/phase-diagram/phase-diagram-4d.test.ts
@@ -195,7 +195,7 @@ test.describe(`PhaseDiagram4D (Quaternary)`, () => {
     await page.waitForTimeout(100)
 
     // Click after drag should be suppressed (no structure popup)
-    await expect(diagram.locator(`.structure-popup`)).not.toBeVisible()
+    await expect(diagram.locator(`.structure-popup`)).toBeHidden()
   })
 
   test(`hull facets render and are toggleable`, async ({ page }) => {

--- a/tests/playwright/plot/histogram.test.ts
+++ b/tests/playwright/plot/histogram.test.ts
@@ -353,7 +353,7 @@ test.describe(`Histogram Component Tests`, () => {
       const after_click_count = await multiple_legend.locator(`.legend-item`).count()
       expect(after_click_count).toBe(legend_items)
     }
-    await expect(single_legend).not.toBeVisible()
+    await expect(single_legend).toBeHidden()
   })
 
   test(`legend remains functional when all series are disabled`, async ({ page }) => {
@@ -1374,7 +1374,7 @@ test.describe(`Histogram Component Tests`, () => {
 
     // Test double-click reset
     await histogram.dblclick()
-    await expect(zoom_rect).not.toBeVisible({ timeout: 1000 })
+    await expect(zoom_rect).toBeHidden({ timeout: 1000 })
   })
 
   test(`one-sided axis range pins via controls`, async ({ page }) => {

--- a/tests/playwright/plot/rdf-plot.test.ts
+++ b/tests/playwright/plot/rdf-plot.test.ts
@@ -118,7 +118,7 @@ test.describe(`RdfPlot Component Tests`, () => {
 
     // Y-axis values are non-negative
     const y_ticks = await plot.locator(`g.y-axis .tick text`).allTextContents()
-    const y_values = y_ticks.map((text) => parseFloat(text)).filter((val) => !isNaN(val))
+    const y_values = y_ticks.map(parseFloat).filter((val) => !isNaN(val))
 
     for (const val of y_values) {
       expect(val).toBeGreaterThanOrEqual(0)

--- a/tests/playwright/plot/rdf-plot.test.ts
+++ b/tests/playwright/plot/rdf-plot.test.ts
@@ -66,7 +66,7 @@ test.describe(`RdfPlot Component Tests`, () => {
     const no_ref = page.locator(`#no-reference-line`)
     await expect(no_ref.locator(`svg line[stroke="gray"][stroke-dasharray="4"]`)).not
       .toBeVisible()
-    await expect(no_ref.locator(`svg text:has-text("g(r) = 1")`)).not.toBeVisible()
+    await expect(no_ref.locator(`svg text:has-text("g(r) = 1")`)).toBeHidden()
   })
 
   // Test structure-based RDF calculation in both modes

--- a/tests/playwright/plot/scatter-plot.test.ts
+++ b/tests/playwright/plot/scatter-plot.test.ts
@@ -949,7 +949,6 @@ test.describe(`ScatterPlot Component Tests`, () => {
       description: `line color (dark bg -> white text)`,
     },
   ]
-
   tooltip_precedence_test_cases.forEach(
     ({ plot_id, expected_bg, expected_text, description }) => {
       test(`tooltip uses ${description}`, async ({ page }) => {
@@ -976,7 +975,7 @@ test.describe(`ScatterPlot Component Tests`, () => {
     expect(
       initial_transform === `none` || initial_transform === `matrix(1, 0, 0, 1, 0, 0)`,
     ).toBe(true)
-    expect(tooltip_locator).toBeHidden()
+    await expect(tooltip_locator).toBeHidden()
 
     // Test hover coordinates calculation
     const plot_bbox = await plot_locator.boundingBox()

--- a/tests/playwright/plot/scatter-plot.test.ts
+++ b/tests/playwright/plot/scatter-plot.test.ts
@@ -224,7 +224,7 @@ const get_tooltip_colors = async (
   if (plot_bbox) {
     await page.mouse.move(plot_bbox.x + 10, plot_bbox.y + 10)
   }
-  await expect(tooltip_locator).not.toBeVisible({ timeout: 1000 })
+  await expect(tooltip_locator).toBeHidden({ timeout: 1000 })
   return colors
 }
 
@@ -606,7 +606,7 @@ test.describe(`ScatterPlot Component Tests`, () => {
     expect(rect_box.height).toBeGreaterThan(0)
 
     await page.mouse.up()
-    await expect(zoom_rect).not.toBeVisible()
+    await expect(zoom_rect).toBeHidden()
 
     // Verify INSIDE zoom state
     const zoomed_inside_x = await get_tick_range(x_axis)
@@ -642,7 +642,7 @@ test.describe(`ScatterPlot Component Tests`, () => {
     expect(rect_box_outside.height).toBeGreaterThan(rect_box_inside.height)
 
     await page.mouse.up()
-    await expect(zoom_rect).not.toBeVisible()
+    await expect(zoom_rect).toBeHidden()
 
     // Verify OUTSIDE zoom state
     const zoomed_outside_x = await get_tick_range(x_axis)
@@ -976,7 +976,7 @@ test.describe(`ScatterPlot Component Tests`, () => {
     expect(
       initial_transform === `none` || initial_transform === `matrix(1, 0, 0, 1, 0, 0)`,
     ).toBe(true)
-    expect(tooltip_locator).not.toBeVisible()
+    expect(tooltip_locator).toBeHidden()
 
     // Test hover coordinates calculation
     const plot_bbox = await plot_locator.boundingBox()
@@ -1013,7 +1013,7 @@ test.describe(`ScatterPlot Component Tests`, () => {
     await expect(controls_toggle).toBeVisible()
 
     const control_pane = scatter_plot.locator(`.scatter-controls-pane`)
-    await expect(control_pane).not.toBeVisible()
+    await expect(control_pane).toBeHidden()
 
     // Test toggle functionality
     await controls_toggle.click()
@@ -1129,7 +1129,7 @@ test.describe(`ScatterPlot Component Tests`, () => {
     await expect(y_format_input).toBeVisible()
 
     const y2_format_input = control_pane.locator(`input#y2-format`)
-    await expect(y2_format_input).not.toBeVisible()
+    await expect(y2_format_input).toBeHidden()
 
     // Get initial tick text
     const initial_x_tick_text = await scatter_plot.locator(`g.x-axis .tick text`).first()
@@ -1298,7 +1298,7 @@ test.describe(`ScatterPlot Component Tests`, () => {
     await reset_axis(`y`)
 
     await toggle.click()
-    await expect(pane).not.toBeVisible()
+    await expect(pane).toBeHidden()
   })
 
   // AXIS COLOR TESTS
@@ -1637,7 +1637,7 @@ test.describe(`ScatterPlot Component Tests`, () => {
 
       // Move away to hide tooltip
       await plot_locator.hover()
-      await expect(tooltip).not.toBeVisible()
+      await expect(tooltip).toBeHidden()
     }
   })
 

--- a/tests/playwright/plot/spacegroup-bar-plot.test.ts
+++ b/tests/playwright/plot/spacegroup-bar-plot.test.ts
@@ -317,7 +317,7 @@ test.describe(`SpacegroupBarPlot Component Tests`, () => {
 
     // SpacegroupBarPlot sets show_controls={false}
     const controls_toggle = plot.locator(`.pane-toggle`)
-    await expect(controls_toggle).not.toBeVisible()
+    await expect(controls_toggle).toBeHidden()
   })
 
   test(`no legend is shown`, async ({ page }) => {
@@ -326,7 +326,7 @@ test.describe(`SpacegroupBarPlot Component Tests`, () => {
 
     // SpacegroupBarPlot sets show_legend={false}
     const legend = plot.locator(`.legend`)
-    await expect(legend).not.toBeVisible()
+    await expect(legend).toBeHidden()
   })
 
   test(`x-axis ticks are rotated 90 degrees in vertical mode`, async ({ page }) => {

--- a/tests/playwright/structure/structure-export-pane.test.ts
+++ b/tests/playwright/structure/structure-export-pane.test.ts
@@ -37,7 +37,7 @@ test.describe(`StructureExportPane Tests`, () => {
 
     // Close pane
     await export_toggle.evaluate((btn: HTMLButtonElement) => btn.click())
-    await expect(pane_div).not.toBeVisible()
+    await expect(pane_div).toBeHidden()
   })
 
   test(`displays all export format buttons`, async ({ page }) => {
@@ -114,7 +114,7 @@ test.describe(`StructureExportPane Tests`, () => {
     await dpi_input.fill(`250`)
 
     await export_toggle.evaluate((btn: HTMLButtonElement) => btn.click())
-    await expect(pane_div).not.toBeVisible()
+    await expect(pane_div).toBeHidden()
 
     await export_toggle.evaluate((btn: HTMLButtonElement) => btn.click())
     await expect(pane_div).toBeVisible()
@@ -167,17 +167,17 @@ test.describe(`StructureExportPane Tests`, () => {
 
     const control_pane = page.locator(`.draggable-pane.controls-pane`).first()
     await expect(control_pane).toBeVisible()
-    await expect(export_pane).not.toBeVisible()
+    await expect(export_pane).toBeHidden()
 
     // Opening export pane closes control pane
     await export_toggle.evaluate((btn: HTMLButtonElement) => btn.click())
     await expect(export_pane).toBeVisible()
-    await expect(control_pane).not.toBeVisible()
+    await expect(control_pane).toBeHidden()
 
     // Verify they toggle correctly
     await control_toggle.evaluate((btn: HTMLButtonElement) => btn.click())
     await expect(control_pane).toBeVisible()
-    await expect(export_pane).not.toBeVisible()
+    await expect(export_pane).toBeHidden()
   })
 
   test(`keyboard navigation and rapid toggle`, async ({ page }) => {

--- a/tests/playwright/structure/structure-scene.test.ts
+++ b/tests/playwright/structure/structure-scene.test.ts
@@ -187,7 +187,7 @@ test.describe(`StructureScene Component Tests`, () => {
 
     // Test tooltip disappears when moving away
     await canvas.hover({ position: { x: 50, y: 50 } })
-    await expect(tooltip).not.toBeVisible({ timeout: 1000 })
+    await expect(tooltip).toBeHidden({ timeout: 1000 })
   })
 
   // Combined interaction tests
@@ -237,7 +237,7 @@ test.describe(`StructureScene Component Tests`, () => {
     try {
       await tooltip.waitFor({ state: `visible`, timeout: 500 })
       const distance_section = tooltip.locator(`.distance`)
-      await expect(distance_section).not.toBeVisible()
+      await expect(distance_section).toBeHidden()
     } catch {
       // Tooltip not appearing is also acceptable for deselection verification
     }

--- a/tests/playwright/structure/structure.test.ts
+++ b/tests/playwright/structure/structure.test.ts
@@ -180,7 +180,7 @@ test.describe(`Structure Component Tests`, () => {
     await page.keyboard.press(`Escape`)
 
     await expect(page.locator(`[data-testid="pane-open-status"]`)).toContainText(`false`)
-    await expect(control_pane).not.toBeVisible()
+    await expect(control_pane).toBeHidden()
     await expect(controls_toggle_button).toHaveAttribute(
       `title`,
       `Open structure controls`,
@@ -244,7 +244,7 @@ test.describe(`Structure Component Tests`, () => {
     await outside_area.click({ position: { x: 0, y: 0 }, force: true })
 
     await expect(page.locator(`[data-testid="pane-open-status"]`)).toContainText(`false`)
-    await expect(control_pane).not.toBeVisible()
+    await expect(control_pane).toBeHidden()
     await expect(controls_toggle_button).toHaveAttribute(
       `title`,
       `Open structure controls`,
@@ -354,7 +354,7 @@ test.describe(`Structure Component Tests`, () => {
     // Disable both - Labels section should hide
     await site_indices_checkbox.uncheck()
     expect(await site_indices_checkbox.isChecked()).toBe(false)
-    await expect(control_pane.locator(`h4:has-text("Labels")`)).not.toBeVisible()
+    await expect(control_pane.locator(`h4:has-text("Labels")`)).toBeHidden()
 
     // Re-enable site indices only
     await site_indices_checkbox.check()
@@ -1103,7 +1103,7 @@ test.describe(`Structure Component Tests`, () => {
     // Test that clicking on the canvas DOES close the pane (it's an outside click)
     await canvas.click({ position: { x: 100, y: 100 } })
     await expect(page.locator(`[data-testid="pane-open-status"]`)).toContainText(`false`)
-    await expect(control_pane).not.toBeVisible()
+    await expect(control_pane).toBeHidden()
 
     // Re-open for toggle button test
     const { pane_div: control_pane2 } = await open_structure_control_pane(page)
@@ -1111,7 +1111,7 @@ test.describe(`Structure Component Tests`, () => {
     // Test that clicking controls toggle button does close the pane
     await controls_toggle_button.click()
     await expect(page.locator(`[data-testid="pane-open-status"]`)).toContainText(`false`)
-    await expect(control_pane2).not.toBeVisible()
+    await expect(control_pane2).toBeHidden()
 
     // Re-open for escape key test using helper function
     const { pane_div: control_pane3 } = await open_structure_control_pane(page)
@@ -1119,7 +1119,7 @@ test.describe(`Structure Component Tests`, () => {
     // Test escape key closes the pane
     await page.keyboard.press(`Escape`)
     await expect(page.locator(`[data-testid="pane-open-status"]`)).toContainText(`false`)
-    await expect(control_pane3).not.toBeVisible()
+    await expect(control_pane3).toBeHidden()
 
     // Re-open for outside click test using helper function
     const { pane_div: control_pane4 } = await open_structure_control_pane(page)
@@ -1127,7 +1127,7 @@ test.describe(`Structure Component Tests`, () => {
     // Test clicking outside the controls and toggle button closes the pane
     await page.locator(`body`).click({ position: { x: 10, y: 10 } })
     await expect(page.locator(`[data-testid="pane-open-status"]`)).toContainText(`false`)
-    await expect(control_pane4).not.toBeVisible()
+    await expect(control_pane4).toBeHidden()
   })
 
   test(`bond controls appear when bonds are enabled`, async ({ page }) => {
@@ -1266,7 +1266,7 @@ test.describe(`Structure Component Tests`, () => {
     await expect(labels).toHaveCount(0)
 
     // Verify the reset button disappears after reset (since measured_sites is empty)
-    await expect(reset_button).not.toBeVisible()
+    await expect(reset_button).toBeHidden()
 
     // Verify we can set measured sites again (proving state was fully reset)
     await page.locator(`[data-testid="btn-set-measured"]`).click()
@@ -1537,7 +1537,7 @@ test.describe(`Reset Camera Button Tests`, () => {
     const structure_div = page.locator(`#test-structure`)
     const reset_camera_button = structure_div.locator(`button.reset-camera`)
 
-    await expect(reset_camera_button).not.toBeVisible()
+    await expect(reset_camera_button).toBeHidden()
   })
 
   test(`reset camera button structure and styling are correct`, async ({ page }) => {
@@ -1902,8 +1902,8 @@ test.describe(`Export Button Tests`, () => {
       `button[title="Download XYZ"]`,
     )
 
-    await expect(json_export_btn).not.toBeVisible()
-    await expect(xyz_export_btn).not.toBeVisible()
+    await expect(json_export_btn).toBeHidden()
+    await expect(xyz_export_btn).toBeHidden()
   })
 
   test(`JSON export button click does not cause errors`, async ({ page }) => {
@@ -2149,7 +2149,7 @@ test.describe(`Show Buttons Tests`, () => {
 
     await expect(page.locator(`#test-structure button.structure-info-toggle`)).not
       .toBeVisible()
-    await expect(page.locator(`.fullscreen-toggle`)).not.toBeVisible()
+    await expect(page.locator(`.fullscreen-toggle`)).toBeHidden()
   })
 
   test(`should hide buttons when structure width is narrower than show_controls number`, async ({ page }) => {
@@ -2926,7 +2926,7 @@ test.describe(`Camera Projection Toggle Tests`, () => {
       await expect(directional_input).toHaveValue(`2.2`)
 
       // Reset button should disappear
-      await expect(lighting_reset).not.toBeVisible()
+      await expect(lighting_reset).toBeHidden()
     })
 
     test(`bonds section reset button appears when bonds are shown`, async ({ page }) => {
@@ -2960,7 +2960,7 @@ test.describe(`Camera Projection Toggle Tests`, () => {
       await expect(bonding_select).toHaveValue(DEFAULTS.structure.bonding_strategy)
 
       // Reset button should disappear
-      await expect(bonds_reset).not.toBeVisible()
+      await expect(bonds_reset).toBeHidden()
     })
 
     test(`labels section reset button appears when labels are shown`, async ({ page }) => {
@@ -2994,11 +2994,11 @@ test.describe(`Camera Projection Toggle Tests`, () => {
       await expect(size_range).toHaveValue(`1`)
 
       // Reset button should disappear
-      await expect(labels_reset).not.toBeVisible()
+      await expect(labels_reset).toBeHidden()
 
       // check that Labels control section hides after disabling labels
       await show_labels_checkbox.uncheck()
-      await expect(page.locator(`h4:has-text("Labels")`)).not.toBeVisible()
+      await expect(page.locator(`h4:has-text("Labels")`)).toBeHidden()
     })
 
     test(`multiple sections can have reset buttons simultaneously`, async ({ page }) => {
@@ -3035,7 +3035,7 @@ test.describe(`Camera Projection Toggle Tests`, () => {
 
       // Only camera reset should disappear
       await expect(visibility_reset).toBeVisible()
-      await expect(camera_reset).not.toBeVisible()
+      await expect(camera_reset).toBeHidden()
       await expect(bg_reset).toBeVisible()
 
       // Projection should be reset but other changes remain

--- a/tests/playwright/trajectory.test.ts
+++ b/tests/playwright/trajectory.test.ts
@@ -230,7 +230,7 @@ test.describe(`Trajectory Component`, () => {
 
     // Check info pane is initially closed
     const info_pane = trajectory_viewer.locator(`.trajectory-info-pane`).first()
-    await expect(info_pane).not.toBeVisible()
+    await expect(info_pane).toBeHidden()
   })
 
   test(`playback controls function properly`, async () => {
@@ -319,7 +319,7 @@ test.describe(`Trajectory Component`, () => {
     test(`controls can be hidden`, async ({ page }) => {
       await expect(
         page.locator(`#no-controls .trajectory-controls`),
-      ).not.toBeVisible()
+      ).toBeHidden()
     })
   })
 
@@ -444,7 +444,7 @@ test.describe(`Trajectory Component`, () => {
       if (await custom_controls.isVisible()) {
         await expect(
           custom_controls.locator(`.trajectory-controls .nav-section`),
-        ).not.toBeVisible()
+        ).toBeHidden()
         await expect(
           custom_controls.locator(`.trajectory-controls button`).first(),
         ).toBeVisible()
@@ -1747,7 +1747,7 @@ test.describe(`Trajectory Demo Page - Unit-Aware Plotting`, () => {
       // Test closing
       await export_toggle.dispatchEvent(`click`)
       await page.waitForTimeout(500)
-      await expect(export_pane).not.toBeVisible()
+      await expect(export_pane).toBeHidden()
     })
 
     test(`video export settings can be configured`, async ({ page }) => {
@@ -2092,7 +2092,7 @@ test.describe(`Trajectory Demo Page - Unit-Aware Plotting`, () => {
         })
       } catch {
         // If filename doesn't appear, check if loading completed
-        await expect(trajectory.locator(`.spinner`)).not.toBeVisible({ timeout: 10000 })
+        await expect(trajectory.locator(`.spinner`)).toBeHidden({ timeout: 10000 })
       }
     })
 

--- a/tests/vitest/brillouin-compute.test.ts
+++ b/tests/vitest/brillouin-compute.test.ts
@@ -79,7 +79,7 @@ describe(`Brillouin Zone Computation`, () => {
 
   describe(`Edge filtering`, () => {
     it(`should have correct edge counts for each lattice type`, () => {
-      const test_cases: Array<[keyof typeof reference_data, number]> = [
+      const test_cases: [keyof typeof reference_data, number][] = [
         [`cubic`, 12],
         [`tetragonal`, 12],
         [`orthorhombic`, 12],

--- a/tests/vitest/math.test.ts
+++ b/tests/vitest/math.test.ts
@@ -1255,9 +1255,9 @@ describe(`tensor conversion utilities`, () => {
       const voigt = math.to_voigt(tensor)
       const reconstructed = math.from_voigt(voigt)
 
-      if (tensor.some((row) => row.some((val) => isNaN(val)))) {
-        expect(voigt.some((val) => isNaN(val))).toBe(true)
-        expect(reconstructed.some((row) => row.some((val) => isNaN(val)))).toBe(true)
+      if (tensor.some((row) => row.some(isNaN))) {
+        expect(voigt.some(isNaN)).toBe(true)
+        expect(reconstructed.some((row) => row.some(isNaN))).toBe(true)
       } else if (tensor.some((row) => row.some((val) => !Number.isFinite(val)))) {
         expect(voigt.some((val) => !Number.isFinite(val))).toBe(true)
       } else {

--- a/tests/vitest/periodic-table/PeriodicTable.test.svelte.ts
+++ b/tests/vitest/periodic-table/PeriodicTable.test.svelte.ts
@@ -383,10 +383,7 @@ describe(`PeriodicTable`, () => {
       ({ values, segments }) => {
         mount(PeriodicTable, {
           target: document.body,
-          props: {
-            heatmap_values: values as never,
-            tile_props: { show_name: false },
-          },
+          props: { heatmap_values: values as never, tile_props: { show_name: false } },
         })
 
         // Verify all expected segments are present

--- a/tests/vitest/phase-diagram/thermodynamics.test.ts
+++ b/tests/vitest/phase-diagram/thermodynamics.test.ts
@@ -453,13 +453,13 @@ describe(`edge cases and error handling`, () => {
 
   test(`compute_quickhull_triangles handles degenerate cases`, () => {
     // All points on a line
-    const colinear = [
+    const collinear = [
       { x: 0, y: 0, z: 0 },
       { x: 1, y: 0, z: 0 },
       { x: 2, y: 0, z: 0 },
       { x: 3, y: 0, z: 0 },
     ]
-    expect(compute_quickhull_triangles(colinear)).toEqual([])
+    expect(compute_quickhull_triangles(collinear)).toEqual([])
 
     // All points on a plane
     const coplanar = [

--- a/tests/vitest/rdf/calc-rdf.test.ts
+++ b/tests/vitest/rdf/calc-rdf.test.ts
@@ -301,7 +301,7 @@ describe(`calculate_rdf`, () => {
       // Check basic RDF properties
       check_basic_rdf_properties(result.r, result.g_r, n_bins)
       expect(result.g_r.some((val) => val > 0)).toBe(true)
-      expect(result.g_r.every((val) => isFinite(val))).toBe(true)
+      expect(result.g_r.every(isFinite)).toBe(true)
 
       // Check no negative or NaN values
       expect(result.g_r.every((val) => val >= 0 && !Number.isNaN(val))).toBe(true)
@@ -402,7 +402,7 @@ describe(`calculate_all_pair_rdfs`, () => {
       const max_g_r = Math.max(...result.g_r)
       expect(max_g_r).toBeGreaterThan(0)
       expect(max_g_r).toBeLessThan(max_peak)
-      expect(result.g_r.every((val) => isFinite(val))).toBe(true)
+      expect(result.g_r.every(isFinite)).toBe(true)
 
       // First few bins should not have crazy values
       for (let idx = 0; idx < Math.min(10, n_bins); idx++) {

--- a/tests/vitest/site/phonons.test.ts
+++ b/tests/vitest/site/phonons.test.ts
@@ -1,162 +1,7 @@
 import type { PhononBandStructure } from '$lib/bands'
-import type { Matrix3x3, Vec3 } from '$lib/math'
-import { writeFileSync } from 'node:fs'
-import { join } from 'node:path'
-import process from 'node:process'
-import { beforeAll, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
-// Test fixtures - sample phonon data
-const sample_phonon_data = {
-  phonon_bandstructure: {
-    lattice_rec: {
-      matrix: [
-        [1.0, 0.0, 0.0],
-        [0.0, 1.0, 0.0],
-        [0.0, 0.0, 1.0],
-      ] as Matrix3x3,
-    },
-    qpoints: [
-      [0.0, 0.0, 0.0],
-      [0.25, 0.0, 0.0],
-      [0.5, 0.0, 0.0],
-      [0.75, 0.0, 0.0],
-      [1.0, 0.0, 0.0],
-    ] as Vec3[],
-    bands: [
-      [0.0, 1.0, 2.0, 1.5, 0.5],
-      [0.5, 1.5, 2.5, 2.0, 1.0],
-      [1.0, 2.0, 3.0, 2.5, 1.5],
-    ],
-    labels_dict: {
-      GAMMA: [0.0, 0.0, 0.0] as Vec3,
-      X: [0.5, 0.0, 0.0] as Vec3,
-      M: [1.0, 0.0, 0.0] as Vec3,
-    },
-    has_nac: false,
-    has_imaginary_modes: false,
-  },
-  phonon_dos: {
-    frequencies: [0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0],
-    densities: [0.1, 0.3, 0.5, 0.4, 0.3, 0.2, 0.1],
-  },
-}
-
-const sample_phonon_with_imaginary = {
-  phonon_bandstructure: {
-    lattice_rec: {
-      matrix: [
-        [2.0, 0.0, 0.0],
-        [0.0, 2.0, 0.0],
-        [0.0, 0.0, 2.0],
-      ] as Matrix3x3,
-    },
-    qpoints: [
-      [0.0, 0.0, 0.0],
-      [0.5, 0.0, 0.0],
-      [1.0, 0.0, 0.0],
-    ] as Vec3[],
-    bands: [
-      [-1.0, 0.0, 1.0], // Has negative frequency (imaginary mode)
-      [0.5, 1.0, 1.5],
-    ],
-    labels_dict: {
-      GAMMA: [0.0, 0.0, 0.0] as Vec3,
-      X: [1.0, 0.0, 0.0] as Vec3,
-    },
-    has_nac: true,
-    has_imaginary_modes: true,
-  },
-}
-
-const sample_phonon_unlabeled_ends = {
-  phonon_bandstructure: {
-    lattice_rec: {
-      matrix: [
-        [1.0, 0.0, 0.0],
-        [0.0, 1.0, 0.0],
-        [0.0, 0.0, 1.0],
-      ] as Matrix3x3,
-    },
-    qpoints: [
-      [0.0, 0.0, 0.0], // Unlabeled start
-      [0.2, 0.0, 0.0],
-      [0.4, 0.0, 0.0], // X label
-      [0.6, 0.0, 0.0],
-      [0.8, 0.0, 0.0], // M label
-      [1.0, 0.0, 0.0], // Unlabeled end
-    ] as Vec3[],
-    bands: [[0.0, 1.0, 2.0, 1.5, 1.0, 0.5]],
-    labels_dict: {
-      X: [0.4, 0.0, 0.0] as Vec3,
-      M: [0.8, 0.0, 0.0] as Vec3,
-    },
-    has_nac: false,
-    has_imaginary_modes: false,
-  },
-}
-
-const sample_phonon_multiple_gamma = {
-  phonon_bandstructure: {
-    lattice_rec: {
-      matrix: [
-        [1.0, 0.0, 0.0],
-        [0.0, 1.0, 0.0],
-        [0.0, 0.0, 1.0],
-      ] as Matrix3x3,
-    },
-    qpoints: [
-      [0.0, 0.0, 0.0], // GAMMA (first)
-      [0.25, 0.0, 0.0],
-      [0.5, 0.0, 0.0], // X
-      [0.25, 0.0, 0.0],
-      [0.0, 0.0, 0.0], // GAMMA (second)
-      [0.0, 0.5, 0.0], // Y
-    ] as Vec3[],
-    bands: [[0.0, 1.0, 2.0, 1.0, 0.0, 1.5]],
-    labels_dict: {
-      GAMMA: [0.0, 0.0, 0.0] as Vec3,
-      X: [0.5, 0.0, 0.0] as Vec3,
-      Y: [0.0, 0.5, 0.0] as Vec3,
-    },
-    has_nac: false,
-    has_imaginary_modes: false,
-  },
-}
-
-// Helper to create temporary test data files
-const test_data_dir = join(process.cwd(), `src/site/phonons`)
-const test_files: string[] = []
-
-type PhononTestData = {
-  phonon_bandstructure?: {
-    lattice_rec: { matrix: Matrix3x3 }
-    qpoints: Vec3[]
-    bands: number[][]
-    labels_dict: Record<string, Vec3>
-    has_nac?: boolean
-    has_imaginary_modes?: boolean
-  }
-  phonon_dos?: {
-    frequencies: number[]
-    densities: number[]
-  }
-}
-
-function create_test_file(name: string, data: PhononTestData): string {
-  const file_path = join(test_data_dir, `${name}.json`)
-  writeFileSync(file_path, JSON.stringify(data))
-  test_files.push(file_path)
-  return file_path
-}
-
-describe(`Phonon Module - Real Import Tests`, () => {
-  beforeAll(() => {
-    create_test_file(`test-sample`, sample_phonon_data)
-    create_test_file(`test-imaginary`, sample_phonon_with_imaginary)
-    create_test_file(`test-unlabeled-ends`, sample_phonon_unlabeled_ends)
-    create_test_file(`test-multiple-gamma`, sample_phonon_multiple_gamma)
-  })
-
+describe(`Phonon Module Tests`, () => {
   it(`imports phonon module with phonon_bands and phonon_dos`, async () => {
     const { phonon_bands, phonon_dos } = await import(`$site/phonons`)
     expect(phonon_bands).toBeDefined()
@@ -166,154 +11,292 @@ describe(`Phonon Module - Real Import Tests`, () => {
     expect(Object.keys(phonon_bands).length).toBeGreaterThan(0)
   })
 
-  it(`transforms band structure with all required fields`, async () => {
+  it(`transforms band structures with all required fields and correct types`, async () => {
     const { phonon_bands } = await import(`$site/phonons`)
-    const band_struct = phonon_bands[`test-sample`] as PhononBandStructure
+    const keys = Object.keys(phonon_bands)
+    expect(keys.length).toBeGreaterThan(0)
 
-    expect(band_struct).toHaveProperty(`lattice_rec`)
-    expect(band_struct).toHaveProperty(`branches`)
-    expect(band_struct).toHaveProperty(`labels_dict`)
-    expect(band_struct).toHaveProperty(`has_nac`)
-    expect(band_struct).toHaveProperty(`has_imaginary_modes`)
-    expect(band_struct.qpoints).toHaveLength(5)
-    expect(band_struct.distance).toHaveLength(5)
-    expect(band_struct.nb_bands).toBe(3)
-    expect(band_struct.bands).toHaveLength(3)
-  })
+    // Test all band structures, not just the first one
+    for (const band_struct of Object.values(phonon_bands) as PhononBandStructure[]) {
+      // Check structure and types
+      expect(band_struct.lattice_rec).toBeDefined()
+      expect(band_struct.lattice_rec.matrix).toBeDefined()
+      expect(Array.isArray(band_struct.lattice_rec.matrix)).toBe(true)
+      expect(band_struct.lattice_rec.matrix).toHaveLength(3)
 
-  it.each([
-    { idx: 0, label: `GAMMA`, coords: [0.0, 0.0, 0.0] },
-    { idx: 1, label: null, coords: [0.25, 0.0, 0.0] },
-    { idx: 2, label: `X`, coords: [0.5, 0.0, 0.0] },
-    { idx: 3, label: null, coords: [0.75, 0.0, 0.0] },
-    { idx: 4, label: `M`, coords: [1.0, 0.0, 0.0] },
-  ])(
-    `assigns label $label at qpoint $idx with coords $coords`,
-    async ({ idx, label, coords }) => {
-      const { phonon_bands } = await import(`$site/phonons`)
-      const band_struct = phonon_bands[`test-sample`]
-      expect(band_struct.qpoints[idx].label).toBe(label)
-      expect(band_struct.qpoints[idx].frac_coords).toEqual(coords)
-    },
-  )
+      expect(Array.isArray(band_struct.qpoints)).toBe(true)
+      expect(band_struct.qpoints.length).toBeGreaterThan(0)
 
-  it(`calculates cumulative distances monotonically`, async () => {
-    const { phonon_bands } = await import(`$site/phonons`)
-    const band_struct = phonon_bands[`test-sample`]
+      expect(Array.isArray(band_struct.branches)).toBe(true)
+      expect(band_struct.branches.length).toBeGreaterThan(0)
 
-    expect(band_struct.qpoints[0].distance).toBe(0)
-    for (let idx = 1; idx < band_struct.qpoints.length; idx++) {
-      const current_dist = band_struct.qpoints[idx].distance
-      const prev_dist = band_struct.qpoints[idx - 1].distance
-      expect(current_dist).toBeDefined()
-      expect(prev_dist).toBeDefined()
-      if (current_dist !== undefined && prev_dist !== undefined) {
-        expect(current_dist).toBeGreaterThan(prev_dist)
+      expect(typeof band_struct.labels_dict).toBe(`object`)
+
+      expect(Array.isArray(band_struct.distance)).toBe(true)
+      expect(band_struct.distance).toHaveLength(band_struct.qpoints.length)
+
+      expect(typeof band_struct.nb_bands).toBe(`number`)
+      expect(band_struct.nb_bands).toBeGreaterThan(0)
+
+      expect(Array.isArray(band_struct.bands)).toBe(true)
+      expect(band_struct.bands).toHaveLength(band_struct.nb_bands)
+
+      // Validate all bands have correct length matching qpoints
+      band_struct.bands.forEach((band) => {
+        expect(Array.isArray(band)).toBe(true)
+        expect(band).toHaveLength(band_struct.qpoints.length)
+        band.forEach((freq) => {
+          expect(typeof freq).toBe(`number`)
+          expect(Number.isFinite(freq)).toBe(true)
+        })
+      })
+
+      // has_nac and has_imaginary_modes are optional boolean fields
+      if (band_struct.has_nac !== undefined) {
+        expect(typeof band_struct.has_nac).toBe(`boolean`)
+      }
+      if (band_struct.has_imaginary_modes !== undefined) {
+        expect(typeof band_struct.has_imaginary_modes).toBe(`boolean`)
       }
     }
-    expect(band_struct.qpoints[4].distance).toBe(
-      band_struct.distance[band_struct.distance.length - 1],
-    )
   })
 
-  it(`creates branches between labeled points`, async () => {
+  it(`assigns labels to qpoints and matches labels_dict`, async () => {
     const { phonon_bands } = await import(`$site/phonons`)
-    const band_struct = phonon_bands[`test-sample`]
 
-    expect(band_struct.branches).toHaveLength(2)
-    expect(band_struct.branches[0]).toEqual({
-      start_index: 0,
-      end_index: 2,
-      name: `GAMMA-X`,
-    })
-    expect(band_struct.branches[1]).toEqual({
-      start_index: 2,
-      end_index: 4,
-      name: `X-M`,
-    })
-  })
+    // Test all band structures
+    for (const band_struct of Object.values(phonon_bands) as PhononBandStructure[]) {
+      const labeled_points = band_struct.qpoints.filter((qpt) => qpt.label !== null)
+      expect(labeled_points.length).toBeGreaterThan(0)
 
-  it(`handles head and tail segments for unlabeled ends`, async () => {
-    const { phonon_bands } = await import(`$site/phonons`)
-    const band_struct = phonon_bands[`test-unlabeled-ends`]
+      // All labeled qpoints should have their labels present in labels_dict
+      labeled_points.forEach((qpt) => {
+        expect(qpt.label).not.toBeNull()
+        if (qpt.label) {
+          expect(band_struct.labels_dict).toHaveProperty(qpt.label)
 
-    expect(band_struct.branches.length).toBeGreaterThanOrEqual(2)
-    const has_head = band_struct.branches.some(
-      (branch) => branch.start_index === 0 && branch.name.startsWith(`0-`),
-    )
-    const has_tail = band_struct.branches.some(
-      (branch) =>
-        branch.end_index === band_struct.qpoints.length - 1 &&
-        branch.name.endsWith(`-end`),
-    )
-    expect(has_head || has_tail).toBe(true)
-  })
+          // Verify the coordinates match (within tolerance)
+          const dict_coords = band_struct.labels_dict[qpt.label]
+          expect(dict_coords).toBeDefined()
+          if (dict_coords) {
+            const coord_diff = qpt.frac_coords.map(
+              (coord, idx) => Math.abs(coord - dict_coords[idx]),
+            )
+            coord_diff.forEach((diff) => {
+              expect(diff).toBeLessThan(1e-5)
+            })
+          }
+        }
+      })
 
-  it(`handles multiple occurrences of same label`, async () => {
-    const { phonon_bands } = await import(`$site/phonons`)
-    const band_struct = phonon_bands[`test-multiple-gamma`]
-
-    expect(band_struct.qpoints[0].label).toBe(`GAMMA`)
-    expect(band_struct.qpoints[4].label).toBe(`GAMMA`)
-    expect(band_struct.branches.length).toBeGreaterThanOrEqual(2)
-  })
-
-  it.each([
-    { key: `test-sample`, has_nac: false, has_imaginary: false },
-    { key: `test-imaginary`, has_nac: true, has_imaginary: true },
-  ])(
-    `preserves has_nac=$has_nac and has_imaginary_modes=$has_imaginary for $key`,
-    async ({ key, has_nac, has_imaginary }) => {
-      const { phonon_bands } = await import(`$site/phonons`)
-      const band_struct = phonon_bands[key]
-      expect(band_struct.has_nac).toBe(has_nac)
-      expect(band_struct.has_imaginary_modes).toBe(has_imaginary)
-    },
-  )
-
-  it(`handles non-orthogonal lattice with correct distance calculation`, async () => {
-    const { phonon_bands } = await import(`$site/phonons`)
-    const band_struct = phonon_bands[`test-sample`]
-
-    expect(band_struct.lattice_rec.matrix).toBeDefined()
-    expect(band_struct.distance[0]).toBe(0)
-    for (let idx = 1; idx < band_struct.distance.length; idx++) {
-      expect(band_struct.distance[idx]).toBeGreaterThan(band_struct.distance[idx - 1])
+      // All labels in labels_dict should appear at least once in qpoints
+      Object.keys(band_struct.labels_dict).forEach((label) => {
+        const has_label = band_struct.qpoints.some((qpt) => qpt.label === label)
+        expect(has_label).toBe(true)
+      })
     }
   })
 
-  it(`exports DOS data with frequencies and densities`, async () => {
+  it(`preserves valid fractional coordinates in qpoints`, async () => {
+    const { phonon_bands } = await import(`$site/phonons`)
+
+    // Test all band structures
+    for (const band_struct of Object.values(phonon_bands) as PhononBandStructure[]) {
+      band_struct.qpoints.forEach((qpoint) => {
+        expect(qpoint.frac_coords).toBeDefined()
+        expect(Array.isArray(qpoint.frac_coords)).toBe(true)
+        expect(qpoint.frac_coords).toHaveLength(3)
+
+        // Fractional coordinates should be finite numbers
+        qpoint.frac_coords.forEach((coord) => {
+          expect(typeof coord).toBe(`number`)
+          expect(Number.isFinite(coord)).toBe(true)
+        })
+
+        // Verify qpoint has distance property
+        expect(typeof qpoint.distance).toBe(`number`)
+        expect(Number.isFinite(qpoint.distance)).toBe(true)
+        expect(qpoint.distance).toBeGreaterThanOrEqual(0)
+      })
+    }
+  })
+
+  it(`calculates cumulative distances correctly and monotonically`, async () => {
+    const { phonon_bands } = await import(`$site/phonons`)
+
+    // Test all band structures
+    for (const band_struct of Object.values(phonon_bands) as PhononBandStructure[]) {
+      expect(band_struct.qpoints[0].distance).toBe(0)
+      expect(band_struct.distance[0]).toBe(0)
+
+      // Verify distances array matches qpoints distances
+      band_struct.qpoints.forEach((qpt, idx) => {
+        expect(qpt.distance).toBe(band_struct.distance[idx])
+      })
+
+      // Distances should be monotonically non-decreasing
+      // (can be equal for consecutive points at same location, e.g. repeated labels)
+      for (let idx = 1; idx < band_struct.qpoints.length; idx++) {
+        const current_dist = band_struct.qpoints[idx].distance
+        const prev_dist = band_struct.qpoints[idx - 1].distance
+        expect(current_dist).toBeDefined()
+        expect(prev_dist).toBeDefined()
+
+        // TypeScript guards: ensure distances are numbers before comparison
+        if (typeof current_dist === `number` && typeof prev_dist === `number`) {
+          expect(current_dist).toBeGreaterThanOrEqual(prev_dist)
+          expect(current_dist).toBeGreaterThanOrEqual(0)
+          expect(Number.isFinite(current_dist)).toBe(true)
+        }
+      }
+    }
+  })
+
+  it(`creates branches that properly cover and connect labeled points`, async () => {
+    const { phonon_bands } = await import(`$site/phonons`)
+
+    // Test all band structures
+    for (const band_struct of Object.values(phonon_bands) as PhononBandStructure[]) {
+      expect(band_struct.branches.length).toBeGreaterThan(0)
+
+      // Validate each branch
+      band_struct.branches.forEach((branch) => {
+        expect(branch).toHaveProperty(`start_index`)
+        expect(branch).toHaveProperty(`end_index`)
+        expect(branch).toHaveProperty(`name`)
+        expect(typeof branch.name).toBe(`string`)
+        expect(branch.name.length).toBeGreaterThan(0)
+        expect(branch.start_index).toBeGreaterThanOrEqual(0)
+        expect(branch.end_index).toBeLessThan(band_struct.qpoints.length)
+        expect(branch.end_index).toBeGreaterThanOrEqual(branch.start_index)
+      })
+
+      // Verify branches are contiguous (no gaps, no overlaps beyond shared endpoints)
+      const sorted_branches = [...band_struct.branches].sort(
+        (branch_a, branch_b) => branch_a.start_index - branch_b.start_index,
+      )
+      expect(sorted_branches[0].start_index).toBe(0)
+      expect(sorted_branches.at(-1)?.end_index).toBe(band_struct.qpoints.length - 1)
+
+      for (let idx = 0; idx < sorted_branches.length - 1; idx++) {
+        const current = sorted_branches[idx]
+        const next = sorted_branches[idx + 1]
+        // Next branch should start where current ends (shared endpoint)
+        expect(next.start_index).toBe(current.end_index)
+      }
+
+      // Verify labeled points are at branch boundaries
+      const labeled_indices = band_struct.qpoints
+        .map((qpt, idx) => (qpt.label ? idx : null))
+        .filter((idx): idx is number => idx !== null)
+
+      labeled_indices.forEach((label_idx) => {
+        const is_branch_boundary = sorted_branches.some(
+          (branch) => branch.start_index === label_idx || branch.end_index === label_idx,
+        )
+        expect(is_branch_boundary).toBe(true)
+      })
+    }
+  })
+
+  it(`exports DOS data with valid frequencies and densities`, async () => {
     const { phonon_dos } = await import(`$site/phonons`)
-    const dos = phonon_dos[`test-sample`]
+    const keys = Object.keys(phonon_dos)
+    expect(keys.length).toBeGreaterThan(0)
 
-    expect(dos).toBeDefined()
-    expect(dos).toHaveProperty(`frequencies`)
-    expect(dos).toHaveProperty(`densities`)
-    expect(dos.frequencies).toHaveLength(7)
-    expect(dos.densities).toHaveLength(7)
-    expect(Array.isArray(dos.frequencies)).toBe(true)
-    expect(Array.isArray(dos.densities)).toBe(true)
+    // Test all DOS data
+    for (const dos of Object.values(phonon_dos)) {
+      expect(dos).toBeDefined()
+      expect(Array.isArray(dos.frequencies)).toBe(true)
+      expect(Array.isArray(dos.densities)).toBe(true)
+      expect(dos.frequencies.length).toBe(dos.densities.length)
+      expect(dos.frequencies.length).toBeGreaterThan(0)
+
+      // Frequencies should be monotonically increasing
+      for (let idx = 1; idx < dos.frequencies.length; idx++) {
+        expect(dos.frequencies[idx]).toBeGreaterThan(dos.frequencies[idx - 1])
+        expect(Number.isFinite(dos.frequencies[idx])).toBe(true)
+      }
+
+      // Densities should be non-negative and finite
+      dos.densities.forEach((density) => {
+        expect(density).toBeGreaterThanOrEqual(0)
+        expect(Number.isFinite(density)).toBe(true)
+      })
+    }
   })
 
-  it(`handles band structure data independently`, async () => {
+  it(`validates cumulative distance consistency and reciprocal lattice presence`, async () => {
     const { phonon_bands } = await import(`$site/phonons`)
-    const band_struct = phonon_bands[`test-imaginary`]
 
-    expect(band_struct).toBeDefined()
-    expect(Array.isArray(band_struct.qpoints)).toBe(true)
-    expect(Array.isArray(band_struct.bands)).toBe(true)
-    expect(Array.isArray(band_struct.branches)).toBe(true)
+    // Verify reciprocal lattice exists and validate distance consistency
+    for (const band_struct of Object.values(phonon_bands) as PhononBandStructure[]) {
+      // Verify lattice exists (used in distance calculations)
+      expect(band_struct.lattice_rec.matrix).toBeDefined()
+      expect(Array.isArray(band_struct.lattice_rec.matrix)).toBe(true)
+      expect(band_struct.lattice_rec.matrix).toHaveLength(3)
+      band_struct.lattice_rec.matrix.forEach((row) => {
+        expect(Array.isArray(row)).toBe(true)
+        expect(row).toHaveLength(3)
+        row.forEach((val) => {
+          expect(typeof val).toBe(`number`)
+          expect(Number.isFinite(val)).toBe(true)
+        })
+      })
+
+      // Check that distances are physically reasonable
+      // Maximum distance in reciprocal space should not exceed a few lattice parameters
+      const max_distance = Math.max(...band_struct.distance)
+      expect(max_distance).toBeLessThan(100) // Sanity check
+      expect(max_distance).toBeGreaterThan(0)
+
+      // Verify distance calculation consistency:
+      // distance[i] should equal sum of all incremental distances up to i
+      let cumulative = 0
+      for (let idx = 1; idx < band_struct.qpoints.length; idx++) {
+        const increment = band_struct.distance[idx] - band_struct.distance[idx - 1]
+        cumulative += increment
+        expect(Math.abs(band_struct.distance[idx] - cumulative)).toBeLessThan(1e-10)
+      }
+    }
   })
 
-  it(`calculates distances efficiently`, async () => {
+  it(`splits single-label paths into head and tail branches`, async () => {
     const { phonon_bands } = await import(`$site/phonons`)
-    const band_struct = phonon_bands[`test-sample`]
 
-    const start = performance.now()
-    const distances = band_struct.distance
-    const end = performance.now()
+    // Check if any band structure has exactly one labeled point
+    for (const band_struct of Object.values(phonon_bands) as PhononBandStructure[]) {
+      const labeled_qpoints = band_struct.qpoints.filter((qpt) => qpt.label !== null)
 
-    expect(end - start).toBeLessThan(10)
-    expect(distances.length).toBe(5)
+      if (labeled_qpoints.length === 1) {
+        const label_idx = band_struct.qpoints.findIndex((qpt) => qpt.label !== null)
+        const label = band_struct.qpoints[label_idx].label
+
+        // Should have head segment if label is not at start
+        if (label_idx > 0) {
+          const head_branch = band_struct.branches.find(
+            (branch) => branch.start_index === 0 && branch.end_index === label_idx,
+          )
+          expect(head_branch).toBeDefined()
+          expect(head_branch?.name).toBe(`0-${label}`)
+        }
+
+        // Should have tail segment if label is not at end
+        if (label_idx < band_struct.qpoints.length - 1) {
+          const tail_branch = band_struct.branches.find(
+            (branch) =>
+              branch.start_index === label_idx &&
+              branch.end_index === band_struct.qpoints.length - 1,
+          )
+          expect(tail_branch).toBeDefined()
+          expect(tail_branch?.name).toBe(`${label}-end`)
+        }
+
+        // Branch endpoints should be inclusive
+        band_struct.branches.forEach((branch) => {
+          expect(branch.end_index).toBeGreaterThanOrEqual(branch.start_index)
+        })
+      }
+    }
   })
 })

--- a/tests/vitest/site/phonons.test.ts
+++ b/tests/vitest/site/phonons.test.ts
@@ -1,0 +1,319 @@
+import type { PhononBandStructure } from '$lib/bands'
+import type { Matrix3x3, Vec3 } from '$lib/math'
+import { writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import process from 'node:process'
+import { beforeAll, describe, expect, it } from 'vitest'
+
+// Test fixtures - sample phonon data
+const sample_phonon_data = {
+  phonon_bandstructure: {
+    lattice_rec: {
+      matrix: [
+        [1.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, 1.0],
+      ] as Matrix3x3,
+    },
+    qpoints: [
+      [0.0, 0.0, 0.0],
+      [0.25, 0.0, 0.0],
+      [0.5, 0.0, 0.0],
+      [0.75, 0.0, 0.0],
+      [1.0, 0.0, 0.0],
+    ] as Vec3[],
+    bands: [
+      [0.0, 1.0, 2.0, 1.5, 0.5],
+      [0.5, 1.5, 2.5, 2.0, 1.0],
+      [1.0, 2.0, 3.0, 2.5, 1.5],
+    ],
+    labels_dict: {
+      GAMMA: [0.0, 0.0, 0.0] as Vec3,
+      X: [0.5, 0.0, 0.0] as Vec3,
+      M: [1.0, 0.0, 0.0] as Vec3,
+    },
+    has_nac: false,
+    has_imaginary_modes: false,
+  },
+  phonon_dos: {
+    frequencies: [0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0],
+    densities: [0.1, 0.3, 0.5, 0.4, 0.3, 0.2, 0.1],
+  },
+}
+
+const sample_phonon_with_imaginary = {
+  phonon_bandstructure: {
+    lattice_rec: {
+      matrix: [
+        [2.0, 0.0, 0.0],
+        [0.0, 2.0, 0.0],
+        [0.0, 0.0, 2.0],
+      ] as Matrix3x3,
+    },
+    qpoints: [
+      [0.0, 0.0, 0.0],
+      [0.5, 0.0, 0.0],
+      [1.0, 0.0, 0.0],
+    ] as Vec3[],
+    bands: [
+      [-1.0, 0.0, 1.0], // Has negative frequency (imaginary mode)
+      [0.5, 1.0, 1.5],
+    ],
+    labels_dict: {
+      GAMMA: [0.0, 0.0, 0.0] as Vec3,
+      X: [1.0, 0.0, 0.0] as Vec3,
+    },
+    has_nac: true,
+    has_imaginary_modes: true,
+  },
+}
+
+const sample_phonon_unlabeled_ends = {
+  phonon_bandstructure: {
+    lattice_rec: {
+      matrix: [
+        [1.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, 1.0],
+      ] as Matrix3x3,
+    },
+    qpoints: [
+      [0.0, 0.0, 0.0], // Unlabeled start
+      [0.2, 0.0, 0.0],
+      [0.4, 0.0, 0.0], // X label
+      [0.6, 0.0, 0.0],
+      [0.8, 0.0, 0.0], // M label
+      [1.0, 0.0, 0.0], // Unlabeled end
+    ] as Vec3[],
+    bands: [[0.0, 1.0, 2.0, 1.5, 1.0, 0.5]],
+    labels_dict: {
+      X: [0.4, 0.0, 0.0] as Vec3,
+      M: [0.8, 0.0, 0.0] as Vec3,
+    },
+    has_nac: false,
+    has_imaginary_modes: false,
+  },
+}
+
+const sample_phonon_multiple_gamma = {
+  phonon_bandstructure: {
+    lattice_rec: {
+      matrix: [
+        [1.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, 1.0],
+      ] as Matrix3x3,
+    },
+    qpoints: [
+      [0.0, 0.0, 0.0], // GAMMA (first)
+      [0.25, 0.0, 0.0],
+      [0.5, 0.0, 0.0], // X
+      [0.25, 0.0, 0.0],
+      [0.0, 0.0, 0.0], // GAMMA (second)
+      [0.0, 0.5, 0.0], // Y
+    ] as Vec3[],
+    bands: [[0.0, 1.0, 2.0, 1.0, 0.0, 1.5]],
+    labels_dict: {
+      GAMMA: [0.0, 0.0, 0.0] as Vec3,
+      X: [0.5, 0.0, 0.0] as Vec3,
+      Y: [0.0, 0.5, 0.0] as Vec3,
+    },
+    has_nac: false,
+    has_imaginary_modes: false,
+  },
+}
+
+// Helper to create temporary test data files
+const test_data_dir = join(process.cwd(), `src/site/phonons`)
+const test_files: string[] = []
+
+type PhononTestData = {
+  phonon_bandstructure?: {
+    lattice_rec: { matrix: Matrix3x3 }
+    qpoints: Vec3[]
+    bands: number[][]
+    labels_dict: Record<string, Vec3>
+    has_nac?: boolean
+    has_imaginary_modes?: boolean
+  }
+  phonon_dos?: {
+    frequencies: number[]
+    densities: number[]
+  }
+}
+
+function create_test_file(name: string, data: PhononTestData): string {
+  const file_path = join(test_data_dir, `${name}.json`)
+  writeFileSync(file_path, JSON.stringify(data))
+  test_files.push(file_path)
+  return file_path
+}
+
+describe(`Phonon Module - Real Import Tests`, () => {
+  beforeAll(() => {
+    create_test_file(`test-sample`, sample_phonon_data)
+    create_test_file(`test-imaginary`, sample_phonon_with_imaginary)
+    create_test_file(`test-unlabeled-ends`, sample_phonon_unlabeled_ends)
+    create_test_file(`test-multiple-gamma`, sample_phonon_multiple_gamma)
+  })
+
+  it(`imports phonon module with phonon_bands and phonon_dos`, async () => {
+    const { phonon_bands, phonon_dos } = await import(`$site/phonons`)
+    expect(phonon_bands).toBeDefined()
+    expect(phonon_dos).toBeDefined()
+    expect(typeof phonon_bands).toBe(`object`)
+    expect(typeof phonon_dos).toBe(`object`)
+    expect(Object.keys(phonon_bands).length).toBeGreaterThan(0)
+  })
+
+  it(`transforms band structure with all required fields`, async () => {
+    const { phonon_bands } = await import(`$site/phonons`)
+    const band_struct = phonon_bands[`test-sample`] as PhononBandStructure
+
+    expect(band_struct).toHaveProperty(`lattice_rec`)
+    expect(band_struct).toHaveProperty(`branches`)
+    expect(band_struct).toHaveProperty(`labels_dict`)
+    expect(band_struct).toHaveProperty(`has_nac`)
+    expect(band_struct).toHaveProperty(`has_imaginary_modes`)
+    expect(band_struct.qpoints).toHaveLength(5)
+    expect(band_struct.distance).toHaveLength(5)
+    expect(band_struct.nb_bands).toBe(3)
+    expect(band_struct.bands).toHaveLength(3)
+  })
+
+  it.each([
+    { idx: 0, label: `GAMMA`, coords: [0.0, 0.0, 0.0] },
+    { idx: 1, label: null, coords: [0.25, 0.0, 0.0] },
+    { idx: 2, label: `X`, coords: [0.5, 0.0, 0.0] },
+    { idx: 3, label: null, coords: [0.75, 0.0, 0.0] },
+    { idx: 4, label: `M`, coords: [1.0, 0.0, 0.0] },
+  ])(
+    `assigns label $label at qpoint $idx with coords $coords`,
+    async ({ idx, label, coords }) => {
+      const { phonon_bands } = await import(`$site/phonons`)
+      const band_struct = phonon_bands[`test-sample`]
+      expect(band_struct.qpoints[idx].label).toBe(label)
+      expect(band_struct.qpoints[idx].frac_coords).toEqual(coords)
+    },
+  )
+
+  it(`calculates cumulative distances monotonically`, async () => {
+    const { phonon_bands } = await import(`$site/phonons`)
+    const band_struct = phonon_bands[`test-sample`]
+
+    expect(band_struct.qpoints[0].distance).toBe(0)
+    for (let idx = 1; idx < band_struct.qpoints.length; idx++) {
+      const current_dist = band_struct.qpoints[idx].distance
+      const prev_dist = band_struct.qpoints[idx - 1].distance
+      expect(current_dist).toBeDefined()
+      expect(prev_dist).toBeDefined()
+      if (current_dist !== undefined && prev_dist !== undefined) {
+        expect(current_dist).toBeGreaterThan(prev_dist)
+      }
+    }
+    expect(band_struct.qpoints[4].distance).toBe(
+      band_struct.distance[band_struct.distance.length - 1],
+    )
+  })
+
+  it(`creates branches between labeled points`, async () => {
+    const { phonon_bands } = await import(`$site/phonons`)
+    const band_struct = phonon_bands[`test-sample`]
+
+    expect(band_struct.branches).toHaveLength(2)
+    expect(band_struct.branches[0]).toEqual({
+      start_index: 0,
+      end_index: 2,
+      name: `GAMMA-X`,
+    })
+    expect(band_struct.branches[1]).toEqual({
+      start_index: 2,
+      end_index: 4,
+      name: `X-M`,
+    })
+  })
+
+  it(`handles head and tail segments for unlabeled ends`, async () => {
+    const { phonon_bands } = await import(`$site/phonons`)
+    const band_struct = phonon_bands[`test-unlabeled-ends`]
+
+    expect(band_struct.branches.length).toBeGreaterThanOrEqual(2)
+    const has_head = band_struct.branches.some(
+      (branch) => branch.start_index === 0 && branch.name.startsWith(`0-`),
+    )
+    const has_tail = band_struct.branches.some(
+      (branch) =>
+        branch.end_index === band_struct.qpoints.length - 1 &&
+        branch.name.endsWith(`-end`),
+    )
+    expect(has_head || has_tail).toBe(true)
+  })
+
+  it(`handles multiple occurrences of same label`, async () => {
+    const { phonon_bands } = await import(`$site/phonons`)
+    const band_struct = phonon_bands[`test-multiple-gamma`]
+
+    expect(band_struct.qpoints[0].label).toBe(`GAMMA`)
+    expect(band_struct.qpoints[4].label).toBe(`GAMMA`)
+    expect(band_struct.branches.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it.each([
+    { key: `test-sample`, has_nac: false, has_imaginary: false },
+    { key: `test-imaginary`, has_nac: true, has_imaginary: true },
+  ])(
+    `preserves has_nac=$has_nac and has_imaginary_modes=$has_imaginary for $key`,
+    async ({ key, has_nac, has_imaginary }) => {
+      const { phonon_bands } = await import(`$site/phonons`)
+      const band_struct = phonon_bands[key]
+      expect(band_struct.has_nac).toBe(has_nac)
+      expect(band_struct.has_imaginary_modes).toBe(has_imaginary)
+    },
+  )
+
+  it(`handles non-orthogonal lattice with correct distance calculation`, async () => {
+    const { phonon_bands } = await import(`$site/phonons`)
+    const band_struct = phonon_bands[`test-sample`]
+
+    expect(band_struct.lattice_rec.matrix).toBeDefined()
+    expect(band_struct.distance[0]).toBe(0)
+    for (let idx = 1; idx < band_struct.distance.length; idx++) {
+      expect(band_struct.distance[idx]).toBeGreaterThan(band_struct.distance[idx - 1])
+    }
+  })
+
+  it(`exports DOS data with frequencies and densities`, async () => {
+    const { phonon_dos } = await import(`$site/phonons`)
+    const dos = phonon_dos[`test-sample`]
+
+    expect(dos).toBeDefined()
+    expect(dos).toHaveProperty(`frequencies`)
+    expect(dos).toHaveProperty(`densities`)
+    expect(dos.frequencies).toHaveLength(7)
+    expect(dos.densities).toHaveLength(7)
+    expect(Array.isArray(dos.frequencies)).toBe(true)
+    expect(Array.isArray(dos.densities)).toBe(true)
+  })
+
+  it(`handles band structure data independently`, async () => {
+    const { phonon_bands } = await import(`$site/phonons`)
+    const band_struct = phonon_bands[`test-imaginary`]
+
+    expect(band_struct).toBeDefined()
+    expect(Array.isArray(band_struct.qpoints)).toBe(true)
+    expect(Array.isArray(band_struct.bands)).toBe(true)
+    expect(Array.isArray(band_struct.branches)).toBe(true)
+  })
+
+  it(`calculates distances efficiently`, async () => {
+    const { phonon_bands } = await import(`$site/phonons`)
+    const band_struct = phonon_bands[`test-sample`]
+
+    const start = performance.now()
+    const distances = band_struct.distance
+    const end = performance.now()
+
+    expect(end - start).toBeLessThan(10)
+    expect(distances.length).toBe(5)
+  })
+})

--- a/tests/vitest/structure/Structure.test.svelte.ts
+++ b/tests/vitest/structure/Structure.test.svelte.ts
@@ -852,7 +852,7 @@ describe(`Structure string parsing`, () => {
           set structure(val) {
             parsed = val
           },
-          on_file_load: (data) => {
+          on_file_load: (data: StructureHandlerData) => {
             loaded = true
             expect(data.total_atoms).toBe(atoms)
             expect(data.filename).toBe(`string`)
@@ -948,7 +948,7 @@ describe(`Structure string parsing`, () => {
       props: {
         data_url: `/test.poscar`,
         structure_string: `ignored`,
-        on_file_load: (data) => filename = data.filename || ``,
+        on_file_load: (data: StructureHandlerData) => filename = data.filename || ``,
       },
     })
     await tick()

--- a/tests/vitest/structure/supercell-performance.test.ts
+++ b/tests/vitest/structure/supercell-performance.test.ts
@@ -1,0 +1,230 @@
+import type { Matrix3x3, Vec3 } from '$lib/math'
+import * as math from '$lib/math'
+import type { PymatgenStructure } from '$lib/structure'
+import { make_supercell, parse_supercell_scaling } from '$lib/structure/supercell'
+import { describe, expect, test } from 'vitest'
+
+// Create a large test structure
+function create_test_structure(num_sites: number): PymatgenStructure {
+  const lattice_matrix: Matrix3x3 = [
+    [10, 0, 0],
+    [0, 10, 0],
+    [0, 0, 10],
+  ]
+
+  const sites = Array.from({ length: num_sites }, (_, idx) => ({
+    species: [{ element: `Fe`, occu: 1, oxidation_state: 0 }],
+    xyz: [Math.random() * 10, Math.random() * 10, Math.random() * 10] as Vec3,
+    abc: [Math.random(), Math.random(), Math.random()] as Vec3,
+    label: `Fe${idx}`,
+    properties: {},
+  }))
+
+  return {
+    '@module': `pymatgen.core.structure`,
+    '@class': `Structure`,
+    lattice: {
+      matrix: lattice_matrix,
+      a: 10,
+      b: 10,
+      c: 10,
+      alpha: 90,
+      beta: 90,
+      gamma: 90,
+      volume: 1000,
+      pbc: [true, true, true] as [boolean, boolean, boolean],
+    },
+    sites,
+    charge: 0,
+  }
+}
+
+describe(`supercell performance profiling`, () => {
+  test(`profile matrix operations`, () => {
+    const matrix: Matrix3x3 = [
+      [10, 1, 0.5],
+      [0.5, 10, 1],
+      [1, 0.5, 10],
+    ]
+
+    const iterations = 10000
+    const timings: Record<string, number> = {}
+
+    // Test transpose
+    let start = performance.now()
+    for (let idx = 0; idx < iterations; idx++) {
+      math.transpose_3x3_matrix(matrix)
+    }
+    timings.transpose = performance.now() - start
+
+    // Test inverse
+    start = performance.now()
+    const transposed = math.transpose_3x3_matrix(matrix)
+    for (let idx = 0; idx < iterations; idx++) {
+      math.matrix_inverse_3x3(transposed)
+    }
+    timings.inverse = performance.now() - start
+
+    // Test matrix-vector multiply
+    const vec: Vec3 = [1, 2, 3]
+    start = performance.now()
+    for (let idx = 0; idx < iterations; idx++) {
+      math.mat3x3_vec3_multiply(matrix, vec)
+    }
+    timings.mat_vec_multiply = performance.now() - start
+
+    console.log(`Matrix operations (${iterations} iterations):`)
+    console.log(`  Transpose: ${timings.transpose.toFixed(2)}ms`)
+    console.log(`  Inverse: ${timings.inverse.toFixed(2)}ms`)
+    console.log(`  Mat-Vec multiply: ${timings.mat_vec_multiply.toFixed(2)}ms`)
+
+    expect(timings.transpose).toBeLessThan(100)
+    expect(timings.inverse).toBeLessThan(500)
+    expect(timings.mat_vec_multiply).toBeLessThan(100)
+  })
+
+  test(`profile supercell generation phases`, () => {
+    const structure = create_test_structure(100)
+    const scaling = `3x3x3`
+    const scaling_factors = parse_supercell_scaling(scaling)
+    const [nx, ny, nz] = scaling_factors
+    const det = nx * ny * nz
+
+    const timings: Record<string, number> = {}
+
+    // Phase 1: Matrix setup
+    let start = performance.now()
+    const new_lattice_matrix = [
+      math.scale(structure.lattice.matrix[0], nx),
+      math.scale(structure.lattice.matrix[1], ny),
+      math.scale(structure.lattice.matrix[2], nz),
+    ] as Matrix3x3
+    const orig_lattice_T = math.transpose_3x3_matrix(structure.lattice.matrix)
+    const new_lattice_T = math.transpose_3x3_matrix(new_lattice_matrix)
+    const new_lattice_T_inv = math.matrix_inverse_3x3(new_lattice_T)
+    timings.matrix_setup = performance.now() - start
+
+    // Phase 2: Translation vector computation
+    start = performance.now()
+    const translations = new Float64Array(det * 3)
+    let trans_idx = 0
+    for (let kk = 0; kk < nz; kk++) {
+      for (let jj = 0; jj < ny; jj++) {
+        for (let ii = 0; ii < nx; ii++) {
+          translations[trans_idx++] = orig_lattice_T[0][0] * ii +
+            orig_lattice_T[0][1] * jj + orig_lattice_T[0][2] * kk
+          translations[trans_idx++] = orig_lattice_T[1][0] * ii +
+            orig_lattice_T[1][1] * jj + orig_lattice_T[1][2] * kk
+          translations[trans_idx++] = orig_lattice_T[2][0] * ii +
+            orig_lattice_T[2][1] * jj + orig_lattice_T[2][2] * kk
+        }
+      }
+    }
+    timings.translation_vectors = performance.now() - start
+
+    // Phase 3: Site generation
+    start = performance.now()
+    const new_sites = new Array(structure.sites.length * det)
+    let site_idx = 0
+    trans_idx = 0
+    for (let kk = 0; kk < nz; kk++) {
+      for (let jj = 0; jj < ny; jj++) {
+        for (let ii = 0; ii < nx; ii++) {
+          const tx = translations[trans_idx++]
+          const ty = translations[trans_idx++]
+          const tz = translations[trans_idx++]
+          const label_suffix = `_${ii}${jj}${kk}`
+
+          for (let orig_idx = 0; orig_idx < structure.sites.length; orig_idx++) {
+            const orig_site = structure.sites[orig_idx]
+            const [ox, oy, oz] = orig_site.xyz
+
+            const new_x = ox + tx
+            const new_y = oy + ty
+            const new_z = oz + tz
+
+            let abc_x = new_lattice_T_inv[0][0] * new_x +
+              new_lattice_T_inv[0][1] * new_y + new_lattice_T_inv[0][2] * new_z
+            let abc_y = new_lattice_T_inv[1][0] * new_x +
+              new_lattice_T_inv[1][1] * new_y + new_lattice_T_inv[1][2] * new_z
+            let abc_z = new_lattice_T_inv[2][0] * new_x +
+              new_lattice_T_inv[2][1] * new_y + new_lattice_T_inv[2][2] * new_z
+
+            // Wrap coordinates
+            abc_x = abc_x % 1
+            if (abc_x < 0) abc_x += 1
+            if (abc_x >= 1 - 1e-10) abc_x = 0
+            abc_y = abc_y % 1
+            if (abc_y < 0) abc_y += 1
+            if (abc_y >= 1 - 1e-10) abc_y = 0
+            abc_z = abc_z % 1
+            if (abc_z < 0) abc_z += 1
+            if (abc_z >= 1 - 1e-10) abc_z = 0
+
+            const final_x = new_lattice_T[0][0] * abc_x +
+              new_lattice_T[0][1] * abc_y + new_lattice_T[0][2] * abc_z
+            const final_y = new_lattice_T[1][0] * abc_x +
+              new_lattice_T[1][1] * abc_y + new_lattice_T[1][2] * abc_z
+            const final_z = new_lattice_T[2][0] * abc_x +
+              new_lattice_T[2][1] * abc_y + new_lattice_T[2][2] * abc_z
+
+            new_sites[site_idx++] = {
+              species: orig_site.species,
+              xyz: [final_x, final_y, final_z] as Vec3,
+              abc: [abc_x, abc_y, abc_z] as Vec3,
+              label: `${orig_site.label}${label_suffix}`,
+              properties: orig_site.properties,
+            }
+          }
+        }
+      }
+    }
+    timings.site_generation = performance.now() - start
+
+    const total = Object.values(timings).reduce((sum, time) => sum + time, 0)
+
+    console.log(
+      `\nSupercell generation phases (100 sites → ${
+        structure.sites.length * det
+      } sites):`,
+    )
+    console.log(
+      `  Matrix setup: ${timings.matrix_setup.toFixed(2)}ms (${
+        ((timings.matrix_setup / total) * 100).toFixed(1)
+      }%)`,
+    )
+    console.log(
+      `  Translation vectors: ${timings.translation_vectors.toFixed(2)}ms (${
+        ((timings.translation_vectors / total) * 100).toFixed(1)
+      }%)`,
+    )
+    console.log(
+      `  Site generation: ${timings.site_generation.toFixed(2)}ms (${
+        ((timings.site_generation / total) * 100).toFixed(1)
+      }%)`,
+    )
+    console.log(`  Total: ${total.toFixed(2)}ms`)
+
+    expect(total).toBeLessThan(100)
+  })
+
+  test(`compare full supercell generation`, () => {
+    const sizes = [50, 100, 200, 500]
+    const results: Array<{ sites: number; time: number }> = []
+
+    console.log(`\nFull supercell generation (3x3x3):`)
+    for (const size of sizes) {
+      const structure = create_test_structure(size)
+      const start = performance.now()
+      make_supercell(structure, `3x3x3`)
+      const time = performance.now() - start
+      results.push({ sites: size, time })
+      console.log(`  ${size} → ${size * 27} sites: ${time.toFixed(2)}ms`)
+    }
+
+    // Check that it scales reasonably (should be roughly linear)
+    const first_rate = results[0].time / results[0].sites
+    const last_rate = results[results.length - 1].time / results[results.length - 1].sites
+    expect(last_rate / first_rate).toBeLessThan(2) // Should not degrade more than 2x
+  })
+})


### PR DESCRIPTION
- Adds `BrillouinBandsDos`, a synchronized three-panel Brillouin-zone, band-structure, and DOS visualization with k-path rendering.
- Generates supercells asynchronously and surfaces loading state in the controls.
- Improves synchronized hover, tooltips with series/path/band context, discontinuous x-axis ticks, path ordering, camera clipping, and instancing.

## Breaking changes
- Renames the public `Dos` type to `DosData`.