### PR TITLE
make `fullscreen` prop `$bindable` in `Structure` and `BrillouinZone`

### DIFF
--- a/src/lib/brillouin/BrillouinZone.svelte
+++ b/src/lib/brillouin/BrillouinZone.svelte
@@ -40,7 +40,7 @@
     vector_scale = $bindable(1.0),
     camera_projection = $bindable(`perspective`),
     show_controls = 0,
-    fullscreen = false,
+    fullscreen = $bindable(false),
     wrapper = $bindable(undefined),
     width = $bindable(0),
     height = $bindable(0),

--- a/src/routes/test/brillouin-zone/+page.svelte
+++ b/src/routes/test/brillouin-zone/+page.svelte
@@ -14,6 +14,7 @@
   let camera_projection = $state<`perspective` | `orthographic`>(`perspective`)
   let show_controls_select = $state<string>(`true`)
   let png_dpi = $state(150)
+  let fullscreen = $state(false)
 
   const show_controls = $derived(
     { true: true, false: false }[show_controls_select] ?? +show_controls_select,
@@ -92,7 +93,12 @@
   <label>Camera Projection: <select id="camera-projection" bind:value={camera_projection}>
       <option value="perspective">perspective</option>
       <option value="orthographic">orthographic</option>
-    </select></label>
+    </select></label><br />
+  <label>Fullscreen: <input
+      data-testid="fullscreen-checkbox"
+      type="checkbox"
+      bind:checked={fullscreen}
+    /></label>
 </section>
 
 <section>
@@ -102,6 +108,7 @@
   <p data-testid="bz-order">{bz_order}</p>
   <p data-testid="show-controls">{show_controls}</p>
   <p data-testid="camera-projection">{camera_projection}</p>
+  <p data-testid="fullscreen-status">{fullscreen}</p>
   <p data-testid="events">{event_calls.map((ec) => ec.event).join(`, `)}</p>
 </section>
 
@@ -120,6 +127,7 @@
   bind:vector_scale
   bind:camera_projection
   bind:png_dpi
+  bind:fullscreen
   {show_controls}
   on_file_load={log_event(`on_file_load`)}
   on_error={log_event(`on_error`)}

--- a/src/routes/test/structure/+page.svelte
+++ b/src/routes/test/structure/+page.svelte
@@ -17,6 +17,7 @@
   let enable_measure_mode = $state(true)
   let supercell_scaling = $state(`1x1x1`)
   let show_image_atoms = $state(true)
+  let fullscreen = $state(false)
 
   // capture event data for testing
   let event_calls = $state<{ event: string; data: unknown }[]>([])
@@ -190,12 +191,19 @@
       data-testid="supercell-input"
     />
   </label><br />
-  <label>
-    Show Image Atoms:
+  <label>Show Image Atoms:
     <input
       type="checkbox"
       bind:checked={show_image_atoms}
       data-testid="image-atoms-checkbox"
+    />
+  </label>
+  <label>
+    Fullscreen:
+    <input
+      type="checkbox"
+      bind:checked={fullscreen}
+      data-testid="fullscreen-checkbox"
     />
   </label>
   <div style="margin-top: 0.5em">
@@ -240,6 +248,7 @@
   {enable_measure_mode}
   bind:supercell_scaling
   bind:show_image_atoms
+  bind:fullscreen
 />
 
 <div data-testid="pane-open-status" style="margin-top: 10px">
@@ -251,6 +260,7 @@
 <div data-testid="canvas-height-status">Canvas Height Status: {canvas.height}</div>
 <div data-testid="gizmo-status">Gizmo Status: {scene_props.show_gizmo}</div>
 <div data-testid="show-buttons-status">Show Buttons Status: {show_controls}</div>
+<div data-testid="fullscreen-status">Fullscreen Status: {fullscreen}</div>
 <div data-testid="performance-mode-status">
   Performance Mode Status: {performance_mode}
 </div>

--- a/tests/playwright/brillouin-zone.test.ts
+++ b/tests/playwright/brillouin-zone.test.ts
@@ -110,6 +110,40 @@ test.describe(`BrillouinZone Component Tests`, () => {
     await expect(btn).toBeVisible()
   })
 
+  test(`fullscreen prop is bindable`, async ({ page }) => {
+    const status = page.locator(`[data-testid="fullscreen-status"]`)
+    const checkbox = page.locator(`[data-testid="fullscreen-checkbox"]`)
+
+    await expect(status).toHaveText(`false`)
+    await expect(checkbox).not.toBeChecked()
+
+    await checkbox.click({ force: true })
+    await expect(status).toHaveText(`true`)
+    await expect(checkbox).toBeChecked()
+
+    await page.evaluate(() => {
+      const el = document.querySelector<HTMLInputElement>(
+        `[data-testid="fullscreen-checkbox"]`,
+      )
+      if (el) {
+        el.checked = false
+        el.dispatchEvent(new Event(`change`, { bubbles: true }))
+      }
+    })
+    await expect(status).toHaveText(`false`)
+    await expect(checkbox).not.toBeChecked()
+  })
+
+  test(`fullscreen binds to component state`, async ({ page }) => {
+    const checkbox = page.locator(`[data-testid="fullscreen-checkbox"]`)
+    const canvas = page.locator(`${BZ_SELECTOR} canvas`)
+
+    await expect(canvas).toBeVisible()
+    await checkbox.click({ force: true })
+    await expect(checkbox).toBeChecked()
+    await expect(canvas).toBeVisible()
+  })
+
   test(`Escape closes panes`, async ({ page }) => {
     await page.locator(`#controls-open`).check()
     await expect(page.locator(`[data-testid="controls-open"]`)).toHaveText(`true`)


### PR DESCRIPTION
- Make fullscreen state bindable in `Structure` and `BrillouinZone` and expose checkbox controls.
- Resolve fullscreen backgrounds against light/dark theme colors.