### PR TITLE
Refactor `extension/vscode` file IO to use VSCode API instead of node:fs

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -18,7 +18,6 @@
   },
   "main": "./dist/extension.cjs",
   "extensionKind": [
-    "ui",
     "workspace"
   ],
   "activationEvents": [

--- a/extensions/vscode/readme.md
+++ b/extensions/vscode/readme.md
@@ -68,6 +68,7 @@ MatterViz supports [VSCode](https://marketplace.visualstudio.com/items?itemName=
 - ✅ **Remote file access**: Visualize structures and trajectories on remote servers (HPC clusters, cloud instances, etc.)
 - ✅ **No manual file transfer**: Files are read directly from the remote filesystem
 - ✅ **File watching**: Changes to remote files are automatically detected and reloaded
+- ⚠️ **File size limit**: Remote and local files are currently limited to 1GB due to memory constraints (see `MAX_STREAMING_FILE_SIZE` in `node-io.ts`)
 
 ## ⚙️ Configuration & Customization
 

--- a/extensions/vscode/readme.md
+++ b/extensions/vscode/readme.md
@@ -61,6 +61,14 @@ Search for "MatterViz" in the VS Code Extensions marketplace.
 
 MatterViz automatically registers as a custom editor for trajectory files such as `.traj`, `.h5`, `.hdf5`, `.xyz.gz`, etc.
 
+### Remote SSH Support
+
+MatterViz supports [VSCode](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh)/[Cursor](https://open-vsx.org/extension/jajera/vsx-remote-ssh) remote SSH connections. Connect to your server via Remote SSH extension, and MatterViz should work just like it does locally.
+
+- ✅ **Remote file access**: Visualize structures and trajectories on remote servers (HPC clusters, cloud instances, etc.)
+- ✅ **No manual file transfer**: Files are read directly from the remote filesystem
+- ✅ **File watching**: Changes to remote files are automatically detected and reloaded
+
 ## ⚙️ Configuration & Customization
 
 MatterViz provides extensive customization options through VSCode settings. Access these via:

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -395,6 +395,7 @@ export const handle_msg = async (
       })
     }
   } else if (msg.command === `saveAs` && msg.content) {
+    let is_binary_save = false
     try {
       const uri = await vscode.window.showSaveDialog({
         defaultUri: vscode.Uri.file(msg.filename || `structure`),
@@ -403,6 +404,7 @@ export const handle_msg = async (
 
       if (uri && msg.content) {
         if (msg.is_binary) {
+          is_binary_save = true
           const base64_data = msg.content.replace(/^data:[^;]+;base64,/, ``)
           if (!base64_data) throw new Error(`Invalid data URL: missing base64 data`)
           await vscode.workspace.fs.writeFile(
@@ -416,7 +418,8 @@ export const handle_msg = async (
       }
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error)
-      vscode.window.showErrorMessage(`Failed to save binary data: ${message}`)
+      const error_type = is_binary_save ? `binary data` : `text file`
+      vscode.window.showErrorMessage(`Failed to save ${error_type}: ${message}`)
     }
   } else if (
     msg.command === `startWatching` &&
@@ -542,7 +545,7 @@ function create_webview_panel(
   file_data: FileData,
   file_path?: string,
   view_column: vscode.ViewColumn = vscode.ViewColumn.Beside,
-): Promise<vscode.WebviewPanel> {
+): vscode.WebviewPanel {
   const panel = vscode.window.createWebviewPanel(
     `matterviz`,
     `MatterViz - ${file_data.filename}`,

--- a/extensions/vscode/src/node-io.ts
+++ b/extensions/vscode/src/node-io.ts
@@ -7,8 +7,10 @@
 import * as vscode from 'vscode'
 
 // Memory management constants for streaming
-export const MAX_STREAMING_FILE_SIZE = 10 * 1024 * 1024 * 1024 // 10GB - practical limit
-export const LARGE_FILE_WARNING_SIZE = 5 * 1024 * 1024 * 1024 // 5GB - warn user
+// NOTE: vscode.workspace.fs.readFile() loads entire file into memory (no streaming support yet)
+// Consider making this a user setting: matterviz.max_file_size_mb (default 1024)
+export const MAX_STREAMING_FILE_SIZE = 1 * 1024 * 1024 * 1024 // set low at 1GB to prevent OOM
+export const LARGE_FILE_WARNING_SIZE = 512 * 1024 * 1024 // 512MB - warn user
 
 export interface StreamingProgress {
   bytes_read: number
@@ -44,15 +46,14 @@ export const stream_file_to_buffer = async (
     console.warn(`Large file detected: ${size_gb}GB. Processing may be slow.`)
   }
 
+  // Report initial progress to show activity started (better UX)
+  on_progress?.({ bytes_read: 0, total_size, progress: 0 })
+
   // Read entire file using VSCode API (works with both local and remote files)
+  // note: loads entire file into memory - no per-chunk progress available. if common user need, check if vscode.workspace.fs.readFile() could support streaming.
   const uint8array = await vscode.workspace.fs.readFile(uri)
 
-  // Report progress (always 100% since we read the whole file at once)
-  on_progress?.({
-    bytes_read: uint8array.length,
-    total_size,
-    progress: 1.0,
-  })
+  on_progress?.({ bytes_read: uint8array.length, total_size, progress: 1.0 }) // Report completion
 
   return uint8array.buffer
 }

--- a/extensions/vscode/tests/extension.test.ts
+++ b/extensions/vscode/tests/extension.test.ts
@@ -420,7 +420,7 @@ describe(`MatterViz Extension`, () => {
       filename: `test.cif`,
     })
     expect(mock_vscode.window.showErrorMessage).toHaveBeenCalledWith(
-      `Failed to save binary data: Write failed`,
+      `Failed to save text file: Write failed`,
     )
   })
 


### PR DESCRIPTION
closes #175

allow MatterViz VSCode extension to work with Remote-SSH connections by migrating from Node.js filesystem APIs to VSCode's workspace filesystem API.

- **Migrated to VSCode Filesystem API**: Replaced `fs.readFileSync()` and `fs.statSync()` with `vscode.workspace.fs.readFile()` and `vscode.workspace.fs.stat()` which handles both local and remote filesystems
  - required making `read_file()`, `get_file()` and related functions async

- **Adjusted large-file limits**: Reduced the maximum streamed file size to 1 GB and warn at 512 MB.
- **Improved lifecycle and errors**: Clean up on extension deactivation and report save/read failures more clearly.
- **Declared workspace-only execution**: Removed the UI extension-host entry.