### PR TITLE
Plot tweaks

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -665,12 +665,12 @@
         },
         "matterviz.histogram.display.x_zero_line": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "Show X-axis zero reference line"
         },
         "matterviz.histogram.display.y_zero_line": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "Show Y-axis zero reference line"
         },
         "matterviz.bar.bar.color": {
@@ -714,12 +714,12 @@
         },
         "matterviz.bar.display.x_zero_line": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "Show X-axis zero reference line"
         },
         "matterviz.bar.display.y_zero_line": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "Show Y-axis zero reference line"
         },
         "matterviz.composition.display_mode": {
@@ -797,12 +797,12 @@
         },
         "matterviz.scatter.display.x_zero_line": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "Show X-axis zero reference line"
         },
         "matterviz.scatter.display.y_zero_line": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "Show Y-axis zero reference line"
         },
         "matterviz.scatter.point.size": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "bugs": "https://github.com/janosh/matterviz/issues",
   "dependencies": {
     "@spglib/moyo-wasm": "^0.7.1",
-    "@sveltejs/kit": "^2.48.0",
+    "@sveltejs/kit": "^2.48.4",
     "@threlte/core": "^8.1.8",
     "@threlte/extras": "^9.5.5",
     "@types/d3-force": "^3.0.10",
@@ -30,9 +30,9 @@
     "h5wasm": "^0.8.7",
     "highlight.js": "^11.11.1",
     "js-yaml": "^4.1.0",
-    "svelte": "^5.42.3",
+    "svelte": "^5.43.2",
     "svelte-multiselect": "11.2.4",
-    "three": "^0.180.0"
+    "three": "^0.181.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.56.1",
@@ -49,12 +49,12 @@
     "@types/d3-scale-chromatic": "^3.1.0",
     "@types/d3-shape": "^3.1.7",
     "@types/d3-time-format": "^4.0.3",
-    "@types/three": "^0.180.0",
-    "@vitest/coverage-v8": "^4.0.4",
+    "@types/three": "^0.181.0",
+    "@vitest/coverage-v8": "^4.0.6",
     "d3-time-format": "^4.1.0",
     "eslint": "^9.38.0",
-    "eslint-plugin-svelte": "^3.12.5",
-    "happy-dom": "^20.0.8",
+    "eslint-plugin-svelte": "^3.13.0",
+    "happy-dom": "^20.0.10",
     "hastscript": "^9.0.1",
     "mdsvex": "^0.12.6",
     "mdsvexamples": "^0.5.0",
@@ -68,7 +68,7 @@
     "typescript": "5.9.3",
     "typescript-eslint": "^8.46.2",
     "vite": "^7.1.12",
-    "vitest": "^4.0.4"
+    "vitest": "^4.0.6"
   },
   "keywords": [
     "svelte",

--- a/src/lib/bands/Dos.svelte
+++ b/src/lib/bands/Dos.svelte
@@ -121,12 +121,12 @@
   // Calculate axis ranges
   let x_range = $derived.by(() => {
     if (!series_data.length) return undefined
-    const all_x = series_data.flatMap((s) => s.x)
+    const all_x = series_data.flatMap((srs) => srs.x)
     return [Math.min(...all_x), Math.max(...all_x)] as [number, number]
   })
   let y_range = $derived.by(() => {
     if (!series_data.length) return undefined
-    const all_y = series_data.flatMap((s) => s.y)
+    const all_y = series_data.flatMap((srs) => srs.y)
     return [0, Math.max(...all_y)] as [number, number]
   })
 

--- a/src/lib/phase-diagram/PhaseDiagram2D.svelte
+++ b/src/lib/phase-diagram/PhaseDiagram2D.svelte
@@ -3,15 +3,13 @@
     AnyStructure,
     CompositionType,
     ElementSymbol,
-    PlotPoint,
-    ScatterTooltipProps,
     UserContentProps,
   } from '$lib'
   import { Icon, is_unary_entry, PD_DEFAULTS, toggle_fullscreen } from '$lib'
   import type { D3InterpolateName } from '$lib/colors'
   import { elem_symbol_to_name, get_electro_neg_formula } from '$lib/composition'
   import { format_fractional, format_num } from '$lib/labels'
-  import { type AxisConfig, ScatterPlot } from '$lib/plot'
+  import { type AxisConfig, type ScatterHandlerProps, ScatterPlot } from '$lib/plot'
   import { SvelteMap } from 'svelte/reactivity'
   import * as helpers from './helpers'
   import type { BasePhaseDiagramProps } from './index'
@@ -48,6 +46,7 @@
     enable_structure_preview = true,
     energy_source_mode = $bindable(`precomputed`),
     phase_stats = $bindable(null),
+    display = $bindable({ x_grid: false, y_grid: false }),
     x_axis = {},
     y_axis = {},
     ...rest
@@ -416,7 +415,6 @@
       merged_config.colors?.annotation || `var(--text-color, #212121)`
     };`,
   )
-  let display = $state({ x_grid: false, y_grid: false })
 </script>
 
 <svelte:document
@@ -426,7 +424,7 @@
 />
 
 <!-- Hover tooltip matching 3D/4D style (content only; container handled by ScatterPlot) -->
-{#snippet tooltip(point: PlotPoint & ScatterTooltipProps)}
+{#snippet tooltip(point: ScatterHandlerProps)}
   {@const entry = point.metadata as unknown as PlotEntry3D}
   {@const is_element = is_unary_entry(entry)}
   {@const elem_symbol = is_element ? Object.keys(entry.composition)[0] : ``}

--- a/src/lib/phase-diagram/PhaseDiagram3D.svelte
+++ b/src/lib/phase-diagram/PhaseDiagram3D.svelte
@@ -181,14 +181,6 @@
   // Cached hull model for e_above_hull queries; recompute only when faces change
   let hull_model = $derived.by(() => thermo.build_lower_hull_model(hull_faces))
 
-  // Total counts based on hull-enriched entries
-  const total_unstable_count = $derived(
-    plot_entries.filter((entry) =>
-      typeof entry.e_above_hull === `number` && entry.e_above_hull > 0 &&
-      !entry.is_stable
-    ).length,
-  )
-
   // Canvas rendering
   let canvas: HTMLCanvasElement
   let ctx: CanvasRenderingContext2D | null = null
@@ -1116,7 +1108,6 @@
         {max_hull_dist_in_data}
         {stable_entries}
         {unstable_entries}
-        {total_unstable_count}
         {camera}
         {merged_controls}
         toggle_props={{ class: `legend-controls-btn` }}

--- a/src/lib/phase-diagram/PhaseDiagram4D.svelte
+++ b/src/lib/phase-diagram/PhaseDiagram4D.svelte
@@ -215,16 +215,10 @@
       entry.is_stable || entry.e_above_hull === 0
     ),
   )
-
   const unstable_entries = $derived(
     plot_entries.filter((entry: PlotEntry3D) =>
       (entry.e_above_hull ?? 0) > 0 && !entry.is_stable
     ),
-  )
-
-  // Total counts based on hull-enriched entries
-  const total_unstable_count = $derived(
-    plot_entries.filter((e) => (e.e_above_hull ?? 0) > 0 && !e.is_stable).length,
   )
 
   // Canvas rendering
@@ -1073,7 +1067,6 @@
         {max_hull_dist_in_data}
         {stable_entries}
         {unstable_entries}
-        {total_unstable_count}
         {camera}
         {merged_controls}
         toggle_props={{ class: `legend-controls-btn` }}

--- a/src/lib/phase-diagram/PhaseDiagramControls.svelte
+++ b/src/lib/phase-diagram/PhaseDiagramControls.svelte
@@ -39,7 +39,6 @@
     can_compute_e_form = false,
     stable_entries,
     unstable_entries,
-    total_unstable_count,
     camera,
     merged_controls,
     controls_open = $bindable(false),
@@ -73,7 +72,6 @@
     // Data for visualization
     stable_entries: PlotEntry3D[]
     unstable_entries: PlotEntry3D[]
-    total_unstable_count: number
     // Camera state
     camera: CameraState
     // Legend configuration
@@ -206,7 +204,7 @@
               merged_controls.show_counts
               ? ` (${
                 unstable_entries.filter((e) => e.visible).length
-              }/${total_unstable_count})`
+              }/${unstable_entries.length})`
               : ``
             }</span>
         </div>

--- a/src/lib/phase-diagram/index.ts
+++ b/src/lib/phase-diagram/index.ts
@@ -52,6 +52,8 @@ export interface BasePhaseDiagramProps<TEntry = PhaseEntry>
   energy_source_mode?: `precomputed` | `on-the-fly`
   // Bindable phase diagram statistics - computed internally but exposed for external use
   phase_stats?: PhaseStats | null
