### PR TITLE
`ElementTile` add `--elem-tile-active-border` CSS variable

### DIFF
--- a/src/lib/bands/BandsAndDos.svelte
+++ b/src/lib/bands/BandsAndDos.svelte
@@ -11,6 +11,7 @@
     bands_props = {},
     dos_props = {},
     shared_y_axis = true,
+    children,
     ...rest
   }: HTMLAttributes<HTMLDivElement> & {
     band_structs: BaseBandStructure | Record<string, BaseBandStructure>
@@ -35,6 +36,7 @@
   class="bands-and-dos {rest.class ?? ``}"
   style={`display: grid; grid-template-columns: 1fr 200px; gap: 0;` + (rest.style ?? ``)}
 >
+  {@render children?.()}
   <Bands
     {band_structs}
     y_axis={bands_y_axis}

--- a/src/lib/bands/BandsAndDos.svelte
+++ b/src/lib/bands/BandsAndDos.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-  import type { ComponentProps } from 'svelte'
+  import type { ComponentProps, Snippet } from 'svelte'
   import type { HTMLAttributes } from 'svelte/elements'
   import Bands from './Bands.svelte'
   import Dos from './Dos.svelte'
-  import type { BaseBandStructure, DosData } from './types'
+  import type { BaseBandStructure, DosData, HoveredData } from './types'
 
   let {
     band_structs,
@@ -20,6 +20,7 @@
     dos_props?: Partial<ComponentProps<typeof Dos>>
     shared_y_axis?: boolean
     class?: string
+    children?: Snippet<[HoveredData]>
   } = $props()
 
   // Shared y-axis configuration - use single object when shared_y_axis is true
@@ -36,7 +37,7 @@
   class="bands-and-dos {rest.class ?? ``}"
   style={`display: grid; grid-template-columns: 1fr 200px; gap: 0;` + (rest.style ?? ``)}
 >
-  {@render children?.()}
+  {@render children?.({ hovered_frequency })}
   <Bands
     {band_structs}
     y_axis={bands_y_axis}

--- a/src/lib/bands/BrillouinBandsDos.svelte
+++ b/src/lib/bands/BrillouinBandsDos.svelte
@@ -17,6 +17,7 @@
     bands_props = {},
     dos_props = {},
     bz_props = {},
+    children,
     ...rest
   }: HTMLAttributes<HTMLDivElement> & {
     structure: PymatgenStructure
@@ -83,6 +84,7 @@
   class="bands-dos-brillouin {screen_class} {rest.class ?? ``}"
   bind:clientWidth
 >
+  {@render children?.()}
   <Bands
     style="grid-area: bands; min-width: 0; min-height: 0; overflow: hidden"
     {band_structs}

--- a/src/lib/bands/BrillouinBandsDos.svelte
+++ b/src/lib/bands/BrillouinBandsDos.svelte
@@ -3,12 +3,12 @@
   import { BrillouinZone, reciprocal_lattice } from '$lib/brillouin'
   import type { InternalPoint } from '$lib/plot'
   import type { PymatgenStructure } from '$lib/structure'
-  import type { ComponentProps } from 'svelte'
+  import type { ComponentProps, Snippet } from 'svelte'
   import type { HTMLAttributes } from 'svelte/elements'
   import Bands from './Bands.svelte'
   import Dos from './Dos.svelte'
   import * as helpers from './helpers'
-  import type { BaseBandStructure, DosData } from './types'
+  import type { BaseBandStructure, DosData, HoveredData } from './types'
 
   let {
     structure,
@@ -26,6 +26,7 @@
     bands_props?: Partial<ComponentProps<typeof Bands>>
     dos_props?: Partial<ComponentProps<typeof Dos>>
     bz_props?: Partial<ComponentProps<typeof BrillouinZone>>
+    children?: Snippet<[HoveredData]>
   } = $props()
 
   let first_band_struct = $derived(
@@ -84,7 +85,7 @@
   class="bands-dos-brillouin {screen_class} {rest.class ?? ``}"
   bind:clientWidth
 >
-  {@render children?.()}
+  {@render children?.({ hovered_frequency, hovered_band_point, hovered_qpoint_index })}
   <Bands
     style="grid-area: bands; min-width: 0; min-height: 0; overflow: hidden"
     {band_structs}

--- a/src/lib/bands/types.ts
+++ b/src/lib/bands/types.ts
@@ -1,5 +1,7 @@
 // TypeScript type definitions for band structures and density of states
 
+import type { InternalPoint } from '$lib/plot'
+
 export type BandStructureType = `phonon` | `electronic`
 export type PathMode = `union` | `intersection` | `strict`
 export type FrequencyUnit = `THz` | `eV` | `meV` | `Ha` | `cm-1`
@@ -70,3 +72,9 @@ export type LineKwargs =
   | Record<string, unknown> // Single dict for all lines
   | { acoustic?: Record<string, unknown>; optical?: Record<string, unknown> } // Per mode
   | ((frequencies: number[], band_idx: number) => Record<string, unknown>) // Callable
+
+export interface HoveredData {
+  hovered_frequency?: number | null
+  hovered_band_point?: InternalPoint | null
+  hovered_qpoint_index?: number | null
+}

--- a/src/lib/brillouin/BrillouinZone.svelte
+++ b/src/lib/brillouin/BrillouinZone.svelte
@@ -24,7 +24,7 @@
     filename?: string
     file_size?: number
     error_msg?: string
-    is_fullscreen?: boolean
+    fullscreen?: boolean
   }
   let {
     structure = $bindable(undefined),
@@ -87,7 +87,7 @@
       hovered?: boolean
       dragover?: boolean
       allow_file_drop?: boolean
-      fullscreen_toggle?: Snippet<[]> | boolean
+      fullscreen_toggle?: Snippet<[{ fullscreen: boolean }]> | boolean
       data_url?: string
       on_file_drop?: (content: string | ArrayBuffer, filename: string) => void
       spinner_props?: ComponentProps<typeof Spinner>
@@ -253,7 +253,7 @@
 <svelte:document
   onfullscreenchange={() => {
     fullscreen = Boolean(document.fullscreenElement)
-    on_fullscreen_change?.({ structure, bz_data, bz_order, is_fullscreen: fullscreen })
+    on_fullscreen_change?.({ structure, bz_data, bz_order, fullscreen })
   }}
 />
 
@@ -307,7 +307,7 @@
             {@attach tooltip()}
           >
             {#if typeof fullscreen_toggle === `function`}
-              {@render fullscreen_toggle()}
+              {@render fullscreen_toggle({ fullscreen })}
             {:else}
               <Icon icon="{fullscreen ? `Exit` : ``}Fullscreen" />
             {/if}

--- a/src/lib/composition/BarChart.svelte
+++ b/src/lib/composition/BarChart.svelte
@@ -53,6 +53,7 @@
     segment_content?: Snippet<[BarSegmentData]>
     interactive?: boolean
     svg_node?: SVGSVGElement | null
+    children?: Snippet<[{ hovered_element: ElementSymbol | null }]>
   } = $props()
 
   let element_colors = $derived(
@@ -270,7 +271,7 @@
     {/if}
   {/each}
 
-  {@render children?.()}
+  {@render children?.({ hovered_element })}
 </svg>
 
 <style>

--- a/src/lib/composition/BarChart.svelte
+++ b/src/lib/composition/BarChart.svelte
@@ -34,6 +34,7 @@
     segment_content,
     interactive = true,
     svg_node = $bindable(null),
+    children,
     ...rest
   }: SVGAttributes<SVGSVGElement> & {
     composition: CompositionType
@@ -268,6 +269,8 @@
       </text>
     {/if}
   {/each}
+
+  {@render children?.()}
 </svg>
 
 <style>

--- a/src/lib/composition/BubbleChart.svelte
+++ b/src/lib/composition/BubbleChart.svelte
@@ -20,6 +20,7 @@
     bubble_content,
     interactive = true,
     svg_node = $bindable(null),
+    children,
     ...rest
   }: SVGAttributes<SVGSVGElement> & {
     composition: CompositionType
@@ -161,6 +162,8 @@
       </foreignObject>
     {/each}
   {/if}
+
+  {@render children?.()}
 </svg>
 
 <style>

--- a/src/lib/composition/BubbleChart.svelte
+++ b/src/lib/composition/BubbleChart.svelte
@@ -32,6 +32,7 @@
     bubble_content?: Snippet<[BubbleSegmentData]>
     interactive?: boolean
     svg_node?: SVGSVGElement | null
+    children?: Snippet<[{ hovered_element: ElementSymbol | null }]>
   } = $props()
 
   let element_colors = $derived(
@@ -163,7 +164,7 @@
     {/each}
   {/if}
 
-  {@render children?.()}
+  {@render children?.({ hovered_element })}
 </svg>
 
 <style>

--- a/src/lib/composition/PieChart.svelte
+++ b/src/lib/composition/PieChart.svelte
@@ -48,6 +48,7 @@
     segment_content?: Snippet<[PieSegmentData]>
     interactive?: boolean
     svg_node?: SVGSVGElement | null
+    children?: Snippet<[{ hovered_element: ElementSymbol | null }]>
   } = $props()
 
   let element_colors = $derived(
@@ -238,7 +239,7 @@
     </g>
   {/if}
 
-  {@render children?.()}
+  {@render children?.({ hovered_element })}
 </svg>
 
 <style>

--- a/src/lib/composition/PieChart.svelte
+++ b/src/lib/composition/PieChart.svelte
@@ -33,6 +33,7 @@
     segment_content,
     interactive = true,
     svg_node = $bindable(null),
+    children,
     ...rest
   }: SVGAttributes<SVGSVGElement> & {
     composition: CompositionType
@@ -236,6 +237,8 @@
       {@render center_content({ composition, total_atoms })}
     </g>
   {/if}
+
+  {@render children?.()}
 </svg>
 
 <style>

--- a/src/lib/element/ElementTile.svelte
+++ b/src/lib/element/ElementTile.svelte
@@ -247,7 +247,7 @@
     line-height: 1em;
   }
   .element-tile.active, .element-tile:hover {
-    border: var(--elem-tile-hover-border-width, 1px) solid;
+    border: var(--elem-tile-active-border, 1px solid currentColor);
   }
   .element-tile.clickable {
     cursor: pointer;

--- a/src/lib/layout/SettingsSection.svelte
+++ b/src/lib/layout/SettingsSection.svelte
@@ -12,7 +12,13 @@
   }: HTMLAttributes<HTMLElementTagNameMap[`section`]> & {
     title: string
     current_values: Record<string, unknown>
-    children: Snippet<[]>
+    children: Snippet<
+      [{
+        current_values: Record<string, unknown>
+        has_changes: boolean
+        reference_values: Record<string, unknown>
+      }]
+    >
     on_reset?: () => void
   } = $props()
 
@@ -97,7 +103,7 @@
   {/if}
 </h4>
 <section {...rest} aria-labelledby="settings-section-title">
-  {@render children()}
+  {@render children?.({ current_values, has_changes, reference_values })}
 </section>
 
 <style>

--- a/src/lib/overlays/DraggablePane.svelte
+++ b/src/lib/overlays/DraggablePane.svelte
@@ -25,7 +25,14 @@
   }: {
     show?: boolean
     show_pane?: boolean
-    children: Snippet<[]>
+    children: Snippet<
+      [{
+        show: boolean
+        show_control_buttons: boolean
+        has_been_dragged: boolean
+        currently_dragging: boolean
+      }]
+    >
     // Toggle button
     toggle_props?: HTMLAttributes<HTMLButtonElement>
     open_icon?: IconName
@@ -229,7 +236,7 @@
       />
     </div>
 
-    {@render children()}
+    {@render children?.({ show, show_control_buttons, has_been_dragged, currently_dragging })}
   </div>
 {/if}
 

--- a/src/lib/plot/BarPlot.svelte
+++ b/src/lib/plot/BarPlot.svelte
@@ -15,9 +15,9 @@
     UserContentProps,
   } from '$lib/plot'
   import { BarPlotControls, find_best_plot_area, PlotLegend } from '$lib/plot'
-  import { DEFAULT_GRID_STYLE } from '$lib/plot/types'
   import { get_relative_coords } from '$lib/plot/interactions'
   import { create_scale, generate_ticks, get_nice_data_range } from '$lib/plot/scales'
+  import { DEFAULT_GRID_STYLE } from '$lib/plot/types'
   import { DEFAULTS } from '$lib/settings'
   import type { Snippet } from 'svelte'
   import type { HTMLAttributes } from 'svelte/elements'
@@ -1073,7 +1073,7 @@
   {/if}
 
   <!-- User-provided children (e.g. for custom absolutely-positioned overlays) -->
-  {@render children?.()}
+  {@render children?.({ height, width })}
 </div>
 
 <style>

--- a/src/lib/plot/PlotControls.svelte
+++ b/src/lib/plot/PlotControls.svelte
@@ -95,6 +95,16 @@
     range_inputs.y = [y_axis.range?.[0] ?? null, y_axis.range?.[1] ?? null]
     range_inputs.y2 = [y2_axis.range?.[0] ?? null, y2_axis.range?.[1] ?? null]
   })
