### PR TITLE
Fix blank `Structure` and `BrillouinZone` PNG exports

### DIFF
--- a/extensions/vscode/vite.config.mjs
+++ b/extensions/vscode/vite.config.mjs
@@ -27,6 +27,7 @@ export default defineConfig(({ mode }) => ({
       output: { entryFileNames: `webview.js`, format: `iife` },
     },
     emptyOutDir: false,
+    chunkSizeWarningLimit: 6000,
   },
   resolve: {
     alias: {

--- a/extensions/vscode/vite.webview.config.ts
+++ b/extensions/vscode/vite.webview.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
       fileName: () => `extension.cjs`,
     },
     rollupOptions: {
-      external: [`vscode`, `fs`, `path`, `node:buffer`],
+      external: [`vscode`, `fs`, `path`, `node:buffer`, `node:fs`, `node:path`, `os`],
     },
     minify: false,
   },

--- a/src/lib/brillouin/BrillouinZoneScene.svelte
+++ b/src/lib/brillouin/BrillouinZoneScene.svelte
@@ -76,6 +76,9 @@
   $effect(() => {
     scene = threlte.scene
     camera = threlte.camera.current
+    if (threlte.renderer) {
+      Object.assign(threlte.renderer.domElement, { __renderer: threlte.renderer })
+    }
   })
 
   extras.interactivity()

--- a/src/lib/composition/parse.ts
+++ b/src/lib/composition/parse.ts
@@ -1,6 +1,7 @@
-import type { AnyStructure, CompositionType, ElementSymbol } from '$lib'
-import { ELEM_SYMBOLS, format_num } from '$lib'
+import type { AnyStructure, ElementSymbol } from '$lib'
+import type { CompositionType } from '$lib/composition'
 import { element_data } from '$lib/element'
+import { ELEM_SYMBOLS, format_num } from '$lib/labels'
 
 // Create symbol/number/mass/electronegativity lookup maps for O(1) access
 export const ATOMIC_NUMBER_TO_SYMBOL: Record<number, ElementSymbol> = {}

--- a/src/lib/io/export.ts
+++ b/src/lib/io/export.ts
@@ -21,9 +21,17 @@ export function export_canvas_as_png(
     }
 
     // Determine filename from either structure or direct filename
-    const filename = typeof structure_or_filename === `string`
+    let filename = typeof structure_or_filename === `string`
       ? structure_or_filename
       : create_structure_filename(structure_or_filename, `png`)
+
+    // Inject DPI into filename
+    const suffix = `-${Math.round(png_dpi)}dpi`
+    if (filename.toLowerCase().endsWith(`.png`)) {
+      filename = filename.replace(/\.png$/i, `${suffix}.png`)
+    } else {
+      filename = `${filename}${suffix}.png`
+    }
 
     // Convert DPI to multiplier (72 DPI is baseline web resolution)
     // Cap to a reasonable upper bound to avoid excessive memory use

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -21,16 +21,14 @@
   import type { Camera, OrthographicCamera, Scene } from 'three'
   import type { AtomColorConfig } from './atom-properties'
   import { get_property_colors } from './atom-properties'
+  import AtomLegend from './AtomLegend.svelte'
   import type { StructureHandlerData } from './index'
-  import {
-    AtomLegend,
-    StructureControls,
-    StructureExportPane,
-    StructureInfoPane,
-    StructureScene,
-  } from './index'
   import { MAX_SELECTED_SITES } from './measure'
   import { parse_any_structure } from './parse'
+  import StructureControls from './StructureControls.svelte'
+  import StructureExportPane from './StructureExportPane.svelte'
+  import StructureInfoPane from './StructureInfoPane.svelte'
+  import StructureScene from './StructureScene.svelte'
 
   // Type alias for event handlers to reduce verbosity
   type EventHandler = (data: StructureHandlerData) => void

--- a/src/lib/structure/StructureControls.svelte
+++ b/src/lib/structure/StructureControls.svelte
@@ -199,10 +199,11 @@
       show_image_atoms = DEFAULTS.structure.show_image_atoms
       lattice_props.show_cell_vectors = DEFAULTS.structure.show_cell_vectors
     }}
-    style="display: flex; flex-wrap: wrap; gap: 1.2ex"
+    style="display: flex; flex-direction: row; flex-wrap: wrap; gap: 12pt"
   >
     Show <label
       {@attach tooltip({ content: SETTINGS_CONFIG.structure.show_atoms.description })}
+      style="gap: 6pt"
     >
       <input type="checkbox" bind:checked={scene_props.show_atoms} />
       Atoms
@@ -211,6 +212,7 @@
       {@attach tooltip({
         content: SETTINGS_CONFIG.structure.show_image_atoms.description,
       })}
+      style="gap: 6pt"
     >
       <input type="checkbox" bind:checked={show_image_atoms} />
       Image Atoms
@@ -219,6 +221,7 @@
       {@attach tooltip({
         content: SETTINGS_CONFIG.structure.show_site_labels.description,
       })}
+      style="gap: 6pt"
     >
       <input type="checkbox" bind:checked={scene_props.show_site_labels} />
       Site Labels
@@ -227,6 +230,7 @@
       {@attach tooltip({
         content: SETTINGS_CONFIG.structure.show_site_indices.description,
       })}
+      style="gap: 6pt"
     >
       <input type="checkbox" bind:checked={scene_props.show_site_indices} />
       Site Indices
@@ -236,17 +240,19 @@
         {@attach tooltip({
           content: SETTINGS_CONFIG.structure.show_force_vectors.description,
         })}
+        style="gap: 6pt"
       >
         <input type="checkbox" bind:checked={scene_props.show_force_vectors} />
         Force Vectors
       </label>
     {/if}
-    <label>
+    <label style="gap: 6pt">
       <input type="checkbox" bind:checked={lattice_props.show_cell_vectors} />
       Lattice Vectors
     </label>
     <label
       {@attach tooltip({ content: SETTINGS_CONFIG.structure.show_bonds.description })}
+      style="gap: 6pt"
     >
       Bonds:
       <select bind:value={scene_props.show_bonds}>
@@ -932,18 +938,47 @@
   .rotation-axes {
     display: flex;
     gap: 10pt;
-    font-size: 0.85em;
   }
   .rotation-axes > div {
     display: grid;
     gap: 0.4em;
     place-items: center;
   }
-
   :global(.controls-pane) {
     font-size: 0.85em;
   }
 