+  // Display configuration for grid lines and other visual elements
+  display?: { x_grid?: boolean; y_grid?: boolean }
 }
 
 // Additional props specific to 3D and 4D phase diagrams

--- a/src/lib/plot/Histogram.svelte
+++ b/src/lib/plot/Histogram.svelte
@@ -527,9 +527,10 @@
           {#if tooltip}
             {@render tooltip(hover_info)}
           {:else}
+            {@const formatter = active_y_axis === `y2` ? y2_axis.format : y_axis.format}
             <div>Value: {format_value(value, x_axis.format || `.3~s`)}</div>
             <div>
-              Count: {format_value(count, y_axis.format || `.3~s`)}
+              Count: {format_value(count, formatter || `.3~s`)}
             </div>
             {#if mode === `overlay`}<div>{property}</div>{/if}
           {/if}

--- a/src/lib/plot/ScatterPlot.svelte
+++ b/src/lib/plot/ScatterPlot.svelte
@@ -36,6 +36,10 @@
     ScatterPoint,
   } from '$lib/plot'
   import { compute_label_positions } from '$lib/plot/utils/label-placement'
+  import {
+    handle_legend_double_click,
+    toggle_series_visibility,
+  } from '$lib/plot/utils/series-visibility'
   import { DEFAULTS } from '$lib/settings'
   import { extent } from 'd3-array'
   import { forceCollide, forceLink, forceManyBody, forceSimulation } from 'd3-force'
@@ -1034,22 +1038,6 @@
     )
   })
 