+
+  let ctrl_state = $derived({
+    show_controls,
+    controls_open,
+    x_axis,
+    y_axis,
+    y2_axis,
+    display,
+    range_inputs,
+  })
 </script>
 
 {#if show_controls}
@@ -116,8 +126,7 @@
       style: `--pane-padding: 12px; --pane-gap: 4px; ${pane_props?.style ?? ``}`,
     }}
   >
-    <!-- Custom controls before base controls -->
-    {@render children?.()}
+    {@render children?.(ctrl_state)}
 
     <!-- Base Display controls -->
     <SettingsSection
@@ -292,6 +301,6 @@
     </SettingsSection>
 
     <!-- Custom controls after base controls -->
-    {@render post_children?.()}
+    {@render post_children?.(ctrl_state)}
   </DraggablePane>
 {/if}

--- a/src/lib/plot/types.ts
+++ b/src/lib/plot/types.ts
@@ -328,13 +328,23 @@ export interface ControlsConfig {
   pane_props?: ComponentProps<typeof DraggablePane>[`pane_props`]
 }
 
+export type ControlsState = {
+  show_controls: boolean
+  controls_open: boolean
+  x_axis: AxisConfig
+  y_axis: AxisConfig
+  y2_axis: AxisConfig
+  display: DisplayConfig
+  range_inputs: Record<string, [number | null, number | null]>
+}
+
 export interface PlotControlsProps {
   // Control pane visibility
   show_controls?: boolean
   controls_open?: boolean
   // Custom snippets for additional controls
-  children?: Snippet<[]>
-  post_children?: Snippet<[]>
+  children?: Snippet<[ControlsState]>
+  post_children?: Snippet<[ControlsState]>
   // Grouped axis and display configs (bindable in practice)
   x_axis?: AxisConfig
   y_axis?: AxisConfig
@@ -370,7 +380,7 @@ export interface BasePlotProps {
   controls_toggle_props?: ComponentProps<typeof DraggablePane>[`toggle_props`]
   controls_pane_props?: ComponentProps<typeof DraggablePane>[`pane_props`]
   // Children
-  children?: Snippet<[]>
+  children?: Snippet<[{ height: number; width: number }]>
 }
 export const line_types = [`solid`, `dashed`, `dotted`] as const
 export type LineType = (typeof line_types)[number]

--- a/src/lib/rdf/RdfPlot.svelte
+++ b/src/lib/rdf/RdfPlot.svelte
@@ -41,14 +41,14 @@
     on_file_drop?: (content: string | ArrayBuffer, filename: string) => void
     loading?: boolean
     error_msg?: string
-    children?: Snippet<[]>
+    children?: Snippet<[{ drag_dropped: Structure[] }]>
   } & ComponentProps<typeof ScatterPlot> = $props()
 
   // Set default axis labels if not provided
   x_axis.label ??= `r (Å)`
   y_axis.label ??= `g(r)`
 
