### PR TITLE
`bindable` `selected_entry` in `PhaseDiagrams` + polymorph stats in `PhaseEntryTooltip`

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -8,7 +8,7 @@
     "vitest": "deno run -A --node-modules-dir npm:vitest",
     "e2e": "npx playwright test",
     "test:install": "npx playwright install chromium",
-    "package": "svelte-package && rm src/site/state.svelte.d.ts",
+    "package": "svelte-package",
     "prepublishOnly": "deno task package",
     "changelog": "deno run -A https://github.com/janosh/workflows/raw/refs/heads/main/scripts/make-release-notes.ts"
   },

--- a/package.json
+++ b/package.json
@@ -115,6 +115,10 @@
       "types": "./dist/element/index.d.ts",
       "default": "./dist/element/index.js"
     },
+    "./feedback": {
+      "types": "./dist/feedback/index.d.ts",
+      "default": "./dist/feedback/index.js"
+    },
     "./io": {
       "types": "./dist/io.d.ts",
       "default": "./dist/io.js"
@@ -126,6 +130,10 @@
     "./math": {
       "types": "./dist/math.d.ts",
       "default": "./dist/math.js"
+    },
+    "./overlays": {
+      "types": "./dist/overlays/index.d.ts",
+      "default": "./dist/overlays/index.js"
     },
     "./periodic-table": {
       "types": "./dist/periodic-table.d.ts",

--- a/src/lib/feedback/ClickFeedback.svelte
+++ b/src/lib/feedback/ClickFeedback.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
-  import { Icon } from '$lib'
+  import { Icon, type IconName } from '$lib'
 
+  // Generic feedback component that shows a transient icon at a specific position.
+  // Commonly used for copy-to-clipboard feedback, but can display icons for
+  // various user interactions.
   let {
     visible = $bindable(false),
     position = { x: 0, y: 0 },
@@ -8,7 +11,7 @@
   }: {
     visible?: boolean
     position: { x: number; y: number }
-    icon?: string
+    icon?: IconName
   } = $props()
 </script>
 

--- a/src/lib/feedback/ClickFeedback.svelte
+++ b/src/lib/feedback/ClickFeedback.svelte
@@ -1,21 +1,26 @@
 <script lang="ts">
   import { Icon } from '$lib'
 
-  let { visible = $bindable(false), position = { x: 0, y: 0 } }: {
+  let {
+    visible = $bindable(false),
+    position = { x: 0, y: 0 },
+    icon = `Check`,
+  }: {
     visible?: boolean
     position: { x: number; y: number }
+    icon?: string
   } = $props()
 </script>
 
 {#if visible}
   {@const { x, y } = position}
-  <div class="copy-feedback" style:left="{x}px" style:top="{y}px">
-    <Icon icon="Check" />
+  <div class="click-feedback" style:left="{x}px" style:top="{y}px">
+    <Icon {icon} />
   </div>
 {/if}
 
 <style>
-  .copy-feedback {
+  .click-feedback {
     position: fixed;
     width: 24px;
     height: 24px;
@@ -24,9 +29,11 @@
     border-radius: 50%;
     display: flex;
     place-content: center;
-    animation: copy-success 1.5s ease-out forwards;
+    animation: click-success 1.5s ease-out forwards;
+    pointer-events: none;
+    z-index: 10000;
   }
-  @keyframes copy-success {
+  @keyframes click-success {
     0% {
       transform: translate(-50%, -50%) scale(0);
       opacity: 0;

--- a/src/lib/feedback/index.ts
+++ b/src/lib/feedback/index.ts
@@ -1,4 +1,4 @@
-export { default as CopyFeedback } from './CopyFeedback.svelte'
+export { default as ClickFeedback } from './ClickFeedback.svelte'
 export { default as DragOverlay } from './DragOverlay.svelte'
 export { default as Spinner } from './Spinner.svelte'
 export { default as StatusMessage } from './StatusMessage.svelte'

--- a/src/lib/phase-diagram/PhaseDiagram.svelte
+++ b/src/lib/phase-diagram/PhaseDiagram.svelte
@@ -19,9 +19,9 @@
 
   let {
     entries,
-    // Only list props that need special handling in this wrapper:
-    // 1. Bindable props (required to use $bindable())
-    // 2. Props with meaningful defaults (optional)
+    // Note: Explicit bind: directives are required here because Svelte 5 doesn't support
+    // spreading bindable props. Each bindable prop must be individually declared with
+    // $bindable() and explicitly bound when passing to child components.
     fullscreen = $bindable(false),
     wrapper = $bindable(),
     show_stable = $bindable(true),

--- a/src/lib/phase-diagram/PhaseDiagram.svelte
+++ b/src/lib/phase-diagram/PhaseDiagram.svelte
@@ -9,13 +9,13 @@
 
   // Union type combining all possible props from 2D, 3D, and 4D components
   // Note: This is a superset - each specific component will only use its relevant props
-  type PhaseDiagramProps = BasePhaseDiagramProps & Hull3DProps & { // 2D-specific props
+  type PhaseDiagramProps = BasePhaseDiagramProps & Hull3DProps & {
     x_axis?: AxisConfig
     y_axis?: AxisConfig
   }
 
-  // Component type that accepts our unified props
-  type UnifiedComponent = Component<PhaseDiagramProps>
+  // Type for dynamic component selection (helps TypeScript understand the union)
+  type PDComponent = Component<PhaseDiagramProps>
 
   let {
     entries,
@@ -64,14 +64,15 @@
   const element_count = $derived(elements.length)
 
   // Map element count to corresponding component
-  // Cast to UnifiedComponent to bypass TypeScript's union type complexity
-  const Component = $derived<UnifiedComponent | null>(
+  // Note: Type assertion needed because TypeScript can't infer that all components
+  // accept a compatible superset of props (BasePhaseDiagramProps + dimension-specific)
+  const Component = $derived<PDComponent | null>(
     element_count === 2
-      ? (PhaseDiagram2D as UnifiedComponent)
+      ? (PhaseDiagram2D as PDComponent)
       : element_count === 3
-      ? (PhaseDiagram3D as UnifiedComponent)
+      ? (PhaseDiagram3D as PDComponent)
       : element_count === 4
-      ? (PhaseDiagram4D as UnifiedComponent)
+      ? (PhaseDiagram4D as PDComponent)
       : null,
   )
 </script>

--- a/src/lib/phase-diagram/PhaseDiagram.svelte
+++ b/src/lib/phase-diagram/PhaseDiagram.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+  import type { AxisConfig } from '$lib/plot'
+  import type { Component } from 'svelte'
+  import { SvelteSet } from 'svelte/reactivity'
+  import type { BasePhaseDiagramProps, Hull3DProps } from './index'
+  import PhaseDiagram2D from './PhaseDiagram2D.svelte'
+  import PhaseDiagram3D from './PhaseDiagram3D.svelte'
+  import PhaseDiagram4D from './PhaseDiagram4D.svelte'
+
+  // Union type combining all possible props from 2D, 3D, and 4D components
+  // Note: This is a superset - each specific component will only use its relevant props
+  type PhaseDiagramProps = BasePhaseDiagramProps & Hull3DProps & { // 2D-specific props
+    x_axis?: AxisConfig
+    y_axis?: AxisConfig
+  }
+
+  // Component type that accepts our unified props
+  type UnifiedComponent = Component<PhaseDiagramProps>
+
+  let {
+    entries,
+    // Only list props that need special handling in this wrapper:
+    // 1. Bindable props (required to use $bindable())
+    // 2. Props with meaningful defaults (optional)
+    fullscreen = $bindable(false),
+    wrapper = $bindable(),
+    show_stable = $bindable(true),
+    show_unstable = $bindable(true),
+    show_hull_faces = $bindable(true),
+    hull_face_opacity = $bindable(0.3),
+    color_mode = $bindable(`energy`),
+    color_scale = $bindable(`interpolateViridis`),
+    info_pane_open = $bindable(false),
+    legend_pane_open = $bindable(false),
+    max_hull_dist_show_phases = $bindable(0.1),
+    max_hull_dist_show_labels = $bindable(0.1),
+    show_stable_labels = $bindable(true),
+    show_unstable_labels = $bindable(false),
+    energy_source_mode = $bindable(`precomputed`),
+    phase_stats = $bindable(null),
+    display = $bindable({ x_grid: false, y_grid: false }),
+    stable_entries = $bindable([]),
+    unstable_entries = $bindable([]),
+    highlighted_entries = $bindable([]),
+    selected_entry = $bindable(null),
+    ...rest // All other PD props (both common and dimension-specific) go to rest
+  }: PhaseDiagramProps = $props()
+
+  // Lightweight element extraction - just count unique elements without processing entries
+  function extract_unique_elements(
+    entries: { composition: Record<string, number> }[],
+  ): string[] {
+    const elements = new SvelteSet<string>()
+    for (const entry of entries) {
+      for (const elem of Object.keys(entry.composition)) {
+        elements.add(elem)
+      }
+    }
+    return Array.from(elements).sort()
+  }
+
+  // Detect dimensionality by counting unique elements (lightweight operation)
+  const elements = $derived(extract_unique_elements(entries))
+  const element_count = $derived(elements.length)
+
+  // Map element count to corresponding component
+  // Cast to UnifiedComponent to bypass TypeScript's union type complexity
+  const Component = $derived<UnifiedComponent | null>(
+    element_count === 2
+      ? (PhaseDiagram2D as UnifiedComponent)
+      : element_count === 3
+      ? (PhaseDiagram3D as UnifiedComponent)
+      : element_count === 4
+      ? (PhaseDiagram4D as UnifiedComponent)
+      : null,
+  )
+</script>
+
+{#if Component}
+  <Component
+    {entries}
+    {...rest}
+    bind:fullscreen
+    bind:wrapper
+    bind:show_stable
+    bind:show_unstable
+    bind:show_hull_faces
+    bind:hull_face_opacity
+    bind:color_mode
+    bind:color_scale
+    bind:info_pane_open
+    bind:legend_pane_open
+    bind:max_hull_dist_show_phases
+    bind:max_hull_dist_show_labels
+    bind:show_stable_labels
+    bind:show_unstable_labels
+    bind:energy_source_mode
+    bind:phase_stats
+    bind:display
+    bind:stable_entries
+    bind:unstable_entries
+    bind:highlighted_entries
+    bind:selected_entry
+  />
+{:else}
+  <!-- Error state for unsupported dimensionalities -->
+  <div
+    class="phase-diagram-error"
+    style="display: flex; align-items: center; justify-content: center; height: var(--pd-height, 500px); border: 1px solid var(--text-color, #ccc); border-radius: 4px; background: var(--pd-bg, transparent)"
+  >
+    <div style="text-align: center; padding: 2em; color: var(--text-color, #666)">
+      <h3 style="margin: 0 0 1em 0">Unsupported Chemical System</h3>
+      <p style="margin: 0">
+        Phase diagrams require 2, 3, or 4 elements. Found {element_count} element{
+          element_count ===
+            1
+          ? ``
+          : `s`
+        }:
+      </p>
+      <p style="margin: 0.5em 0 0 0; font-weight: bold">
+        {elements.join(`, `)}
+      </p>
+    </div>
+  </div>
+{/if}

--- a/src/lib/phase-diagram/PhaseDiagram2D.svelte
+++ b/src/lib/phase-diagram/PhaseDiagram2D.svelte
@@ -58,6 +58,7 @@
     x_axis = {},
     y_axis = {},
     selected_entry = $bindable(null),
+    children,
     ...rest
   }: BasePhaseDiagramProps<PhaseDiagramEntry> & {
     x_axis?: AxisConfig
@@ -495,7 +496,6 @@
   <line y1={pad.t} y2={height - pad.b} {x1} x2={x1} {...stroke} />
   <line x1={pad.l} x2={width - pad.r} y1={y0} y2={y0} {...stroke} />
 {/snippet}
-
 {#key reset_counter}
   <ScatterPlot
     {...rest}
@@ -558,6 +558,12 @@
     }}
     padding={{ t: 30, b: 60, l: 60, r: 30 }}
   >
+    {@render children?.({
+      stable_entries,
+      unstable_entries,
+      highlighted_entries,
+      selected_entry,
+    })}
     <h3 style="position: absolute; left: 1em; top: 1ex; margin: 0">
       {phase_stats?.chemical_system}
     </h3>

--- a/src/lib/phase-diagram/PhaseDiagram2D.svelte
+++ b/src/lib/phase-diagram/PhaseDiagram2D.svelte
@@ -100,7 +100,9 @@
   // Process data and element set
   const pd_data = $derived(thermo.process_pd_entries(effective_entries))
 
-  const polymorph_stats_map = $derived(helpers.compute_all_polymorph_stats(entries)) // Pre-compute polymorph stats once for O(1) tooltip lookups
+  const polymorph_stats_map = $derived(
+    helpers.compute_all_polymorph_stats(effective_entries),
+  ) // Pre-compute polymorph stats once for O(1) tooltip lookups
 
   const elements = $derived.by(() => {
     if (pd_data.elements.length > 2) {

--- a/src/lib/phase-diagram/PhaseDiagram2D.svelte
+++ b/src/lib/phase-diagram/PhaseDiagram2D.svelte
@@ -100,6 +100,8 @@
   // Process data and element set
   const pd_data = $derived(thermo.process_pd_entries(effective_entries))
 
+  const polymorph_stats_map = $derived(helpers.compute_all_polymorph_stats(entries)) // Pre-compute polymorph stats once for O(1) tooltip lookups
+
   const elements = $derived.by(() => {
     if (pd_data.elements.length > 2) {
       console.error(
@@ -474,7 +476,7 @@
 {#snippet tooltip(point: ScatterHandlerProps)}
   {@const entry = point.metadata as unknown as PhaseData}
   {#if entry}
-    <PhaseEntryTooltip {entry} all_entries={entries} />
+    <PhaseEntryTooltip {entry} {polymorph_stats_map} />
   {/if}
 {/snippet}
 

--- a/src/lib/phase-diagram/PhaseDiagram3D.svelte
+++ b/src/lib/phase-diagram/PhaseDiagram3D.svelte
@@ -266,7 +266,7 @@
   $effect(() => {
     // deno-fmt-ignore
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-    [show_stable, show_unstable, show_hull_faces, color_mode, color_scale, max_hull_dist_show_phases, show_stable_labels, show_unstable_labels, max_hull_dist_show_labels, camera.elevation, camera.azimuth, camera.zoom, camera.center_x, camera.center_y, plot_entries, hull_face_color, hull_face_opacity, highlighted_entries.length, resolved_text_color]
+    [show_hull_faces, color_mode, color_scale, show_stable_labels, show_unstable_labels, max_hull_dist_show_labels, camera.elevation, camera.azimuth, camera.zoom, camera.center_x, camera.center_y, plot_entries, hull_face_color, hull_face_opacity, highlighted_entries, resolved_text_color]
 
     render_once()
   })
@@ -690,14 +690,14 @@
 
       // Draw pulsating highlight for selected entry
       if (selected_entry && entry.entry_id === selected_entry.entry_id) {
-        const highlight_size = size * (2.8 + 0.6 * Math.sin(pulse_time * 4))
-        ctx.fillStyle = `rgba(33, 150, 243, ${pulse_opacity * 0.7})`
-        ctx.strokeStyle = `rgba(33, 150, 243, ${pulse_opacity})`
-        ctx.lineWidth = 3 * container_scale
-        ctx.beginPath()
-        ctx.arc(projected.x, projected.y, highlight_size, 0, 2 * Math.PI)
-        ctx.fill()
-        ctx.stroke()
+        helpers.draw_selection_highlight(
+          ctx,
+          projected,
+          size,
+          container_scale,
+          pulse_time,
+          pulse_opacity,
+        )
       }
 
       // Draw highlight for highlighted entries

--- a/src/lib/phase-diagram/PhaseDiagram3D.svelte
+++ b/src/lib/phase-diagram/PhaseDiagram3D.svelte
@@ -58,6 +58,7 @@
     highlighted_entries = $bindable([]),
     highlight_style = {},
     selected_entry = $bindable(null),
+    children,
     ...rest
   }: BasePhaseDiagramProps<PhaseDiagramEntry> & Hull3DProps & {
     highlight_style?: HighlightStyle
@@ -925,17 +926,9 @@
   })
 
   // Resolve text color for canvas rendering (canvas context can't resolve CSS variables)
-  const resolved_text_color = $derived.by(() => {
-    if (!wrapper) return `#212121`
-    const styles = getComputedStyle(wrapper)
-    // First try to get the configured annotation color
-    const annotation_color = merged_config.colors?.annotation
-    if (annotation_color && !annotation_color.startsWith(`var(`)) {
-      return annotation_color
-    }
-    // Otherwise resolve from CSS variable
-    return styles.getPropertyValue(`--text-color`)?.trim() || `#212121`
-  })
+  const resolved_text_color = $derived(
+    helpers.resolve_canvas_text_color(wrapper, merged_config.colors?.annotation),
+  )
 
   // Performance: Cache canvas dimensions and formation energy range
   let canvas_dims = $state({ width: 600, height: 600, scale: 1 })
@@ -1014,6 +1007,12 @@
   }}
   aria-label="Ternary phase diagram visualization"
 >
+  {@render children?.({
+      stable_entries,
+      unstable_entries,
+      highlighted_entries,
+      selected_entry,
+    })}
   <h3 style="position: absolute; left: 1em; top: 1ex; margin: 0">
     {phase_stats?.chemical_system}
   </h3>

--- a/src/lib/phase-diagram/PhaseDiagram3D.svelte
+++ b/src/lib/phase-diagram/PhaseDiagram3D.svelte
@@ -49,6 +49,9 @@
     info_pane_open = $bindable(false),
     legend_pane_open = $bindable(false),
     max_hull_dist_show_phases = $bindable(0.5), // eV/atom above hull for showing entries
+    max_hull_dist_show_labels = $bindable(0.1), // eV/atom above hull for showing labels
+    show_stable_labels = $bindable(true),
+    show_unstable_labels = $bindable(false),
     on_file_drop,
     enable_structure_preview = true,
     energy_source_mode = $bindable(`precomputed`),
@@ -273,11 +276,6 @@
 
     render_once()
   })
-
-  // Label controls with smart defaults based on entry count
-  let show_stable_labels = $state(true)
-  let show_unstable_labels = $state(false)
-  let max_hull_dist_show_labels = $state(0.1) // eV/atom above hull for showing labels
 
   // Function to extract structure data from a phase diagram entry
   function extract_structure_from_entry(

--- a/src/lib/phase-diagram/PhaseDiagram3D.svelte
+++ b/src/lib/phase-diagram/PhaseDiagram3D.svelte
@@ -99,6 +99,8 @@
   const processed_entries = $derived(effective_entries)
   const pd_data = $derived(thermo.process_pd_entries(processed_entries))
 
+  const polymorph_stats_map = $derived(helpers.compute_all_polymorph_stats(entries)) // Pre-compute polymorph stats once for O(1) tooltip lookups
+
   const elements = $derived.by(() => {
     if (pd_data.elements.length > 3) {
       console.error(
@@ -1185,7 +1187,7 @@
       style:background={get_point_color(entry)}
       {@attach contrast_color({ luminance_threshold: 0.49 })}
     >
-      <PhaseEntryTooltip {entry} all_entries={entries} />
+      <PhaseEntryTooltip {entry} {polymorph_stats_map} />
     </div>
   {/if}
 

--- a/src/lib/phase-diagram/PhaseDiagram3D.svelte
+++ b/src/lib/phase-diagram/PhaseDiagram3D.svelte
@@ -60,13 +60,7 @@
     selected_entry = $bindable(null),
     ...rest
   }: BasePhaseDiagramProps<PhaseDiagramEntry> & Hull3DProps & {
-    // Bindable stable and unstable entries - computed internally but exposed for external use
-    stable_entries?: PhaseDiagramEntry[]
-    unstable_entries?: PhaseDiagramEntry[]
-    // Highlighted entries with customizable visual effects
-    highlighted_entries?: (string | PhaseDiagramEntry)[] // Array of entry IDs or full entries
     highlight_style?: HighlightStyle
-    selected_entry?: PhaseDiagramEntry | null
   } = $props()
 
   const merged_controls = $derived({ ...default_controls, ...controls })

--- a/src/lib/phase-diagram/PhaseDiagram3D.svelte
+++ b/src/lib/phase-diagram/PhaseDiagram3D.svelte
@@ -99,7 +99,9 @@
   const processed_entries = $derived(effective_entries)
   const pd_data = $derived(thermo.process_pd_entries(processed_entries))
 
-  const polymorph_stats_map = $derived(helpers.compute_all_polymorph_stats(entries)) // Pre-compute polymorph stats once for O(1) tooltip lookups
+  const polymorph_stats_map = $derived(
+    helpers.compute_all_polymorph_stats(processed_entries),
+  ) // Pre-compute polymorph stats once for O(1) tooltip lookups
 
   const elements = $derived.by(() => {
     if (pd_data.elements.length > 3) {

--- a/src/lib/phase-diagram/PhaseDiagram4D.svelte
+++ b/src/lib/phase-diagram/PhaseDiagram4D.svelte
@@ -52,14 +52,7 @@
     selected_entry = $bindable(null),
     ...rest
   }: BasePhaseDiagramProps<PhaseDiagramEntry> & Hull3DProps & {
-    on_point_hover?: (data: HoverData3D | null) => void
-    // Bindable stable and unstable entries - computed internally but exposed for external use
-    stable_entries?: PhaseDiagramEntry[]
-    unstable_entries?: PhaseDiagramEntry[]
-    // Highlighted entries with customizable visual effects
-    highlighted_entries?: (string | PhaseDiagramEntry)[] // Array of entry IDs or full entries
     highlight_style?: HighlightStyle
-    selected_entry?: PhaseDiagramEntry | null
   } = $props()
 
   const merged_controls = $derived({ ...default_controls, ...controls })

--- a/src/lib/phase-diagram/PhaseDiagram4D.svelte
+++ b/src/lib/phase-diagram/PhaseDiagram4D.svelte
@@ -92,7 +92,9 @@
 
   const pd_data = $derived(thermo.process_pd_entries(processed_entries))
 
-  const polymorph_stats_map = $derived(helpers.compute_all_polymorph_stats(entries)) // Pre-compute polymorph stats once for O(1) tooltip lookups
+  const polymorph_stats_map = $derived(
+    helpers.compute_all_polymorph_stats(processed_entries),
+  ) // Pre-compute polymorph stats once for O(1) tooltip lookups
 
   const elements = $derived.by(() => {
     if (pd_data.elements.length > 4) {
@@ -718,13 +720,6 @@
 
       // Draw pulsating highlight for selected entry (before main point)
       if (selected_entry && entry.entry_id === selected_entry.entry_id) {
-        const highlight_options = {
-          color: `rgba(102, 240, 255, 1)`, // Light cyan
-          size_multiplier: 1.8,
-          pulse_amplitude: 0.3,
-          fill_opacity: 0.6,
-          line_width: 2,
-        }
         helpers.draw_selection_highlight(
           ctx,
           projected,
@@ -732,7 +727,6 @@
           container_scale,
           pulse_time,
           pulse_opacity,
-          highlight_options,
         )
       }
 

--- a/src/lib/phase-diagram/PhaseDiagram4D.svelte
+++ b/src/lib/phase-diagram/PhaseDiagram4D.svelte
@@ -92,6 +92,8 @@
 
   const pd_data = $derived(thermo.process_pd_entries(processed_entries))
 
+  const polymorph_stats_map = $derived(helpers.compute_all_polymorph_stats(entries)) // Pre-compute polymorph stats once for O(1) tooltip lookups
+
   const elements = $derived.by(() => {
     if (pd_data.elements.length > 4) {
       console.error(
@@ -1128,7 +1130,7 @@
       style:background={get_point_color(entry)}
       {@attach contrast_color({ luminance_threshold: 0.49 })}
     >
-      <PhaseEntryTooltip {entry} all_entries={entries} />
+      <PhaseEntryTooltip {entry} {polymorph_stats_map} />
     </div>
   {/if}
 

--- a/src/lib/phase-diagram/PhaseDiagram4D.svelte
+++ b/src/lib/phase-diagram/PhaseDiagram4D.svelte
@@ -41,6 +41,9 @@
     info_pane_open = $bindable(false),
     legend_pane_open = $bindable(false),
     max_hull_dist_show_phases = $bindable(0.1), // eV/atom above hull for showing entries
+    max_hull_dist_show_labels = $bindable(0.1), // eV/atom above hull for showing labels
+    show_stable_labels = $bindable(true),
+    show_unstable_labels = $bindable(false),
     on_file_drop,
     enable_structure_preview = true,
     energy_source_mode = $bindable(`precomputed`),
@@ -305,11 +308,6 @@
   })
 
   // Visibility toggles are now bindable props
-
-  // Label controls with smart defaults based on entry count
-  let show_stable_labels = $state(true)
-  let show_unstable_labels = $state(false)
-  let max_hull_dist_show_labels = $state(0.1) // eV/atom above hull for showing labels
 
   // Smart label defaults - hide labels if too many entries
   $effect(() => {

--- a/src/lib/phase-diagram/PhaseDiagram4D.svelte
+++ b/src/lib/phase-diagram/PhaseDiagram4D.svelte
@@ -50,6 +50,7 @@
     highlighted_entries = $bindable([]),
     highlight_style = {},
     selected_entry = $bindable(null),
+    children,
     ...rest
   }: BasePhaseDiagramProps<PhaseDiagramEntry> & Hull3DProps & {
     highlight_style?: HighlightStyle
@@ -64,17 +65,9 @@
   })
 
   // Resolve text color for canvas rendering (canvas context can't resolve CSS variables)
-  const resolved_text_color = $derived.by(() => {
-    if (!wrapper) return `#212121`
-    const styles = getComputedStyle(wrapper)
-    // First try to get the configured annotation color
-    const annotation_color = merged_config.colors?.annotation
-    if (annotation_color && !annotation_color.startsWith(`var(`)) {
-      return annotation_color
-    }
-    // Otherwise resolve from CSS variable
-    return styles.getPropertyValue(`--text-color`)?.trim() || `#212121`
-  })
+  const resolved_text_color = $derived(
+    helpers.resolve_canvas_text_color(wrapper, merged_config.colors?.annotation),
+  )
 
   let { // Compute energy mode information
     has_precomputed_e_form,
@@ -118,7 +111,6 @@
       )
       return []
     }
-
     return pd_data.elements
   })
 
@@ -983,7 +975,7 @@
     fullscreen = Boolean(document.fullscreenElement)
   }}
   onmousemove={handle_mouse_move}
-  onmouseup={() => is_dragging = false}
+  onmouseup={() => [is_dragging, drag_started] = [false, false]}
 />
 
 <div
@@ -1006,6 +998,12 @@
   }}
   aria-label="Phase diagram visualization"
 >
+  {@render children?.({
+      stable_entries,
+      unstable_entries,
+      highlighted_entries,
+      selected_entry,
+    })}
   <h3 style="position: absolute; left: 1em; top: 1ex; margin: 0">
     {phase_stats?.chemical_system}
   </h3>

--- a/src/lib/phase-diagram/PhaseDiagram4D.svelte
+++ b/src/lib/phase-diagram/PhaseDiagram4D.svelte
@@ -292,7 +292,7 @@
   $effect(() => {
     // deno-fmt-ignore
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-    [show_stable, show_unstable, show_hull_faces, color_mode, color_scale, max_hull_dist_show_phases, camera.rotation_x, camera.rotation_y, camera.zoom, camera.center_x, camera.center_y, plot_entries, hull_face_color, hull_face_opacity]
+    [show_hull_faces, color_mode, color_scale, camera.rotation_x, camera.rotation_y, camera.zoom, camera.center_x, camera.center_y, plot_entries, hull_face_color, hull_face_opacity]
 
     render_once()
   })
@@ -718,15 +718,22 @@
 
       // Draw pulsating highlight for selected entry (before main point)
       if (selected_entry && entry.entry_id === selected_entry.entry_id) {
-        const highlight_size = size * (1.8 + 0.3 * Math.sin(pulse_time * 4))
-        ctx.fillStyle = `rgba(102, 240, 255, ${pulse_opacity * 0.6})` // Light cyan with pulsing opacity
-        ctx.strokeStyle = `rgba(102, 240, 255, ${pulse_opacity})`
-        ctx.lineWidth = 2 * container_scale
-
-        ctx.beginPath()
-        ctx.arc(projected.x, projected.y, highlight_size, 0, 2 * Math.PI)
-        ctx.fill()
-        ctx.stroke()
+        const highlight_options = {
+          color: `rgba(102, 240, 255, 1)`, // Light cyan
+          size_multiplier: 1.8,
+          pulse_amplitude: 0.3,
+          fill_opacity: 0.6,
+          line_width: 2,
+        }
+        helpers.draw_selection_highlight(
+          ctx,
+          projected,
+          size,
+          container_scale,
+          pulse_time,
+          pulse_opacity,
+          highlight_options,
+        )
       }
 
       // Draw highlight for highlighted entries

--- a/src/lib/phase-diagram/PhaseDiagramControls.svelte
+++ b/src/lib/phase-diagram/PhaseDiagramControls.svelte
@@ -5,7 +5,7 @@
   import type { ComponentProps } from 'svelte'
   import { tooltip } from 'svelte-multiselect'
   import type { HTMLAttributes } from 'svelte/elements'
-  import type { PDControlsType, PlotEntry3D } from './types'
+  import type { PDControlsType, PhaseDiagramEntry } from './types'
 
   interface CameraState {
     elevation?: number // Elevation angle in degrees (for ternary)
@@ -70,8 +70,8 @@
     max_hull_dist_show_labels?: number
     max_hull_dist_in_data?: number
     // Data for visualization
-    stable_entries: PlotEntry3D[]
-    unstable_entries: PlotEntry3D[]
+    stable_entries: PhaseDiagramEntry[]
+    unstable_entries: PhaseDiagramEntry[]
     // Camera state (optional - only used for 3D/4D diagrams)
     camera?: CameraState
     // Legend configuration

--- a/src/lib/phase-diagram/PhaseDiagramInfoPane.svelte
+++ b/src/lib/phase-diagram/PhaseDiagramInfoPane.svelte
@@ -3,7 +3,7 @@
   import type { ComponentProps } from 'svelte'
   import type { HTMLAttributes } from 'svelte/elements'
   import PhaseDiagramStats from './PhaseDiagramStats.svelte'
-  import type { PhaseStats, PlotEntry3D } from './types'
+  import type { PhaseDiagramEntry, PhaseStats } from './types'
 
   let {
     phase_stats,
@@ -18,8 +18,8 @@
     ...rest
   }: Omit<HTMLAttributes<HTMLDivElement>, `onclose`> & {
     phase_stats: PhaseStats | null
-    stable_entries: PlotEntry3D[]
-    unstable_entries: PlotEntry3D[]
+    stable_entries: PhaseDiagramEntry[]
+    unstable_entries: PhaseDiagramEntry[]
     max_hull_dist_show_phases: number
     max_hull_dist_show_labels: number
     label_threshold: number

--- a/src/lib/phase-diagram/PhaseDiagramStats.svelte
+++ b/src/lib/phase-diagram/PhaseDiagramStats.svelte
@@ -2,14 +2,14 @@
   import { format_num, Histogram, Icon, type InfoItem } from '$lib'
   import type { HTMLAttributes } from 'svelte/elements'
   import { SvelteSet } from 'svelte/reactivity'
-  import type { PhaseStats, PlotEntry3D } from './types'
+  import type { PhaseDiagramEntry, PhaseStats } from './types'
 
   let { phase_stats, stable_entries, unstable_entries, ...rest }:
     & HTMLAttributes<HTMLDivElement>
     & {
       phase_stats: PhaseStats | null
-      stable_entries: PlotEntry3D[]
-      unstable_entries: PlotEntry3D[]
+      stable_entries: PhaseDiagramEntry[]
+      unstable_entries: PhaseDiagramEntry[]
     } = $props()
 
   let copied_items = new SvelteSet<string>()

--- a/src/lib/phase-diagram/PhaseEntryTooltip.svelte
+++ b/src/lib/phase-diagram/PhaseEntryTooltip.svelte
@@ -3,11 +3,13 @@
   import { is_unary_entry } from '$lib'
   import { elem_symbol_to_name, get_electro_neg_formula } from '$lib/composition'
   import { format_fractional, format_num } from '$lib/labels'
-  import { calculate_polymorph_stats } from './helpers'
+  import type { PolymorphStats } from './helpers'
   import type { PhaseData } from './types'
 
-  let { entry, all_entries }: { entry: PhaseData; all_entries?: PhaseData[] } =
-    $props()
+  let { entry, polymorph_stats_map }: {
+    entry: PhaseData
+    polymorph_stats_map?: Map<string, PolymorphStats>
+  } = $props()
 
   const is_element = $derived(is_unary_entry(entry))
   const elem_symbol = $derived(
@@ -16,8 +18,11 @@
   const elem_name = $derived(
     is_element && elem_symbol ? elem_symbol_to_name[elem_symbol] ?? `` : ``,
   )
+  // O(1) lookup of pre-computed polymorph stats
   const polymorph_stats = $derived(
-    all_entries ? calculate_polymorph_stats(entry, all_entries) : null,
+    entry.entry_id && polymorph_stats_map
+      ? polymorph_stats_map.get(entry.entry_id)
+      : null,
   )
 </script>
 

--- a/src/lib/phase-diagram/PhaseEntryTooltip.svelte
+++ b/src/lib/phase-diagram/PhaseEntryTooltip.svelte
@@ -28,11 +28,13 @@
 
 <div class="tooltip-title">
   {#if entry.entry_id}
-    <strong>ID: {entry.entry_id}</strong>
+    <strong style="display: block">ID: {entry.entry_id}</strong>
   {/if}
-  {@html get_electro_neg_formula(entry.composition)}{
-    is_element && elem_name ? ` (${elem_name})` : ``
-  }
+  <strong style="display: block">
+    {@html get_electro_neg_formula(entry.composition)}{
+      is_element && elem_name ? ` (${elem_name})` : ``
+    }
+  </strong>
 </div>
 
 <div>E<sub>above hull</sub>: {format_num(entry.e_above_hull ?? 0, `.3~`)} eV/atom</div>
@@ -55,11 +57,19 @@
   >
     Polymorphs:
     {polymorph_stats.total}
-    <span title="{polymorph_stats.higher} higher in energy">↑{
-        polymorph_stats.higher
-      }</span>
-    <span title="{polymorph_stats.lower} lower in energy">↓{polymorph_stats.lower}</span>
-    <span title="{polymorph_stats.equal} equal in energy">={polymorph_stats.equal}</span>
+    {#if polymorph_stats.total > 0}
+      <span title="{polymorph_stats.higher} higher in energy">↑{
+          polymorph_stats.higher
+        }</span>
+      <span title="{polymorph_stats.lower} lower in energy">↓{
+          polymorph_stats.lower
+        }</span>
+      {#if polymorph_stats.equal > 0}
+        <span title="{polymorph_stats.equal} equal in energy">
+          ={polymorph_stats.equal}
+        </span>
+      {/if}
+    {/if}
   </div>
 {/if}
 

--- a/src/lib/phase-diagram/barycentric-coords.ts
+++ b/src/lib/phase-diagram/barycentric-coords.ts
@@ -1,7 +1,7 @@
 import type { ElementSymbol } from '$lib'
 import type { Vec3 } from '$lib/math'
 import { compute_e_form_per_atom, find_lowest_energy_unary_refs } from './thermodynamics'
-import type { PhaseEntry, PlotEntry3D, Point3D, TernaryPlotEntry } from './types'
+import type { PhaseData, PhaseDiagramEntry, Point3D } from './types'
 import { is_unary_entry } from './types'
 
 // ================= Ternary coordinates =================
@@ -75,10 +75,10 @@ export function calculate_face_centroid(p1: Point3D, p2: Point3D, p3: Point3D): 
 }
 
 export function get_ternary_3d_coordinates(
-  entries: PhaseEntry[],
+  entries: PhaseData[],
   elements: ElementSymbol[],
-  el_refs?: Record<string, PhaseEntry>, // Optional: pass precomputed refs to avoid recomputing
-): TernaryPlotEntry[] {
+  el_refs?: Record<string, PhaseData>, // Optional: pass precomputed refs to avoid recomputing
+): PhaseDiagramEntry[] {
   if (elements.length !== 3) {
     throw new Error(
       `Ternary phase diagram requires exactly 3 elements, got ${elements.length}`,
@@ -125,13 +125,13 @@ export function get_ternary_3d_coordinates(
   // Map entries to ternary plot coordinates
   const result = within_system.map((entry) => {
     const barycentric = composition_to_barycentric_3d(entry.composition, elements)
-    const e_form = typeof entry.e_form_per_atom === `number` &&
+    const e_form_per_atom = typeof entry.e_form_per_atom === `number` &&
         Number.isFinite(entry.e_form_per_atom)
       ? entry.e_form_per_atom
       : compute_e_form_per_atom(entry, refs) ?? NaN
-    const xyz = barycentric_to_ternary_xyz(barycentric, e_form)
+    const xyz = barycentric_to_ternary_xyz(barycentric, e_form_per_atom)
     const is_element = is_unary_entry(entry)
-    return { ...entry, ...xyz, barycentric, e_form, is_element, visible: true }
+    return { ...entry, ...xyz, is_element, visible: true }
   })
   return result
 }
@@ -191,9 +191,9 @@ export function barycentric_to_tetrahedral(barycentric: number[]): Point3D {
 }
 
 export function compute_4d_coords(
-  entries: PhaseEntry[],
+  entries: PhaseData[],
   elements: ElementSymbol[],
-): PlotEntry3D[] {
+): PhaseDiagramEntry[] {
   if (elements.length !== 4) {
     throw new Error(`Quaternary phase diagram requires exactly ${4} elements`)
   }

--- a/src/lib/phase-diagram/helpers.ts
+++ b/src/lib/phase-diagram/helpers.ts
@@ -429,7 +429,7 @@ function apply_alpha_to_color(color: string, alpha: number): string {
     return color.replace(/rgb\(/, `rgba(`).replace(/\)$/, `, ${alpha})`)
   }
 
-  const hex_match = color.match(/^#?([0-9a-fA-F]{3,6})$/) // Convert hex to rgba
+  const hex_match = color.match(/^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/) // Convert hex to rgba
   if (hex_match) {
     let hex = hex_match[1]
     // Expand short form (e.g., "03F") to full form (e.g., "0033FF")

--- a/src/lib/phase-diagram/helpers.ts
+++ b/src/lib/phase-diagram/helpers.ts
@@ -44,6 +44,21 @@ export function get_point_color_for_entry(
     : `#666`
 }
 
+// Resolve text color for canvas rendering (canvas context can't resolve CSS variables).
+export function resolve_canvas_text_color(
+  wrapper: HTMLDivElement | undefined, // The wrapper element to read computed styles from
+  annotation_color: string | undefined, // The configured annotation color (may contain CSS var)
+): string { // Resolved text color as a hex string
+  if (!wrapper) return `#212121`
+  const styles = getComputedStyle(wrapper)
+  // First try to get the configured annotation color
+  if (annotation_color && !annotation_color.startsWith(`var(`)) {
+    return annotation_color
+  }
+  // Otherwise resolve from CSS variable
+  return styles.getPropertyValue(`--text-color`)?.trim() || `#212121`
+}
+
 // Robust drag-and-drop JSON parsing for phase diagram entries
 export async function parse_pd_entries_from_drop(
   event: DragEvent,

--- a/src/lib/phase-diagram/index.ts
+++ b/src/lib/phase-diagram/index.ts
@@ -128,8 +128,5 @@ export const PD_STYLE = Object.freeze({
     dash: [3, 3] as [number, number],
     line_width: 2,
   }),
-  z_index: Object.freeze({
-    tooltip: 6000,
-    copy_feedback: 10000,
-  }),
+  z_index: Object.freeze({ tooltip: 6, copy_feedback: 10 }),
 })

--- a/src/lib/phase-diagram/index.ts
+++ b/src/lib/phase-diagram/index.ts
@@ -1,6 +1,7 @@
 import type { D3InterpolateName } from '$lib/colors'
 import type { HTMLAttributes } from 'svelte/elements'
 import type {
+  HighlightStyle,
   HoverData3D,
   PDControlsType,
   PhaseData,
@@ -19,13 +20,13 @@ export * from './thermodynamics'
 export * from './types'
 
 // Base props shared across all phase diagram components (2D, 3D, 4D)
-export interface BasePhaseDiagramProps<TEntry = PhaseData>
+export interface BasePhaseDiagramProps<AnyDimEntry = PhaseData>
   extends Omit<HTMLAttributes<HTMLDivElement>, `entries`> {
   entries: PhaseData[]
   controls?: Partial<PDControlsType>
   config?: Partial<PhaseDiagramConfig>
-  on_point_click?: (entry: TEntry) => void
-  on_point_hover?: (data: HoverData3D<TEntry> | null) => void
+  on_point_click?: (entry: AnyDimEntry) => void
+  on_point_hover?: (data: HoverData3D<AnyDimEntry> | null) => void
   fullscreen?: boolean
   enable_fullscreen?: boolean
   enable_info_pane?: boolean
@@ -54,6 +55,13 @@ export interface BasePhaseDiagramProps<TEntry = PhaseData>
   phase_stats?: PhaseStats | null
   // Display configuration for grid lines and other visual elements
   display?: { x_grid?: boolean; y_grid?: boolean }
+  // Bindable stable and unstable entries - computed internally but exposed for external use
+  stable_entries?: AnyDimEntry[]
+  unstable_entries?: AnyDimEntry[]
+  // Highlighted entries with customizable visual effects
+  highlighted_entries?: (string | AnyDimEntry)[]
+  highlight_style?: HighlightStyle
+  selected_entry?: AnyDimEntry | null
 }
 
 // Additional props specific to 3D and 4D phase diagrams

--- a/src/lib/phase-diagram/index.ts
+++ b/src/lib/phase-diagram/index.ts
@@ -10,6 +10,7 @@ import type {
 } from './types'
 
 export * from './barycentric-coords'
+export { default as PhaseDiagram } from './PhaseDiagram.svelte'
 export { default as PhaseDiagram2D } from './PhaseDiagram2D.svelte'
 export { default as PhaseDiagram3D } from './PhaseDiagram3D.svelte'
 export { default as PhaseDiagram4D } from './PhaseDiagram4D.svelte'

--- a/src/lib/phase-diagram/index.ts
+++ b/src/lib/phase-diagram/index.ts
@@ -1,4 +1,5 @@
 import type { D3InterpolateName } from '$lib/colors'
+import type { Snippet } from 'svelte'
 import type { HTMLAttributes } from 'svelte/elements'
 import type {
   HighlightStyle,
@@ -20,9 +21,16 @@ export { default as PhaseDiagramStats } from './PhaseDiagramStats.svelte'
 export * from './thermodynamics'
 export * from './types'
 
+export interface BasePhaseDiagramChildrenProps<AnyDimEntry = PhaseData> {
+  stable_entries: AnyDimEntry[]
+  unstable_entries: AnyDimEntry[]
+  highlighted_entries: (string | AnyDimEntry)[]
+  selected_entry: AnyDimEntry | null
+}
+
 // Base props shared across all phase diagram components (2D, 3D, 4D)
 export interface BasePhaseDiagramProps<AnyDimEntry = PhaseData>
-  extends Omit<HTMLAttributes<HTMLDivElement>, `entries`> {
+  extends Omit<HTMLAttributes<HTMLDivElement>, `entries` | `children`> {
   entries: PhaseData[]
   controls?: Partial<PDControlsType>
   config?: Partial<PhaseDiagramConfig>
@@ -63,6 +71,7 @@ export interface BasePhaseDiagramProps<AnyDimEntry = PhaseData>
   highlighted_entries?: (string | AnyDimEntry)[]
   highlight_style?: HighlightStyle
   selected_entry?: AnyDimEntry | null
+  children?: Snippet<[BasePhaseDiagramChildrenProps<AnyDimEntry>]>
 }
 
 // Additional props specific to 3D and 4D phase diagrams

--- a/src/lib/phase-diagram/index.ts
+++ b/src/lib/phase-diagram/index.ts
@@ -3,8 +3,8 @@ import type { HTMLAttributes } from 'svelte/elements'
 import type {
   HoverData3D,
   PDControlsType,
+  PhaseData,
   PhaseDiagramConfig,
-  PhaseEntry,
   PhaseStats,
 } from './types'
 
@@ -19,9 +19,9 @@ export * from './thermodynamics'
 export * from './types'
 
 // Base props shared across all phase diagram components (2D, 3D, 4D)
-export interface BasePhaseDiagramProps<TEntry = PhaseEntry>
+export interface BasePhaseDiagramProps<TEntry = PhaseData>
   extends Omit<HTMLAttributes<HTMLDivElement>, `entries`> {
-  entries: PhaseEntry[]
+  entries: PhaseData[]
   controls?: Partial<PDControlsType>
   config?: Partial<PhaseDiagramConfig>
   on_point_click?: (entry: TEntry) => void
@@ -46,7 +46,7 @@ export interface BasePhaseDiagramProps<TEntry = PhaseEntry>
   show_stable_labels?: boolean
   show_unstable_labels?: boolean
   // Callback for when JSON files are dropped
-  on_file_drop?: (entries: PhaseEntry[]) => void
+  on_file_drop?: (entries: PhaseData[]) => void
   // Enable structure preview overlay when hovering over entries with structure data
   enable_structure_preview?: boolean
   energy_source_mode?: `precomputed` | `on-the-fly`
@@ -75,7 +75,7 @@ export interface EnergyModeInfo {
   can_compute_e_form: boolean
   can_compute_hull: boolean
   energy_mode: `precomputed` | `on-the-fly`
-  unary_refs: Record<string, PhaseEntry>
+  unary_refs: Record<string, PhaseData>
 }
 
 // Default legend configuration shared by 3D and 4D diagrams

--- a/src/lib/phase-diagram/thermodynamics.ts
+++ b/src/lib/phase-diagram/thermodynamics.ts
@@ -4,8 +4,8 @@ import * as math from '$lib/math'
 import type {
   ConvexHullFace,
   ConvexHullTriangle,
+  PhaseData,
   PhaseDiagramData,
-  PhaseEntry,
   Plane,
   Point3D,
 } from './types'
@@ -13,7 +13,7 @@ import { is_unary_entry } from './types'
 
 // ================= Thermodynamics & metadata =================
 
-export function process_pd_entries(entries: PhaseEntry[]): PhaseDiagramData {
+export function process_pd_entries(entries: PhaseData[]): PhaseDiagramData {
   const eps = 1e-6
   const stable_entries = entries.filter((entry) => {
     if (typeof entry.is_stable === `boolean`) return entry.is_stable
@@ -39,7 +39,7 @@ export function process_pd_entries(entries: PhaseEntry[]): PhaseDiagramData {
   return { entries, stable_entries, unstable_entries, elements, el_refs }
 }
 
-function get_corrected_energy_per_atom(entry: PhaseEntry): number | null {
+function get_corrected_energy_per_atom(entry: PhaseData): number | null {
   const atoms = Object.values(entry.composition).reduce((sum, amt) => sum + amt, 0)
   if (atoms <= 0) return null
   const base_total_energy = typeof entry.energy_per_atom === `number`
@@ -50,8 +50,8 @@ function get_corrected_energy_per_atom(entry: PhaseEntry): number | null {
 }
 
 export function compute_e_form_per_atom(
-  entry: PhaseEntry,
-  el_refs: Record<string, PhaseEntry>,
+  entry: PhaseData,
+  el_refs: Record<string, PhaseData>,
 ): number | null {
   const atoms = Object.values(entry.composition).reduce((sum, amt) => sum + amt, 0)
   if (atoms <= 0) return null
@@ -74,9 +74,9 @@ export function compute_e_form_per_atom(
 }
 
 export function find_lowest_energy_unary_refs(
-  entries: PhaseEntry[],
-): Record<string, PhaseEntry> {
-  const refs: Record<string, PhaseEntry> = {}
+  entries: PhaseData[],
+): Record<string, PhaseData> {
+  const refs: Record<string, PhaseData> = {}
   for (const entry of entries) {
     if (!is_unary_entry(entry)) continue
     const el = Object.keys(entry.composition).find(
@@ -107,7 +107,7 @@ export function find_lowest_energy_unary_refs(
 }
 
 export function get_phase_diagram_stats(
-  processed_entries: PhaseEntry[],
+  processed_entries: PhaseData[],
   elements: ElementSymbol[],
   max_arity: 3 | 4,
 ): {

--- a/src/lib/phase-diagram/types.ts
+++ b/src/lib/phase-diagram/types.ts
@@ -2,7 +2,7 @@ import type { CompositionType, ElementSymbol, Sides } from '$lib'
 import type { Vec3 } from '$lib/math'
 
 // Unified phase diagram entry interface supporting both pymatgen and Materials Project formats
-export interface PhaseEntry {
+export interface PhaseData {
   // Core required fields
   composition: CompositionType
   energy: number
@@ -20,26 +20,28 @@ export interface PhaseEntry {
   '@module'?: string
   '@class'?: string
   correction?: number
-  energy_adjustments?: unknown[]
+  energy_adjustments?: Record<string, number>[]
   parameters?: Record<string, unknown>
   data?: Record<string, unknown>
   structure?: Record<string, unknown>
 
   // Materials Project-specific fields (optional)
   attributes?: Record<string, unknown>
+
+  [key: string]: unknown // Allow additional properties for flexibility
 }
 
 // Legacy type aliases for backward compatibility
-export type PDEntry = PhaseEntry
-export type PymatgenEntry = PhaseEntry
+export type PDEntry = PhaseData
+export type PymatgenEntry = PhaseData
 
 // Processed phase diagram data
 export interface PhaseDiagramData {
-  entries: PhaseEntry[]
-  stable_entries: PhaseEntry[]
-  unstable_entries: PhaseEntry[]
+  entries: PhaseData[]
+  stable_entries: PhaseData[]
+  unstable_entries: PhaseData[]
   elements: ElementSymbol[]
-  el_refs: Record<string, PhaseEntry>
+  el_refs: Record<string, PhaseData>
 }
 
 // 3D point for tetrahedral coordinates
@@ -50,7 +52,7 @@ export interface Point3D {
 }
 
 // Plot entry with 3D coordinates for quaternary diagrams
-export interface PlotEntry3D extends PhaseEntry, Point3D {
+export interface PhaseDiagramEntry extends PhaseData, Point3D {
   is_element: boolean
   size?: number
   visible: boolean
@@ -112,14 +114,8 @@ export interface ConvexHullTriangle {
   centroid: Point3D
 }
 
-// Ternary plot entry with additional face information
-export interface TernaryPlotEntry extends PlotEntry3D {
-  barycentric: [number, number, number] // Barycentric coordinates for ternary system
-  e_form: number // for z-axis positioning
-}
-
 // Hover data for tooltips
-export interface HoverData3D<T = PlotEntry3D> {
+export interface HoverData3D<T = PhaseDiagramEntry> {
   entry: T
   position: { x: number; y: number }
 }
@@ -140,20 +136,20 @@ export interface PhaseStats {
 }
 
 // Arity helpers (inlined from former arity.ts)
-export function get_arity(entry: PhaseEntry) {
+export function get_arity(entry: PhaseData) {
   return Object.values(entry.composition).filter((v) => v > 0).length
 }
 
-export const is_unary_entry = (entry: PhaseEntry) => get_arity(entry) === 1
-export const is_binary_entry = (entry: PhaseEntry) => get_arity(entry) === 2
-export const is_ternary_entry = (entry: PhaseEntry) => get_arity(entry) === 3
-export const is_quaternary_entry = (entry: PhaseEntry) => get_arity(entry) === 4
-export const is_quinary_entry = (entry: PhaseEntry) => get_arity(entry) === 5
-export const is_senary_entry = (entry: PhaseEntry) => get_arity(entry) === 6
-export const is_septenary_entry = (entry: PhaseEntry) => get_arity(entry) === 7
-export const is_octonary_entry = (entry: PhaseEntry) => get_arity(entry) === 8
-export const is_nonary_entry = (entry: PhaseEntry) => get_arity(entry) === 9
-export const is_denary_entry = (entry: PhaseEntry) => get_arity(entry) === 10
+export const is_unary_entry = (entry: PhaseData) => get_arity(entry) === 1
+export const is_binary_entry = (entry: PhaseData) => get_arity(entry) === 2
+export const is_ternary_entry = (entry: PhaseData) => get_arity(entry) === 3
+export const is_quaternary_entry = (entry: PhaseData) => get_arity(entry) === 4
+export const is_quinary_entry = (entry: PhaseData) => get_arity(entry) === 5
+export const is_senary_entry = (entry: PhaseData) => get_arity(entry) === 6
+export const is_septenary_entry = (entry: PhaseData) => get_arity(entry) === 7
+export const is_octonary_entry = (entry: PhaseData) => get_arity(entry) === 8
+export const is_nonary_entry = (entry: PhaseData) => get_arity(entry) === 9
+export const is_denary_entry = (entry: PhaseData) => get_arity(entry) === 10
 
 // Highlight styles for phase diagram entries
 export interface HighlightStyle {

--- a/src/lib/phase-diagram/types.ts
+++ b/src/lib/phase-diagram/types.ts
@@ -27,8 +27,6 @@ export interface PhaseData {
 
   // Materials Project-specific fields (optional)
   attributes?: Record<string, unknown>
-
-  [key: string]: unknown // Allow additional properties for flexibility
 }
 
 // Legacy type aliases for backward compatibility

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -1132,7 +1132,13 @@
             range_padding={0}
             style="height: 100%"
             {...scatter_props}
-            legend={{ ...scatter_props.legend ?? {}, on_toggle: handle_legend_toggle }}
+            legend={{
+              ...scatter_props.legend ?? {},
+              on_toggle: (series_idx) => {
+                handle_legend_toggle(series_idx)
+                scatter_props.legend?.on_toggle?.(series_idx)
+              },
+            }}
             class="plot {scatter_props.class ?? ``}"
           >
             {#snippet tooltip({ x, y, metadata })}
@@ -1147,6 +1153,7 @@
           </ScatterPlot>
         {:else if display_mode === `histogram` || display_mode === `structure+histogram`}
           <Histogram
+            {...histogram_props}
             series={plot_series}
             x_axis={{
               label: String(histogram_props.x_axis?.label ?? y_axis_labels.y1),
@@ -1156,9 +1163,11 @@
             mode={histogram_props.mode ?? `overlay`}
             show_legend={histogram_props.show_legend ?? plot_series.length > 1}
             legend={histogram_props.legend}
-            on_series_toggle={handle_legend_toggle}
+            on_series_toggle={(series_idx) => {
+              handle_legend_toggle(series_idx)
+              histogram_props.on_series_toggle?.(series_idx)
+            }}
             style="height: 100%"
-            {...histogram_props}
             class="plot {histogram_props.class ?? ``}"
             --ctrl-btn-top="6ex"
           >

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -337,16 +337,13 @@
   $effect(() => {
     if (!plot_series.length) return
 
-    // Extract property keys from visible series
+    // Extract property keys from visible series metadata
     const visible_keys = plot_series
       .filter((srs) => srs.visible)
+      // Get property key from series metadata (stored during series generation)
       .map((srs) => {
-        // Find original property key by matching label in config
-        for (const [key, config] of Object.entries(extended_config)) {
-          if (config.label === srs.label) return key
-        }
-        // Fallback: clean up label to use as key
-        return srs.label?.toLowerCase().replace(/<[^>]*>/g, ``) || ``
+        const metadata = Array.isArray(srs.metadata) ? srs.metadata[0] : srs.metadata
+        return metadata?.property_key
       })
       .filter(Boolean)
 

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -1134,10 +1134,8 @@
             padding={{ t: 20, b: 60, l: 100, r: has_y2_series ? 100 : 20 }}
             range_padding={0}
             style="height: 100%"
-            legend={scatter_props?.legend
-            ? { ...scatter_props.legend, on_toggle: handle_legend_toggle }
-            : { on_toggle: handle_legend_toggle }}
             {...scatter_props}
+            legend={{ ...scatter_props.legend ?? {}, on_toggle: handle_legend_toggle }}
             class="plot {scatter_props.class ?? ``}"
           >
             {#snippet tooltip({ x, y, metadata })}

--- a/src/lib/trajectory/plotting.ts
+++ b/src/lib/trajectory/plotting.ts
@@ -156,6 +156,7 @@ function create_series_from_stats(
       markers: n < 30 ? `line+points` : `line`,
       metadata: Array(n).fill({
         series_label: unit ? `${clean_label} (${unit})` : clean_label,
+        property_key: key, // Store original property key for robust lookups
       }),
       line_style: { stroke: color, stroke_width: 2 },
       point_style: { fill: color, radius: 4, stroke: color, stroke_width: 1 },
@@ -520,6 +521,7 @@ export function generate_streaming_plot_series(
       markers: data_points.length < 1000 ? `line+points` : `line`,
       metadata: data_points.map(() => ({
         series_label: unit ? `${clean_label} (${unit})` : clean_label,
+        property_key, // Store original property key for robust lookups
       })),
       line_style: { stroke: color, stroke_width: 2 },
       point_style: { fill: color, radius: 4, stroke: color, stroke_width: 1 },

--- a/src/lib/trajectory/plotting.ts
+++ b/src/lib/trajectory/plotting.ts
@@ -174,26 +174,23 @@ function group_and_assign_series(
 ): UnitGroup[] {
   // Group by unit
   const unit_map = new Map<string, DataSeries[]>()
-  series.forEach((srs) => {
+  for (const srs of series) {
     const unit = srs.unit || `dimensionless`
-    if (!unit_map.has(unit)) unit_map.set(unit, [])
-    const unit_group = unit_map.get(unit)
-    if (unit_group) unit_group.push(srs)
-  })
+    const group = unit_map.get(unit) ?? []
+    group.push(srs)
+    unit_map.set(unit, group)
+  }
 
   // Create unit groups with priority and visibility
   const groups = Array.from(unit_map.entries()).map(([unit, group_series]) => {
     const priority = calculate_priority(unit, group_series)
-    const has_default_visible = group_series.some((srs) =>
-      is_default_visible(srs.label || ``, default_visible_properties)
-    )
+    const has_default_visible = group_series.some((srs) => {
+      const metadata = Array.isArray(srs.metadata) ? srs.metadata[0] : srs.metadata
+      const property_key = (metadata?.property_key as string) || srs.label || ``
+      return is_default_visible(property_key, default_visible_properties)
+    })
 
-    return {
-      unit,
-      series: group_series,
-      priority,
-      is_visible: has_default_visible,
-    }
+    return { unit, series: group_series, priority, is_visible: has_default_visible }
   }).sort((a, b) => a.priority - b.priority)
 
   // Apply 2-group visibility limit
@@ -224,13 +221,13 @@ function apply_group_assignments(series: DataSeries[], unit_groups: UnitGroup[])
   }
 
   // Apply to series
-  series.forEach((srs) => {
+  for (const srs of series) {
     const group = unit_groups.find((g) => g.series.includes(srs))
     if (group) {
       srs.visible = group.is_visible
       srs.y_axis = axis_map.get(group) || `y1`
     }
-  })
+  }
 }
 
 // Helper functions
@@ -239,7 +236,8 @@ function extract_label_and_unit(
   property_config: Record<string, { label: string; unit: string }>,
 ): { clean_label: string; unit: string } {
   const config = property_config[key] || property_config[key.toLowerCase()]
-  return config ? { clean_label: config.label, unit: config.unit } : {
+  if (config) return { clean_label: config.label, unit: config.unit }
+  return {
     clean_label: key.charAt(0).toUpperCase() + key.slice(1).replace(/_/g, ` `),
     unit: ``,
   }
@@ -267,16 +265,22 @@ function calculate_priority(unit: string, group_series: DataSeries[]): number {
   return 1000 // Default low priority
 }
 
-function is_default_visible(label: string, default_properties: Set<string>): boolean {
-  const clean_label = label.toLowerCase().replace(/<[^>]*>/g, ``)
-  return Array.from(default_properties).some((prop) => {
-    const prop_lower = prop.toLowerCase()
-    if (prop_lower === `force_max`) {
-      return clean_label.includes(`force`) || clean_label.includes(`fmax`) ||
-        clean_label === `f`
-    }
-    return clean_label.includes(prop_lower)
-  })
+// Normalize property keys for robust matching (handles case, underscores, and common aliases)
+const normalize_property_key = (key: string): string => {
+  const normalized = key.toLowerCase().replace(/<[^>]*>/g, ``).replace(/_/g, ` `).trim()
+  // Map common force property aliases to canonical form
+  return [`fmax`, `f`, `force maximum`].includes(normalized) ? `force max` : normalized
+}
+
+const is_default_visible = (
+  property_key: string,
+  default_properties: Set<string>,
+): boolean => {
+  const normalized_key = normalize_property_key(property_key)
+  for (const prop of default_properties) {
+    if (normalize_property_key(prop) === normalized_key) return true
+  }
+  return false
 }
 
 // Optimized series visibility toggling
@@ -332,20 +336,21 @@ export function toggle_series_visibility(
 
 function create_unit_groups_from_series(series: DataSeries[]): UnitGroup[] {
   const unit_map = new Map<string, DataSeries[]>()
-
-  series.forEach((srs) => {
+  for (const srs of series) {
     const unit = srs.unit || `dimensionless`
-    if (!unit_map.has(unit)) unit_map.set(unit, [])
-    const unit_group = unit_map.get(unit)
-    if (unit_group) unit_group.push(srs)
-  })
+    const group = unit_map.get(unit) ?? []
+    group.push(srs)
+    unit_map.set(unit, group)
+  }
 
-  return Array.from(unit_map.entries()).map(([unit, group_series]) => ({
-    unit,
-    series: group_series,
-    priority: calculate_priority(unit, group_series),
-    is_visible: group_series.some((srs) => srs.visible),
-  })).sort((a, b) => a.priority - b.priority)
+  return Array.from(unit_map.entries())
+    .map(([unit, group_series]) => ({
+      unit,
+      series: group_series,
+      priority: calculate_priority(unit, group_series),
+      is_visible: group_series.some((srs) => srs.visible),
+    }))
+    .sort((a, b) => a.priority - b.priority)
 }
 
 function update_group_visibility_and_axes(
@@ -353,51 +358,43 @@ function update_group_visibility_and_axes(
   unit_groups: UnitGroup[],
 ): void {
   // Update group visibility based on series
-  unit_groups.forEach((group) => {
+  for (const group of unit_groups) {
     group.is_visible = group.series.some((srs1) =>
-      series.find((srs2) => srs2.label === srs1.label && srs2.unit === srs1.unit)
-        ?.visible || false
+      series.find((srs2) => srs2.label === srs1.label && srs2.unit === srs1.unit)?.visible
     )
-  })
+  }
 
   // Apply 2-group limit
-  const visible_groups = unit_groups.filter((group) => group.is_visible)
-  if (visible_groups.length > 2) {
-    const groups_to_hide = visible_groups.slice(2)
-    groups_to_hide.forEach((group) => {
+  if (unit_groups.filter((g) => g.is_visible).length > 2) {
+    for (const group of unit_groups.filter((g) => g.is_visible).slice(2)) {
       group.is_visible = false
-      group.series.forEach((srs1) => {
-        const series_idx = series.findIndex((srs2) =>
+      for (const srs1 of group.series) {
+        const idx = series.findIndex((srs2) =>
           srs2.label === srs1.label && srs2.unit === srs1.unit
         )
-        if (series_idx !== -1) {
-          series[series_idx] = { ...series[series_idx], visible: false }
-        }
-      })
-    })
+        if (idx !== -1) series[idx] = { ...series[idx], visible: false }
+      }
+    }
   }
 
   // Assign axes
-  const final_visible = unit_groups.filter((group) => group.is_visible)
-  final_visible.sort((g1, g2) => g1.priority - g2.priority)
+  const final_visible = unit_groups
+    .filter((group) => group.is_visible)
+    .sort((g1, g2) => g1.priority - g2.priority)
 
   const axis_map = new Map<UnitGroup, `y1` | `y2`>()
-  if (final_visible.length === 1) {
-    axis_map.set(final_visible[0], `y1`)
-  } else if (final_visible.length === 2) {
-    axis_map.set(final_visible[0], `y1`)
-    axis_map.set(final_visible[1], `y2`)
-  }
+  if (final_visible.length >= 1) axis_map.set(final_visible[0], `y1`)
+  if (final_visible.length === 2) axis_map.set(final_visible[1], `y2`)
 
   // Apply to series
-  series.forEach((srs, idx) => {
+  for (const [idx, srs] of series.entries()) {
     const group = unit_groups.find((g) =>
       g.series.some((gs) => gs.label === srs.label && gs.unit === srs.unit)
     )
     if (group && axis_map.has(group)) {
       series[idx] = { ...srs, y_axis: axis_map.get(group) }
     }
-  })
+  }
 }
 
 // Utility functions

--- a/src/routes/(demos)/phase-diagram/+page.svelte
+++ b/src/routes/(demos)/phase-diagram/+page.svelte
@@ -2,9 +2,9 @@
   import type { ElementSymbol } from '$lib'
   import { decompress_data } from '$lib/io/decompress'
   import type {
+    PhaseDiagramEntry,
     PhaseStats,
     PymatgenEntry,
-    TernaryPlotEntry,
   } from '$lib/phase-diagram'
   import {
     PhaseDiagram2D,
@@ -30,8 +30,8 @@
 
   // State for the 3D example with stats display
   let phase_stats = $state<PhaseStats | null>(null)
-  let stable_entries = $state<TernaryPlotEntry[]>([])
-  let unstable_entries = $state<TernaryPlotEntry[]>([])
+  let stable_entries = $state<PhaseDiagramEntry[]>([])
+  let unstable_entries = $state<PhaseDiagramEntry[]>([])
   let max_hull_dist_show_phases = $state(0.5)
 
   onMount(async () => {

--- a/src/routes/(demos)/trajectory/+page.svelte
+++ b/src/routes/(demos)/trajectory/+page.svelte
@@ -4,6 +4,7 @@
   import { Trajectory, type TrajHandlerData } from 'matterviz/trajectory'
 
   let active_file = $state(``) // last drag-and-dropped trajectory file
+  let visible_props_cantor_qha = $state<string[] | undefined>(undefined)
 
   const trajectory_files_paths = [
     `/trajectories/flame-gold-cluster-55-atoms.h5`,
@@ -17,14 +18,39 @@
 <h1>Trajectory</h1>
 
 {#each trajectory_files_paths as file (file)}
-  <Trajectory
-    data_url={file}
-    class="full-bleed"
-    style="margin-top: 5em; max-height: 700px"
-    on_file_load={(data: TrajHandlerData) => {
-      if (data.filename) active_file = data.filename
-    }}
-  />
+  {#if file === `/trajectories/Cr0.25Fe0.25Co0.25Ni0.25-mace-omat-qha.xyz.gz`}
+    <h2>Bindable <code>visible_properties</code> Demo</h2>
+    <p>
+      This trajectory has multiple properties (energy, force_max, volume, etc.). The plot
+      shows those defined in the <code>visible_properties</code> on page load. But the
+      prop is two-way bindable and allows for external monitoring and modification. Toggle
+      other properties in the plot legend to see the binding below update to show which
+      properties are currently displayed.
+    </p>
+    <strong
+      style="display: block; margin: 1em auto; padding: 1em; background: var(--surface-bg-hover); border-radius: 4px; font-family: monospace; font-size: 0.9em"
+    >
+      bind:visible_properties = {JSON.stringify(visible_props_cantor_qha)}
+    </strong>
+    <Trajectory
+      data_url={file}
+      bind:visible_properties={visible_props_cantor_qha}
+      class="full-bleed"
+      style="margin-top: 1em; max-height: 700px"
+      on_file_load={(data: TrajHandlerData) => {
+        if (data.filename) active_file = data.filename
+      }}
+    />
+  {:else}
+    <Trajectory
+      data_url={file}
+      class="full-bleed"
+      style="margin-top: 5em; max-height: 700px"
+      on_file_load={(data: TrajHandlerData) => {
+        if (data.filename) active_file = data.filename
+      }}
+    />
+  {/if}
 {/each}
 
 <p style="margin: 2em auto; text-align: center">

--- a/tests/vitest/phase-diagram/barycentric-coords.test.ts
+++ b/tests/vitest/phase-diagram/barycentric-coords.test.ts
@@ -15,7 +15,7 @@ import {
   TETRAHEDRON_VERTICES,
   TRIANGLE_VERTICES,
 } from '$lib/phase-diagram/barycentric-coords'
-import type { PhaseEntry } from '$lib/phase-diagram/types'
+import type { PhaseData } from '$lib/phase-diagram/types'
 import { describe, expect, test } from 'vitest'
 
 describe(`ternary: constants and projections`, () => {
@@ -82,7 +82,7 @@ describe(`ternary: composition and plotting`, () => {
 
   test(`get_ternary_3d_coordinates filters entries and projects coords`, () => {
     const elements = [`A`, `B`, `C`] as unknown as ElementSymbol[]
-    const entries: PhaseEntry[] = [
+    const entries: PhaseData[] = [
       {
         composition: { A: 1 } as unknown as CompositionType,
         energy: 0,
@@ -179,7 +179,7 @@ describe(`quaternary: barycentric and projection`, () => {
 describe(`quaternary: compute_4d_coords`, () => {
   test(`filters entries outside chemical system and projects coords`, () => {
     const elems = [`A`, `B`, `C`, `D`] as unknown as ElementSymbol[]
-    const entries: PhaseEntry[] = [
+    const entries: PhaseData[] = [
       { composition: { A: 1 } as unknown as CompositionType, energy: 0 },
       { composition: { A: 1, B: 1 } as unknown as CompositionType, energy: 0 },
       { composition: { A: 1, E: 1 } as unknown as CompositionType, energy: 0 },

--- a/tests/vitest/phase-diagram/types.test.ts
+++ b/tests/vitest/phase-diagram/types.test.ts
@@ -1,4 +1,4 @@
-import type { PhaseEntry } from '$lib/phase-diagram/types'
+import type { PhaseData } from '$lib/phase-diagram/types'
 import {
   get_arity,
   is_binary_entry,
@@ -15,7 +15,7 @@ import {
 import { describe, expect, test } from 'vitest'
 
 describe(`arity helpers`, () => {
-  const make = (comp: Record<string, number>) => ({ composition: comp } as PhaseEntry)
+  const make = (comp: Record<string, number>) => ({ composition: comp } as PhaseData)
 
   test(`get_arity counts positive amounts only`, () => {
     expect(get_arity(make({ A: 1, B: 0, C: -1 }))).toBe(1)

--- a/tests/vitest/trajectory/plotting.test.ts
+++ b/tests/vitest/trajectory/plotting.test.ts
@@ -504,4 +504,26 @@ describe(`integration and regression tests`, () => {
     expect(labels.y1).toBe(`Visible (eV)`) // Only visible series included
     expect(labels.y2).toBe(`Another (Å)`)
   })
+
+  it.each([
+    { label_search: `energy`, expected_key: `energy` },
+    { label_search: `f`, expected_key: `force_max` },
+    { label_search: `volume`, expected_key: `volume` },
+  ])(
+    `should store property_key=$expected_key in $label_search series metadata`,
+    ({ label_search, expected_key }) => {
+      const trajectory = create_trajectory(COMMON_TRAJECTORIES.multi_property)
+      const series = generate_plot_series(trajectory, test_extractor, {
+        property_config: DEFAULT_PROPERTY_CONFIG,
+      })
+
+      const found_series = find_series_by_label(series, label_search)
+      expect(found_series).toBeDefined()
+      expect(found_series?.metadata).toBeInstanceOf(Array)
+      expect(found_series?.metadata).toHaveLength(3) // 3 frames in COMMON_TRAJECTORIES.multi_property
+
+      const metadata = (found_series?.metadata as Record<string, unknown>[])[0]
+      expect(metadata.property_key).toBe(expected_key)
+    },
+  )
 })


### PR DESCRIPTION
- Show entry IDs and polymorph statistics in phase-diagram tooltips, expose bindable selected entries, and add a wrapper that selects the 2D/3D/4D diagram from element count.
- Add bindable trajectory `visible_properties` and custom `property_labels`.
- Replace copy feedback with configurable `ClickFeedback` and unify the public phase-diagram data API around `PhaseData` and `PhaseDiagramEntry`.