-  // Function to toggle series visibility
-  function toggle_series_visibility(series_idx: number) {
-    series = toggle_series_visibility(series, series_idx)
-  }
-
-  // Function to handle double-click on legend item
-  function handle_legend_double_click(double_clicked_idx: number) {
-    const result = handle_legend_double_click(
-      series,
-      double_clicked_idx,
-      previous_series_visibility,
-    )
-    series = result.series
-    previous_series_visibility = result.previous_visibility
-  }
-
   // Legend drag handlers
   function handle_legend_drag_start(event: MouseEvent) {
     if (!svg_element) return
@@ -1698,9 +1686,19 @@
         draggable={legend?.draggable ?? true}
         {...legend}
         on_toggle={(legend?.on_toggle as ((series_idx: number) => void) | undefined) ??
-        toggle_series_visibility}
+        ((series_idx: number) => {
+          series = toggle_series_visibility(series, series_idx)
+        })}
         on_double_click={(legend?.on_double_click as ((series_idx: number) => void) | undefined) ??
-        handle_legend_double_click}
+        ((double_clicked_idx: number) => {
+          const result = handle_legend_double_click(
+            series,
+            double_clicked_idx,
+            previous_series_visibility,
+          )
+          series = result.series
+          previous_series_visibility = result.previous_visibility
+        })}
         wrapper_style={`
           position: absolute;
           left: ${

--- a/src/lib/plot/ScatterPlot.svelte
+++ b/src/lib/plot/ScatterPlot.svelte
@@ -42,7 +42,6 @@
   } from '$lib/plot/utils/series-visibility'
   import { DEFAULTS } from '$lib/settings'
   import { extent } from 'd3-array'
-  import { forceCollide, forceLink, forceManyBody, forceSimulation } from 'd3-force'
   import {
     scaleLinear,
     scaleLog,
@@ -1027,14 +1026,8 @@
     label_positions = compute_label_positions(
       filtered_series,
       actual_label_config,
-      {
-        x_scale_fn,
-        y_scale_fn,
-        y2_scale_fn,
-        x_axis_format: x_axis.format,
-      },
+      { x_scale_fn, y_scale_fn, y2_scale_fn, x_axis },
       { width, height, pad },
-      { forceSimulation, forceLink, forceCollide, forceManyBody },
     )
   })
 

--- a/src/lib/plot/ScatterPlot.svelte
+++ b/src/lib/plot/ScatterPlot.svelte
@@ -1553,12 +1553,15 @@
                   : point.point_style?.fill ?? `cornflowerblue`}
                   {...point_events &&
                   Object.fromEntries(
-                    Object.entries(point_events).map((
-                      [event_name, handler],
-                    ) => [event_name, (event: Event) => handler({ point, event })]),
+                    Object.entries(point_events)
+                      .filter(([event_name]) => event_name !== `onclick`).map((
+                        [event_name, handler],
+                      ) => [event_name, (event: Event) => handler({ point, event })]),
                   )}
                   onclick={(event: MouseEvent) => {
-                    // Construct handler props synchronously to avoid stale derived reads
+                    // Call user-provided onclick handler first if it exists
+                    point_events?.onclick?.({ point, event })
+                    // then handle internal logic
                     const props = construct_handler_props(point)
                     tooltip_point = point
                     if (props) on_point_click?.({ ...props, event })

--- a/src/lib/plot/ScatterPlot.svelte
+++ b/src/lib/plot/ScatterPlot.svelte
@@ -16,6 +16,7 @@
     Point,
     PointStyle,
     ScaleType,
+    ScatterHandlerEvent,
     ScatterHandlerProps,
     Sides,
     StyleOverrides,
@@ -129,10 +130,8 @@
       string,
       (payload: { point: InternalPoint; event: Event }) => void
     >
-    on_point_click?: (data: ScatterHandlerProps & { event: MouseEvent }) => void
-    on_point_hover?: (
-      data: (ScatterHandlerProps & { event: MouseEvent }) | null,
-    ) => void
+    on_point_click?: (data: ScatterHandlerEvent) => void
+    on_point_hover?: (data: ScatterHandlerEvent | null) => void
     selected_series_idx?: number
   } = $props()
 

--- a/src/lib/plot/data-transform.ts
+++ b/src/lib/plot/data-transform.ts
@@ -37,7 +37,7 @@ export function create_data_points(
   filter_fn?: (series: DataSeries) => boolean,
 ): Point[] {
   return series
-    .filter(filter_fn || ((s) => s.visible ?? true))
+    .filter(filter_fn || ((srs) => srs.visible ?? true))
     .flatMap(({ x: xs, y: ys }, series_idx) => {
       const length = Math.min(xs.length, ys.length)
       if (xs.length !== ys.length) {

--- a/src/lib/plot/types.ts
+++ b/src/lib/plot/types.ts
@@ -126,10 +126,10 @@ export interface Tooltip {
   items?: { label: string; value: string; color?: string }[]
 }
 
-export interface TooltipProps {
+export interface TooltipProps<Metadata = Record<string, unknown>> {
   x: number
   y: number
-  metadata?: Record<string, unknown> | null
+  metadata?: Metadata | null
   label?: string | null
   series_idx: number
   x_axis: AxisConfig
@@ -137,7 +137,8 @@ export interface TooltipProps {
   y2_axis?: AxisConfig
 }
 
-export interface ScatterHandlerProps extends TooltipProps {
+export interface ScatterHandlerProps<Metadata = Record<string, unknown>>
+  extends TooltipProps<Metadata> {
   cx: number
   cy: number
   x_formatted: string
@@ -150,8 +151,12 @@ export interface ScatterHandlerProps extends TooltipProps {
     tick_format?: string | null
   }
 }
+export type ScatterHandlerEvent<Metadata = Record<string, unknown>> =
+  & ScatterHandlerProps<Metadata>
+  & { event: MouseEvent }
 
-export interface BarHandlerProps extends TooltipProps {
+export interface BarHandlerProps<Metadata = Record<string, unknown>>
+  extends TooltipProps<Metadata> {
   bar_idx: number
   orient_x: number
   orient_y: number
@@ -159,7 +164,8 @@ export interface BarHandlerProps extends TooltipProps {
   color: string
 }
 
-export interface HistogramHandlerProps extends TooltipProps {
+export interface HistogramHandlerProps<Metadata = Record<string, unknown>>
+  extends TooltipProps<Metadata> {
   value: number
   count: number
   property: string

--- a/src/lib/plot/types.ts
+++ b/src/lib/plot/types.ts
@@ -130,23 +130,40 @@ export interface TooltipProps {
   x: number
   y: number
   metadata?: Record<string, unknown> | null
-  color?: string | null
   label?: string | null
   series_idx: number
+  x_axis: AxisConfig
+  y_axis: AxisConfig
+  y2_axis?: AxisConfig
 }
 
-export interface ScatterTooltipProps extends TooltipProps {
+export interface ScatterHandlerProps extends TooltipProps {
   cx: number
   cy: number
   x_formatted: string
   y_formatted: string
+  color_value?: number | null
+  colorbar?: {
+    value?: number | null
+    title?: string | null
+    scale?: unknown
+    tick_format?: string | null
+  }
 }
 
-export interface BarTooltipProps extends TooltipProps {
+export interface BarHandlerProps extends TooltipProps {
   bar_idx: number
   orient_x: number
   orient_y: number
-  y_axis: `y1` | `y2`
+  active_y_axis: `y1` | `y2`
+  color: string
+}
+
+export interface HistogramHandlerProps extends TooltipProps {
+  value: number
+  count: number
+  property: string
+  active_y_axis: `y1` | `y2`
 }
 
 export type TimeInterval = `day` | `month` | `year`

--- a/src/lib/plot/utils/label-placement.ts
+++ b/src/lib/plot/utils/label-placement.ts
@@ -1,0 +1,161 @@
+import type { DataSeries, InternalPoint, LabelPlacementConfig, XyObj } from '$lib/plot'
+import type { forceCollide, forceLink, forceManyBody, forceSimulation } from 'd3-force'
+import type { ScaleContinuousNumeric } from 'd3-scale'
+
+export interface LabelNode {
+  id: string
+  anchor_x: number
+  anchor_y: number
+  point_node: InternalPoint
+  label_width: number
+  label_height: number
+  x?: number
+  y?: number
+}
+
+export interface AnchorNode {
+  id: string
+  fx: number
+  fy: number
+  point_radius: number
+}
+
+function parse_font_size(size_str?: string): number {
+  if (!size_str) return 12
+  const match = size_str.match(/^(\d+(?:\.\d+)?)(px|em|rem)?$/)
+  if (!match) return 12
+  const value = parseFloat(match[1])
+  return match[2] === `em` || match[2] === `rem` ? value * 16 : value
+}
+
+export function compute_label_positions(
+  filtered_series: (DataSeries & { filtered_data: InternalPoint[] })[],
+  config: LabelPlacementConfig & {
+    max_labels?: number
+    charge_strength?: number
+    charge_distance_max?: number
+  },
+  scales: {
+    x_scale_fn: ScaleContinuousNumeric<number, number>
+    y_scale_fn: ScaleContinuousNumeric<number, number>
+    y2_scale_fn: ScaleContinuousNumeric<number, number>
+    x_axis_format?: string
+  },
+  bounds: {
+    width: number
+    height: number
+    pad: { t: number; b: number; l: number; r: number }
+  },
+  force_imports: {
+    forceSimulation: typeof forceSimulation
+    forceLink: typeof forceLink
+    forceCollide: typeof forceCollide
+    forceManyBody: typeof forceManyBody
+  },
+): Record<string, XyObj> {
+  const { width, height, pad } = bounds
+  const { x_scale_fn, y_scale_fn, y2_scale_fn, x_axis_format } = scales
+  const { forceSimulation, forceLink, forceCollide, forceManyBody } = force_imports
+
+  const label_nodes: LabelNode[] = []
+  const anchor_nodes: AnchorNode[] = []
+  const links: { source: string; target: string }[] = []
+
+  for (const series of filtered_series) {
+    for (const pt of series.filtered_data) {
+      if (!pt.point_label?.auto_placement || !pt.point_label.text) continue
+
+      const ax = x_axis_format?.startsWith(`%`)
+        ? x_scale_fn(new Date(pt.x))
+        : x_scale_fn(pt.x)
+      const ay = (series.y_axis === `y2` ? y2_scale_fn : y_scale_fn)(pt.y)
+      const id = `${pt.series_idx}-${pt.point_idx}`
+      const font_size = parse_font_size(pt.point_label.font_size)
+      const w = pt.point_label.text.length * font_size * 0.6 + 10
+      const h = font_size * 1.2
+      const r = pt.point_style?.radius ?? 3
+
+      label_nodes.push({
+        id,
+        anchor_x: ax,
+        anchor_y: ay,
+        point_node: pt,
+        label_width: w,
+        label_height: h,
+        x: ax + (pt.point_label.offset?.x ?? 5),
+        y: ay + (pt.point_label.offset?.y ?? r + h / 2 + 3),
+      })
+      anchor_nodes.push({ id: `anchor-${id}`, fx: ax, fy: ay, point_radius: r })
+      links.push({ source: id, target: `anchor-${id}` })
+    }
+  }
+
+  if (label_nodes.length === 0) return {}
+  if (config.max_labels && label_nodes.length > config.max_labels) {
+    return Object.fromEntries(
+      label_nodes.map((n) => [n.id, { x: n.x ?? 0, y: n.y ?? 0 }]),
+    )
+  }
+
+  const sim = forceSimulation([...label_nodes, ...anchor_nodes])
+    .force(
+      `link`,
+      forceLink(links).id((d) => (d as { id: string }).id).distance(config.link_distance)
+        .strength(config.link_strength),
+    )
+    .force(
+      `collide`,
+      forceCollide().radius((n) => {
+        const l = n as LabelNode
+        const a = n as AnchorNode
+        return l.label_width
+          ? Math.sqrt(l.label_width ** 2 + l.label_height ** 2) / 2 + 2
+          : (a.point_radius ?? 0) + 2
+      }).strength(config.collision_strength),
+    )
+    .force(
+      `charge`,
+      forceManyBody().strength((n) => {
+        const a = n as AnchorNode
+        return a.point_radius !== undefined && a.fx !== undefined
+          ? -(config.charge_strength ?? 50)
+          : 0
+      }).distanceMax(config.charge_distance_max ?? 30),
+    )
+
+  sim.stop().tick(config.placement_ticks)
+
+  const [min_dist, max_dist] = config.link_distance_range ?? [null, null]
+  const result: Record<string, XyObj> = {}
+
+  for (const node of label_nodes) {
+    const node_x = node.x ?? 0
+    const node_y = node.y ?? 0
+    let x = Math.max(
+      pad.l + node.label_width / 2,
+      Math.min(width - pad.r - node.label_width / 2, node_x),
+    )
+    let y = Math.max(
+      pad.t + node.label_height / 2,
+      Math.min(height - pad.b - node.label_height / 2, node_y),
+    )
+
+    if (min_dist || max_dist) {
+      const dx = x - node.anchor_x
+      const dy = y - node.anchor_y
+      const dist = Math.sqrt(dx ** 2 + dy ** 2)
+      if (max_dist && dist > max_dist) {
+        const s = max_dist / dist
+        x = node.anchor_x + dx * s
+        y = node.anchor_y + dy * s
+      } else if (min_dist && dist > 0 && dist < min_dist) {
+        const s = min_dist / dist
+        x = node.anchor_x + dx * s
+        y = node.anchor_y + dy * s
+      }
+    }
+    result[node.id] = { x, y }
+  }
+
+  return result
+}

--- a/src/lib/plot/utils/label-placement.ts
+++ b/src/lib/plot/utils/label-placement.ts
@@ -1,5 +1,6 @@
-import type { DataSeries, InternalPoint, LabelPlacementConfig, XyObj } from '$lib/plot'
-import type { forceCollide, forceLink, forceManyBody, forceSimulation } from 'd3-force'
+import type { AxisConfig, DataSeries, XyObj } from '$lib/plot'
+import { InternalPoint, LabelPlacementConfig } from '$lib/plot/types'
+import { forceCollide, forceLink, forceManyBody, forceSimulation } from 'd3-force'
 import type { ScaleContinuousNumeric } from 'd3-scale'
 
 export interface LabelNode {
@@ -39,23 +40,16 @@ export function compute_label_positions(
     x_scale_fn: ScaleContinuousNumeric<number, number>
     y_scale_fn: ScaleContinuousNumeric<number, number>
     y2_scale_fn: ScaleContinuousNumeric<number, number>
-    x_axis_format?: string
+    x_axis: AxisConfig
   },
   bounds: {
     width: number
     height: number
     pad: { t: number; b: number; l: number; r: number }
   },
-  force_imports: {
-    forceSimulation: typeof forceSimulation
-    forceLink: typeof forceLink
-    forceCollide: typeof forceCollide
-    forceManyBody: typeof forceManyBody
-  },
 ): Record<string, XyObj> {
   const { width, height, pad } = bounds
-  const { x_scale_fn, y_scale_fn, y2_scale_fn, x_axis_format } = scales
-  const { forceSimulation, forceLink, forceCollide, forceManyBody } = force_imports
+  const { x_scale_fn, y_scale_fn, y2_scale_fn, x_axis } = scales
 
   const label_nodes: LabelNode[] = []
   const anchor_nodes: AnchorNode[] = []
@@ -65,7 +59,7 @@ export function compute_label_positions(
     for (const pt of series.filtered_data) {
       if (!pt.point_label?.auto_placement || !pt.point_label.text) continue
 
-      const ax = x_axis_format?.startsWith(`%`)
+      const ax = x_axis.format?.startsWith(`%`)
         ? x_scale_fn(new Date(pt.x))
         : x_scale_fn(pt.x)
       const ay = (series.y_axis === `y2` ? y2_scale_fn : y_scale_fn)(pt.y)

--- a/src/lib/plot/utils/series-visibility.ts
+++ b/src/lib/plot/utils/series-visibility.ts
@@ -45,22 +45,23 @@ export function handle_legend_double_click(
 
   if (is_isolated && prev_visibility) {
     return {
-      series: series.map((
-        s,
-        i,
-      ) => (current[i] !== prev_visibility[i]
-        ? { ...s, visible: prev_visibility[i] }
-        : s)
-      ),
+      series: series.map((srs, idx) => {
+        // Only restore visibility if we have a saved value for this index
+        // (new series added after isolation should keep their current visibility)
+        if (idx < prev_visibility.length && current[idx] !== prev_visibility[idx]) {
+          return { ...srs, visible: prev_visibility[idx] }
+        }
+        return srs
+      }),
       previous_visibility: null,
     }
   }
 
   const new_prev = current.filter((v) => v).length > 1 ? [...current] : null
   return {
-    series: series.map((s, i) => {
-      const in_group = label ? s.label === label : i === idx
-      return (s?.visible ?? true) !== in_group ? { ...s, visible: in_group } : s
+    series: series.map((srs, srs_idx) => {
+      const in_group = label ? srs.label === label : srs_idx === idx
+      return (srs?.visible ?? true) !== in_group ? { ...srs, visible: in_group } : srs
     }),
     previous_visibility: new_prev,
   }

--- a/src/lib/plot/utils/series-visibility.ts
+++ b/src/lib/plot/utils/series-visibility.ts
@@ -37,7 +37,7 @@ export function handle_legend_double_click(
   prev_visibility: boolean[] | null,
 ): { series: DataSeries[]; previous_visibility: boolean[] | null } {
   const label = series[idx]?.label
-  const current = series.map((s) => s?.visible ?? true)
+  const current = series.map((srs) => srs?.visible ?? true)
   const is_isolated = series.every((s, i) => {
     const in_group = label ? s.label === label : i === idx
     return in_group ? (s?.visible ?? true) : !(s?.visible ?? true)

--- a/src/lib/plot/utils/series-visibility.ts
+++ b/src/lib/plot/utils/series-visibility.ts
@@ -1,0 +1,67 @@
+import type { DataSeries } from '$lib/plot'
+
+export function have_compatible_units(series1: DataSeries, series2: DataSeries): boolean {
+  if (!series1.unit || !series2.unit) return true
+  return series1.unit === series2.unit
+}
+
+export function toggle_series_visibility(
+  series: DataSeries[],
+  series_idx: number,
+): DataSeries[] {
+  if (series_idx < 0 || series_idx >= series.length || !series[series_idx]) return series
+
+  const toggled = series[series_idx] as DataSeries
+  const new_visibility = !(toggled.visible ?? true)
+  const target_axis = toggled.y_axis ?? `y1`
+
+  return series.map((srs, idx) => {
+    if (
+      (toggled.label && srs.label === toggled.label) ||
+      (idx === series_idx && !toggled.label)
+    ) {
+      return { ...srs, visible: new_visibility }
+    }
+    if (new_visibility && (srs.y_axis ?? `y1`) === target_axis) {
+      if (!have_compatible_units(toggled, srs) && (srs.visible ?? true)) {
+        return { ...srs, visible: false }
+      }
+    }
+    return srs
+  })
+}
+
+export function handle_legend_double_click(
+  series: DataSeries[],
+  idx: number,
+  prev_visibility: boolean[] | null,
+): { series: DataSeries[]; previous_visibility: boolean[] | null } {
+  const label = series[idx]?.label
+  const current = series.map((s) => s?.visible ?? true)
+  const is_isolated = series.every((s, i) => {
+    const in_group = label ? s.label === label : i === idx
+    return in_group ? (s?.visible ?? true) : !(s?.visible ?? true)
+  })
+
+  if (is_isolated && prev_visibility) {
+    return {
+      series: series.map((
+        s,
+        i,
+      ) => (current[i] !== prev_visibility[i]
+        ? { ...s, visible: prev_visibility[i] }
+        : s)
+      ),
+      previous_visibility: null,
+    }
+  }
+
+  const new_prev = current.filter((v) => v).length > 1 ? [...current] : null
+  return {
+    series: series.map((s, i) => {
+      const in_group = label ? s.label === label : i === idx
+      return (s?.visible ?? true) !== in_group ? { ...s, visible: in_group } : s
+    }),
+    previous_visibility: new_prev,
+  }
+}

--- a/src/lib/rdf/calc-rdf.ts
+++ b/src/lib/rdf/calc-rdf.ts
@@ -63,7 +63,7 @@ export function calculate_rdf(
 
   // Note: Sites with mixed occupancy are treated as the first species only.
   // TODO For proper occupancy support, contributions should be weighted by species occupancy.
-  const elements = sites.map((s) => s.species[0].element)
+  const elements = sites.map((site) => site.species[0].element)
   const centers = center_species
     ? sites.filter((_, idx) => elements[idx] === center_species)
     : sites
@@ -120,7 +120,8 @@ export function calculate_all_pair_rdfs(
   structure: Structure,
   options: Omit<RdfOptions, `center_species` | `neighbor_species`> = {},
 ): RdfPattern[] {
-  const elems = [...new Set(structure.sites.map((s) => s.species[0].element))].sort()
+  const elems = [...new Set(structure.sites.map((site) => site.species[0].element))]
+    .sort()
 
   // If auto_expand is true, expand the structure once and reuse it for all pairs
   // to avoid repeated supercell computations

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -276,11 +276,11 @@ const DISPLAY_CONFIG = {
     description: `Show Y2-axis grid lines`,
   },
   x_zero_line: {
-    value: false,
+    value: true,
     description: `Show X-axis zero reference line`,
   },
   y_zero_line: {
-    value: false,
+    value: true,
     description: `Show Y-axis zero reference line`,
   },
 } as const

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -423,7 +423,8 @@ export const SETTINGS_CONFIG: SettingsConfig = {
     },
     zoom_to_cursor: {
       value: true,
-      description: `Zoom toward cursor position instead of scene center`,
+      description:
+        `Zoom toward cursor position instead of scene center (double click canvas to reset camera)`,
     },
     max_zoom: {
       value: 500,

--- a/src/lib/symmetry/index.ts
+++ b/src/lib/symmetry/index.ts
@@ -39,7 +39,7 @@ export function to_cell_json(structure: PymatgenStructure): string {
     m21,
     m22,
   ]
-  const positions = structure.sites.map((s) => s.abc)
+  const positions = structure.sites.map((site) => site.abc)
   const numbers = structure.sites.map((site, idx) => {
     const sym = site.species?.[0]?.element
     const num = sym !== null ? symbol_to_atomic_number[sym] : undefined

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -345,7 +345,7 @@
 
   // Check if there are any Y2 series to determine padding
   let has_y2_series = $derived(
-    plot_series.some((s) => s.y_axis === `y2` && s.visible),
+    plot_series.some((srs) => srs.y_axis === `y2` && srs.visible),
   )
 
   // Step navigation functions

--- a/src/lib/trajectory/parse.ts
+++ b/src/lib/trajectory/parse.ts
@@ -1212,7 +1212,7 @@ export async function parse_trajectory_data(
 
       return create_trajectory_frame(
         positions,
-        species.map((s) => s.element),
+        species.map((specie) => specie.element),
         matrix,
         [true, true, true],
         idx,
@@ -1226,7 +1226,7 @@ export async function parse_trajectory_data(
         filename,
         source_format: `pymatgen_trajectory`,
         frame_count: frames.length,
-        species_list: [...new Set(species.map((s) => s.element))],
+        species_list: [...new Set(species.map((specie) => specie.element))],
         periodic_boundary_conditions: [true, true, true],
       },
     }

--- a/src/lib/trajectory/plotting.ts
+++ b/src/lib/trajectory/plotting.ts
@@ -300,17 +300,19 @@ export function toggle_series_visibility(
 
   // Handle smart group replacement for new groups
   if (new_visibility && !target_group.is_visible) {
-    const visible_groups = unit_groups.filter((g) => g.is_visible)
+    const visible_groups = unit_groups.filter((group) => group.is_visible)
     if (visible_groups.length >= 2) {
       // Hide lowest priority group (highest priority number)
-      const lowest_priority_group = visible_groups.sort((a, b) => a.priority - b.priority)
+      const lowest_priority_group = visible_groups.sort((g1, g2) =>
+        g1.priority - g2.priority
+      )
         .pop() // Get the last (lowest priority) group
       if (lowest_priority_group) {
         lowest_priority_group.is_visible = false
         // Also hide the actual series in this group
-        lowest_priority_group.series.forEach((srs) => {
-          const series_idx = updated_series.findIndex((s) =>
-            s.label === srs.label && s.unit === srs.unit
+        lowest_priority_group.series.forEach((srs1) => {
+          const series_idx = updated_series.findIndex((srs2) =>
+            srs2.label === srs1.label && srs2.unit === srs1.unit
           )
           if (series_idx !== -1) {
             updated_series[series_idx] = { ...updated_series[series_idx], visible: false }
@@ -351,20 +353,21 @@ function update_group_visibility_and_axes(
 ): void {
   // Update group visibility based on series
   unit_groups.forEach((group) => {
-    group.is_visible = group.series.some((srs) =>
-      series.find((s) => s.label === srs.label && s.unit === srs.unit)?.visible || false
+    group.is_visible = group.series.some((srs1) =>
+      series.find((srs2) => srs2.label === srs1.label && srs2.unit === srs1.unit)
+        ?.visible || false
     )
   })
 
   // Apply 2-group limit
-  const visible_groups = unit_groups.filter((g) => g.is_visible)
+  const visible_groups = unit_groups.filter((group) => group.is_visible)
   if (visible_groups.length > 2) {
     const groups_to_hide = visible_groups.slice(2)
     groups_to_hide.forEach((group) => {
       group.is_visible = false
-      group.series.forEach((srs) => {
-        const series_idx = series.findIndex((s) =>
-          s.label === srs.label && s.unit === srs.unit
+      group.series.forEach((srs1) => {
+        const series_idx = series.findIndex((srs2) =>
+          srs2.label === srs1.label && srs2.unit === srs1.unit
         )
         if (series_idx !== -1) {
           series[series_idx] = { ...series[series_idx], visible: false }
@@ -374,8 +377,8 @@ function update_group_visibility_and_axes(
   }
 
   // Assign axes
-  const final_visible = unit_groups.filter((g) => g.is_visible)
-  final_visible.sort((a, b) => a.priority - b.priority)
+  const final_visible = unit_groups.filter((group) => group.is_visible)
+  final_visible.sort((g1, g2) => g1.priority - g2.priority)
 
   const axis_map = new Map<UnitGroup, `y1` | `y2`>()
   if (final_visible.length === 1) {
@@ -565,11 +568,12 @@ function determine_axis_from_groups(
   })) as DataSeries[]
 
   const groups = group_and_assign_series(mock_series, new Set([property]))
-  const target_group = groups.find((g) =>
-    g.series.some((s) => s.label === property && s.unit === unit)
+  const target_group = groups.find((group) =>
+    group.series.some((srs) => srs.label === property && srs.unit === unit)
   )
 
-  return target_group && groups.filter((g) => g.is_visible).indexOf(target_group) === 1
+  return target_group &&
+      groups.filter((group) => group.is_visible).indexOf(target_group) === 1
     ? `y2`
     : `y1`
 }

--- a/src/routes/(demos)/plot/scatter-plot/+page.md
+++ b/src/routes/(demos)/plot/scatter-plot/+page.md
@@ -39,7 +39,7 @@ A simple scatter plot showing different display modes (points, lines, or both). 
   let hovered_point_info = $state('No point hovered yet.')
 
   // It's good practice to type event handlers if you know the structure
-  function handle_point_click({ point }) {
+  function on_point_click({ point }) {
     const { x, y, metadata, series_idx, point_idx } = point
     clicked_point_info = `Clicked: Point (${x}, ${y}), Series: '${
       metadata?.series_label ??
@@ -103,7 +103,7 @@ A simple scatter plot showing different display modes (points, lines, or both). 
   ]}
   x_axis={{ label: 'X Axis' }}
   y_axis={{ label: 'Y Value' }}
