### PR TITLE
SymmetryStats

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -12,3 +12,8 @@ jobs:
     uses: janosh/workflows/.github/workflows/deno-gh-pages.yml@main
     with:
       deno-version: 2.3.7
+      # TODO remove once site build no longer fails without, started 2025-11-06 with sveltekit 2.48
+      build-cmd: |
+        rm -rf static/{molecules,structures,trajectories}
+        cp -r src/site/{molecules,structures,trajectories} static/
+        deno task build

--- a/contributing.md
+++ b/contributing.md
@@ -40,8 +40,8 @@ npx playwright test
 
 **New features should include tests.** Bug fixes should include a test that fails on the old code and passes with your fix.
 
-- Unit tests go in [`tests/vitest/`](tests/vitest)
-- E2E tests go in [`tests/playwright/`](tests/playwright)
+- Unit tests go in [`tests/vitest/`](https://github.com/janosh/matterviz/tree/main/tests/vitest)
+- E2E tests go in [`tests/playwright/`](https://github.com/janosh/matterviz/tree/main/tests/playwright)
 - Test functions should have typing annotations and concise docstrings explaining what they test.
 
 Before you start committing, create and check out a descriptively named branch:

--- a/package.json
+++ b/package.json
@@ -143,6 +143,10 @@
       "types": "./dist/structure/index.d.ts",
       "default": "./dist/structure/index.js"
     },
+    "./symmetry": {
+      "types": "./dist/symmetry/index.d.ts",
+      "default": "./dist/symmetry/index.js"
+    },
     "./theme": {
       "types": "./dist/theme/index.d.ts",
       "default": "./dist/theme/index.js"

--- a/src/lib/FilePicker.svelte
+++ b/src/lib/FilePicker.svelte
@@ -4,7 +4,7 @@
   import type { HTMLAttributes } from 'svelte/elements'
 
   let {
-    files,
+    files = [],
     active_files = [],
     show_category_filters = false,
     on_drag_start,
@@ -25,7 +25,7 @@
     },
     ...rest
   }: HTMLAttributes<HTMLDivElement> & {
-    files: FileInfo[]
+    files?: FileInfo[]
     active_files?: string[]
     show_category_filters?: boolean
     on_drag_start?: (file: FileInfo, event: DragEvent) => void

--- a/src/lib/coordination/CoordinationBarPlot.svelte
+++ b/src/lib/coordination/CoordinationBarPlot.svelte
@@ -2,8 +2,8 @@
   import type {
     AnyStructure,
     AxisConfig,
+    BarHandlerProps,
     BarSeries,
-    BarTooltipProps,
     Orientation,
   } from '$lib'
   import { StatusMessage } from '$lib'
@@ -267,7 +267,7 @@
     : `No coordination data to display`}
   />
 {:else}
-  {#snippet tooltip(info: BarTooltipProps)}
+  {#snippet tooltip(info: BarHandlerProps)}
     {@const cn = info.x}
     {@const count = info.y}
     {@const element = info.metadata?.element as string | undefined}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -22,6 +22,7 @@ export * from './plot'
 export * from './rdf'
 export * from './settings'
 export * from './structure'
+export * from './symmetry'
 export * from './theme'
 export { default as Trajectory } from './trajectory/Trajectory.svelte'
 export * from './utils'
@@ -81,17 +82,6 @@ export interface FileInfo {
   category?: string
   category_icon?: string
 }
-
-export const crystal_systems = [
-  `triclinic`,
-  `monoclinic`,
-  `orthorhombic`,
-  `tetragonal`,
-  `trigonal`,
-  `hexagonal`,
-  `cubic`,
-] as const
-export type CrystalSystem = (typeof crystal_systems)[number]
 
 // Helper function to escape HTML special characters to prevent XSS
 export function escape_html(unsafe_string: string): string {

--- a/src/lib/plot/SpacegroupBarPlot.svelte
+++ b/src/lib/plot/SpacegroupBarPlot.svelte
@@ -5,7 +5,6 @@
   import type { CrystalSystem } from '$lib/symmetry'
   import * as symmetry from '$lib/symmetry'
   import * as spg from '$lib/symmetry/spacegroups'
-  import { spacegroup_to_crystal_sys } from '$lib/symmetry/spacegroups'
   import type { ComponentProps } from 'svelte'
   import { SvelteMap } from 'svelte/reactivity'
 
@@ -160,7 +159,7 @@
 
 {#snippet tooltip(info: BarHandlerProps)}
   {@const { x: sg, y: count } = info}
-  {@const system = spacegroup_to_crystal_sys(sg)}
+  {@const system = spg.spacegroup_to_crystal_sys(sg)}
   Space Group: {format_value(sg, `.0f`)} ({spg.SPACEGROUP_NUM_TO_SYMBOL[sg]})<br />
   {#if system}
     Crystal System: {system}<br />

--- a/src/lib/plot/SpacegroupBarPlot.svelte
+++ b/src/lib/plot/SpacegroupBarPlot.svelte
@@ -1,18 +1,11 @@
 <script lang="ts">
-  import { type BarSeries, type BarTooltipProps, format_num } from '$lib'
+  import { type BarHandlerProps, type BarSeries, format_num } from '$lib'
   import { format_value } from '$lib/labels'
   import { BarPlot } from '$lib/plot'
   import type { CrystalSystem } from '$lib/symmetry'
-  import {
-    CRYSTAL_SYSTEM_COLORS,
-    CRYSTAL_SYSTEM_RANGES,
-    CRYSTAL_SYSTEMS,
-  } from '$lib/symmetry'
-  import {
-    normalize_spacegroup,
-    SPACEGROUP_NUM_TO_SYMBOL,
-    spacegroup_to_crystal_system,
-  } from '$lib/symmetry/spacegroups'
+  import * as symmetry from '$lib/symmetry'
+  import * as spg from '$lib/symmetry/spacegroups'
+  import { spacegroup_to_crystal_sys } from '$lib/symmetry/spacegroups'
   import type { ComponentProps } from 'svelte'
   import { SvelteMap } from 'svelte/reactivity'
 
@@ -31,7 +24,7 @@
 
   // Normalize input data to space group numbers
   const normalized_data = $derived(
-    data.map(normalize_spacegroup).filter((sg): sg is number => sg !== null),
+    data.map(spg.normalize_spacegroup).filter((sg): sg is number => sg !== null),
   )
 
   // Compute histogram of space group numbers
@@ -53,12 +46,12 @@
       { count: number; spacegroups: number[] }
     >()
 
-    for (const system of CRYSTAL_SYSTEMS) {
+    for (const system of symmetry.CRYSTAL_SYSTEMS) {
       stats.set(system, { count: 0, spacegroups: [] })
     }
 
     for (const [sg, count] of histogram) {
-      const system = spacegroup_to_crystal_system(sg)
+      const system = spg.spacegroup_to_crystal_sys(sg)
       if (system) {
         const stat = stats.get(system)!
         stat.count += count
@@ -95,7 +88,7 @@
 
     // Group data by crystal system
     for (const sg of sorted_spacegroups) {
-      const system = spacegroup_to_crystal_system(sg)
+      const system = spg.spacegroup_to_crystal_sys(sg)
       if (system) {
         let series = series_by_system.get(system)
         if (!series) {
@@ -109,11 +102,11 @@
 
     // Convert to BarSeries array, maintaining order of crystal systems
     const result: BarSeries[] = []
-    for (const system of CRYSTAL_SYSTEMS) {
+    for (const system of symmetry.CRYSTAL_SYSTEMS) {
       const data = series_by_system.get(system)
       if (data) {
         const { x, y } = data
-        const color = CRYSTAL_SYSTEM_COLORS[system]
+        const color = symmetry.CRYSTAL_SYSTEM_COLORS[system]
         result.push({ x, y, color, label: system, bar_width: 0.9, visible: true })
       }
     }
@@ -127,11 +120,11 @@
   const crystal_system_regions = $derived.by(() => {
     const [range_min, range_max] = x_range
 
-    return CRYSTAL_SYSTEMS.map((system) => {
-      const [sg_start, sg_end] = CRYSTAL_SYSTEM_RANGES[system]
+    return symmetry.CRYSTAL_SYSTEMS.map((system) => {
+      const [sg_start, sg_end] = symmetry.CRYSTAL_SYSTEM_RANGES[system]
       const stats = crystal_system_stats.get(system)
       const count = stats?.count ?? 0
-      const color = CRYSTAL_SYSTEM_COLORS[system]
+      const color = symmetry.CRYSTAL_SYSTEM_COLORS[system]
       return { system, sg_start, sg_end, count, color }
     }).filter(
       (region) => region.sg_end >= range_min && region.sg_start <= range_max, // Only visible systems
@@ -165,10 +158,10 @@
   )
 </script>
 
-{#snippet tooltip(info: BarTooltipProps)}
+{#snippet tooltip(info: BarHandlerProps)}
   {@const { x: sg, y: count } = info}
-  {@const system = spacegroup_to_crystal_system(sg)}
-  Space Group: {format_value(sg, `.0f`)} ({SPACEGROUP_NUM_TO_SYMBOL[sg]})<br />
+  {@const system = spacegroup_to_crystal_sys(sg)}
+  Space Group: {format_value(sg, `.0f`)} ({spg.SPACEGROUP_NUM_TO_SYMBOL[sg]})<br />
   {#if system}
     Crystal System: {system}<br />
   {/if}

--- a/src/lib/plot/types.ts
+++ b/src/lib/plot/types.ts
@@ -126,7 +126,7 @@ export interface Tooltip {
   items?: { label: string; value: string; color?: string }[]
 }
 
-export interface TooltipProps<Metadata = Record<string, unknown>> {
+export interface HandlerProps<Metadata = Record<string, unknown>> {
   x: number
   y: number
   metadata?: Metadata | null
@@ -138,7 +138,7 @@ export interface TooltipProps<Metadata = Record<string, unknown>> {
 }
 
 export interface ScatterHandlerProps<Metadata = Record<string, unknown>>
-  extends TooltipProps<Metadata> {
+  extends HandlerProps<Metadata> {
   cx: number
   cy: number
   x_formatted: string
@@ -156,7 +156,7 @@ export type ScatterHandlerEvent<Metadata = Record<string, unknown>> =
   & { event: MouseEvent; point: InternalPoint }
 
 export interface BarHandlerProps<Metadata = Record<string, unknown>>
-  extends TooltipProps<Metadata> {
+  extends HandlerProps<Metadata> {
   bar_idx: number
   orient_x: number
   orient_y: number
@@ -165,7 +165,7 @@ export interface BarHandlerProps<Metadata = Record<string, unknown>>
 }
 
 export interface HistogramHandlerProps<Metadata = Record<string, unknown>>
-  extends TooltipProps<Metadata> {
+  extends HandlerProps<Metadata> {
   value: number
   count: number
   property: string

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -92,6 +92,12 @@ export interface SettingsConfig {
   background_color: SettingType<string>
   background_opacity: SettingType<number>
 
+  // Symmetry Analysis
+  symmetry: {
+    symprec: SettingType<number>
+    algo: SettingType<`Standard` | `Spglib`>
+  }
+
   structure: { // Structure viewer settings
     // Atoms & Bonds
     atom_radius: SettingType<number>
@@ -309,6 +315,21 @@ export const SETTINGS_CONFIG: SettingsConfig = {
     description: `Opacity of the background (0.0 = transparent, 1.0 = opaque)`,
     minimum: 0,
     maximum: 1,
+  },
+
+  // Symmetry Analysis
+  symmetry: {
+    symprec: {
+      value: 1e-4,
+      description: `Symmetry precision tolerance for spacegroup detection`,
+      minimum: 1e-8,
+      maximum: 1,
+    },
+    algo: {
+      value: `Standard` as const,
+      description: `Algorithm for symmetry analysis`,
+      enum: { Standard: `Standard`, Spglib: `Spglib` },
+    },
   },
 
   // Structure viewer settings

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -11,7 +11,7 @@
   import { get_elem_amounts, get_pbc_image_sites } from '$lib/structure'
   import { is_valid_supercell_input, make_supercell } from '$lib/structure/supercell'
   import type { SymmetrySettings } from '$lib/symmetry'
-  import { analyze_structure_symmetry, ensure_moyo_wasm_ready } from '$lib/symmetry'
+  import * as symmetry from '$lib/symmetry'
   import type { MoyoDataset } from '@spglib/moyo-wasm'
   import { Canvas } from '@threlte/core'
   import type { ComponentProps, Snippet } from 'svelte'
@@ -87,7 +87,7 @@
     // Symmetry analysis data (bindable for external access)
     symmetry_data = $bindable<MoyoDataset | null>(null),
     // Symmetry analysis settings (bindable for external control)
-    symmetry_settings = $bindable({}),
+    symmetry_settings = $bindable(symmetry.default_sym_settings),
     children,
     on_file_load,
     on_error,
@@ -287,10 +287,10 @@
     symmetry_data = null
     symmetry_error = undefined
 
-    ensure_moyo_wasm_ready()
+    symmetry.ensure_moyo_wasm_ready()
       .then(() =>
         run_id === symmetry_run_id
-          ? analyze_structure_symmetry(current_structure, current_settings)
+          ? symmetry.analyze_structure_symmetry(current_structure, current_settings)
           : null
       )
       .then((data) => {

--- a/src/lib/symmetry/SymmetryStats.svelte
+++ b/src/lib/symmetry/SymmetryStats.svelte
@@ -82,10 +82,12 @@
         type="number"
         step="1e-5"
         value={settings.symprec}
-        oninput={(evt) =>
-        settings = {
-          ...settings,
-          symprec: parseFloat(evt.currentTarget.value),
+        oninput={(evt) => {
+          const { value } = evt.currentTarget
+          const parsed = parseFloat(value)
+          if (Number.isFinite(parsed)) {
+            settings = { ...settings, symprec: parsed }
+          }
         }}
       />
     </label>

--- a/src/lib/symmetry/SymmetryStats.svelte
+++ b/src/lib/symmetry/SymmetryStats.svelte
@@ -1,0 +1,189 @@
+<script lang="ts">
+  import type { MoyoDataset } from '@spglib/moyo-wasm'
+  import type { Snippet } from 'svelte'
+  import { tooltip } from 'svelte-multiselect'
+  import type { HTMLAttributes } from 'svelte/elements'
+  import { type SymmetrySettings, wyckoff_positions_from_moyo } from './index'
+
+  let {
+    sym_data,
+    settings = $bindable({ symprec: 1e-4, algo: `Standard` }),
+    show_tooltips = true,
+    children,
+    header,
+    ...rest
+  }: HTMLAttributes<HTMLDivElement> & {
+    sym_data?: MoyoDataset
+    settings?: SymmetrySettings
+    show_tooltips?: boolean
+    children?: Snippet<[{ sym_data?: MoyoDataset }]>
+    header?: Snippet<[{ sym_data?: MoyoDataset }]>
+  } = $props()
+
+  const wyckoff_count = $derived(
+    sym_data ? wyckoff_positions_from_moyo(sym_data).length : 0,
+  )
+
+  const sym_ops_counts = $derived.by(() => {
+    const EPS = 1e-10
+    if (!sym_data?.operations) {
+      return { translations: 0, rotations: 0, roto_translations: 0 }
+    }
+
+    return sym_data.operations.reduce(
+      (acc, op) => {
+        const has_translation = op.translation.some((coord) => Math.abs(coord) > EPS)
+        const is_identity = String(op.rotation) === `1,0,0,0,1,0,0,0,1`
+
+        if (is_identity && has_translation) acc.translations++
+        else if (!has_translation) acc.rotations++
+        else acc.roto_translations++
+
+        return acc
+      },
+      { translations: 0, rotations: 0, roto_translations: 0 },
+    )
+  })
+
+  const titles = {
+    symprec:
+      `Symmetry precision control in spglib/moyo. Lower values (e.g. 1e-4, the default) are more strict, higher values (e.g. 1e-1) are more tolerant of numerical errors in atomic positions.`,
+    algo:
+      `Symmetry detection algorithm: Standard uses moyo's newer recommended settings, spglib is useful if you need compatible results to an existing set of spglib-detected symmetries.`,
+    space_group:
+      `International Tables Space group number (1-230) - unique identifier for each space group. Higher numbers indicate more symmetries in the crystal.`,
+    hermann_mauguin:
+      `Hermann-Mauguin symbol describes symmetry operations. Format: Lattice type + Point group symmetry. Example: P4/mmm = Primitive + 4-fold rotation + mirror planes`,
+    hall_number:
+      `Hall number: alternative numbering system for space groups. Useful for crystallographic software compatibility.`,
+    pearson_symbol:
+      `Pearson symbol. Format: Crystal system + Number of atoms per unit cell. Example: tP2 = tetragonal primitive with 2 atoms`,
+    symmetry_operations:
+      `Total symmetry operations that map the crystal structure onto itself. Includes rotations, translations, and combinations.`,
+    distinct_orbits:
+      `Number of unique Wyckoff positions (symmetry-equivalent atomic sites) in the crystal structure.`,
+    translations: `Number of translations in the crystal structure.`,
+    rotations: `Number of rotations in the crystal structure.`,
+    roto_translations: `Number of roto-translations in the crystal structure.`,
+  }
+  const tooltips: Record<string, string> = $derived(show_tooltips ? titles : {})
+</script>
+
+<div {...rest} class="symmetry-stats {rest.class ?? ``}">
+  {#if sym_data}
+    {@render header?.({ sym_data })}
+  {/if}
+
+  <!-- Always show controls so users can adjust settings even after errors -->
+  <div class="controls">
+    <label>
+      <span {@attach tooltip()} title={tooltips?.symprec}>Symprec</span>
+      <input
+        type="number"
+        step="1e-5"
+        value={settings.symprec}
+        oninput={(evt) =>
+        settings = {
+          ...settings,
+          symprec: parseFloat(evt.currentTarget.value),
+        }}
+      />
+    </label>
+    <label>
+      <span {@attach tooltip()} title={tooltips?.algo}>Setting</span>
+
+      <select
+        value={settings.algo}
+        onchange={(evt) =>
+        settings = {
+          ...settings,
+          algo: evt.currentTarget.value as `Standard` | `Spglib`,
+        }}
+      >
+        <option value="Standard">Standard</option>
+        <option value="Spglib">Spglib</option>
+      </select>
+    </label>
+  </div>
+
+  {@render children?.({ sym_data })}
+  {#if sym_data}
+    <div class="stats-grid">
+      <div
+        title="{tooltips?.space_group} at {settings.symprec} (using {settings.algo} algo)"
+        {@attach tooltip()}
+      >
+        Space Group <strong>{sym_data.number}</strong>
+      </div>
+      <div title={tooltips?.hermann_mauguin} {@attach tooltip()}>
+        Hermann-Mauguin <strong>{sym_data.hm_symbol ?? `N/A`}</strong>
+      </div>
+      <div title={tooltips?.hall_number} {@attach tooltip()}>
+        Hall Number <strong>{sym_data.hall_number}</strong>
+      </div>
+      <div title={tooltips?.pearson_symbol} {@attach tooltip()}>
+        Pearson <strong>{sym_data.pearson_symbol}</strong>
+      </div>
+      <div title={tooltips?.distinct_orbits} {@attach tooltip()}>
+        Wyckoff Positions <strong>{wyckoff_count}</strong>
+      </div>
+      <div
+        class="sym-ops-summary"
+        title="{sym_ops_counts.translations} translations + {sym_ops_counts.rotations} rotations + {sym_ops_counts.roto_translations} roto-translations"
+        {@attach tooltip()}
+      >
+        Total sym ops: <strong>{sym_data.operations.length}</strong>
+        ({sym_ops_counts.translations}T + {sym_ops_counts.rotations}R + {
+          sym_ops_counts.roto_translations
+        }RT)
+      </div>
+    </div>
+  {:else}
+    <div class="no-data">
+      <p>No symmetry data available</p>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .controls {
+    display: flex;
+    gap: 1em;
+    background: var(--surface-bg);
+    padding: 4pt 8pt;
+    border-radius: 4pt;
+    margin: 0 0 1em 0;
+  }
+  .controls label {
+    display: flex;
+    gap: 6pt;
+    place-items: center;
+  }
+  .controls label input {
+    padding: 2pt 4pt;
+    max-width: 100px;
+  }
+  .stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(275px, 1fr));
+    gap: 1ex 1em;
+    margin-block: 1ex;
+    align-items: start;
+  }
+  .stats-grid strong {
+    margin: 0 0 0 3pt;
+  }
+  .no-data {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100px;
+    padding: 2em;
+    background: var(--surface-bg, #f5f5f5);
+    border-radius: 4pt;
+    color: var(--text-muted, #666);
+  }
+  .no-data p {
+    margin: 0;
+  }
+</style>

--- a/src/lib/symmetry/index.ts
+++ b/src/lib/symmetry/index.ts
@@ -1,5 +1,6 @@
 import type { Vec3 } from '$lib'
 import { atomic_number_to_symbol, symbol_to_atomic_number } from '$lib/composition/parse'
+import { DEFAULTS } from '$lib/settings'
 import type { AnyStructure, PymatgenStructure } from '$lib/structure'
 import type { MoyoCell, MoyoDataset } from '@spglib/moyo-wasm'
 import init, { analyze_cell } from '@spglib/moyo-wasm'
@@ -9,15 +10,7 @@ export * from './spacegroups'
 export { default as SymmetryStats } from './SymmetryStats.svelte'
 export { default as WyckoffTable } from './WyckoffTable.svelte'
 
-export const crystal_systems = [
-  `Triclinic`,
-  `Monoclinic`,
-  `Orthorhombic`,
-  `Tetragonal`,
-  `Trigonal`,
-  `Hexagonal`,
-  `Cubic`,
-] as const
+// Keys are standard crystallographic symbols (P, I, F, A, B, C, R)
 export const bravais_lattices = {
   P: `Primitive`,
   I: `Body-centered`,
@@ -28,7 +21,6 @@ export const bravais_lattices = {
   R: `Rhombohedral`,
 } as const
 
-export type CrystalSystem = (typeof crystal_systems)[number]
 export type BravaisLattice = (typeof bravais_lattices)[keyof typeof bravais_lattices]
 
 export type SymmetrySettings = {
@@ -36,8 +28,8 @@ export type SymmetrySettings = {
   algo: `Standard` | `Spglib`
 }
 export const default_sym_settings = {
-  symprec: 1e-4,
-  algo: `Standard`,
+  symprec: DEFAULTS.symmetry.symprec,
+  algo: DEFAULTS.symmetry.algo,
 } as const satisfies SymmetrySettings
 
 export type WyckoffPos = {

--- a/src/lib/symmetry/index.ts
+++ b/src/lib/symmetry/index.ts
@@ -27,18 +27,8 @@ export function to_cell_json(structure: PymatgenStructure): string {
   // nalgebra Matrix3 deserializes as a flat list in COLUMN-MAJOR of the internal basis B
   // Internal B = transpose(row-basis RB). column-major(B) == row-major(RB).
   // So supply row-major of the pymatgen lattice.matrix (RB).
-  const [[m00, m01, m02], [m10, m11, m12], [m20, m21, m22]] = structure.lattice.matrix
-  const basis: MoyoCell[`lattice`][`basis`] = [
-    m00,
-    m01,
-    m02,
-    m10,
-    m11,
-    m12,
-    m20,
-    m21,
-    m22,
-  ]
+  const [v_a, v_b, v_c] = structure.lattice.matrix
+  const basis: MoyoCell[`lattice`][`basis`] = [...v_a, ...v_b, ...v_c]
   const positions = structure.sites.map((site) => site.abc)
   const numbers = structure.sites.map((site, idx) => {
     const sym = site.species?.[0]?.element

--- a/src/lib/symmetry/spacegroups.ts
+++ b/src/lib/symmetry/spacegroups.ts
@@ -35,7 +35,7 @@ export const CRYSTAL_SYSTEMS = [
 export type CrystalSystem = (typeof CRYSTAL_SYSTEMS)[number]
 
 // Convert space group number to crystal system
-export function spacegroup_number_to_crystal_system(
+export function spacegroup_num_to_crystal_sys(
   spacegroup: number,
 ): CrystalSystem | null {
   for (const [system, [min, max]] of Object.entries(CRYSTAL_SYSTEM_RANGES)) {
@@ -47,24 +47,18 @@ export function spacegroup_number_to_crystal_system(
 }
 
 // Convert space group (number or symbol) to crystal system
-export function spacegroup_to_crystal_system(
+export function spacegroup_to_crystal_sys(
   spacegroup: number | string,
 ): CrystalSystem | null {
-  if (typeof spacegroup === `number`) {
-    return spacegroup_number_to_crystal_system(spacegroup)
-  }
+  if (typeof spacegroup === `number`) return spacegroup_num_to_crystal_sys(spacegroup)
 
   // Try to parse as symbol
   const number = SPACEGROUP_SYMBOL_TO_NUM[spacegroup]
-  if (number !== undefined) {
-    return spacegroup_number_to_crystal_system(number)
-  }
+  if (number !== undefined) return spacegroup_num_to_crystal_sys(number)
 
   // Try to parse string as number
   const parsed = parseInt(spacegroup, 10)
-  if (!isNaN(parsed)) {
-    return spacegroup_number_to_crystal_system(parsed)
-  }
+  if (!isNaN(parsed)) return spacegroup_num_to_crystal_sys(parsed)
 
   return null
 }

--- a/src/lib/xrd/XrdPlot.svelte
+++ b/src/lib/xrd/XrdPlot.svelte
@@ -3,7 +3,7 @@
   import { plot_colors } from '$lib/colors'
   import { decompress_file, handle_url_drop } from '$lib/io'
   import { format_value } from '$lib/labels'
-  import type { AxisConfig, BarSeries, BarTooltipProps } from '$lib/plot'
+  import type { AxisConfig, BarHandlerProps, BarSeries } from '$lib/plot'
   import { BarPlot } from '$lib/plot'
   import { parse_any_structure } from '$lib/structure/parse'
   import { is_valid_structure } from '$lib/structure/validation'
@@ -247,7 +247,7 @@
     : `No XRD data to display`}
   />
 {:else}
-  {#snippet tooltip(info: BarTooltipProps)}
+  {#snippet tooltip(info: BarHandlerProps)}
     {@const angle_text = `${format_value(info.x, `.2f`)}°`}
     {@const intensity_text = `${format_value(info.y, `.1f`)}`}
     {@const hkls = info.metadata?.hkls as Hkl[] | undefined}

--- a/src/routes/(demos)/structure/+page.md
+++ b/src/routes/(demos)/structure/+page.md
@@ -56,13 +56,13 @@ Showcasing structures with different crystal systems.
 
 ```svelte example
 <script>
-  import { crystal_systems, Structure } from 'matterviz'
+  import { CRYSTAL_SYSTEMS, Structure } from 'matterviz'
   import { structures } from '$site/structures'
 </script>
 
 <ul class="crystal-systems">
   {#each structures.filter((struct) =>
-      crystal_systems.some((system) => struct.id.includes(system))
+      CRYSTAL_SYSTEMS.some((system) => struct.id.includes(system))
     ) as
     structure
   }

--- a/src/routes/(demos)/structure/symmetry/+page.svelte
+++ b/src/routes/(demos)/structure/symmetry/+page.svelte
@@ -6,27 +6,33 @@
   import type { AnyStructure } from '$lib/structure'
   import { Structure } from '$lib/structure'
   import {
-    analyze_structure_symmetry,
+    default_sym_settings,
     ensure_moyo_wasm_ready,
     map_wyckoff_to_all_atoms,
+    type SymmetrySettings,
+    SymmetryStats,
     wyckoff_positions_from_moyo,
     WyckoffTable,
   } from '$lib/symmetry'
   import { structure_files } from '$site/structures'
   import type { MoyoDataset } from '@spglib/moyo-wasm'
   import { onMount } from 'svelte'
-  import { tooltip } from 'svelte-multiselect'
 
   let wasm_ready = $state(false)
   let error = $state<string | null>(null)
-  let sym_data = $state<MoyoDataset | null>(null)
-  let symprec = $state(1e-4)
-  let setting = $state<`Standard` | `Spglib`>(`Standard`)
   let current_filename = $state(`Bi2Zr2O8-Fm3m.json`)
   let current_structure = $state<AnyStructure | null>(null)
   let displayed_structure = $state<AnyStructure | undefined>(undefined)
   let hovered_wyckoff_sites = $state<number[]>([])
   let active_wyckoff_sites = $state<number[]>([])
+  // Symmetry data for each example
+  let top_ex_sym_data = $state<MoyoDataset | null>(null)
+  let two_col_sym_data = $state<MoyoDataset | null>(null)
+  let stacked_sym_data = $state<MoyoDataset | null>(null)
+  // Symmetry settings for layout examples (independent controls)
+  let wide_example_symmetry_settings = $state<SymmetrySettings>(default_sym_settings)
+  let two_col_sym_settings = $state<SymmetrySettings>(default_sym_settings)
+  let stacked_sym_settings = $state<SymmetrySettings>(default_sym_settings)
 
   onMount(() => { // Initialize WASM
     ensure_moyo_wasm_ready()
@@ -41,38 +47,14 @@
     if (file && file !== current_filename) current_filename = file
   })
 
-  // Analyze structure when dependencies change
-  $effect(() => {
-    if (!wasm_ready || !current_structure) return
-    analyze_structure()
-  })
-
-  async function analyze_structure() {
-    if (!current_structure || !(`lattice` in current_structure)) {
-      error = `Not a periodic structure`
-      return
-    }
-
-    error = null
-    sym_data = null
-
-    try {
-      sym_data = await analyze_structure_symmetry(
-        current_structure,
-        symprec,
-        setting,
-      )
-    } catch (exc) {
-      error = `Analysis failed: ${exc}`
-    }
-  }
-
-  // Derived values
-  const base_wyckoff_positions = $derived(wyckoff_positions_from_moyo(sym_data))
+  // Derived values for wyckoff positions
+  const base_wyckoff_positions = $derived(
+    wyckoff_positions_from_moyo(top_ex_sym_data ?? null),
+  )
   const wyckoff_positions = $derived.by(() => {
     if (
       !base_wyckoff_positions || !displayed_structure || !current_structure ||
-      !sym_data
+      !top_ex_sym_data
     ) return base_wyckoff_positions
 
     // Only apply mapping for periodic structures with lattice
@@ -84,25 +66,8 @@
       base_wyckoff_positions,
       displayed_structure,
       current_structure,
-      sym_data,
+      top_ex_sym_data,
     )
-  })
-  const operation_counts = $derived.by(() => {
-    const EPS = 1e-10
-    if (!sym_data?.operations) {
-      return { translations: 0, rotations: 0, roto_translations: 0 }
-    }
-
-    return sym_data.operations.reduce((acc, op) => {
-      const has_translation = op.translation.some((x) => Math.abs(x) > EPS)
-      const is_identity = String(op.rotation) === `1,0,0,0,1,0,0,0,1`
-
-      if (is_identity && has_translation) acc.translations++
-      else if (!has_translation) acc.rotations++
-      else acc.roto_translations++
-
-      return acc
-    }, { translations: 0, rotations: 0, roto_translations: 0 })
   })
 </script>
 
@@ -115,89 +80,35 @@
 
 <div class="symmetry-grid bleed-1400">
   <div class="symmetry-info">
-    {#if wasm_ready}
-      <div class="controls">
-        <label>
-          <span
-            {@attach tooltip()}
-            title="Symmetry precision control in spglib/moyo. Lower values (e.g. 1e-4, the default) are more strict, higher values (e.g. 1e-1) are more tolerant of numerical errors in atomic positions."
-          >Symprec</span>
-          <input type="number" step="1e-5" bind:value={symprec} />
-        </label>
-        <label>
-          <span
-            {@attach tooltip()}
-            title="Symmetry detection algorithm: Standard uses moyo's newer recommended settings, spglib is useful if you need compatible results to an existing set of spglib-detected symmetries."
-          >Setting</span>
-
-          <select bind:value={setting}>
-            <option value="Standard">Standard</option>
-            <option value="Spglib">Spglib</option>
-          </select>
-        </label>
+    {#if !wasm_ready}
+      <div class="loading-placeholder">
+        <div class="loading-spinner"></div>
+        <p>Loading symmetry analysis...</p>
       </div>
-    {:else}
-      <span class="status warn">Loading WASM...</span>
-    {/if}
-    {#if error}
+    {:else if error}
       <pre class="error" style="color: var(--error-color)">{error}</pre>
-    {:else if sym_data}
-      <div class="symmetry-stats">
-        <div
-          title="International Tables space group number (1-230) - unique identifier for each space group. Higher numbers indicate more symmetries in the crystal."
-          {@attach tooltip()}
-        >
-          Space group <strong>{sym_data.number}</strong>
-        </div>
-        <div
-          title="Hermann-Mauguin symbol describes symmetry operations. Format: Lattice type + Point group symmetry. Example: P4/mmm = Primitive + 4-fold rotation + mirror planes"
-          {@attach tooltip()}
-        >
-          Hermann-Mauguin <strong>{sym_data.hm_symbol ?? `N/A`}</strong>
-        </div>
-        <div
-          title="Hall number: alternative numbering system for space groups. Useful for crystallographic software compatibility."
-          {@attach tooltip()}
-        >
-          Hall number <strong>{sym_data.hall_number}</strong>
-        </div>
-        <div
-          title="Pearson symbol. Format: Crystal system + Number of atoms per unit cell. Example: tP2 = tetragonal primitive with 2 atoms"
-          {@attach tooltip()}
-        >
-          Pearson <strong>{sym_data.pearson_symbol}</strong>
-        </div>
-        <div
-          title="Total symmetry operations that map the crystal structure onto itself. Includes rotations, translations, and combinations."
-          {@attach tooltip()}
-        >
-          Symmetry operations <strong>{sym_data.operations.length}</strong>
-          <ul>
-            <li>translations <strong>{operation_counts.translations}</strong></li>
-            <li>rotations <strong>{operation_counts.rotations}</strong></li>
-            <li>
-              roto-translations <strong>{operation_counts.roto_translations}</strong>
-            </li>
-          </ul>
-        </div>
-        <div
-          title="Number of unique Wyckoff positions (symmetry-equivalent atomic sites) in the crystal structure."
-          {@attach tooltip()}
-        >
-          Distinct orbits <strong>{wyckoff_positions.length}</strong>
-        </div>
-      </div>
+    {:else if top_ex_sym_data}
+      <SymmetryStats
+        sym_data={top_ex_sym_data}
+        bind:settings={wide_example_symmetry_settings}
+      />
       <WyckoffTable
         {wyckoff_positions}
         on_hover={(site_indices) => hovered_wyckoff_sites = site_indices ?? []}
         on_click={(site_indices) => active_wyckoff_sites = site_indices ?? []}
       />
+    {:else}
+      <div class="empty-state">
+        <p>Load a structure to analyze its symmetry</p>
+      </div>
     {/if}
   </div>
 
   <Structure
     data_url="/structures/{current_filename}"
     bind:displayed_structure
+    bind:symmetry_data={top_ex_sym_data}
+    bind:symmetry_settings={wide_example_symmetry_settings}
     scene_props={{
       active_sites: active_wyckoff_sites,
       selected_sites: hovered_wyckoff_sites,
@@ -222,6 +133,55 @@
   </Structure>
 </div>
 
+<!-- Layout Examples Section -->
+<section style="margin: 4em 0">
+  <h2 style="text-align: center; margin-bottom: 2em">Layout Examples</h2>
+
+  {#if top_ex_sym_data}
+    <!-- Example 3: Two Column - Stats Left, Structure Right -->
+    <div class="example-section">
+      <h3>Two Column - Stats + Structure</h3>
+      <div class="two-column-layout">
+        <div>
+          <SymmetryStats
+            sym_data={two_col_sym_data}
+            bind:settings={two_col_sym_settings}
+          />
+        </div>
+        <Structure
+          data_url="/structures/{current_filename}"
+          show_controls={true}
+          bind:symmetry_data={two_col_sym_data}
+          bind:symmetry_settings={two_col_sym_settings}
+          style="height: 300px; border-radius: 8pt"
+        />
+      </div>
+    </div>
+
+    <!-- Example 5: Grid Layout - Stats Above, Structure Below -->
+    <div class="example-section">
+      <h3>Stacked Layout - Stats Above Structure</h3>
+      <div class="stacked-layout">
+        <SymmetryStats
+          sym_data={stacked_sym_data}
+          bind:settings={stacked_sym_settings}
+        />
+        <Structure
+          data_url="/structures/{current_filename}"
+          show_controls={true}
+          bind:symmetry_data={stacked_sym_data}
+          bind:symmetry_settings={stacked_sym_settings}
+          style="height: 400px; border-radius: 8pt; margin-top: 1em"
+        />
+      </div>
+    </div>
+  {:else}
+    <p style="text-align: center; color: var(--text-muted, #666)">
+      Load a structure above to see layout examples
+    </p>
+  {/if}
+</section>
+
 <p style="margin: 2em 0; text-align: center">
   Drag any structure onto the viewer:
 </p>
@@ -234,43 +194,54 @@
 />
 
 <style>
-  .status.warn {
-    color: #b8860b;
-  }
   .symmetry-grid {
     display: grid;
     grid-template-columns: auto 1fr;
     gap: 2em;
     margin-block: 2em;
   }
-  .symmetry-info .symmetry-stats {
+  .loading-placeholder,
+  .empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-height: 300px;
+    padding: 2em;
+    background: var(--surface-bg, #f5f5f5);
+    border-radius: 8pt;
+    color: var(--text-muted, #666);
+  }
+  .loading-placeholder p,
+  .empty-state p {
+    margin: 1em 0 0;
+    font-size: 0.95em;
+  }
+  .loading-spinner {
+    box-sizing: border-box;
+    width: 40px;
+    height: 40px;
+    border: 4px solid var(--surface-bg-darker, #e0e0e0);
+    border-top-color: var(--accent-color, #0066cc);
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+  }
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+  /* layout example CSS */
+  .example-section {
+    margin: 3em 0;
+  }
+  .two-column-layout {
     display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 1ex 1em;
-    margin-block: 1ex;
-    align-items: start;
+    grid-template-columns: 1fr 1fr;
+    gap: 2em;
   }
-  .symmetry-info strong {
-    margin: 0 0 0 3pt;
-  }
-  .symmetry-info .controls {
-    display: flex;
-    gap: 1em;
-    background: var(--surface-bg);
-    padding: 4pt 8pt;
-    border-radius: 4pt;
-    margin: 0 0 1em 0;
-  }
-  .symmetry-info .controls label {
-    display: flex;
-    gap: 6pt;
-    place-items: center;
-  }
-  .symmetry-info .controls label input {
-    padding: 2pt 4pt;
-    max-width: 100px;
-  }
-  .symmetry-info ul {
-    margin: 0;
+  .stacked-layout {
+    max-width: 900px;
+    margin: 0 auto;
   }
 </style>

--- a/src/routes/(demos)/structure/symmetry/+page.svelte
+++ b/src/routes/(demos)/structure/symmetry/+page.svelte
@@ -133,6 +133,17 @@
   </Structure>
 </div>
 
+<p style="margin: 2em 0; text-align: center">
+  Drag any structure onto the viewer:
+</p>
+
+<FilePicker
+  files={structure_files}
+  show_category_filters
+  on_drag_end={() => {/* noop to avoid TS complaining */}}
+  style="margin-bottom: 3em"
+/>
+
 <!-- Layout Examples Section -->
 <section style="margin: 4em 0">
   <h2 style="text-align: center; margin-bottom: 2em">Layout Examples</h2>
@@ -181,17 +192,6 @@
     </p>
   {/if}
 </section>
-
-<p style="margin: 2em 0; text-align: center">
-  Drag any structure onto the viewer:
-</p>
-
-<FilePicker
-  files={structure_files}
-  show_category_filters
-  on_drag_end={() => {/* noop to avoid TS complaining */}}
-  style="margin-bottom: 3em"
-/>
 
 <style>
   .symmetry-grid {

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { page } from '$app/state'
   import { Icon } from '$lib'
-
   import pkg from '$root/package.json'
 
   let online: boolean = $state(true)

--- a/tests/vitest/plot/BarPlot.test.ts
+++ b/tests/vitest/plot/BarPlot.test.ts
@@ -1,5 +1,5 @@
 import { BarPlot } from '$lib'
-import type { BarMode, BarSeries, BarTooltipProps, Orientation } from '$lib/plot'
+import type { BarHandlerProps, BarMode, BarSeries, Orientation } from '$lib/plot'
 import { mount } from 'svelte'
 import { describe, expect, test, vi } from 'vitest'
 
@@ -170,7 +170,7 @@ describe(`BarPlot`, () => {
       target: document.body,
       props: {
         series: [basic],
-        tooltip: (data: BarTooltipProps) => {
+        tooltip: (data: BarHandlerProps) => {
           const div_el = document.createElement(`div`)
           div_el.className = `custom-tooltip`
           div_el.textContent = `x: ${data.x}, y: ${data.y}`

--- a/tests/vitest/symmetry/SymmetryStats.test.ts
+++ b/tests/vitest/symmetry/SymmetryStats.test.ts
@@ -1,0 +1,519 @@
+import { SymmetryStats } from '$lib/symmetry'
+import type { MoyoDataset } from '@spglib/moyo-wasm'
+import { flushSync, mount, unmount } from 'svelte'
+import { describe, expect, test } from 'vitest'
+import { doc_query } from '../setup'
+
+/**
+ * Helper function to create mock MoyoDataset for testing
+ */
+function create_mock_sym_data(overrides: Partial<MoyoDataset> = {}): MoyoDataset {
+  const default_data: MoyoDataset = {
+    number: 225,
+    hm_symbol: `Fm-3m`,
+    hall_number: 523,
+    pearson_symbol: `cF4`,
+    operations: [
+      {
+        rotation: new Int32Array([1, 0, 0, 0, 1, 0, 0, 0, 1]),
+        translation: new Float64Array([0.0, 0.0, 0.0]),
+      },
+      {
+        rotation: new Int32Array([-1, 0, 0, 0, -1, 0, 0, 0, 1]),
+        translation: new Float64Array([0.0, 0.0, 0.5]),
+      },
+      {
+        rotation: new Int32Array([1, 0, 0, 0, 1, 0, 0, 0, 1]),
+        translation: new Float64Array([0.5, 0.0, 0.0]),
+      },
+    ],
+    std_cell: {
+      lattice: {
+        basis: new Float64Array([5.0, 0.0, 0.0, 0.0, 5.0, 0.0, 0.0, 0.0, 5.0]),
+      },
+      positions: [[0.0, 0.0, 0.0]],
+      numbers: new Int32Array([1]),
+    },
+    wyckoffs: [`a`],
+  }
+  return { ...default_data, ...overrides }
+}
+
+describe(`SymmetryStats`, () => {
+  test.each([null, undefined])(
+    `displays no-data message when sym_data is %s`,
+    (sym_data) => {
+      mount(SymmetryStats, { target: document.body, props: { sym_data } })
+
+      const container = doc_query(`.symmetry-stats`)
+      const no_data_div = container.querySelector(`.no-data`)
+
+      expect(no_data_div).toBeTruthy()
+      expect(no_data_div?.textContent).toContain(`No symmetry data available`)
+
+      // Controls should still be visible so users can adjust settings
+      expect(container.querySelector(`.controls`)).toBeTruthy()
+      // Stats-grid should not be rendered without data
+      expect(container.querySelector(`.stats-grid`)).toBeFalsy()
+    },
+  )
+
+  test(`renders all symmetry information`, () => {
+    const sym_data = create_mock_sym_data({
+      number: 225,
+      hm_symbol: `Fm-3m`,
+      hall_number: 523,
+      pearson_symbol: `cF4`,
+    })
+    mount(SymmetryStats, { target: document.body, props: { sym_data } })
+
+    const container = doc_query(`.symmetry-stats`)
+    const text = container.textContent || ``
+
+    // Verify all key information is displayed
+    expect(text).toContain(`Space Group`)
+    expect(text).toContain(`225`)
+    expect(text).toContain(`Hermann-Mauguin`)
+    expect(text).toContain(`Fm-3m`)
+    expect(text).toContain(`Hall Number`)
+    expect(text).toContain(`523`)
+    expect(text).toContain(`Pearson`)
+    expect(text).toContain(`cF4`)
+    expect(text).toContain(`Wyckoff Positions`)
+    expect(text).toContain(`Total sym ops:`)
+  })
+
+  describe(`Controls section`, () => {
+    test(`renders symprec input with correct default value`, () => {
+      const sym_data = create_mock_sym_data()
+      mount(SymmetryStats, {
+        target: document.body,
+        props: { sym_data },
+      })
+
+      const symprec_input = doc_query<HTMLInputElement>(`.controls input[type="number"]`)
+      expect(symprec_input).toBeTruthy()
+      expect(symprec_input.value).toBe(`0.0001`) // 1e-4
+      // Step can be represented as "1e-5" or "0.00001", both are valid
+      expect(parseFloat(symprec_input.step)).toBe(1e-5)
+    })
+
+    test(`renders setting select with correct default value`, () => {
+      const sym_data = create_mock_sym_data()
+      mount(SymmetryStats, {
+        target: document.body,
+        props: { sym_data },
+      })
+
+      const setting_select = doc_query<HTMLSelectElement>(`.controls select`)
+      expect(setting_select).toBeTruthy()
+      expect(setting_select.value).toBe(`Standard`)
+
+      // Check both options are present
+      const options = Array.from(setting_select.options).map((opt) => opt.value)
+      expect(options).toEqual([`Standard`, `Spglib`])
+    })
+
+    test(`accepts custom symprec value`, () => {
+      const sym_data = create_mock_sym_data()
+      mount(SymmetryStats, {
+        target: document.body,
+        props: { sym_data, settings: { symprec: 1e-5, algo: `Standard` } },
+      })
+
+      const symprec_input = doc_query<HTMLInputElement>(`.controls input[type="number"]`)
+      expect(symprec_input.value).toBe(`0.00001`) // 1e-5
+    })
+
+    test(`accepts custom setting value`, () => {
+      const sym_data = create_mock_sym_data()
+      mount(SymmetryStats, {
+        target: document.body,
+        props: { sym_data, settings: { symprec: 1e-4, algo: `Spglib` } },
+      })
+
+      const setting_select = doc_query<HTMLSelectElement>(`.controls select`)
+      // Note: initial value might not update immediately, check after flush
+      flushSync()
+      expect(setting_select.value).toBe(`Spglib`)
+    })
+
+    test(`symprec input is bindable`, () => {
+      const sym_data = create_mock_sym_data()
+      mount(SymmetryStats, {
+        target: document.body,
+        props: { sym_data, settings: { symprec: 1e-4, algo: `Standard` } },
+      })
+
+      const symprec_input = doc_query<HTMLInputElement>(`.controls input[type="number"]`)
+      expect(symprec_input.value).toBe(`0.0001`)
+
+      // User changes the input value
+      symprec_input.value = `0.001`
+      symprec_input.dispatchEvent(new Event(`input`, { bubbles: true }))
+      flushSync()
+
+      expect(symprec_input.value).toBe(`0.001`)
+    })
+  })
+
+  describe(`Stats grid section`, () => {
+    test(`displays wyckoff count computed from sym_data`, () => {
+      // Test with 1 wyckoff position
+      const sym_data_one = create_mock_sym_data({ wyckoffs: [`a`] })
+      mount(SymmetryStats, {
+        target: document.body,
+        props: { sym_data: sym_data_one },
+      })
+
+      let stats_grid = doc_query(`.stats-grid`)
+      expect(stats_grid.textContent).toContain(`Wyckoff Positions`)
+      expect(stats_grid.textContent).toContain(`1`)
+
+      document.body.innerHTML = ``
+
+      // Test with multiple wyckoff positions with different letters/elements
+      const sym_data_multi = create_mock_sym_data({
+        wyckoffs: [`a`, `b`, `c`],
+        std_cell: {
+          lattice: {
+            basis: new Float64Array([5.0, 0.0, 0.0, 0.0, 5.0, 0.0, 0.0, 0.0, 5.0]),
+          },
+          positions: [[0.0, 0.0, 0.0], [0.5, 0.0, 0.0], [0.0, 0.5, 0.0]],
+          numbers: [1, 2, 3],
+        },
+      })
+      mount(SymmetryStats, {
+        target: document.body,
+        props: { sym_data: sym_data_multi },
+      })
+
+      stats_grid = doc_query(`.stats-grid`)
+      expect(stats_grid.textContent).toContain(`3`)
+
+      document.body.innerHTML = ``
+
+      // Test with empty wyckoffs array
+      const sym_data_empty = create_mock_sym_data({
+        wyckoffs: [],
+        std_cell: {
+          lattice: {
+            basis: new Float64Array([5.0, 0.0, 0.0, 0.0, 5.0, 0.0, 0.0, 0.0, 5.0]),
+          },
+          positions: [],
+          numbers: [],
+        },
+      })
+      mount(SymmetryStats, {
+        target: document.body,
+        props: { sym_data: sym_data_empty },
+      })
+
+      stats_grid = doc_query(`.stats-grid`)
+      expect(stats_grid.textContent).toContain(`0`)
+    })
+
+    test(`displays "N/A" when Hermann-Mauguin symbol is missing`, () => {
+      const sym_data = create_mock_sym_data({ hm_symbol: undefined })
+      mount(SymmetryStats, {
+        target: document.body,
+        props: { sym_data },
+      })
+
+      const stats_grid = doc_query(`.stats-grid`)
+      expect(stats_grid.textContent).toContain(`Hermann-Mauguin`)
+      expect(stats_grid.textContent).toContain(`N/A`)
+    })
+  })
+
+  describe(`Operations summary section`, () => {
+    test(`displays total number of operations`, () => {
+      const sym_data = create_mock_sym_data()
+      mount(SymmetryStats, {
+        target: document.body,
+        props: { sym_data },
+      })
+
+      const ops_summary = doc_query(`.sym-ops-summary`)
+      expect(ops_summary.textContent).toContain(`Total sym ops:`)
+      expect(ops_summary.textContent).toContain(`3`)
+    })
+
+    test(`calculates and displays operation breakdown correctly`, () => {
+      // Create operations: 1 identity (pure translation), 1 rotation, 1 roto-translation
+      const sym_data = create_mock_sym_data({
+        operations: [
+          {
+            // Identity + translation = pure translation
+            rotation: new Int32Array([1, 0, 0, 0, 1, 0, 0, 0, 1]),
+            translation: new Float64Array([0.5, 0.0, 0.0]),
+          },
+          {
+            // Non-identity rotation, no translation = pure rotation
+            rotation: new Int32Array([-1, 0, 0, 0, -1, 0, 0, 0, 1]),
+            translation: new Float64Array([0.0, 0.0, 0.0]),
+          },
+          {
+            // Non-identity rotation + translation = roto-translation
+            rotation: new Int32Array([-1, 0, 0, 0, -1, 0, 0, 0, 1]),
+            translation: new Float64Array([0.5, 0.0, 0.0]),
+          },
+        ],
+      })
+      mount(SymmetryStats, {
+        target: document.body,
+        props: { sym_data },
+      })
+
+      const ops_summary = doc_query(`.sym-ops-summary`)
+      const breakdown_text = ops_summary.textContent || ``
+
+      // Check breakdown format: (nT + nR + nRT)
+      expect(breakdown_text).toMatch(/1T/)
+      expect(breakdown_text).toMatch(/1R/)
+      expect(breakdown_text).toMatch(/1RT/)
+    })
+
+    test(`handles operations with no symmetry operations`, () => {
+      const sym_data = create_mock_sym_data({ operations: [] })
+      mount(SymmetryStats, {
+        target: document.body,
+        props: { sym_data },
+      })
+
+      const ops_summary = doc_query(`.sym-ops-summary`)
+      expect(ops_summary.textContent).toContain(`0`)
+      expect(ops_summary.textContent).toContain(`0T`)
+      expect(ops_summary.textContent).toContain(`0R`)
+      expect(ops_summary.textContent).toContain(`0RT`)
+    })
+  })
+
+  describe(`Tooltips`, () => {
+    test(`shows tooltips by default`, () => {
+      const sym_data = create_mock_sym_data()
+      mount(SymmetryStats, {
+        target: document.body,
+        props: { sym_data },
+      })
+
+      const symprec_label = doc_query(`.controls label:has(input[type="number"]) span`)
+      expect(symprec_label.title).toContain(`Symmetry precision`)
+
+      const setting_label = doc_query(`.controls label:has(select) span`)
+      expect(setting_label.title).toContain(`Standard`)
+
+      const space_group_div = Array.from(document.querySelectorAll(`.stats-grid > div`))
+        .find((el) => el.textContent?.includes(`Space Group`)) as HTMLElement
+      expect(space_group_div.title).toContain(`Space group number`)
+    })
+
+    test(`hides tooltips when show_tooltips=false`, () => {
+      const sym_data = create_mock_sym_data()
+      mount(SymmetryStats, {
+        target: document.body,
+        props: {
+          sym_data,
+          show_tooltips: false,
+          settings: { symprec: 1e-4, algo: `Standard` },
+        },
+      })
+
+      const symprec_label = doc_query(`.controls label:has(input[type="number"]) span`)
+      expect(symprec_label.title).toBe(``)
+
+      const setting_label = doc_query(`.controls label:has(select) span`)
+      expect(setting_label.title).toBe(``)
+
+      // Note: Space Group and sym-ops-summary use template strings, so they always show
+      const space_group_div = Array.from(document.querySelectorAll(`.stats-grid > div`))
+        .find((el) => el.textContent?.includes(`Space Group`)) as HTMLElement
+      expect(space_group_div.title).toContain(`at 0.0001 (using Standard algo)`)
+
+      const hermann_mauguin_div = Array.from(
+        document.querySelectorAll(`.stats-grid > div`),
+      )
+        .find((el) => el.textContent?.includes(`Hermann-Mauguin`)) as HTMLElement
+      expect(hermann_mauguin_div.title).toBe(``)
+    })
+  })
+
+  describe(`Custom HTML attributes`, () => {
+    test(`passes through custom HTML attributes`, () => {
+      const sym_data = create_mock_sym_data()
+      mount(SymmetryStats, {
+        target: document.body,
+        props: {
+          sym_data,
+          id: `custom-id`,
+          'data-testid': `test-stats`,
+        },
+      })
+
+      const container = doc_query(`.symmetry-stats`)
+      expect(container.id).toBe(`custom-id`)
+      expect(container.getAttribute(`data-testid`)).toBe(`test-stats`)
+    })
+
+    test(`passes through custom styles`, () => {
+      const sym_data = create_mock_sym_data()
+      mount(SymmetryStats, {
+        target: document.body,
+        props: {
+          sym_data,
+          style: `--accent-color: red; padding: 20px`,
+        },
+      })
+
+      const container = doc_query(`.symmetry-stats`)
+      expect(container.getAttribute(`style`)).toContain(`--accent-color: red`)
+      expect(container.getAttribute(`style`)).toContain(`padding: 20px`)
+    })
+
+    test(`merges custom class with default class`, () => {
+      const sym_data = create_mock_sym_data()
+      mount(SymmetryStats, {
+        target: document.body,
+        props: {
+          sym_data,
+          class: `custom-class`,
+        },
+      })
+
+      const container = doc_query(`.symmetry-stats`)
+      expect(container.classList.contains(`symmetry-stats`)).toBe(true)
+      expect(container.classList.contains(`custom-class`)).toBe(true)
+    })
+  })
+
+  describe(`Edge cases`, () => {
+    test.each([1e-10, 1e-2, 0.5, 1.0])(
+      `accepts extreme symprec values: %f`,
+      (symprec) => {
+        const sym_data = create_mock_sym_data()
+        mount(SymmetryStats, {
+          target: document.body,
+          props: { sym_data, settings: { symprec, algo: `Standard` } },
+        })
+
+        const symprec_input = doc_query<HTMLInputElement>(
+          `.controls input[type="number"]`,
+        )
+        expect(parseFloat(symprec_input.value)).toBeCloseTo(symprec, 10)
+      },
+    )
+
+    test(`correctly classifies symmetry operations by type`, () => {
+      const EPS = 1e-10
+      const sym_data = create_mock_sym_data({
+        operations: [
+          {
+            // Identity rotation + translation = pure translation
+            rotation: new Int32Array([1, 0, 0, 0, 1, 0, 0, 0, 1]),
+            translation: new Float64Array([0.5, 0.0, 0.0]),
+          },
+          {
+            // Non-identity rotation + no translation = pure rotation
+            rotation: new Int32Array([-1, 0, 0, 0, -1, 0, 0, 0, 1]),
+            translation: new Float64Array([0.0, 0.0, 0.0]),
+          },
+          {
+            // Non-identity rotation + translation = roto-translation
+            rotation: new Int32Array([0, -1, 0, 1, 0, 0, 0, 0, 1]),
+            translation: new Float64Array([0.25, 0.25, 0.0]),
+          },
+          {
+            // Identity + very small translation (below EPS) = pure rotation
+            rotation: new Int32Array([1, 0, 0, 0, 1, 0, 0, 0, 1]),
+            translation: new Float64Array([EPS / 2, 0.0, 0.0]),
+          },
+        ],
+      })
+      mount(SymmetryStats, {
+        target: document.body,
+        props: { sym_data },
+      })
+
+      const ops_summary = doc_query(`.sym-ops-summary`)
+      const breakdown_text = ops_summary.textContent || ``
+
+      // Verify correct breakdown: 1T + 2R + 1RT
+      expect(breakdown_text).toMatch(/1T\s/)
+      expect(breakdown_text).toMatch(/2R\s/)
+      expect(breakdown_text).toMatch(/1RT/)
+      expect(breakdown_text).toContain(`4`) // Total operations
+    })
+  })
+
+  describe(`Null and undefined handling`, () => {
+    test.each([null, undefined])(
+      `no-data state has proper styling when sym_data is %s`,
+      (sym_data) => {
+        mount(SymmetryStats, {
+          target: document.body,
+          props: { sym_data },
+        })
+
+        const no_data_div = doc_query(`.no-data`)
+        expect(no_data_div).toBeTruthy()
+
+        // Check that the no-data div is a child of symmetry-stats
+        expect(document.querySelector(`.symmetry-stats .no-data`)).toBeTruthy()
+
+        // Verify the message paragraph exists
+        const message = no_data_div.querySelector(`p`)
+        expect(message).toBeTruthy()
+        expect(message?.textContent).toBe(`No symmetry data available`)
+      },
+    )
+
+    test.each([null, undefined])(
+      `can be styled with custom attributes when sym_data is %s`,
+      (sym_data) => {
+        mount(SymmetryStats, {
+          target: document.body,
+          props: {
+            sym_data,
+            class: `custom-class`,
+            id: `test-id`,
+          },
+        })
+
+        const container = doc_query(`.symmetry-stats`)
+        expect(container.id).toBe(`test-id`)
+        expect(container.classList.contains(`custom-class`)).toBe(true)
+
+        // Verify no-data message is still displayed
+        const no_data_div = container.querySelector(`.no-data`)
+        expect(no_data_div).toBeTruthy()
+      },
+    )
+
+    test.each([null, undefined])(
+      `transitions properly from valid data to %s`,
+      (sym_data) => {
+        const valid_sym_data = create_mock_sym_data()
+        const component = mount(SymmetryStats, {
+          target: document.body,
+          props: { sym_data: valid_sym_data },
+        })
+
+        // Initially should show stats
+        expect(document.querySelector(`.stats-grid`)).toBeTruthy()
+        expect(document.querySelector(`.no-data`)).toBeFalsy()
+
+        // Update to null/undefined
+        unmount(component)
+        document.body.innerHTML = ``
+        mount(SymmetryStats, {
+          target: document.body,
+          props: { sym_data },
+        })
+
+        // Now should show no-data message
+        expect(document.querySelector(`.stats-grid`)).toBeFalsy()
+        expect(document.querySelector(`.no-data`)).toBeTruthy()
+      },
+    )
+  })
+})

--- a/tests/vitest/symmetry/spacegroups.test.ts
+++ b/tests/vitest/symmetry/spacegroups.test.ts
@@ -1,25 +1,16 @@
-import {
-  CRYSTAL_SYSTEM_COLORS,
-  CRYSTAL_SYSTEM_RANGES,
-  CRYSTAL_SYSTEMS,
-  type CrystalSystem,
-  normalize_spacegroup,
-  SPACEGROUP_NUM_TO_SYMBOL,
-  spacegroup_number_to_crystal_system,
-  SPACEGROUP_SYMBOL_TO_NUM,
-  spacegroup_to_crystal_system,
-} from '$lib/symmetry/spacegroups'
+import type { CrystalSystem } from '$lib/symmetry/spacegroups'
+import * as spg from '$lib/symmetry/spacegroups'
 import { describe, expect, test } from 'vitest'
 
 describe(`CRYSTAL_SYSTEM_RANGES`, () => {
   test(`should have 7 contiguous systems from 1-230`, () => {
-    expect(Object.keys(CRYSTAL_SYSTEM_RANGES)).toHaveLength(7)
-    expect(CRYSTAL_SYSTEM_RANGES.triclinic[0]).toBe(1)
-    expect(CRYSTAL_SYSTEM_RANGES.cubic[1]).toBe(230)
+    expect(Object.keys(spg.CRYSTAL_SYSTEM_RANGES)).toHaveLength(7)
+    expect(spg.CRYSTAL_SYSTEM_RANGES.triclinic[0]).toBe(1)
+    expect(spg.CRYSTAL_SYSTEM_RANGES.cubic[1]).toBe(230)
 
-    for (let idx = 0; idx < CRYSTAL_SYSTEMS.length - 1; idx++) {
-      const [, current_max] = CRYSTAL_SYSTEM_RANGES[CRYSTAL_SYSTEMS[idx]]
-      const [next_min] = CRYSTAL_SYSTEM_RANGES[CRYSTAL_SYSTEMS[idx + 1]]
+    for (let idx = 0; idx < spg.CRYSTAL_SYSTEMS.length - 1; idx++) {
+      const [, current_max] = spg.CRYSTAL_SYSTEM_RANGES[spg.CRYSTAL_SYSTEMS[idx]]
+      const [next_min] = spg.CRYSTAL_SYSTEM_RANGES[spg.CRYSTAL_SYSTEMS[idx + 1]]
       expect(next_min).toBe(current_max + 1)
     }
   })
@@ -35,14 +26,14 @@ describe(`CRYSTAL_SYSTEM_RANGES`, () => {
       [`cubic`, 195, 230],
     ] as const,
   )(`should have correct range for %s: [%i, %i]`, (system, min, max) => {
-    expect(CRYSTAL_SYSTEM_RANGES[system]).toEqual([min, max])
+    expect(spg.CRYSTAL_SYSTEM_RANGES[system]).toEqual([min, max])
   })
 })
 
 describe(`CRYSTAL_SYSTEM_COLORS`, () => {
   test(`should match pymatviz colors`, () => {
-    expect(Object.keys(CRYSTAL_SYSTEM_COLORS)).toHaveLength(7)
-    expect(CRYSTAL_SYSTEM_COLORS).toEqual({
+    expect(Object.keys(spg.CRYSTAL_SYSTEM_COLORS)).toHaveLength(7)
+    expect(spg.CRYSTAL_SYSTEM_COLORS).toEqual({
       triclinic: `red`,
       monoclinic: `teal`,
       orthorhombic: `blue`,
@@ -56,7 +47,7 @@ describe(`CRYSTAL_SYSTEM_COLORS`, () => {
 
 describe(`CRYSTAL_SYSTEMS`, () => {
   test(`should have 7 systems in correct order`, () => {
-    expect(CRYSTAL_SYSTEMS).toEqual([
+    expect(spg.CRYSTAL_SYSTEMS).toEqual([
       `triclinic`,
       `monoclinic`,
       `orthorhombic`,
@@ -68,7 +59,7 @@ describe(`CRYSTAL_SYSTEMS`, () => {
   })
 })
 
-describe(`spacegroup_number_to_crystal_system`, () => {
+describe(`spacegroup_num_to_crystal_sys`, () => {
   test.each(
     [
       [1, `triclinic`],
@@ -87,18 +78,18 @@ describe(`spacegroup_number_to_crystal_system`, () => {
       [230, `cubic`],
     ] as const,
   )(`should return %s for space group %i`, (spacegroup, expected_system) => {
-    expect(spacegroup_number_to_crystal_system(spacegroup)).toBe(expected_system)
+    expect(spg.spacegroup_num_to_crystal_sys(spacegroup)).toBe(expected_system)
   })
 
   test.each([0, -1, 231, 1000, -100])(
     `should return null for invalid number %i`,
     (invalid_number) => {
-      expect(spacegroup_number_to_crystal_system(invalid_number)).toBeNull()
+      expect(spg.spacegroup_num_to_crystal_sys(invalid_number)).toBeNull()
     },
   )
 })
 
-describe(`spacegroup_to_crystal_system`, () => {
+describe(`spacegroup_to_crystal_sys`, () => {
   test.each(
     [
       [1, `triclinic`],
@@ -125,13 +116,13 @@ describe(`spacegroup_to_crystal_system`, () => {
       [`I4_1/a-32/d`, `cubic`],
     ] as const,
   )(`should return %s for %s`, (input, expected) => {
-    expect(spacegroup_to_crystal_system(input)).toBe(expected)
+    expect(spg.spacegroup_to_crystal_sys(input)).toBe(expected)
   })
 
   test.each([`invalid`, `P999`, ``, `unknown`, `0`, `231`, `-1`])(
     `should return null for invalid input '%s'`,
     (invalid_input) => {
-      expect(spacegroup_to_crystal_system(invalid_input)).toBeNull()
+      expect(spg.spacegroup_to_crystal_sys(invalid_input)).toBeNull()
     },
   )
 })
@@ -155,13 +146,13 @@ describe(`normalize_spacegroup`, () => {
     [`P999`, null],
     [``, null],
   ])(`should return %s for %s`, (input, expected) => {
-    expect(normalize_spacegroup(input)).toBe(expected)
+    expect(spg.normalize_spacegroup(input)).toBe(expected)
   })
 })
 
 describe(`SPACEGROUP_SYMBOL_TO_NUM`, () => {
   test(`should cover all 230 space groups`, () => {
-    const unique_numbers = new Set(Object.values(SPACEGROUP_SYMBOL_TO_NUM))
+    const unique_numbers = new Set(Object.values(spg.SPACEGROUP_SYMBOL_TO_NUM))
     expect(unique_numbers.size).toBe(230)
     for (let num = 1; num <= 230; num++) {
       expect([...unique_numbers]).toContain(num)
@@ -182,17 +173,17 @@ describe(`SPACEGROUP_SYMBOL_TO_NUM`, () => {
     [`P6_3/mmc`, 194],
     [`I4/mmm`, 139],
   ])(`should map '%s' to %i`, (symbol, number) => {
-    expect(SPACEGROUP_SYMBOL_TO_NUM[symbol]).toBe(number)
+    expect(spg.SPACEGROUP_SYMBOL_TO_NUM[symbol]).toBe(number)
   })
 })
 
 describe(`SPACEGROUP_NUM_TO_SYMBOL`, () => {
   test(`should bidirectionally map all 230 space groups`, () => {
-    expect(Object.keys(SPACEGROUP_NUM_TO_SYMBOL)).toHaveLength(230)
+    expect(Object.keys(spg.SPACEGROUP_NUM_TO_SYMBOL)).toHaveLength(230)
     for (let num = 1; num <= 230; num++) {
-      const symbol = SPACEGROUP_NUM_TO_SYMBOL[num]
+      const symbol = spg.SPACEGROUP_NUM_TO_SYMBOL[num]
       expect(typeof symbol).toBe(`string`)
-      expect(SPACEGROUP_SYMBOL_TO_NUM[symbol]).toBe(num)
+      expect(spg.SPACEGROUP_SYMBOL_TO_NUM[symbol]).toBe(num)
     }
   })
 
@@ -204,7 +195,7 @@ describe(`SPACEGROUP_NUM_TO_SYMBOL`, () => {
     [225, `Fm-3m`],
     [230, `Ia-3d`],
   ])(`should map %i to %s`, (number, expected) => {
-    const symbol = SPACEGROUP_NUM_TO_SYMBOL[number]
+    const symbol = spg.SPACEGROUP_NUM_TO_SYMBOL[number]
     if (Array.isArray(expected)) {
       expect(expected).toContain(symbol)
     } else {
@@ -216,31 +207,31 @@ describe(`SPACEGROUP_NUM_TO_SYMBOL`, () => {
 describe(`Integration tests`, () => {
   test(`should process all 230 space groups through full pipeline`, () => {
     for (let num = 1; num <= 230; num++) {
-      const crystal_system = spacegroup_number_to_crystal_system(num)
-      const symbol = SPACEGROUP_NUM_TO_SYMBOL[num]
+      const crystal_system = spg.spacegroup_num_to_crystal_sys(num)
+      const symbol = spg.SPACEGROUP_NUM_TO_SYMBOL[num]
 
-      expect(CRYSTAL_SYSTEMS).toContain(crystal_system as CrystalSystem)
-      expect(SPACEGROUP_SYMBOL_TO_NUM[symbol]).toBe(num)
-      expect(spacegroup_to_crystal_system(symbol)).toBe(crystal_system)
-      expect(normalize_spacegroup(num)).toBe(num)
-      expect(normalize_spacegroup(symbol)).toBe(num)
+      expect(spg.CRYSTAL_SYSTEMS).toContain(crystal_system as CrystalSystem)
+      expect(spg.SPACEGROUP_SYMBOL_TO_NUM[symbol]).toBe(num)
+      expect(spg.spacegroup_to_crystal_sys(symbol)).toBe(crystal_system)
+      expect(spg.normalize_spacegroup(num)).toBe(num)
+      expect(spg.normalize_spacegroup(symbol)).toBe(num)
     }
   })
 
   test(`should respect crystal system boundaries`, () => {
-    for (const system of CRYSTAL_SYSTEMS) {
-      const [min, max] = CRYSTAL_SYSTEM_RANGES[system]
+    for (const system of spg.CRYSTAL_SYSTEMS) {
+      const [min, max] = spg.CRYSTAL_SYSTEM_RANGES[system]
       const mid = Math.floor((min + max) / 2)
 
-      expect(spacegroup_number_to_crystal_system(min)).toBe(system)
-      expect(spacegroup_number_to_crystal_system(mid)).toBe(system)
-      expect(spacegroup_number_to_crystal_system(max)).toBe(system)
+      expect(spg.spacegroup_num_to_crystal_sys(min)).toBe(system)
+      expect(spg.spacegroup_num_to_crystal_sys(mid)).toBe(system)
+      expect(spg.spacegroup_num_to_crystal_sys(max)).toBe(system)
 
       if (min > 1) {
-        expect(spacegroup_number_to_crystal_system(min - 1)).not.toBe(system)
+        expect(spg.spacegroup_num_to_crystal_sys(min - 1)).not.toBe(system)
       }
       if (max < 230) {
-        expect(spacegroup_number_to_crystal_system(max + 1)).not.toBe(system)
+        expect(spg.spacegroup_num_to_crystal_sys(max + 1)).not.toBe(system)
       }
     }
   })
@@ -250,11 +241,11 @@ describe(`Integration tests`, () => {
     [225, `225`, `Fm-3m`],
     [1, `1`, `P1`],
   ])(`should handle multiple input formats for %i`, (num, num_str, symbol) => {
-    const expected_system = spacegroup_number_to_crystal_system(num)
-    expect(spacegroup_to_crystal_system(num)).toBe(expected_system)
-    expect(spacegroup_to_crystal_system(num_str)).toBe(expected_system)
-    expect(spacegroup_to_crystal_system(symbol)).toBe(expected_system)
-    expect(normalize_spacegroup(num)).toBe(num)
-    expect(normalize_spacegroup(symbol)).toBe(num)
+    const expected_system = spg.spacegroup_num_to_crystal_sys(num)
+    expect(spg.spacegroup_to_crystal_sys(num)).toBe(expected_system)
+    expect(spg.spacegroup_to_crystal_sys(num_str)).toBe(expected_system)
+    expect(spg.spacegroup_to_crystal_sys(symbol)).toBe(expected_system)
+    expect(spg.normalize_spacegroup(num)).toBe(num)
+    expect(spg.normalize_spacegroup(symbol)).toBe(num)
   })
 })


### PR DESCRIPTION
- Add `SymmetryStats` for interactive symmetry inspection and controls.
- Expose the symmetry module and defaults publicly, and let `Structure` accept configurable symmetry settings.
- Rename plot-tooltip types to a handler-style API.