-  let dropped: Structure[] = $state([])
+  let drag_dropped: Structure[] = $state([])
   let dragging = $state(false)
 
   function format_structure_label(struct: Structure, label_base: string): string {
@@ -69,8 +69,9 @@
           ? new TextDecoder().decode(content)
           : content
         const parsed_struct = parse_any_structure(text, filename)
-        if (is_valid_structure(parsed_struct)) dropped = [...dropped, parsed_struct]
-        else error_msg = `Structure has no lattice or sites; cannot compute RDF`
+        if (is_valid_structure(parsed_struct)) {
+          drag_dropped = [...drag_dropped, parsed_struct]
+        } else error_msg = `Structure has no lattice or sites; cannot compute RDF`
       } catch (exc) {
         error_msg = `Failed to process structure: ${
           exc instanceof Error ? exc.message : String(exc)
@@ -127,7 +128,7 @@
         )
       }
     }
-    dropped.forEach((struct, idx) =>
+    drag_dropped.forEach((struct, idx) =>
       struct_list.push({
         struct,
         label: format_structure_label(struct, `Dropped ${idx + 1}`),
@@ -173,10 +174,10 @@
 
 <StatusMessage bind:message={error_msg} type="error" dismissible />
 
-{#if enable_drop && dropped.length > 0}
+{#if enable_drop && drag_dropped.length > 0}
   <div class="dropped-info">
-    {dropped.length} structure{dropped.length > 1 ? `s` : ``} loaded
-    <button onclick={() => (dropped = [])}>Clear</button>
+    {drag_dropped.length} structure{drag_dropped.length > 1 ? `s` : ``} loaded
+    <button onclick={() => (drag_dropped = [])}>Clear</button>
   </div>
 {/if}
 
@@ -231,7 +232,7 @@
       {/if}
     {/snippet}
 
-    {@render children?.()}
+    {@render children?.({ drag_dropped })}
   </ScatterPlot>
 {/if}
 

--- a/src/lib/structure/CanvasTooltip.svelte
+++ b/src/lib/structure/CanvasTooltip.svelte
@@ -6,13 +6,13 @@
 
     let { position, children, ...rest }: HTMLAttributes<HTMLDivElement> & {
       position: Vec3
-      children: Snippet<[]>
+      children: Snippet<[{ position: Vec3 }]>
     } = $props()
 </script>
 
 <HTML {position} pointerEvents="none">
   <div {...rest} class="tooltip {rest.class ?? ``}" role="tooltip">
-    {@render children()}
+    {@render children({ position })}
   </div>
 </HTML>
 

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -114,7 +114,7 @@
       enable_info_pane?: boolean
       enable_measure_mode?: boolean
       info_pane_open?: boolean
-      fullscreen_toggle?: Snippet<[]> | boolean
+      fullscreen_toggle?: Snippet<[{ fullscreen: boolean }]> | boolean
       bottom_left?: Snippet<[{ structure?: AnyStructure }]>
       data_url?: string // URL to load structure from (alternative to providing structure directly)
       // Generic callback for when files are dropped - receives raw content and filename
@@ -137,7 +137,7 @@
       symmetry_data?: MoyoDataset | null
       // structure content as string (alternative to providing structure directly or via data_url)
       structure_string?: string
-      children?: Snippet<[{ structure?: AnyStructure }]>
+      children?: Snippet<[{ structure?: AnyStructure; fullscreen: boolean }]>
       on_file_load?: EventHandler
       on_error?: EventHandler
       on_fullscreen_change?: EventHandler
@@ -604,7 +604,7 @@
 <svelte:document
   onfullscreenchange={() => {
     fullscreen = Boolean(document.fullscreenElement)
-    on_fullscreen_change?.({ structure, is_fullscreen: fullscreen })
+    on_fullscreen_change?.({ structure, fullscreen })
   }}
 />
 
@@ -648,7 +648,7 @@
   {...rest}
   class="structure {rest.class ?? ``}"
 >
-  {@render children?.({ structure })}
+  {@render children?.({ structure, fullscreen })}
   {#if loading}
     <Spinner text="Loading structure..." {...spinner_props} />
   {:else if error_msg}

--- a/src/lib/structure/index.ts
+++ b/src/lib/structure/index.ts
@@ -183,7 +183,7 @@ export interface StructureHandlerData {
   file_size?: number
   total_atoms?: number
   error_msg?: string
-  is_fullscreen?: boolean
+  fullscreen?: boolean
   camera_position?: Vec3
   camera_has_moved?: boolean
   color_scheme?: string

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -779,7 +779,7 @@
 <svelte:document
   onfullscreenchange={() => {
     fullscreen = !!document.fullscreenElement
-    on_fullscreen_change?.({ trajectory, is_fullscreen: fullscreen })
+    on_fullscreen_change?.({ trajectory, fullscreen })
   }}
 />
 

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -123,7 +123,7 @@
     error_snippet?: Snippet<[{ error_msg: string; on_dismiss: () => void }]>
     show_controls?: boolean // show/hide the trajectory controls bar
     // show/hide the fullscreen button
-    fullscreen_toggle?: Snippet<[]> | boolean
+    fullscreen_toggle?: Snippet<[{ fullscreen: boolean }]> | boolean
     // automatically start playing when trajectory data is loaded
     auto_play?: boolean
     // display mode: 'structure+scatter' (default), 'structure' (only structure), 'scatter' (only scatter), 'histogram' (only histogram), 'structure+histogram' (structure with histogram)
@@ -1042,7 +1042,7 @@
                 class="fullscreen-button"
               >
                 {#if typeof fullscreen_toggle === `function`}
-                  {@render fullscreen_toggle()}
+                  {@render fullscreen_toggle({ fullscreen })}
                 {:else}
                   <Icon icon="{fullscreen ? `Exit` : ``}Fullscreen" />
                 {/if}

--- a/src/lib/trajectory/index.ts
+++ b/src/lib/trajectory/index.ts
@@ -57,7 +57,7 @@ export interface TrajHandlerData {
   error_msg?: string
   fps?: number
   mode?: ComponentProps<typeof Trajectory>[`display_mode`]
-  is_fullscreen?: boolean
+  fullscreen?: boolean
 }
 
 // Function interfaces for extensibility

--- a/src/lib/xrd/XrdPlot.svelte
+++ b/src/lib/xrd/XrdPlot.svelte
@@ -8,7 +8,7 @@
   import { parse_any_structure } from '$lib/structure/parse'
   import { is_valid_structure } from '$lib/structure/validation'
   import { compute_xrd_pattern } from '$lib/xrd/calc-xrd'
-  import type { ComponentProps, Snippet } from 'svelte'
+  import type { ComponentProps } from 'svelte'
   import type { Hkl, HklFormat, PatternEntry, XrdPattern } from './index'
 
   function is_xrd_pattern(obj: unknown): obj is XrdPattern {
@@ -51,7 +51,6 @@
     on_file_drop,
     loading = $bindable(false),
     error_msg = $bindable(undefined),
-    children,
     ...rest
   }: ComponentProps<typeof BarPlot> & {
     patterns:
@@ -69,7 +68,6 @@
     on_file_drop?: (content: string | ArrayBuffer, filename: string) => void
     loading?: boolean
     error_msg?: string
-    children?: Snippet<[]>
   } = $props()
 
   let dragover = $state(false)
@@ -292,6 +290,5 @@
     }}
     class={(rest.class ?? ``) + (dragover ? ` dragover` : ``)}
     style={`overflow: visible; ${rest.style ?? ``}`}
-    {children}
   />
 {/if}

--- a/src/routes/(demos)/periodic-table/+page.svelte
+++ b/src/routes/(demos)/periodic-table/+page.svelte
@@ -76,6 +76,10 @@
     // only show every 3rd element to demo missing color
     return full_values.map((value, idx) => (idx % 3 === 0 ? value : 0))
   })
+
+  // Active elements border demo
+  let active_elements_demo = $state([`H`, `C`, `N`, `O`, `Fe`, `Cu`, `Au`, `Ag`])
+  let active_tile_border = $state({ width: `2px`, style: `solid`, color: `#ff0000` })
 </script>
 
 <svelte:window bind:innerWidth={window_width} />
@@ -180,6 +184,40 @@
           disabled={missing_use_category || !missing_heatmap_values?.length}
         />
       </label>
+    </TableInset>
+  {/snippet}
+</PeriodicTable>
+
+<h2>Active Elements Border Styling</h2>
+<p>
+  Customize active element borders with CSS custom property <code
+  >--elem-tile-active-border</code>.
+</p>
+
+<PeriodicTable
+  tile_props={{ show_name: window_width > 800 }}
+  active_elements={active_elements_demo}
+  style={`--elem-tile-active-border: ${active_tile_border.width} ${active_tile_border.style} ${active_tile_border.color}`}
+  {onenter}
+>
+  {#snippet inset()}
+    <TableInset
+      style="display: flex; gap: 1em; place-content: center; flex-wrap: wrap; align-items: center"
+    >
+      <select bind:value={active_tile_border.width}>
+        <option>1px</option>
+        <option>2px</option>
+        <option>3px</option>
+      </select>
+      <select bind:value={active_tile_border.style}>
+        <option>solid</option>
+        <option>dashed</option>
+        <option>dotted</option>
+      </select>
+      <input type="color" bind:value={active_tile_border.color} style="height: 1.5em" />
+      <code style="background: var(--sms-ui-bg); padding: 4px 8px; border-radius: 4px">
+        {active_tile_border.width} {active_tile_border.style} {active_tile_border.color}
+      </code>
     </TableInset>
   {/snippet}
 </PeriodicTable>

--- a/src/routes/test/bands-and-dos/+page.svelte
+++ b/src/routes/test/bands-and-dos/+page.svelte
@@ -66,7 +66,14 @@
   band_structs={mock_band_structure}
   doses={high_freq_dos}
   shared_y_axis={false}
-/>
+>
+  <div
+    class="custom-overlay"
+    style="position: absolute; top: 10px; right: 10px; background: rgba(255, 255, 255, 0.9); padding: 8px; border-radius: 4px; font-size: 12px; pointer-events: none"
+  >
+    Custom Overlay
+  </div>
+</BandsAndDos>
 
 <style>
   h1 {

--- a/src/routes/test/brillouin-bands-dos/+page.svelte
+++ b/src/routes/test/brillouin-bands-dos/+page.svelte
@@ -190,7 +190,14 @@
         densities: mock_dos.densities.map((dens) => dens * 1.2),
       },
     }}