-  point_events={{ onclick: handle_point_click, ondblclick: handle_point_double_click }}
+  point_events={{ onclick: on_point_click, ondblclick: handle_point_double_click }}
   on_point_hover={handle_point_hover}
   style="height: 300px"
 />

--- a/src/routes/(demos)/plot/scatter-plot/+page.md
+++ b/src/routes/(demos)/plot/scatter-plot/+page.md
@@ -248,7 +248,7 @@ Demonstrate various point styles, custom tooltips, and hover effects:
 </script>
 
 <ScatterPlot
-  series={series_with_styles.map((s) => ({ ...s, markers: 'points' }))}
+  series={series_with_styles.map((srs) => ({ ...srs, markers: 'points' }))}
   x_axis={{ label: 'X Axis' }}
   y_axis={{ label: 'Point Style Examples', range: [0, 12] }}
   change={(point) => (hovered_point = point)}
@@ -451,7 +451,7 @@ This example shows categorized data with color coding, custom tick intervals, an
 {/each}
 
 <ScatterPlot
-  series={series_data.map((s) => ({ ...s, markers: 'points' }))}
+  series={series_data.map((srs) => ({ ...srs, markers: 'points' }))}
   x_axis={{ label: "X Value", range: [-15, 15], ticks: ticks.x }}
   y_axis={{ label: "Y Value", range: [-15, 15], ticks: ticks.y }}
   style="height: 400px;"