+  :global(.controls-pane section) {
+    display: flex;
+    flex-direction: column;
+    gap: 6pt;
+  }
+  :global(.controls-pane h4) {
+    margin: 10pt 0 4pt !important;
+  }
+  :global(.controls-pane h4:first-of-type) {
+    margin-top: 0 !important;
+  }
+  .pane-row {
+    display: flex;
+    gap: 12pt;
+    justify-content: space-between;
+    width: 100%;
+  }
+  label {
+    display: flex;
+    align-items: center;
+    gap: 10pt;
+  }
+  input,
+  select {
+    font-size: inherit;
+    font-family: inherit;
+  }
+  input[type='range'] {
+    flex: 1;
+    min-width: 40px;
+  }
   @keyframes spin {
     from {
       transform: rotate(0deg);

--- a/src/lib/structure/StructureExportPane.svelte
+++ b/src/lib/structure/StructureExportPane.svelte
@@ -208,9 +208,9 @@
     font-size: 0.95em;
   }
   .export-buttons button {
-    width: 1.9em;
+    min-width: 1.9em;
     height: 1.6em;
-    padding: 0;
+    padding: 0 4pt;
     margin: 0 0 0 4pt;
     box-sizing: border-box;
   }

--- a/src/lib/structure/StructureExportPane.svelte
+++ b/src/lib/structure/StructureExportPane.svelte
@@ -205,6 +205,7 @@
           type="button"
           onclick={() => handle_3d_export(format)}
           disabled={!scene}
+          title="Download {label}"
           {@attach tooltip({ content: hint })}
         >
           ⬇

--- a/src/lib/structure/StructureExportPane.svelte
+++ b/src/lib/structure/StructureExportPane.svelte
@@ -111,6 +111,20 @@
       console.error(`Failed to export ${format.toUpperCase()}:`, error)
     }
   }
+
+  let has_canvas = $state(false)
+
+  $effect(() => {
+    if (!wrapper) {
+      has_canvas = false
+      return
+    }
+    const check = () => (has_canvas = Boolean(wrapper.querySelector(`canvas`)))
+    check()
+    const observer = new MutationObserver(check)
+    observer.observe(wrapper, { childList: true, subtree: true })
+    return () => observer.disconnect()
+  })
 </script>
 
 <DraggablePane
@@ -154,7 +168,7 @@
       PNG
       <button
         type="button"