-  />
+  >
+    <div
+      class="custom-overlay"
+      style="position: absolute; top: 10px; right: 10px; background: rgba(255, 255, 255, 0.9); padding: 8px; border-radius: 4px; font-size: 12px; pointer-events: none; z-index: 10"
+    >
+      Custom Overlay
+    </div>
+  </BrillouinBandsDos>
 </div>
 
 <style>

--- a/tests/playwright/bands/bands-and-dos.test.ts
+++ b/tests/playwright/bands/bands-and-dos.test.ts
@@ -156,4 +156,22 @@ test.describe(`BandsAndDos Component Tests`, () => {
       expect(hovered_dos_lines).toBeGreaterThan(initial_dos_lines)
     }
   })
+
+  test(`renders children snippet content`, async ({ page }) => {
+    // Navigate to section with children (independent-axes)
+    await page.locator(`#independent-axes`).scrollIntoViewIfNeeded()
+
+    // Find the bands-and-dos container after the independent-axes heading
+    const container = page.locator(`#independent-axes + .bands-and-dos`)
+    await expect(container).toBeVisible()
+
+    // Verify the custom overlay child element is rendered
+    const custom_overlay = container.locator(`.custom-overlay`)
+    await expect(custom_overlay).toBeVisible()
+    await expect(custom_overlay).toHaveText(`Custom Overlay`)
+
+    // Verify the main functionality is still working
+    const plots = container.locator(`.scatter`)
+    expect(await plots.count()).toBe(2)
+  })
 })