@@ -542,7 +542,7 @@ Using time data on the x-axis with custom formatting:
   </label>
 
   <ScatterPlot
-    series={time_series.map((s) => ({ ...s, markers: 'line+points' }))}
+    series={time_series.map((srs) => ({ ...srs, markers: 'line+points' }))}
     x_axis={{ format: date_format, ticks: -7, label: 'Date' }}
     y_axis={{ format: y_format, ticks: 5, label: 'Value' }}
     style="height: 350px"
@@ -843,7 +843,7 @@ ScatterPlot supports logarithmic scaling for data that spans multiple orders of 
   </div>
 
   <ScatterPlot
-    series={all_series.map((s) => ({ ...s, markers: 'line+points' }))}
+    series={all_series.map((srs) => ({ ...srs, markers: 'line+points' }))}
     x_axis={{
       scale_type: x_scale_type,
       range: x_range,
@@ -984,7 +984,7 @@ This example combines multiple features including different display modes, custo
   </div>
 
   <ScatterPlot
-    series={displayed_series.map((s) => ({ ...s, markers: display_mode }))}
+    series={displayed_series.map((srs) => ({ ...srs, markers: display_mode }))}
     x_axis={{ label: axis_labels.x }}
     y_axis={{ label: axis_labels.y }}
     change={(point) => (hovered_point = point)}
@@ -1044,7 +1044,7 @@ This example combines multiple features including different display modes, custo
   </div>
 
   <ScatterPlot
-    series={random_series.map((s) => ({ ...s, markers: 'points' }))}
+    series={random_series.map((srs) => ({ ...srs, markers: 'points' }))}
     x_axis={{ label: axis_labels.x, range: [-15, 15], ticks: ticks.x }}
     y_axis={{ label: axis_labels.y, range: [-15, 15], ticks: ticks.y }}
     bind:display
@@ -1179,7 +1179,7 @@ This example demonstrates how the color bar automatically positions itself in on
 </div>
 
 <ScatterPlot
-  series={plot_series.map((s) => ({ ...s, markers: 'points+text' }))}
+  series={plot_series.map((srs) => ({ ...srs, markers: 'points+text' }))}
   x_axis={{ label: 'X Position', range: [0, 100], format: '.2' }}
   y_axis={{ label: 'Y Position', range: [0, 100], format: '.2' }}
   color_scale={{ scheme: `turbo` }}
@@ -1314,7 +1314,7 @@ This example demonstrates automatic placement with both clustered points (showin
   </p>
 
   <ScatterPlot
-    series={series_data.map((s) => ({ ...s, markers: 'points' }))}
+    series={series_data.map((srs) => ({ ...srs, markers: 'points' }))}
     x_axis={{ label: 'X Position', range: [0, 100] }}
     y_axis={{ label: 'Y Position', range: [0, 100] }}
     style="height: 500px"
@@ -1500,7 +1500,7 @@ This example demonstrates how lines are clipped when they extend beyond the fixe
 </script>
 
 <ScatterPlot
-  series={clipping_series.map((s) => ({ ...s, markers: 'line' }))}
+  series={clipping_series.map((srs) => ({ ...srs, markers: 'line' }))}
   x_axis={{ range: [-5, 5], label: 'X Axis (Fixed Range)' }}
   y_axis={{ range: [-5, 5], label: 'Y Axis (Fixed Range)' }}
   style="height: 400px"

--- a/src/routes/(demos)/structure/xrd/+page.svelte
+++ b/src/routes/(demos)/structure/xrd/+page.svelte
@@ -27,7 +27,7 @@
   }
 
   // On-the-fly computed patterns
-  const compute_ids = structures.map((struct) => struct.id ?? ``)
+  const compute_ids = structures.map(get_struct_id)
   let compute_id = $state<string>(compute_ids[0] || ``)
   const computed_struct = $derived<PymatgenStructure | null>(
     structures_by_id[compute_id] ?? null,
@@ -78,17 +78,17 @@
       }
     }
   })