-        disabled={!wrapper?.querySelector(`canvas`)}
+        disabled={!has_canvas}
         onclick={() => {
           const canvas = wrapper?.querySelector(`canvas`) as HTMLCanvasElement
           if (canvas) {

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -184,6 +184,11 @@
   $effect(() => {
     scene = threlte.scene
     camera = threlte.camera.current
+    if (threlte.renderer) {
+      Object.assign(threlte.renderer.domElement, {
+        __renderer: threlte.renderer,
+      })
+    }
   })
 
   // Expose rotation target for external reset

--- a/src/lib/structure/parse.ts
+++ b/src/lib/structure/parse.ts
@@ -1,4 +1,4 @@
-import { ELEM_SYMBOLS, type ElementSymbol, type Site, type Vec3 } from '$lib'
+import type { ElementSymbol } from '$lib'
 import type { OptimadeStructure } from '$lib/api/optimade'
 import {
   COMPRESSION_EXTENSIONS_REGEX,
@@ -10,8 +10,10 @@ import {
   VASP_FILES_REGEX,
   XYZ_EXTXYZ_REGEX,
 } from '$lib/constants'
+import { ELEM_SYMBOLS } from '$lib/labels'
 import * as math from '$lib/math'
-import type { AnyStructure, PymatgenStructure } from '$lib/structure'
+import type { Vec3 } from '$lib/math'
+import type { AnyStructure, PymatgenStructure, Site } from '$lib/structure'
 import { load as yaml_load } from 'js-yaml'
 
 export interface ParsedStructure {

--- a/tests/playwright/bands/brillouin-bands-dos.test.ts
+++ b/tests/playwright/bands/brillouin-bands-dos.test.ts
@@ -3,12 +3,12 @@ import { Buffer } from 'node:buffer'
 
 test.describe(`BrillouinBandsDos Component Tests`, () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(`/test/brillouin-bands-dos`, { waitUntil: `networkidle` })
+    await page.goto(`/test/brillouin-bands-dos`, { waitUntil: `domcontentloaded` })
     // Wait for the default container and basic structure to be present
     const container = page.locator(`[data-testid="bz-bands-dos-default"]`)
     await expect(container).toBeVisible()
     // Wait for canvas (BZ) to be present
-    await expect(container.locator(`canvas`).first()).toBeVisible()
+    await expect(container.locator(`canvas`).first()).toBeVisible({ timeout: 10000 })
   })
 
   test(`renders all three panels with content`, async ({ page }) => {
@@ -19,7 +19,10 @@ test.describe(`BrillouinBandsDos Component Tests`, () => {
     await expect(container.locator(`svg`).nth(0).locator(`path[fill="none"]`).first())
       .toBeVisible()
     // DOS may take longer to render, give it more time
-    await expect(container.locator(`svg`).nth(1).locator(`path[fill="none"]`).first())
+    const dos_svg = container.locator(`svg`).nth(1)
+    await expect(dos_svg).toBeVisible()
+    await expect(dos_svg.locator(`g.y-axis`)).toBeVisible()
+    await expect(dos_svg.locator(`path[fill="none"]`).first())
       .toBeVisible({ timeout: 15000 })
 
     // Check for high-symmetry labels in bands

--- a/tests/playwright/bohr-atoms.test.ts
+++ b/tests/playwright/bohr-atoms.test.ts
@@ -1,4 +1,4 @@
-import { element_data } from '$lib/element'
+import element_data from '$lib/element/data'
 import { expect, test } from '@playwright/test'
 
 test.describe(`Bohr Atoms page`, () => {

--- a/tests/playwright/element-detail-pages.test.ts
+++ b/tests/playwright/element-detail-pages.test.ts
@@ -1,5 +1,5 @@
 // deno-lint-ignore-file no-await-in-loop
-import { element_data } from '$lib/element'
+import element_data from '$lib/element/data'
 import { expect, test } from '@playwright/test'
 
 test.describe(`Element detail page`, () => {

--- a/tests/playwright/optimade.test.ts
+++ b/tests/playwright/optimade.test.ts
@@ -3,9 +3,8 @@ import { expect, test } from '@playwright/test'
 test.describe(`OPTIMADE route`, () => {
   test.beforeEach(async ({ page }) => {
     // Mock structure and links requests
-    await page.route(`**/*`, async (route) => {
+    await page.route(`**/v1/**`, async (route) => {
       const url = route.request().url()
-      console.log(`Intercepted: ${url}`)
       if (url.includes(`providers.optimade.org/v1/links`)) {
         await route.fulfill({
           json: {
@@ -129,14 +128,16 @@ test.describe(`OPTIMADE route`, () => {
     await expect(page.locator(`h2:has-text("mp-1")`)).toBeVisible()
 
     // Click on OQMD provider button
-    await page.locator(`button.db-select:has-text("oqmd")`).click()
+    await page.locator(`button.db-select:has-text("oqmd")`).first().click()
 
     // Wait for provider change and verify input is cleared
     await expect(page.locator(`input.structure-input`)).toHaveValue(``)
 
     // Verify OQMD provider is selected
     // The selected class is on the parent div of the button
-    await expect(page.locator(`.db-grid > div:has(button.db-select:has-text("oqmd"))`))
+    await expect(
+      page.locator(`.db-grid > div:has(button.db-select:has-text("oqmd"))`).first(),
+    )
       .toHaveClass(
         /selected/,
       )
@@ -200,11 +201,11 @@ test.describe(`OPTIMADE route`, () => {
     await page.goto(`/optimade-mp-1`, { waitUntil: `domcontentloaded` })
 
     // Wait for suggestions to load
-    await expect(page.locator(`text=Suggested Structures from`)).toBeVisible()
+    await expect(page.locator(`text=Suggested Structures`)).toBeVisible()
 
     // Capture the structure ID from first suggestion card
-    const first_suggestion_card = page.locator(`.suggestion-card`).first()
-    const structure_id = await first_suggestion_card.locator(`.suggestion-id`)
+    const first_suggestion_card = page.locator(`.structure-suggestions button`).first()
+    const structure_id = await first_suggestion_card.locator(`span`).first()
       .textContent()
 
     // Click on first suggestion card

--- a/tests/playwright/optimade.test.ts
+++ b/tests/playwright/optimade.test.ts
@@ -69,6 +69,23 @@ test.describe(`OPTIMADE route`, () => {
           })
         } else if (url.includes(`invalid-id`)) {
           await route.fulfill({ json: { data: null } })
+        } else if (url.includes(`mp-149`)) {
+          await route.fulfill({
+            json: {
+              data: {
+                id: `mp-149`,
+                type: `structures`,
+                attributes: {
+                  chemical_formula_descriptive: `Si`,
+                  lattice_vectors: [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+                  species: [{ name: `Si`, chemical_symbols: [`Si`], concentration: [1] }],
+                  species_at_sites: [`Si`],
+                  cartesian_site_positions: [[0, 0, 0]],
+                  structure_features: [],
+                },
+              },
+            },
+          })
         } else if (url.includes(`page_limit`)) {
           // Mock suggestions response
           await route.fulfill({
@@ -128,19 +145,16 @@ test.describe(`OPTIMADE route`, () => {
     await expect(page.locator(`h2:has-text("mp-1")`)).toBeVisible()
 
     // Click on OQMD provider button
-    await page.locator(`button.db-select:has-text("oqmd")`).first().click()
+    await page.locator(`button.db-select`, { hasText: `oqmd` }).click()
 
     // Wait for provider change and verify input is cleared
     await expect(page.locator(`input.structure-input`)).toHaveValue(``)
 
     // Verify OQMD provider is selected
     // The selected class is on the parent div of the button
-    await expect(
-      page.locator(`.db-grid > div:has(button.db-select:has-text("oqmd"))`).first(),
+    await expect(page.locator(`.db-grid > div`, { hasText: `oqmd` })).toHaveClass(
+      /selected/,
     )
-      .toHaveClass(
-        /selected/,
-      )
 
     // Verify suggestions section appears (use partial text match)
     await expect(page.locator(`text=Suggested Structures`)).toBeVisible()
@@ -167,7 +181,7 @@ test.describe(`OPTIMADE route`, () => {
     await page.locator(`input.structure-input`).fill(`test-structure-id`)
 
     // Click on a different provider (use first to avoid ambiguity)
-    await page.locator(`button.db-select:has-text("cod")`).first().click()
+    await page.locator(`button.db-select`, { hasText: `cod` }).click()
 
     // Verify input is cleared
     await expect(page.locator(`input.structure-input`)).toHaveValue(``)
@@ -180,19 +194,16 @@ test.describe(`OPTIMADE route`, () => {
     await expect(page.locator(`h2:has-text("mp-1")`)).toBeVisible()
 
     // Switch to COD provider
-    await page.locator(`button.db-select:has-text("cod")`).first().click()
+    await page.locator(`button.db-select`, { hasText: `cod` }).click()
     await expect(page.locator(`input.structure-input`)).toHaveValue(``)
-    await expect(
-      page.locator(`.db-grid > div:has(button.db-select:has-text("cod"))`).first(),
+    await expect(page.locator(`.db-grid > div`, { hasText: `cod` })).toHaveClass(
+      /selected/,
     )
-      .toHaveClass(/selected/)
 
     // Switch back to MP provider
-    await page.locator(`button.db-select:has-text("mp")`).first().click()
+    await page.locator(`button.db-select`, { hasText: `mp` }).click()
     await expect(page.locator(`input.structure-input`)).toHaveValue(``)
-    await expect(
-      page.locator(`.db-grid > div:has(button.db-select:has-text("mp"))`).first(),
-    ).toHaveClass(
+    await expect(page.locator(`.db-grid > div`, { hasText: `mp` })).toHaveClass(
       /selected/,
     )
   })
@@ -215,6 +226,6 @@ test.describe(`OPTIMADE route`, () => {
     await expect(page.locator(`input.structure-input`)).toHaveValue(structure_id ?? ``)
 
     // Verify loading state appears
-    await expect(page.locator(`text=Loading structure data from`)).toBeVisible()
+    await expect(page.locator(`text=Loading structure from`)).toBeVisible()
   })
 })

--- a/tests/playwright/periodic-table.test.ts
+++ b/tests/playwright/periodic-table.test.ts
@@ -1,5 +1,5 @@
 // deno-lint-ignore-file no-await-in-loop
-import { element_data } from '$lib/element'
+import element_data from '$lib/element/data'
 import {
   CATEGORY_COUNTS,
   ELEM_HEATMAP_KEYS,

--- a/tests/playwright/periodic-table.test.ts
+++ b/tests/playwright/periodic-table.test.ts
@@ -57,8 +57,8 @@ test.describe(`Periodic Table`, () => {
     await expect(page.locator(`.element-tile`).first()).toBeVisible({ timeout: 10000 })
     await page.waitForLoadState(`domcontentloaded`)
 
-    for (const tile of random_sample(await page.$$(`.element-tile`), 5)) {
-      await tile.hover({ timeout: 5000 })
+    for (const tile of random_sample(await page.$$(`.element-tile`), 3)) {
+      await tile.hover({ timeout: 5000, force: true })
     }
 
     expect(logs, logs.join(`\n`)).toHaveLength(0)

--- a/tests/playwright/phase-diagram/phase-diagram-2d.test.ts
+++ b/tests/playwright/phase-diagram/phase-diagram-2d.test.ts
@@ -79,7 +79,7 @@ test.describe(`PhaseDiagram2D (Binary)`, () => {
     const markers = scatter.locator(`path.marker`)
     const count_before = await markers.count()
     await number_input.fill(`0`)
-    // Trigger change event explicitly if needed, or blur
+    // Trigger change handlers by blurring the input
     await number_input.blur()
 
     // Wait for info pane to update

--- a/tests/playwright/phase-diagram/phase-diagram-2d.test.ts
+++ b/tests/playwright/phase-diagram/phase-diagram-2d.test.ts
@@ -8,7 +8,7 @@ test.describe(`PhaseDiagram2D (Binary)`, () => {
 
   test(`renders binary phase diagram with scatter plot and colorbar`, async ({ page }) => {
     await expect(page.getByRole(`heading`, { name: `Phase Diagrams` })).toBeVisible()
-    const binary_grid = page.locator(`.binary-grid`)
+    const binary_grid = page.locator(`.binary-grid`).first()
     await expect(binary_grid).toBeVisible()
 
     const pd2d = binary_grid.locator(`.phase-diagram-2d`).first()
@@ -79,6 +79,8 @@ test.describe(`PhaseDiagram2D (Binary)`, () => {
     const markers = scatter.locator(`path.marker`)
     const count_before = await markers.count()
     await number_input.fill(`0`)
+    // Trigger change event explicitly if needed, or blur
+    await number_input.blur()
 
     // Wait for info pane to update
     await expect

--- a/tests/playwright/phase-diagram/phase-diagram-3d.test.ts
+++ b/tests/playwright/phase-diagram/phase-diagram-3d.test.ts
@@ -3,12 +3,12 @@ import { dom_click } from './utils'
 
 test.describe(`PhaseDiagram3D (Ternary)`, () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(`/phase-diagram`, { waitUntil: `networkidle` })
+    await page.goto(`/phase-diagram`, { waitUntil: `domcontentloaded` })
   })
 
   test(`renders ternary diagram canvas and toggles hull faces`, async ({ page }) => {
     await expect(page.getByRole(`heading`, { name: `Phase Diagrams` })).toBeVisible()
-    const ternary_grid = page.locator(`.ternary-grid`)
+    const ternary_grid = page.locator(`.ternary-grid`).first()
     await expect(ternary_grid).toBeVisible()
 
     const diagram = ternary_grid.locator(`.phase-diagram-3d`).first()

--- a/tests/vitest/io/export.test.ts
+++ b/tests/vitest/io/export.test.ts
@@ -42,7 +42,7 @@ describe(`Export functionality`, () => {
       expect(mock_canvas.toBlob).toHaveBeenCalled()
       expect(mock_download).toHaveBeenCalledWith(
         expect.any(Blob),
-        expect.stringContaining(`.png`),
+        expect.stringContaining(`-72dpi.png`),
         `image/png`,
       )
     })
@@ -53,7 +53,7 @@ describe(`Export functionality`, () => {
       expect(mock_canvas.toBlob).toHaveBeenCalled()
       expect(mock_download).toHaveBeenCalledWith(
         expect.any(Blob),
-        `custom-filename.png`,
+        `custom-filename-72dpi.png`,
         `image/png`,
       )
     })
@@ -84,7 +84,7 @@ describe(`Export functionality`, () => {
       expect(mock_renderer.setSize).toHaveBeenCalledWith(100, 100, false)
       expect(mock_download).toHaveBeenCalledWith(
         expect.any(Blob),
-        expect.stringContaining(`.png`),
+        expect.stringContaining(`-144dpi.png`),
         `image/png`,
       )
     })

--- a/tests/vitest/io/export.test.ts
+++ b/tests/vitest/io/export.test.ts
@@ -4,6 +4,7 @@ import {
   export_svg_as_svg,
 } from '$lib/io/export'
 import { download } from '$lib/io/fetch'
+import type { Camera, Scene, WebGLRenderer } from 'three'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { simple_structure } from '../setup'
 
@@ -19,23 +20,14 @@ function create_mock_svg(view_box = `0 0 100 100`): SVGElement {
   return svg
 }
 
-function create_mock_canvas(): HTMLCanvasElement & { __customRenderer?: unknown } {
+function create_mock_canvas(): HTMLCanvasElement & { __renderer?: WebGLRenderer } {
   const canvas = document.createElement(`canvas`) as HTMLCanvasElement & {
-    __customRenderer?: unknown
+    __renderer?: WebGLRenderer
   }
   canvas.toBlob = vi.fn((cb: (blob: Blob | null) => void) =>
     cb(new Blob([`pngdata`], { type: `image/png` }))
-  ) as unknown as (HTMLCanvasElement & { __customRenderer?: unknown })[`toBlob`]
+  ) as (HTMLCanvasElement & { __renderer?: WebGLRenderer })[`toBlob`]
   return canvas
-}
-
-function create_mock_image(): HTMLImageElement {
-  return {
-    crossOrigin: ``,
-    onload: null,
-    onerror: null,
-    src: ``,
-  } as unknown as HTMLImageElement
 }
 
 describe(`Export functionality`, () => {
@@ -75,8 +67,19 @@ describe(`Export functionality`, () => {
         setSize: vi.fn(),
         render: vi.fn(),
       }
-      mock_canvas.__customRenderer = mock_renderer
-      export_canvas_as_png(mock_canvas, simple_structure, 144)
+      // Using explicit mocks rather than 'any' for stricter type checking
+      const mock_scene = { isScene: true } as Scene
+      const mock_camera = { isCamera: true } as Camera
+
+      mock_canvas.__renderer = mock_renderer as unknown as WebGLRenderer
+      export_canvas_as_png(mock_canvas, simple_structure, 144, mock_scene, mock_camera)
+
+      // Verify force render was called before high-res capture logic
+      // Note: It might be called again inside the resolution adjustment block if that block also triggered a render (it doesn't currently, but previous logic might have).
+      // What matters: must be called at least once to ensure buffer population.
+      expect(mock_renderer.render).toHaveBeenCalledWith(mock_scene, mock_camera)
+      expect(mock_renderer.render).toHaveBeenCalledTimes(2) // Called once for forced render, once for high-res render
+
       expect(mock_renderer.setPixelRatio).toHaveBeenCalledWith(2)
       expect(mock_renderer.setSize).toHaveBeenCalledWith(100, 100, false)
       expect(mock_download).toHaveBeenCalledWith(
@@ -94,7 +97,7 @@ describe(`Export functionality`, () => {
         setup: (canvas: HTMLCanvasElement) => {
           canvas.toBlob = vi.fn((cb: (blob: Blob | null) => void) =>
             cb(null)
-          ) as unknown as (HTMLCanvasElement & { __customRenderer?: unknown })[`toBlob`]
+          ) as unknown as (HTMLCanvasElement & { __renderer?: unknown })[`toBlob`]
         },
       },
     ])(`handles canvas issues`, ({ canvas, warn_msg, setup }) => {
@@ -192,7 +195,12 @@ describe(`Export functionality`, () => {
       mock_canvas.getContext = vi.fn(() =>
         mock_context
       ) as unknown as HTMLCanvasElement[`getContext`]
-      mock_image = create_mock_image()
+      mock_image = {
+        crossOrigin: ``,
+        onload: null,
+        onerror: null,
+        src: ``,
+      } as HTMLImageElement
       mock_xml_serializer = { serializeToString: vi.fn(() => `<svg></svg>`) }
       globalThis.XMLSerializer = function () {
         return mock_xml_serializer
@@ -275,7 +283,7 @@ describe(`Export functionality`, () => {
     it(`handles toBlob null`, () => {
       mock_canvas.toBlob = vi.fn((cb: (b: Blob | null) => void) =>
         cb(null)
-      ) as unknown as (HTMLCanvasElement & { __customRenderer?: unknown })[`toBlob`]
+      ) as unknown as (HTMLCanvasElement & { __renderer?: unknown })[`toBlob`]
       const warn = vi.spyOn(console, `warn`).mockImplementation(() => {})
       export_svg_as_png(mock_svg, `f.png`)
       mock_image.onload?.call(mock_image, new Event(`load`))

--- a/tests/vitest/structure/StructureExportPane.test.ts
+++ b/tests/vitest/structure/StructureExportPane.test.ts
@@ -34,10 +34,13 @@ describe(`StructureExportPane`, () => {
     const canvas = document.createElement(`canvas`)
     wrapper_div.appendChild(canvas)
     document.body.appendChild(wrapper_div)
-
-    // Create minimal mock Scene object
     mock_scene = {} as Scene
   })
+
+  const get_button = (title_part: string) =>
+    Array.from(document.querySelectorAll(`button`)).find((btn) =>
+      btn.title?.includes(title_part)
+    )
 
   test(`displays all text export format buttons`, () => {
     mount(StructureExportPane, {
@@ -50,10 +53,9 @@ describe(`StructureExportPane`, () => {
       expect(document.body.textContent).toContain(label)
     }
 
-    // Should have exactly 2 buttons per format (download + copy) × 4 formats = 8
-    const h4_elements = Array.from(document.querySelectorAll(`h4`))
-    const text_h4 = h4_elements.find((h4) => h4.textContent?.includes(`Export as text`))
-    const text_section = text_h4?.nextElementSibling
+    // 2 buttons per format (download + copy) * 4 formats = 8
+    const text_section = Array.from(document.querySelectorAll(`h4`))
+      .find((h4) => h4.textContent?.includes(`Export as text`))?.nextElementSibling
     const buttons = text_section?.querySelectorAll(`button`)
     expect(buttons?.length).toBe(8)
   })
@@ -63,77 +65,53 @@ describe(`StructureExportPane`, () => {
     { format: `xyz`, label: `XYZ`, fn_name: `export_structure_as_xyz` },
     { format: `cif`, label: `CIF`, fn_name: `export_structure_as_cif` },
     { format: `poscar`, label: `POSCAR`, fn_name: `export_structure_as_poscar` },
-  ])(
-    `calls correct export function for $label download`,
-    async ({ label, fn_name }) => {
-      mount(StructureExportPane, {
-        target: document.body,
-        props: {
-          structure: simple_structure,
-        },
-      })
+  ])(`calls correct export function for $label download`, async ({ label, fn_name }) => {
+    mount(StructureExportPane, {
+      target: document.body,
+      props: { structure: simple_structure },
+    })
 
-      const export_fn = export_funcs[fn_name as keyof typeof export_funcs]
-      expect(export_fn).not.toHaveBeenCalled()
+    const export_fn = export_funcs[fn_name as keyof typeof export_funcs]
+    expect(export_fn).not.toHaveBeenCalled()
 
-      // Find download button for this format (⬇ button)
-      const format_div = Array.from(document.querySelectorAll(`.export-buttons > div`))
-        .find(
-          (div) => div.textContent?.includes(label),
-        )
-      expect(format_div).toBeTruthy()
+    const download_btn = get_button(`Download ${label}`)
+    expect(download_btn).toBeTruthy()
 
-      const download_btn = format_div?.querySelector(`button[title*="Download"]`)
-      expect(download_btn).toBeTruthy()
-
-      download_btn?.dispatchEvent(new Event(`click`, { bubbles: true }))
-      await vi.waitFor(() => expect(export_fn).toHaveBeenCalledWith(simple_structure))
-    },
-  )
+    download_btn?.dispatchEvent(new Event(`click`, { bubbles: true }))
+    await vi.waitFor(() => expect(export_fn).toHaveBeenCalledWith(simple_structure))
+  })
 
   test.each([
     {
-      format: `json`,
       label: `JSON`,
       str_fn_name: `structure_to_json_str`,
       expected_content: `{"test": "json"}`,
     },
     {
-      format: `xyz`,
       label: `XYZ`,
       str_fn_name: `structure_to_xyz_str`,
       expected_content: `3\ntest\nH 0 0 0`,
     },
     {
-      format: `cif`,
       label: `CIF`,
       str_fn_name: `structure_to_cif_str`,
       expected_content: `data_test\n_cell_length_a 1.0`,
     },
     {
-      format: `poscar`,
       label: `POSCAR`,
       str_fn_name: `structure_to_poscar_str`,
       expected_content: `test\n1.0\n1 0 0`,
     },
   ])(
-    `copies $label content to clipboard correctly`,
+    `copies $label content to clipboard`,
     async ({ label, str_fn_name, expected_content }) => {
       mount(StructureExportPane, {
         target: document.body,
-        props: {
-          structure: simple_structure,
-        },
+        props: { structure: simple_structure },
       })
 
       const str_fn = export_funcs[str_fn_name as keyof typeof export_funcs]
-
-      // Find copy button for this format (📋 button)
-      const format_div = Array.from(document.querySelectorAll(`.export-buttons > div`))
-        .find(
-          (div) => div.textContent?.includes(label),
-        )
-      const copy_btn = format_div?.querySelector(`button[title*="Copy"]`)
+      const copy_btn = get_button(`Copy ${label}`)
       expect(copy_btn).toBeTruthy()
 
       copy_btn?.dispatchEvent(new Event(`click`, { bubbles: true }))
@@ -147,32 +125,20 @@ describe(`StructureExportPane`, () => {
 
   test(`shows checkmark feedback after successful copy`, async () => {
     vi.useFakeTimers()
-
     mount(StructureExportPane, {
       target: document.body,
       props: { structure: simple_structure },
     })
 
-    const format_div = Array.from(document.querySelectorAll(`.export-buttons > div`))
-      .find(
-        (div) => div.textContent?.includes(`JSON`),
-      )
-    const copy_btn = format_div?.querySelector(`button[title*="Copy"]`)
-
-    // Initial state should show clipboard emoji
+    const copy_btn = get_button(`Copy JSON`)
     expect(copy_btn?.textContent).toContain(`📋`)
 
     copy_btn?.dispatchEvent(new Event(`click`, { bubbles: true }))
 
-    await vi.waitFor(() => {
-      expect(copy_btn?.textContent).toContain(`✅`)
-    })
+    await vi.waitFor(() => expect(copy_btn?.textContent).toContain(`✅`))
 
-    // After 1 second, should revert to clipboard emoji
     vi.advanceTimersByTime(1000)
-    await vi.waitFor(() => {
-      expect(copy_btn?.textContent).toContain(`📋`)
-    })
+    await vi.waitFor(() => expect(copy_btn?.textContent).toContain(`📋`))
 
     vi.useRealTimers()
   })
@@ -185,12 +151,7 @@ describe(`StructureExportPane`, () => {
       props: { structure: undefined },
     })
 
-    const format_div = Array.from(document.querySelectorAll(`.export-buttons > div`))
-      .find(
-        (div) => div.textContent?.includes(`JSON`),
-      )
-    const copy_btn = format_div?.querySelector(`button[title*="Copy"]`)
-
+    const copy_btn = get_button(`Copy JSON`)
     copy_btn?.dispatchEvent(new Event(`click`, { bubbles: true }))
 
     await vi.waitFor(() => {
@@ -198,7 +159,6 @@ describe(`StructureExportPane`, () => {
         expect.stringContaining(`No structure available for copying`),
       )
     })
-
     console_warn_spy.mockRestore()
   })
 
@@ -220,16 +180,14 @@ describe(`StructureExportPane`, () => {
     expect(dpi_input.max).toBe(`500`)
   })
 
-  test(`PNG export button is enabled with canvas`, () => {
+  test(`PNG export button is enabled with canvas`, async () => {
     mount(StructureExportPane, {
       target: document.body,
       props: { structure: simple_structure, wrapper: wrapper_div },
     })
 
-    const png_buttons = Array.from(document.querySelectorAll(`button`)).filter(
-      (btn) => btn.title?.includes(`PNG`),
-    )
-    expect(png_buttons[0]?.disabled).toBe(false)
+    const png_btn = get_button(`PNG`)
+    await vi.waitFor(() => expect(png_btn?.disabled).toBe(false))
   })
 
   test(`displays 3D model export formats`, () => {
@@ -253,15 +211,9 @@ describe(`StructureExportPane`, () => {
 
     const export_fn = export_funcs[fn_name as keyof typeof export_funcs]
 
-    // Find the 3D model export section
-    const h4_elements = Array.from(document.querySelectorAll(`h4`))
-    const models_h4 = h4_elements.find((h4) =>
-      h4.textContent?.includes(`Export as 3D model`)
-    )
-    expect(models_h4).toBeTruthy()
-
-    const models_section = models_h4?.nextElementSibling
-    expect(models_section).toBeTruthy()
+    // Find the 3D model export section to be specific, though buttons are unique enough here
+    const models_section = Array.from(document.querySelectorAll(`h4`))
+      .find((h4) => h4.textContent?.includes(`Export as 3D model`))?.nextElementSibling
 
     const format_div = Array.from(models_section?.querySelectorAll(`div`) || []).find((
       div,
@@ -271,10 +223,9 @@ describe(`StructureExportPane`, () => {
     expect(download_btn?.disabled).toBe(false)
 
     download_btn?.dispatchEvent(new Event(`click`, { bubbles: true }))
-
-    await vi.waitFor(() => {
+    await vi.waitFor(() =>
       expect(export_fn).toHaveBeenCalledWith(mock_scene, simple_structure)
-    })
+    )
   })
 
   test(`3D export buttons are disabled without scene`, () => {
@@ -283,51 +234,35 @@ describe(`StructureExportPane`, () => {
       props: { structure: simple_structure, scene: undefined },
     })
 
-    const h4_elements = Array.from(document.querySelectorAll(`h4`))
-    const models_h4 = h4_elements.find((h4) =>
-      h4.textContent?.includes(`Export as 3D model`)
-    )
-    const models_section = models_h4?.nextElementSibling
+    const models_section = Array.from(document.querySelectorAll(`h4`))
+      .find((h4) => h4.textContent?.includes(`Export as 3D model`))?.nextElementSibling
 
     const buttons = models_section?.querySelectorAll(`button`)
-    buttons?.forEach((btn) => {
-      expect(btn.disabled).toBe(true)
-    })
+    buttons?.forEach((btn) => expect(btn.disabled).toBe(true))
   })
 
-  test(`toggle button has correct title when closed`, () => {
+  test(`toggle button title when closed`, () => {
     mount(StructureExportPane, {
       target: document.body,
-      props: {
-        export_pane_open: false,
-      },
+      props: { export_pane_open: false },
     })
-
-    const toggle = doc_query(`.structure-export-toggle`)
-    expect(toggle.title).toBe(`Export Structure`)
+    expect(doc_query(`.structure-export-toggle`).title).toBe(`Export Structure`)
   })
 
-  test(`toggle button has empty title when open`, () => {
+  test(`toggle button title when open`, () => {
     mount(StructureExportPane, {
       target: document.body,
-      props: {
-        export_pane_open: true,
-      },
+      props: { export_pane_open: true },
     })
-
-    const toggle = doc_query(`.structure-export-toggle`)
-    expect(toggle.title).toBe(``)
+    expect(doc_query(`.structure-export-toggle`).title).toBe(``)
   })
 
   test(`handles clipboard API errors gracefully`, async () => {
     const console_error_spy = vi.spyOn(console, `error`).mockImplementation(() => {})
     const clipboard_error = new Error(`Clipboard API not available`)
 
-    // Mock clipboard.writeText to reject
     Object.assign(navigator, {
-      clipboard: {
-        writeText: vi.fn().mockRejectedValueOnce(clipboard_error),
-      },
+      clipboard: { writeText: vi.fn().mockRejectedValueOnce(clipboard_error) },
     })
 
     mount(StructureExportPane, {
@@ -335,12 +270,7 @@ describe(`StructureExportPane`, () => {
       props: { structure: simple_structure },
     })
 
-    const format_div = Array.from(document.querySelectorAll(`.export-buttons > div`))
-      .find(
-        (div) => div.textContent?.includes(`JSON`),
-      )
-    const copy_btn = format_div?.querySelector(`button[title*="Copy"]`)
-
+    const copy_btn = get_button(`Copy JSON`)
     copy_btn?.dispatchEvent(new Event(`click`, { bubbles: true }))
 
     await vi.waitFor(() => {
@@ -349,7 +279,6 @@ describe(`StructureExportPane`, () => {
         clipboard_error,
       )
     })
-
     console_error_spy.mockRestore()
   })
 
@@ -359,14 +288,9 @@ describe(`StructureExportPane`, () => {
       sites: simple_structure.sites,
     }
 
-    // Mock the functions to throw errors for formats that require lattice
     vi.mocked(export_funcs.structure_to_cif_str).mockImplementationOnce(() => {
       throw new Error(`No lattice found`)
     })
-    vi.mocked(export_funcs.structure_to_poscar_str).mockImplementationOnce(() => {
-      throw new Error(`No lattice found`)
-    })
-
     const console_error_spy = vi.spyOn(console, `error`).mockImplementation(() => {})
 
     mount(StructureExportPane, {
@@ -374,12 +298,8 @@ describe(`StructureExportPane`, () => {
       props: { structure: structure_without_lattice },
     })
 
-    // Try to copy CIF
-    const cif_div = Array.from(document.querySelectorAll(`.export-buttons > div`)).find((
-      div,
-    ) => div.textContent?.includes(`CIF`))
-    const cif_copy_btn = cif_div?.querySelector(`button[title*="Copy"]`)
-    cif_copy_btn?.dispatchEvent(new Event(`click`, { bubbles: true }))
+    const copy_btn = get_button(`Copy CIF`)
+    copy_btn?.dispatchEvent(new Event(`click`, { bubbles: true }))
 
     await vi.waitFor(() => {
       expect(console_error_spy).toHaveBeenCalledWith(
@@ -387,7 +307,6 @@ describe(`StructureExportPane`, () => {
         expect.any(Error),
       )
     })
-
     console_error_spy.mockRestore()
   })
 
@@ -397,118 +316,91 @@ describe(`StructureExportPane`, () => {
       props: { structure: simple_structure, scene: mock_scene },
     })
 
-    // Get all buttons from the text export section
-    const h4_elements = Array.from(document.querySelectorAll(`h4`))
-    const text_h4 = h4_elements.find((h4) => h4.textContent?.includes(`Export as text`))
-    expect(text_h4).toBeTruthy()
+    const text_section = Array.from(document.querySelectorAll(`h4`))
+      .find((h4) => h4.textContent?.includes(`Export as text`))?.nextElementSibling
 
-    const text_section = text_h4?.nextElementSibling
-    expect(text_section).toBeTruthy()
+    const download_buttons = Array.from(text_section?.querySelectorAll(`button`) || [])
+      .filter(
+        (btn) => btn.textContent?.trim() === `⬇`,
+      )
+    expect(download_buttons.length).toBe(4)
+    download_buttons.forEach((btn) => expect(btn.title).toContain(`Download`))
 
-    // Check download buttons (exact text match)
-    const download_buttons = Array.from(
-      text_section?.querySelectorAll(`button`) || [],
-    ).filter((btn) => btn.textContent?.trim() === `⬇`)
-    expect(download_buttons.length).toBe(4) // JSON, XYZ, CIF, POSCAR
-
-    download_buttons.forEach((btn) => {
-      const title = btn.getAttribute(`title`)
-      expect(title).toBeTruthy()
-      expect(title).toContain(`Download`)
-    })
-
-    // Check copy buttons (exact text match)
-    const copy_buttons = Array.from(
-      text_section?.querySelectorAll(`button`) || [],
-    ).filter((btn) => btn.textContent?.trim() === `📋`)
-    expect(copy_buttons.length).toBe(4) // JSON, XYZ, CIF, POSCAR
-
+    const copy_buttons = Array.from(text_section?.querySelectorAll(`button`) || [])
+      .filter(
+        (btn) => btn.textContent?.trim() === `📋`,
+      )
+    expect(copy_buttons.length).toBe(4)
     copy_buttons.forEach((btn) => {
-      const title = btn.getAttribute(`title`)
-      expect(title).toBeTruthy()
-      expect(title).toContain(`Copy`)
-      expect(title).toContain(`clipboard`)
+      expect(btn.title).toContain(`Copy`)
+      expect(btn.title).toContain(`clipboard`)
     })
   })
 
-  test(`custom pane_props are applied correctly`, () => {
+  test(`custom props are applied correctly`, () => {
     mount(StructureExportPane, {
       target: document.body,
       props: {
         pane_props: { style: `max-height: 400px`, class: `custom-export-pane` },
+        export_pane_open: false,
+        toggle_props: { class: `custom-export-toggle` },
       },
     })
 
     const pane = doc_query(`.export-pane`)
     expect(pane.classList.contains(`custom-export-pane`)).toBe(true)
     expect(pane.style.maxHeight).toBe(`400px`)
-  })
-
-  test(`custom toggle_props are applied correctly`, () => {
-    mount(StructureExportPane, {
-      target: document.body,
-      props: {
-        export_pane_open: false,
-        toggle_props: { class: `custom-export-toggle` },
-      },
-    })
 
     const toggle = doc_query(`.structure-export-toggle`)
     expect(toggle.classList.contains(`custom-export-toggle`)).toBe(true)
   })
 
-  test(`PNG export button invokes export_canvas_as_png with camera when provided`, async () => {
-    // Need to import the export module to check mocks
+  test(`PNG export button invokes export_canvas_as_png`, async () => {
     const mock_camera = { type: `PerspectiveCamera` } as Camera
+    const png_dpi = 200
 
     mount(StructureExportPane, {
       target: document.body,
       props: {
         structure: simple_structure,
         wrapper: wrapper_div,
-        png_dpi: 200,
+        png_dpi,
         camera: mock_camera,
         scene: mock_scene,
       },
     })
 
-    const png_button = Array.from(document.querySelectorAll(`button`)).find((btn) =>
-      btn.title?.includes(`PNG`)
-    )
-    expect(png_button).toBeTruthy()
-    expect(png_button?.disabled).toBe(false)
+    const png_btn = get_button(`PNG`)
+    expect(png_btn).toBeTruthy()
+    await vi.waitFor(() => expect(png_btn?.disabled).toBe(false))
 
-    png_button?.dispatchEvent(new Event(`click`, { bubbles: true }))
+    png_btn?.dispatchEvent(new Event(`click`, { bubbles: true }))
 
     await vi.waitFor(() => {
       expect(export_canvas_as_png).toHaveBeenCalledWith(
         wrapper_div.querySelector(`canvas`),
         simple_structure,
-        200,
+        png_dpi,
         mock_scene,
         mock_camera,
       )
     })
   })
 
-  test(`PNG export button invokes export_canvas_as_png with undefined camera when not provided`, async () => {
+  test(`PNG export button uses defaults when optional props missing`, async () => {
     mount(StructureExportPane, {
       target: document.body,
       props: {
         structure: simple_structure,
         wrapper: wrapper_div,
-        png_dpi: 150,
-        camera: undefined,
         scene: mock_scene,
+        // default png_dpi is 150, camera undefined
       },
     })
 
-    const png_button = Array.from(document.querySelectorAll(`button`)).find((btn) =>
-      btn.title?.includes(`PNG`)
-    )
-    expect(png_button).toBeTruthy()
-
-    png_button?.dispatchEvent(new Event(`click`, { bubbles: true }))
+    const png_btn = get_button(`PNG`)
+    await vi.waitFor(() => expect(png_btn?.disabled).toBe(false))
+    png_btn?.dispatchEvent(new Event(`click`, { bubbles: true }))
 
     await vi.waitFor(() => {
       expect(export_canvas_as_png).toHaveBeenCalledWith(
@@ -516,34 +408,6 @@ describe(`StructureExportPane`, () => {
         simple_structure,
         150,
         mock_scene,
-        undefined,
-      )
-    })
-  })
-
-  test(`PNG export button passes correct DPI value`, async () => {
-    const png_dpi = 300
-    mount(StructureExportPane, {
-      target: document.body,
-      props: {
-        structure: simple_structure,
-        wrapper: wrapper_div,
-        png_dpi,
-      },
-    })
-
-    const png_button = Array.from(document.querySelectorAll(`button`)).find((btn) =>
-      btn.title?.includes(`PNG`)
-    )
-
-    png_button?.dispatchEvent(new Event(`click`, { bubbles: true }))
-
-    await vi.waitFor(() => {
-      expect(export_canvas_as_png).toHaveBeenCalledWith(
-        wrapper_div.querySelector(`canvas`),
-        simple_structure,
-        png_dpi,
-        undefined,
         undefined,
       )
     })

--- a/tests/vitest/structure/StructureExportPane.test.ts
+++ b/tests/vitest/structure/StructureExportPane.test.ts
@@ -37,10 +37,15 @@ describe(`StructureExportPane`, () => {
     mock_scene = {} as Scene
   })
 
-  const get_button = (title_part: string) =>
-    Array.from(document.querySelectorAll(`button`)).find((btn) =>
+  const get_button = (title_part: string) => {
+    const matches = Array.from(document.querySelectorAll(`button`)).filter((btn) =>
       btn.title?.includes(title_part)
     )
+    if (matches.length > 1) {
+      console.warn(`Multiple buttons match "${title_part}": ${matches.length} found`)
+    }
+    return matches[0]
+  }
 
   test(`displays all text export format buttons`, () => {
     mount(StructureExportPane, {
@@ -321,14 +326,14 @@ describe(`StructureExportPane`, () => {
 
     const download_buttons = Array.from(text_section?.querySelectorAll(`button`) || [])
       .filter(
-        (btn) => btn.textContent?.trim() === `⬇`,
+        (btn) => btn.title?.includes(`Download`),
       )
     expect(download_buttons.length).toBe(4)
     download_buttons.forEach((btn) => expect(btn.title).toContain(`Download`))
 
     const copy_buttons = Array.from(text_section?.querySelectorAll(`button`) || [])
       .filter(
-        (btn) => btn.textContent?.trim() === `📋`,
+        (btn) => btn.title?.includes(`Copy`) && btn.title?.includes(`clipboard`),
       )
     expect(copy_buttons.length).toBe(4)
     copy_buttons.forEach((btn) => {


### PR DESCRIPTION
by forcing render before capture. closes #204

- Include the selected DPI in PNG export filenames.
- Detect export canvases reactively so export controls remain available.