--- a/tests/playwright/bands/brillouin-bands-dos.test.ts
+++ b/tests/playwright/bands/brillouin-bands-dos.test.ts
@@ -341,4 +341,23 @@ test.describe(`BrillouinBandsDos Component Tests`, () => {
       expect(hovered_dos_lines).toBeGreaterThan(initial_dos_lines)
     }
   })
+
+  test(`renders children snippet content`, async ({ page }) => {
+    // Navigate to section with children (multiple-structures)
+    await page.locator(`#multiple-structures`).scrollIntoViewIfNeeded()
+
+    // Find the container with children (multiple structures example)
+    const container = page.locator(`[data-testid="bz-bands-dos-multiple"]`)
+    await expect(container).toBeVisible()
+
+    // Verify the custom overlay child element is rendered
+    const custom_overlay = container.locator(`.custom-overlay`)
+    await expect(custom_overlay).toBeVisible()
+    await expect(custom_overlay).toHaveText(`Custom Overlay`)
+
+    // Verify all three panels are still working
+    await expect(container.locator(`canvas`).first()).toBeVisible()
+    await expect(container.locator(`svg`).nth(0)).toBeVisible()
+    await expect(container.locator(`svg`).nth(1)).toBeVisible()
+  })
 })

--- a/tests/vitest/composition/BarChart.test.ts
+++ b/tests/vitest/composition/BarChart.test.ts
@@ -224,6 +224,22 @@ describe(`BarChart component`, () => {
     // With high min_segment_size_for_label, fewer internal labels should be shown
     expect(bar_labels.length).toBeLessThanOrEqual(6)
   })