-  let selected_patterns = $derived<{ label: string; pattern: XrdPattern }[]>(
-    selected_ids
-      .map((id) => structures_by_id[id]).filter(Boolean).map((struct) => {
-        const struct_id = get_struct_id(struct)
-        const pat = xrd_cache.get(struct_id)
-        return pat
-          ? { label: `${struct_id} ${formula_for(struct_id)}`, pattern: pat }
-          : null
-      })
-      .filter(Boolean) as { label: string; pattern: XrdPattern }[],
-  )
+  let selected_patterns = $derived.by(() => {
+    const out: { label: string; pattern: XrdPattern }[] = []
+    for (const id of selected_ids) {
+      const struct = structures_by_id[id]
+      if (!struct) continue
+      const sid = get_struct_id(struct)
+      const pat = xrd_cache.get(sid)
+      if (pat) out.push({ label: `${sid} ${formula_for(sid)}`, pattern: pat })
+    }
+    return out
+  })
 
   // Precomputed carousel removed; computing on the fly below
 

--- a/src/routes/(demos)/structure/xrd/+page.svelte
+++ b/src/routes/(demos)/structure/xrd/+page.svelte
@@ -15,7 +15,7 @@
 
   // Map structures by id for O(1) lookup
   const structures_by_id = $derived<Record<string, PymatgenStructure>>(
-    Object.fromEntries(structures.map((s) => [get_struct_id(s), s])),
+    Object.fromEntries(structures.map((struct) => [get_struct_id(struct), struct])),
   )
 
   // Helper: convert #rrggbb to #rrggbbaa
@@ -27,7 +27,7 @@
   }
 
   // On-the-fly computed patterns