+
+  test(`renders children content`, () => {
+    mount(BarChart, {
+      target: document.body,
+      props: {
+        composition: { H: 2, O: 1 },
+        children: () => {
+          const elem = document.createElement(`div`)
+          elem.className = `custom-child`
+          document.body.appendChild(elem)
+        },
+      },
+    })
+
+    expect(document.querySelector(`.custom-child`)).toBeTruthy()
+  })
 })
 
 describe(`BarChart calculations`, () => {

--- a/tests/vitest/composition/BubbleChart.test.ts
+++ b/tests/vitest/composition/BubbleChart.test.ts
@@ -32,6 +32,22 @@ describe(`BubbleChart component`, () => {
     const n_buttons = document.querySelectorAll(`circle[role="button"]`).length
     expect(n_buttons).toBeGreaterThan(0)
   })
+
+  test(`renders children content`, () => {
+    mount(BubbleChart, {
+      target: document.body,
+      props: {
+        composition: { H: 2, O: 1 },
+        children: () => {
+          const elem = document.createElement(`div`)
+          elem.className = `custom-child`
+          document.body.appendChild(elem)
+        },
+      },
+    })
+
+    expect(document.querySelector(`.custom-child`)).toBeTruthy()
+  })
 })
 
 describe(`BubbleChart calculations`, () => {

--- a/tests/vitest/composition/PieChart.test.ts
+++ b/tests/vitest/composition/PieChart.test.ts
@@ -34,6 +34,22 @@ describe(`PieChart component`, () => {
       document.querySelectorAll(`path[role="button"]`).length,
     ).toBeGreaterThan(0)
   })
+
+  test(`renders children snippet`, () => {
+    mount(PieChart, {
+      target: document.body,
+      props: {
+        composition: { H: 2, O: 1 },
+        children: () => {
+          const elem = document.createElement(`div`)
+          elem.className = `custom-child`
+          document.body.appendChild(elem)
+        },
+      },
+    })
+
+    expect(document.querySelector(`.custom-child`)).toBeTruthy()
+  })
 })
 
 describe(`PieChart data processing`, () => {


### PR DESCRIPTION
also add `children` prop to `Bands`, `Dos`, `BarChart`, `BubbleChart`, `PieChart`

closes #191

- Pass hover, dimensions, control state, fullscreen state, positions, and dropped-item context to injected child renderers.
- Derive element-tile hover and active borders from the current text color.