-  const compute_ids = structures.map((s) => s.id ?? ``)
+  const compute_ids = structures.map((struct) => struct.id ?? ``)
   let compute_id = $state<string>(compute_ids[0] || ``)
   const computed_struct = $derived<PymatgenStructure | null>(
     structures_by_id[compute_id] ?? null,
@@ -57,10 +57,10 @@
 
   // Multi-select demo: allow overlaying multiple structures
   let selected_ids = $state<string[]>(compute_ids.slice(0, 4))
-  function toggle_select(id: string) {
-    selected_ids = selected_ids.includes(id)
-      ? selected_ids.filter((x) => x !== id)
-      : [...selected_ids, id]
+  function toggle_select(struct_id: string) {
+    selected_ids = selected_ids.includes(struct_id)
+      ? selected_ids.filter((x) => x !== struct_id)
+      : [...selected_ids, struct_id]
   }
   // Fill cache for all selected structures (side-effect done outside of $derived)
   $effect(() => {
@@ -80,10 +80,8 @@
   })
   let selected_patterns = $derived<{ label: string; pattern: XrdPattern }[]>(
     selected_ids
-      .map((id) => structures_by_id[id])
-      .filter((s): s is PymatgenStructure => !!s)
-      .map((s) => {
-        const struct_id = get_struct_id(s)
+      .map((id) => structures_by_id[id]).filter(Boolean).map((struct) => {
+        const struct_id = get_struct_id(struct)
         const pat = xrd_cache.get(struct_id)
         return pat
           ? { label: `${struct_id} ${formula_for(struct_id)}`, pattern: pat }

--- a/src/routes/test/scatter-plot/+page.svelte
+++ b/src/routes/test/scatter-plot/+page.svelte
@@ -616,7 +616,7 @@
   </label>
   {#key enable_auto_placement}
     <ScatterPlot
-      series={auto_placement_test_series.map((s) => ({ ...s, markers: `points` }))}
+      series={auto_placement_test_series.map((srs) => ({ ...srs, markers: `points` }))}
       x_axis={{ label: `X`, range: [0, 100] }}
       y_axis={{ label: `Y`, range: [0, 100] }}
       style="height: 450px; width: 100%"
@@ -652,7 +652,7 @@
   </div>
 
   <ScatterPlot
-    series={auto_placement_plot_series.map((s) => ({ ...s, markers: `points` }))}
+    series={auto_placement_plot_series.map((srs) => ({ ...srs, markers: `points` }))}
     x_axis={{ label: `X Position`, range: [0, 100] }}
     y_axis={{ label: `Y Position`, range: [0, 100] }}
     color_scale={{ scheme: `Turbo` }}
@@ -669,24 +669,24 @@
   <h2>Legend Rendering Tests</h2>
   <h3>Single Series (Default Legend) - No Legend Expected</h3>
   <ScatterPlot
-    series={legend_single_series.map((s) => ({ ...s, markers: `points` }))}
+    series={legend_single_series.map((srs) => ({ ...srs, markers: `points` }))}
     id="legend-single-default"
   />
   <h3>Single Series (legend=null) - No Legend Expected</h3>
   <ScatterPlot
-    series={legend_single_series.map((s) => ({ ...s, markers: `points` }))}
+    series={legend_single_series.map((srs) => ({ ...srs, markers: `points` }))}
     legend={null}
     id="legend-single-null"
   />
   <h3>Single Series (Configured Legend) - Legend Expected</h3>
   <ScatterPlot
-    series={legend_single_series.map((s) => ({ ...s, markers: `points` }))}
+    series={legend_single_series.map((srs) => ({ ...srs, markers: `points` }))}
     legend={{ layout: `horizontal` }}
     id="legend-single-config"
   />
   <h3>Multi Series (Default Legend) - Legend Expected</h3>
   <ScatterPlot
-    series={legend_multi_series.map((s) => ({ ...s, markers: `points` }))}
+    series={legend_multi_series.map((srs) => ({ ...srs, markers: `points` }))}
     legend={{ draggable: true }}
     id="legend-multi-default"
   />
@@ -939,7 +939,7 @@
   <h2>Point Event Test</h2>
   <p>Clicking a point should update the text below.</p>
   <ScatterPlot
-    series={point_event_data.map((s) => ({ ...s, markers: `points` }))}
+    series={point_event_data.map((srs) => ({ ...srs, markers: `points` }))}
     x_axis={{ label: `X` }}
     y_axis={{ label: `Y` }}
     point_events={{

--- a/src/routes/test/scatter-plot/+page.svelte
+++ b/src/routes/test/scatter-plot/+page.svelte
@@ -468,12 +468,12 @@
   let last_clicked_point_id = $state<string | null>(null)
   let last_double_clicked_point_id = $state<string | null>(null)
 
-  function handle_point_click({ point }: { point: InternalPoint }) {
+  function on_point_click({ point }: { point: InternalPoint }) {
     last_clicked_point_id =
       `Point: series ${point.series_idx}, index ${point.point_idx} (x=${point.x}, y=${point.y})`
   }
 
-  function handle_point_double_click({ point }: { point: InternalPoint }) {
+  function on_point_double_click({ point }: { point: InternalPoint }) {
     last_double_clicked_point_id =
       `DblClick: series ${point.series_idx}, index ${point.point_idx} (x=${point.x}, y=${point.y})`
   }
@@ -943,8 +943,8 @@
     x_axis={{ label: `X` }}
     y_axis={{ label: `Y` }}
     point_events={{
-      onclick: handle_point_click,
-      ondblclick: handle_point_double_click,
+      onclick: on_point_click,
+      ondblclick: on_point_double_click,
     }}
   />
   <p data-testid="last-clicked-point">

--- a/tests/playwright/plot/scatter-plot.test.ts
+++ b/tests/playwright/plot/scatter-plot.test.ts
@@ -122,7 +122,7 @@ const get_colorbar_transform = async (
   if (transform.startsWith(`matrix`)) {
     const parts = transform.match(/matrix\((.+)\)/)
     if (parts && parts[1]) {
-      const values = parts[1].split(`,`).map((s) => parseFloat(s.trim()))
+      const values = parts[1].split(`,`).map((str) => parseFloat(str.trim()))
       if (values.length === 6) {
         const tx = values[4]
         const ty = values[5]

--- a/tests/vitest/plot/PlotControls.test.svelte.ts
+++ b/tests/vitest/plot/PlotControls.test.svelte.ts
@@ -152,7 +152,7 @@ describe(`PlotControls`, () => {
     mount_controls({ show_ticks: false })
     expect(
       Array.from(document.querySelectorAll(`section`))
-        .find((s) => s.textContent?.includes(`Ticks`)),
+        .find((section) => section.textContent?.includes(`Ticks`)),
     ).toBeUndefined()
 
     mount_controls({ show_ticks: true })
@@ -177,7 +177,7 @@ describe(`PlotControls`, () => {
 
     const expected_sections = [`Display`, `Axis Range`, `Tick Format`]
     expected_sections.forEach((name) => {
-      const section = sections.find((s) => s.textContent?.includes(name))
+      const section = sections.find((section) => section.textContent?.includes(name))
       const reset = section?.querySelector<HTMLButtonElement>(`button`)
       expect(reset).not.toBeNull()
     })

--- a/tests/vitest/plot/series-visibility.test.ts
+++ b/tests/vitest/plot/series-visibility.test.ts
@@ -1,0 +1,129 @@
+import type { DataSeries } from '$lib/plot'
+import {
+  handle_legend_double_click,
+  have_compatible_units,
+  toggle_series_visibility,
+} from '$lib/plot/utils/series-visibility'
+import { describe, expect, test } from 'vitest'
+
+describe(`have_compatible_units`, () => {
+  test.each([
+    { unit1: undefined, unit2: undefined, expected: true, desc: `both have no units` },
+    { unit1: `eV`, unit2: undefined, expected: true, desc: `only one has a unit` },
+    { unit1: `eV`, unit2: `eV`, expected: true, desc: `both have same unit` },
+    { unit1: `eV`, unit2: `GPa`, expected: false, desc: `different units` },
+  ])(`returns $expected when $desc`, ({ unit1, unit2, expected }) => {
+    const s1: DataSeries = { x: [1], y: [2], unit: unit1 }
+    const s2: DataSeries = { x: [3], y: [4], unit: unit2 }
+    expect(have_compatible_units(s1, s2)).toBe(expected)
+  })
+})
+
+describe(`toggle_series_visibility`, () => {
+  test(`toggles visibility of a single series`, () => {
+    const series: DataSeries[] = [
+      { x: [1], y: [2], visible: true },
+      { x: [3], y: [4], visible: true },
+    ]
+    const result = toggle_series_visibility(series, 0)
+    expect(result[0].visible).toBe(false)
+    expect(result[1].visible).toBe(true)
+  })
+
+  test.each([
+    { idx: -1, desc: `negative index` },
+    { idx: 10, desc: `out of bounds index` },
+  ])(`returns original series for $desc`, ({ idx }) => {
+    const series: DataSeries[] = [{ x: [1], y: [2] }]
+    expect(toggle_series_visibility(series, idx)).toBe(series)
+  })
+
+  test(`toggles all series with the same label`, () => {
+    const series: DataSeries[] = [
+      { x: [1], y: [2], label: `A`, visible: true },
+      { x: [3], y: [4], label: `B`, visible: true },
+      { x: [5], y: [6], label: `A`, visible: true },
+    ]
+    const result = toggle_series_visibility(series, 0)
+    expect(result.map((s) => s.visible)).toEqual([false, true, false])
+  })
+
+  test(`hides incompatible units when making series visible`, () => {
+    const series: DataSeries[] = [
+      { x: [1], y: [2], unit: `eV`, visible: false },
+      { x: [3], y: [4], unit: `GPa`, visible: true },
+    ]
+    const result = toggle_series_visibility(series, 0)
+    expect(result.map((s) => s.visible)).toEqual([true, false])
+  })
+})
+
+describe(`handle_legend_double_click`, () => {
+  test(`isolates a single series`, () => {
+    const series: DataSeries[] = [
+      { x: [1], y: [2], label: `A`, visible: true },
+      { x: [3], y: [4], label: `B`, visible: true },
+      { x: [5], y: [6], label: `C`, visible: true },
+    ]
+    const result = handle_legend_double_click(series, 1, null)
+    expect(result.series.map((s) => s.visible)).toEqual([false, true, false])
+    expect(result.previous_visibility).toEqual([true, true, true])
+  })
+
+  test(`restores visibility when already isolated`, () => {
+    const series: DataSeries[] = [
+      { x: [1], y: [2], label: `A`, visible: false },
+      { x: [3], y: [4], label: `B`, visible: true },
+      { x: [5], y: [6], label: `C`, visible: false },
+    ]
+    const result = handle_legend_double_click(series, 1, [true, true, true])
+    expect(result.series.map((s) => s.visible)).toEqual([true, true, true])
+    expect(result.previous_visibility).toBe(null)
+  })
+
+  test.each([
+    { new_vis: true, desc: `keeps true visibility` },
+    { new_vis: false, desc: `keeps false visibility` },
+  ])(
+    `handles new series added after isolation - $desc`,
+    ({ new_vis }) => {
+      const series: DataSeries[] = [
+        { x: [1], y: [2], label: `A`, visible: false },
+        { x: [3], y: [4], label: `B`, visible: true },
+        { x: [5], y: [6], label: `C`, visible: false },
+        { x: [7], y: [8], label: `D`, visible: new_vis },
+      ]
+      const result = handle_legend_double_click(series, 1, [true, true, true])
+      expect(result.series.map((s) => s.visible)).toEqual([true, true, true, new_vis])
+      expect(result.previous_visibility).toBe(null)
+    },
+  )
+
+  test(`isolates series by label`, () => {
+    const series: DataSeries[] = [
+      { x: [1], y: [2], label: `A`, visible: true },
+      { x: [3], y: [4], label: `B`, visible: true },
+      { x: [5], y: [6], label: `A`, visible: true },
+    ]
+    const result = handle_legend_double_click(series, 0, null)
+    expect(result.series.map((s) => s.visible)).toEqual([true, false, true])
+  })
+
+  test(`does not save previous visibility when only one series is visible`, () => {
+    const series: DataSeries[] = [
+      { x: [1], y: [2], label: `A`, visible: true },
+      { x: [3], y: [4], label: `B`, visible: false },
+    ]
+    expect(handle_legend_double_click(series, 0, null).previous_visibility).toBe(null)
+  })
+
+  test(`isolates series without label by index`, () => {
+    const series: DataSeries[] = [
+      { x: [1], y: [2], visible: true },
+      { x: [3], y: [4], visible: true },
+      { x: [5], y: [6], visible: true },
+    ]
+    const result = handle_legend_double_click(series, 1, null)
+    expect(result.series.map((s) => s.visible)).toEqual([false, true, false])
+  })
+})

--- a/tests/vitest/structure/Structure.test.svelte.ts
+++ b/tests/vitest/structure/Structure.test.svelte.ts
@@ -864,7 +864,7 @@ describe(`Structure string parsing`, () => {
       if (parsed) {
         expect(parsed.sites).toHaveLength(atoms)
         elements.forEach((el) =>
-          expect(parsed?.sites.map((s) => s.species[0].element)).toContain(el)
+          expect(parsed?.sites.map((site) => site.species[0].element)).toContain(el)
         )
         expect(!!(`lattice` in parsed && parsed.lattice)).toBe(has_lattice)
       }

--- a/tests/vitest/structure/index.test.ts
+++ b/tests/vitest/structure/index.test.ts
@@ -110,7 +110,7 @@ describe.each(structures)(`structure-utils`, (structure) => {
 })
 
 // Consolidated tests for center of mass, formulas, and elements
-test.each(structures.filter((s) => s.id && ref_data[s.id]))(
+test.each(structures.filter((struct) => struct.id && ref_data[struct.id]))(
   `%s calculations`,
   (struct) => {
     const expected_data = ref_data[struct.id as keyof typeof ref_data]

--- a/tests/vitest/symmetry/index.test.ts
+++ b/tests/vitest/symmetry/index.test.ts
@@ -250,12 +250,12 @@ describe(`structure validation`, () => {
       structure.sites?.forEach((site, idx) => issues.push(...validateSite(site, idx)))
 
       return { id: structure.id || `unknown`, issues }
-    }).filter((s) => s.issues.length > 0)
+    }).filter((site) => site.issues.length > 0)
 
     expect(
       failed.length,
       `Structures with issues:\n${
-        failed.map((s) => `${s.id}: ${s.issues.join(`, `)}`).join(`\n`)
+        failed.map((site) => `${site.id}: ${site.issues.join(`, `)}`).join(`\n`)
       }`,
     ).toBe(0)
   })
@@ -263,10 +263,11 @@ describe(`structure validation`, () => {
   test(`composition consistency`, () => {
     structures.slice(0, 5).forEach((structure) => {
       const elements = new Set(
-        structure.sites.flatMap((s) => s.species.map((sp) => sp.element)),
+        structure.sites.flatMap((site) => site.species.map((sp) => sp.element)),
       )
       const totalOccupancy = structure.sites.reduce(
-        (sum, s) => sum + s.species.reduce((sSum, sp) => sSum + sp.occu, 0),
+        (sum, site) =>
+          sum + site.species.reduce((spec_sum, specie) => spec_sum + specie.occu, 0),
         0,
       )
 
@@ -274,13 +275,8 @@ describe(`structure validation`, () => {
       expect(totalOccupancy).toBeGreaterThan(0)
 
       if (`lattice` in structure && structure.lattice) {
-        expect([
-          structure.lattice.a,
-          structure.lattice.b,
-          structure.lattice.c,
-          structure.lattice.volume,
-        ])
-          .toEqual(expect.arrayContaining([expect.any(Number)]))
+        const { a, b, c, volume } = structure.lattice
+        expect([a, b, c, volume]).toEqual(expect.arrayContaining([expect.any(Number)]))
       }
     })
   })

--- a/tests/vitest/symmetry/symmetry-utils.test.ts
+++ b/tests/vitest/symmetry/symmetry-utils.test.ts
@@ -294,6 +294,6 @@ describe(`wyckoff_positions_from_moyo`, () => {
         [`4a`, `4a`, `4a`, `4a`, `2b`, `2b`],
       ),
     )
-    expect(sorted.map((s) => s.wyckoff)).toEqual([`2b`, `4a`])
+    expect(sorted.map((site) => site.wyckoff)).toEqual([`2b`, `4a`])
   })
 })

--- a/tests/vitest/trajectory/plotting.test.ts
+++ b/tests/vitest/trajectory/plotting.test.ts
@@ -93,12 +93,8 @@ function assert_unit_group_constraints(series: DataSeries[]): void {
   expect(visible_units.size).toBeLessThanOrEqual(2)
 }
 
-function find_series_by_label(
-  series: DataSeries[],
-  search_term: string,
-): DataSeries | undefined {
-  return series.find((s) => s.label?.toLowerCase().includes(search_term.toLowerCase()))
-}
+const find_series_by_label = (series: DataSeries[], search_term: string) =>
+  series.find((srs) => srs.label?.toLowerCase().includes(search_term.toLowerCase()))
 
 describe(`generate_plot_series`, () => {
   it(`should handle basic trajectory generation with unit grouping`, () => {
@@ -175,7 +171,7 @@ describe(`generate_plot_series`, () => {
     })
 
     const energy_series = find_series_by_label(series, `energy`)
-    const a_series = series.find((s) => s.label === `A`)
+    const a_series = find_series_by_label(series, `A`)
 
     // Energy gets y1 (higher priority), lattice params get y2
     expect(energy_series?.y_axis).toBe(`y1`)
@@ -320,9 +316,9 @@ describe(`toggle_series_visibility`, () => {
     const updated_series = toggle_series_visibility(initial_series, 1)
 
     // A should NOT be hidden when B is shown (same unit group)
-    expect(updated_series.find((s) => s.label === `A`)?.visible).toBe(true)
-    expect(updated_series.find((s) => s.label === `B`)?.visible).toBe(true)
-    expect(updated_series.find((s) => s.label === `Energy`)?.visible).toBe(true)
+    expect(find_series_by_label(updated_series, `A`)?.visible).toBe(true)
+    expect(find_series_by_label(updated_series, `B`)?.visible).toBe(true)
+    expect(find_series_by_label(updated_series, `Energy`)?.visible).toBe(true)
 
     const visible_units = new Set(
       updated_series.filter((srs) => srs.visible).map((srs) => srs.unit),
@@ -342,10 +338,10 @@ describe(`toggle_series_visibility`, () => {
       const initial_series = create_replacement_test_series()
       const updated = toggle_series_visibility(initial_series, 2) // Show B (same unit as A)
 
-      expect(updated.find((s) => s.label === `Energy`)?.visible).toBe(true)
-      expect(updated.find((s) => s.label === `A`)?.visible).toBe(true)
-      expect(updated.find((s) => s.label === `B`)?.visible).toBe(true)
-      expect(updated.find((s) => s.label === `Volume`)?.visible).toBe(false)
+      expect(find_series_by_label(updated, `Energy`)?.visible).toBe(true)
+      expect(find_series_by_label(updated, `A`)?.visible).toBe(true)
+      expect(find_series_by_label(updated, `B`)?.visible).toBe(true)
+      expect(find_series_by_label(updated, `Volume`)?.visible).toBe(false)
 
       const visible_units = new Set(
         updated.filter((srs) => srs.visible).map((srs) => srs.unit),
@@ -360,10 +356,10 @@ describe(`toggle_series_visibility`, () => {
       // Then show Volume (new unit) - should trigger smart replacement
       updated = toggle_series_visibility(updated, 3)
 
-      expect(updated.find((s) => s.label === `Energy`)?.visible).toBe(true)
-      expect(updated.find((s) => s.label === `Volume`)?.visible).toBe(true)
-      expect(updated.find((s) => s.label === `A`)?.visible).toBe(false)
-      expect(updated.find((s) => s.label === `B`)?.visible).toBe(false)
+      expect(find_series_by_label(updated, `Energy`)?.visible).toBe(true)
+      expect(find_series_by_label(updated, `Volume`)?.visible).toBe(true)
+      expect(find_series_by_label(updated, `A`)?.visible).toBe(false)
+      expect(find_series_by_label(updated, `B`)?.visible).toBe(false)
 
       const visible_units = new Set(
         updated.filter((srs) => srs.visible).map((srs) => srs.unit),
@@ -377,7 +373,7 @@ describe(`toggle_series_visibility`, () => {
       updated = toggle_series_visibility(updated, 3) // Show Volume
 
       assert_unit_group_constraints(updated)
-      expect(updated.filter((s) => s.visible).length).toBeGreaterThan(0)
+      expect(updated.filter((srs) => srs.visible).length).toBeGreaterThan(0)
     })
   })
 })
@@ -488,11 +484,11 @@ describe(`integration and regression tests`, () => {
     })
 
     // Series labels should not include units (units added by axis labeling)
-    series.forEach((s) => expect(s.label).not.toMatch(/\([^)]+\)/))
+    series.forEach((srs) => expect(srs.label).not.toMatch(/\([^)]+\)/))
 
     // But unit field should be properly set
     const energy_series = find_series_by_label(series, `energy`)
-    const a_series = series.find((s) => s.label === `A`)
+    const a_series = find_series_by_label(series, `A`)
     expect(energy_series?.unit).toBe(`eV`)
     if (a_series) expect(a_series.unit).toBe(`Å`)
   })

--- a/tests/vitest/trajectory/streaming.test.ts
+++ b/tests/vitest/trajectory/streaming.test.ts
@@ -498,8 +498,8 @@ describe(`Trajectory Streaming`, () => {
       })
 
       // Find volume and energy series
-      const volume_series = series.find((s) => s.label === `Volume`)
-      const energy_series = series.find((s) => s.label === `Energy`)
+      const volume_series = series.find((srs) => srs.label === `Volume`)
+      const energy_series = series.find((srs) => srs.label === `Energy`)
 
       // Volume should be properly labeled as "Volume" not "volume" or "Series 1"
       expect(volume_series).toBeDefined()
@@ -514,7 +514,7 @@ describe(`Trajectory Streaming`, () => {
       expect(energy_series?.y).toEqual([-10, -10.5, -11])
 
       // No series should have generic names like "Series 1"
-      const generic_series = series.filter((s) => s.label?.startsWith(`Series `))
+      const generic_series = series.filter((srs) => srs.label?.startsWith(`Series `))
       expect(generic_series).toHaveLength(0)
     })
   })


### PR DESCRIPTION
- Add X/Y grid visibility controls to phase diagrams.
- Improve scatter-label placement to reduce overlaps.
- Enforce unit compatibility when managing series visibility.
- Show zero-reference lines by default in histograms, bar charts, and scatter plots.