### PR TITLE
Highlight selected entry in `PhaseDiagram2D`

### DIFF
--- a/src/lib/app.css
+++ b/src/lib/app.css
@@ -10,6 +10,7 @@
   /* Svelte MultiSelect */
   --sms-options-bg: var(--page-bg);
   --sms-active-color: light-dark(var(--accent-color), cornflowerblue);
+  --border-radius: 3pt;
 }
 
 /* Targeted theme transitions for performance */

--- a/src/lib/app.css
+++ b/src/lib/app.css
@@ -51,7 +51,7 @@ button, a.btn {
   color: var(--text-color);
   cursor: pointer;
   border: none;
-  border-radius: 3pt;
+  border-radius: var(--border-radius);
   padding: 2pt 4pt;
 }
 button:disabled {
@@ -64,7 +64,7 @@ a:hover {
 code, kbd {
   overflow-wrap: break-word;
   padding: 1pt 3pt;
-  border-radius: 3pt;
+  border-radius: var(--border-radius);
   background-color: var(--code-bg);
 }
 kbd {
@@ -78,7 +78,7 @@ pre code {
 }
 pre {
   position: relative;
-  border-radius: 4pt;
+  border-radius: var(--border-radius);
   font-size: 0.95em;
   background-color: var(--pre-bg);
   padding: 1ex 1em;
@@ -124,7 +124,7 @@ textarea {
 /* Modern flat input styling */
 input {
   border: none;
-  border-radius: 3pt;
+  border-radius: var(--border-radius);
 }
 input[type='number'] {
   min-width: 40px;
@@ -134,7 +134,7 @@ input[type='color'] {
   border: none;
   padding: 0;
   outline: none;
-  border-radius: 3pt;
+  border-radius: var(--border-radius);
   overflow: hidden;
   cursor: pointer;
 }

--- a/src/lib/bands/helpers.ts
+++ b/src/lib/bands/helpers.ts
@@ -232,7 +232,7 @@ const parse_qpoint = (
 }
 
 const EV_TO_THZ = 241.7989 // 1 eV = 241.8 THz
-const PMG_CM_TO_THZ = 1 / 33.35641 // cm⁻¹ to THz conversion factor
+const CM_TO_THZ = 1 / 33.35641 // cm⁻¹ to THz conversion factor
 
 // Convert pymatgen PhononBandStructureSymmLine to matterviz format
 function convert_pymatgen_band_structure(
@@ -289,7 +289,7 @@ function convert_pymatgen_band_structure(
   // Convert bands to THz based on input unit
   const convert_to_thz = (val: number): number => {
     if (unit === `ev`) return val * EV_TO_THZ
-    if (unit === `cm-1`) return val * PMG_CM_TO_THZ
+    if (unit === `cm-1`) return val * CM_TO_THZ
     return val // THz (default) - no conversion
   }
 
@@ -344,9 +344,6 @@ export function normalize_band_structure(
 
   return band_struct as unknown as types.BaseBandStructure
 }
-
-// Conversion factor: 1 THz = 33.35641 cm⁻¹
-const CM_TO_THZ = 1 / 33.35641
 
 // Validate and normalize a DOS object.
 // Supports both matterviz and pymatgen formats.

--- a/src/lib/bands/helpers.ts
+++ b/src/lib/bands/helpers.ts
@@ -232,6 +232,7 @@ const parse_qpoint = (
 }
 
 const EV_TO_THZ = 241.7989 // 1 eV = 241.8 THz
+const PMG_CM_TO_THZ = 1 / 33.35641 // cm⁻¹ to THz conversion factor
 
 // Convert pymatgen PhononBandStructureSymmLine to matterviz format
 function convert_pymatgen_band_structure(
@@ -241,6 +242,8 @@ function convert_pymatgen_band_structure(
   const raw_bands = pmg.bands as number[][] | undefined
   const labels_dict = pmg.labels_dict as Record<string, Vec3> | undefined
   const lattice_rec = pmg.lattice_rec as { matrix?: Matrix3x3 } | undefined
+  // pymatgen defaults to THz, but may specify 'ev' or 'cm-1'
+  const unit = (pmg.unit as string | undefined)?.toLowerCase() ?? `thz`
 
   if (
     !Array.isArray(raw_qpts) || !Array.isArray(raw_bands) ||
@@ -283,11 +286,18 @@ function convert_pymatgen_band_structure(
     branches.push({ start_index: 0, end_index: qpoints.length - 1, name: `path` })
   }
 
+  // Convert bands to THz based on input unit
+  const convert_to_thz = (val: number): number => {
+    if (unit === `ev`) return val * EV_TO_THZ
+    if (unit === `cm-1`) return val * PMG_CM_TO_THZ
+    return val // THz (default) - no conversion
+  }
+
   return {
     qpoints,
     branches,
     distance,
-    bands: raw_bands.map((band) => band.map((f) => f * EV_TO_THZ)),
+    bands: raw_bands.map((band) => band.map(convert_to_thz)),
     nb_bands: raw_bands.length,
     labels_dict: labels_dict ?? {},
     recip_lattice: { matrix: lattice_rec?.matrix ?? [[1, 0, 0], [0, 1, 0], [0, 0, 1]] },

--- a/src/lib/brillouin/BrillouinZone.svelte
+++ b/src/lib/brillouin/BrillouinZone.svelte
@@ -381,7 +381,7 @@
     width: var(--bz-width, 100%);
     max-width: var(--bz-max-width, 100%);
     min-width: var(--bz-min-width, 300px);
-    border-radius: var(--bz-border-radius, 3pt);
+    border-radius: var(--bz-border-radius, var(--border-radius));
     background: var(--bz-bg, var(--surface-bg));
     color: var(--bz-text-color, var(--text-color));
   }

--- a/src/lib/composition/Formula.svelte
+++ b/src/lib/composition/Formula.svelte
@@ -192,7 +192,7 @@
     gap: var(--formula-tooltip-gap, 5pt);
     padding: var(--formula-tooltip-padding, 3pt 4pt);
     background: var(--formula-tooltip-bg, rgba(0, 0, 0, 0.9));
-    border-radius: var(--formula-tooltip-border-radius, 3pt);
+    border-radius: var(--formula-tooltip-border-radius, var(--border-radius));
     box-shadow: var(--formula-tooltip-box-shadow, 0 4px 12px rgba(0, 0, 0, 0.3));
     z-index: var(--tooltip-z-index, 2);
   }

--- a/src/lib/element/ElementPhoto.svelte
+++ b/src/lib/element/ElementPhoto.svelte
@@ -32,7 +32,7 @@
     width: 100%;
     object-fit: cover;
     margin: 0;
-    border-radius: var(--element-photo-border-radius, 4pt);
+    border-radius: var(--element-photo-border-radius, var(--border-radius));
   }
   div {
     aspect-ratio: 1;
@@ -47,7 +47,7 @@
       rgba(0, 0, 100, 0.3)
     );
     color: var(--text-color);
-    border-radius: var(--element-photo-border-radius, 4pt);
+    border-radius: var(--element-photo-border-radius, var(--border-radius));
     width: 100%;
     container-type: inline-size;
   }

--- a/src/lib/element/ElementTile.svelte
+++ b/src/lib/element/ElementTile.svelte
@@ -227,7 +227,7 @@
     display: flex;
     place-items: center;
     place-content: center;
-    border-radius: var(--elem-tile-border-radius, 2pt);
+    border-radius: var(--elem-tile-border-radius, var(--border-radius));
     box-sizing: border-box;
     color: var(--elem-tile-text-color);
     /* add persistent invisible border so content doesn't move on hover */

--- a/src/lib/feedback/FullscreenToggle.svelte
+++ b/src/lib/feedback/FullscreenToggle.svelte
@@ -35,7 +35,7 @@
     align-items: center;
     justify-content: center;
     padding: var(--fullscreen-btn-padding, 2pt);
-    border-radius: var(--fullscreen-btn-border-radius, 3pt);
+    border-radius: var(--fullscreen-btn-border-radius, var(--border-radius));
     background-color: transparent;
     cursor: pointer;
     opacity: 0;

--- a/src/lib/feedback/StatusMessage.svelte
+++ b/src/lib/feedback/StatusMessage.svelte
@@ -65,14 +65,14 @@
 <style>
   .message {
     margin-bottom: 0.5em;
-    border-radius: var(--border-radius);
+    border-radius: var(--status-message-border-radius, var(--border-radius));
   }
   button {
     margin-left: 1em;
     padding: 0.25em 0.75em;
     background: #e0e0e0;
     border: 1px solid #ccc;
-    border-radius: 3px;
+    border-radius: var(--status-message-button-border-radius, var(--border-radius));
     cursor: pointer;
   }
   button:hover {

--- a/src/lib/feedback/StatusMessage.svelte
+++ b/src/lib/feedback/StatusMessage.svelte
@@ -65,7 +65,7 @@
 <style>
   .message {
     margin-bottom: 0.5em;
-    border-radius: 4px;
+    border-radius: var(--border-radius);
   }
   button {
     margin-left: 1em;

--- a/src/lib/layout/SettingsSection.svelte
+++ b/src/lib/layout/SettingsSection.svelte
@@ -120,7 +120,7 @@
     gap: 2pt;
     padding: var(--reset-btn-padding, 1pt 4pt);
     font-size: 0.65em;
-    border-radius: var(--reset-btn-border-radius, 2pt);
+    border-radius: var(--reset-btn-border-radius, var(--border-radius));
     background: var(--btn-bg, rgba(0, 0, 0, 0.1));
     color: var(--text-color-muted, #6b7280);
     border: 1px solid var(--border-color, #d1d5db);

--- a/src/lib/overlays/ContextMenu.svelte
+++ b/src/lib/overlays/ContextMenu.svelte
@@ -101,7 +101,7 @@
   .context-menu {
     background: var(--surface-bg);
     border: 1px solid var(--border-color);
-    border-radius: var(--border-radius, 4px);
+    border-radius: var(--border-radius, var(--border-radius));
     box-shadow: 0 8px 16px -4px rgba(0, 0, 0, 0.3), 0 4px 8px -2px rgba(0, 0, 0, 0.1);
     backdrop-filter: blur(4px);
     min-width: var(--context-menu-min-width, 160px);

--- a/src/lib/overlays/ContextMenu.svelte
+++ b/src/lib/overlays/ContextMenu.svelte
@@ -101,7 +101,7 @@
   .context-menu {
     background: var(--surface-bg);
     border: 1px solid var(--border-color);
-    border-radius: var(--border-radius, var(--border-radius));
+    border-radius: var(--context-menu-border-radius, var(--border-radius));
     box-shadow: 0 8px 16px -4px rgba(0, 0, 0, 0.3), 0 4px 8px -2px rgba(0, 0, 0, 0.1);
     backdrop-filter: blur(4px);
     min-width: var(--context-menu-min-width, 160px);

--- a/src/lib/overlays/DraggablePane.svelte
+++ b/src/lib/overlays/DraggablePane.svelte
@@ -248,7 +248,7 @@
     display: flex;
     place-items: center;
     padding: var(--pane-toggle-padding, 2pt);
-    border-radius: var(--pane-toggle-border-radius, 3pt);
+    border-radius: var(--pane-toggle-border-radius, var(--border-radius));
     background-color: transparent;
     transition: var(--pane-toggle-transition, background-color 0.2s);
     font-size: var(--pane-toggle-font-size, clamp(0.9em, 2cqmin, 1.4em));
@@ -260,7 +260,7 @@
     position: absolute; /* Use absolute so pane scrolls with page content */
     background: var(--pane-bg, var(--page-bg, light-dark(white, black)));
     border: var(--pane-border, 1px solid rgba(255, 255, 255, 0.15));
-    border-radius: var(--pane-border-radius, 6px);
+    border-radius: var(--pane-border-radius, var(--border-radius));
     padding: var(--pane-padding, 1ex);
     box-sizing: border-box;
     z-index: var(--pane-z-index, 10);

--- a/src/lib/periodic-table/PeriodicTable.svelte
+++ b/src/lib/periodic-table/PeriodicTable.svelte
@@ -423,7 +423,7 @@
     background: var(--tooltip-bg, rgba(0, 0, 0, 0.8));
     color: var(--tooltip-color, light-dark(black, white));
     padding: var(--tooltip-padding, 4px 6px);
-    border-radius: var(--tooltip-border-radius, 6px);
+    border-radius: var(--tooltip-border-radius, var(--border-radius));
     font-size: var(--tooltip-font-size, 14px);
     text-align: var(--tooltip-text-align, center);
     line-height: var(--tooltip-line-height, 1.2);

--- a/src/lib/phase-diagram/PhaseDiagram.svelte
+++ b/src/lib/phase-diagram/PhaseDiagram.svelte
@@ -100,18 +100,12 @@
   />
 {:else}
   <!-- Error state for unsupported dimensionalities -->
-  <div
-    class="phase-diagram-error"
-    style="display: flex; align-items: center; justify-content: center; height: var(--pd-height, 500px); border: 1px solid var(--text-color, #ccc); border-radius: 4px; background: var(--pd-bg, transparent)"
-  >
+  <div class="phase-diagram-error">
     <div style="text-align: center; padding: 2em; color: var(--text-color, #666)">
       <h3 style="margin: 0 0 1em 0">Unsupported Chemical System</h3>
       <p style="margin: 0">
         Phase diagrams require 2, 3, or 4 elements. Found {element_count} element{
-          element_count ===
-            1
-          ? ``
-          : `s`
+          element_count === 1 ? `` : `s`
         }:
       </p>
       <p style="margin: 0.5em 0 0 0; font-weight: bold">
@@ -120,3 +114,16 @@
     </div>
   </div>
 {/if}
+
+<style>
+  .phase-diagram-error {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    height: var(--pd-height, 500px);
+    border: 1px solid var(--text-color, #ccc);
+    border-radius: var(--border-radius);
+    background: var(--pd-bg, transparent);
+  }
+</style>

--- a/src/lib/phase-diagram/PhaseDiagram2D.svelte
+++ b/src/lib/phase-diagram/PhaseDiagram2D.svelte
@@ -392,12 +392,11 @@
   })
 
   const max_hull_dist_in_data = $derived(
-    helpers.calc_max_hull_dist_in_data(effective_entries),
+    helpers.calc_max_hull_dist_in_data(plot_entries),
   )
-
   // Phase diagram statistics - compute internally and expose via bindable prop
   $effect(() => {
-    phase_stats = thermo.get_phase_diagram_stats(effective_entries, elements, 3)
+    phase_stats = thermo.get_phase_diagram_stats(plot_entries, elements, 3)
   })
 
   function extract_structure_from_entry(

--- a/src/lib/phase-diagram/PhaseDiagram2D.svelte
+++ b/src/lib/phase-diagram/PhaseDiagram2D.svelte
@@ -331,13 +331,13 @@
       const hl = is_highlighted(entry) ? merged_highlight_style : null
 
       return {
-        fill: hl?.effect === `color`
+        fill: hl && (hl.effect === `color` || hl.effect === `both`)
           ? hl.color
           : is_energy_mode
           ? undefined
           : merged_config.colors?.[is_stable ? `stable` : `unstable`],
         stroke: is_stable ? `#ffffff` : `#000000`,
-        radius: hl?.effect === `size`
+        radius: hl && (hl.effect === `size` || hl.effect === `both`)
           ? base_radius * hl.size_multiplier
           : base_radius,
         symbol_type: marker_to_d3_symbol(entry.marker),
@@ -384,10 +384,13 @@
   const scatter_series = $derived([scatter_points_series, ...hull_segments_series])
 
   // Map selected_entry to ScatterPlot point index (series_idx: 0 = points series)
+  // Use object identity comparison (e === entry) instead of entry_id comparison
+  // because synthetic elemental entries lack entry_id, and undefined === undefined
+  // would incorrectly match the first entry with undefined entry_id
   const selected_scatter_point = $derived.by(() => {
     const entry = selected_entry
     if (!entry) return null
-    const idx = visible_entries.findIndex((e) => e.entry_id === entry.entry_id)
+    const idx = visible_entries.findIndex((vis_entry) => vis_entry === entry)
     return idx >= 0 ? { series_idx: 0, point_idx: idx } : null
   })
 

--- a/src/lib/phase-diagram/PhaseDiagram2D.svelte
+++ b/src/lib/phase-diagram/PhaseDiagram2D.svelte
@@ -9,6 +9,7 @@
   import { Icon, is_unary_entry, PD_DEFAULTS, toggle_fullscreen } from '$lib'
   import type { D3InterpolateName } from '$lib/colors'
   import { ClickFeedback, DragOverlay } from '$lib/feedback'
+  import { symbol_map } from '$lib/labels'
   import type {
     AxisConfig,
     ScatterHandlerEvent,
@@ -24,7 +25,12 @@
   import PhaseEntryTooltip from './PhaseEntryTooltip.svelte'
   import StructurePopup from './StructurePopup.svelte'
   import * as thermo from './thermodynamics'
-  import type { HoverData3D, PhaseData, PhaseDiagramEntry } from './types'
+  import type {
+    HighlightStyle,
+    HoverData3D,
+    PhaseData,
+    PhaseDiagramEntry,
+  } from './types'
 
   // Binary phase diagram rendered as energy vs composition (x in [0, 1])
   let {
@@ -56,12 +62,14 @@
     stable_entries = $bindable([]),
     unstable_entries = $bindable([]),
     highlighted_entries = $bindable([]),
+    highlight_style = {},
     x_axis = {},
     y_axis = {},
     selected_entry = $bindable(null),
     children,
     ...rest
   }: BasePhaseDiagramProps<PhaseDiagramEntry> & {
+    highlight_style?: HighlightStyle
     x_axis?: AxisConfig
     y_axis?: AxisConfig
   } = $props()
@@ -74,6 +82,15 @@
     colors: { ...default_pd_config.colors, ...(config.colors || {}) },
     margin: { t: 40, r: 40, b: 60, l: 60, ...(config.margin || {}) },
   })
+
+  // Merge highlight style with defaults (consistent with 3D/4D)
+  const merged_highlight_style = $derived(
+    helpers.merge_highlight_style(highlight_style),
+  )
+
+  // Helper to check if entry is highlighted
+  const is_highlighted = (entry: PhaseDiagramEntry): boolean =>
+    helpers.is_entry_highlighted(entry, highlighted_entries)
 
   let { // Compute energy mode information
     has_precomputed_e_form,
@@ -295,43 +312,49 @@
     ),
   )
 
-  // Map MarkerSymbol to D3SymbolName (capitalize first letter)
+  // Map MarkerSymbol to D3SymbolName (type-safe via symbol_map lookup)
   const marker_to_d3_symbol = (marker?: string): D3SymbolName | undefined => {
     if (!marker) return undefined
-    return (marker.charAt(0).toUpperCase() + marker.slice(1)) as D3SymbolName
+    const name = marker.charAt(0).toUpperCase() + marker.slice(1)
+    return name in symbol_map ? (name as D3SymbolName) : undefined
   }
 
   // Pre-compute visible entries to avoid redundant filtering
   const visible_entries = $derived(plot_entries.filter((e) => e.visible))
 
   const scatter_points_series = $derived.by(() => {
-    const xs = visible_entries.map((e) => e.x)
-    const ys = visible_entries.map((e) => e.y)
-
-    // Stability mode: explicit per-point styles; Energy mode: use color_scale
     const is_energy_mode = color_mode === `energy`
-    const point_style = visible_entries.map((e) => {
-      const is_stable = e.is_stable || e.e_above_hull === 0
+
+    const point_style = visible_entries.map((entry) => {
+      const is_stable = entry.is_stable || entry.e_above_hull === 0
+      const base_radius = entry.size || (is_stable ? 6 : 4)
+      const hl = is_highlighted(entry) ? merged_highlight_style : null
+
       return {
-        fill: is_energy_mode
+        fill: hl?.effect === `color`
+          ? hl.color
+          : is_energy_mode
           ? undefined
-          : is_stable
-          ? (merged_config.colors?.stable || `#0072B2`)
-          : (merged_config.colors?.unstable || `#E69F00`),
+          : merged_config.colors?.[is_stable ? `stable` : `unstable`],
         stroke: is_stable ? `#ffffff` : `#000000`,
-        radius: e.size || (is_stable ? 6 : 4),
-        symbol_type: marker_to_d3_symbol(e.marker),
+        radius: hl?.effect === `size`
+          ? base_radius * hl.size_multiplier
+          : base_radius,
+        symbol_type: marker_to_d3_symbol(entry.marker),
+        is_highlighted: !!hl,
+        highlight_effect: hl?.effect,
+        highlight_color: hl?.color,
       }
     })
 
     return {
-      x: xs,
-      y: ys,
-      metadata: visible_entries, // keep PD entry alongside each point
+      x: visible_entries.map((entry) => entry.x),
+      y: visible_entries.map((entry) => entry.y),
+      metadata: visible_entries,
       markers: `points` as const,
       point_style,
       ...(is_energy_mode
-        ? { color_values: visible_entries.map((e) => e.e_above_hull ?? 0) }
+        ? { color_values: visible_entries.map((entry) => entry.e_above_hull ?? 0) }
         : {}),
     }
   })

--- a/src/lib/phase-diagram/PhaseDiagram3D.svelte
+++ b/src/lib/phase-diagram/PhaseDiagram3D.svelte
@@ -1140,7 +1140,7 @@
     width: 100%;
     height: var(--pd-height, 500px);
     background: var(--pd-3d-bg, var(--pd-bg));
-    border-radius: 4px;
+    border-radius: var(--pd-border-radius, var(--border-radius));
   }
   .phase-diagram-3d:fullscreen {
     border-radius: 0;

--- a/src/lib/phase-diagram/PhaseDiagram3D.svelte
+++ b/src/lib/phase-diagram/PhaseDiagram3D.svelte
@@ -348,12 +348,11 @@
   )
 
   const max_hull_dist_in_data = $derived(
-    helpers.calc_max_hull_dist_in_data(processed_entries),
+    helpers.calc_max_hull_dist_in_data(plot_entries),
   )
-
   // Phase diagram statistics - compute internally and expose via bindable prop
   $effect(() => {
-    phase_stats = thermo.get_phase_diagram_stats(processed_entries, elements, 3)
+    phase_stats = thermo.get_phase_diagram_stats(plot_entries, elements, 3)
   })
 
   // 3D to 2D projection for ternary diagrams

--- a/src/lib/phase-diagram/PhaseDiagram4D.svelte
+++ b/src/lib/phase-diagram/PhaseDiagram4D.svelte
@@ -1131,7 +1131,7 @@
     width: 100%;
     height: var(--pd-height, 500px);
     background: var(--pd-4d-bg, var(--pd-bg));
-    border-radius: 4px;
+    border-radius: var(--pd-border-radius, var(--border-radius));
   }
   .phase-diagram-4d:fullscreen {
     border-radius: 0;

--- a/src/lib/phase-diagram/PhaseDiagram4D.svelte
+++ b/src/lib/phase-diagram/PhaseDiagram4D.svelte
@@ -405,12 +405,11 @@
   )
 
   const max_hull_dist_in_data = $derived(
-    helpers.calc_max_hull_dist_in_data(processed_entries),
+    helpers.calc_max_hull_dist_in_data(plot_entries),
   )
-
   // Phase diagram statistics - compute internally and expose via bindable prop
   $effect(() => {
-    phase_stats = thermo.get_phase_diagram_stats(processed_entries, elements, 4)
+    phase_stats = thermo.get_phase_diagram_stats(plot_entries, elements, 4)
   })
 
   // Utility: convert hex color to rgba string with alpha

--- a/src/lib/phase-diagram/PhaseDiagramControls.svelte
+++ b/src/lib/phase-diagram/PhaseDiagramControls.svelte
@@ -430,7 +430,7 @@
   .legend-item {
     display: flex;
     align-items: center;
-    border-radius: 4px;
+    border-radius: var(--pd-border-radius, var(--border-radius));
     cursor: pointer;
     white-space: nowrap;
   }

--- a/src/lib/phase-diagram/PhaseDiagramStats.svelte
+++ b/src/lib/phase-diagram/PhaseDiagramStats.svelte
@@ -255,7 +255,7 @@
 <style>
   .phase-diagram-stats {
     background: var(--pd-stats-bg, var(--pd-bg));
-    border-radius: 4px;
+    border-radius: var(--pd-border-radius, var(--border-radius));
     padding: 0 1em 1em;
   }
   section div {

--- a/src/lib/phase-diagram/types.ts
+++ b/src/lib/phase-diagram/types.ts
@@ -164,7 +164,7 @@ export const is_denary_entry = (entry: PhaseData) => get_arity(entry) === 10
 
 // Highlight styles for phase diagram entries
 export interface HighlightStyle {
-  effect?: `pulse` | `glow` | `size` | `color`
+  effect?: `pulse` | `glow` | `size` | `color` | `both`
   color?: string
   size_multiplier?: number
   opacity?: number

--- a/src/lib/plot/BarPlot.svelte
+++ b/src/lib/plot/BarPlot.svelte
@@ -1104,7 +1104,7 @@
     min-height: var(--barplot-min-height, 300px);
     container-type: size;
     z-index: var(--barplot-z-index, auto);
-    border-radius: var(--border-radius, 4px);
+    border-radius: var(--barplot-border-radius, var(--border-radius));
     flex: var(--barplot-flex, 1);
     display: var(--barplot-display, flex);
     flex-direction: column;

--- a/src/lib/plot/ColorBar.svelte
+++ b/src/lib/plot/ColorBar.svelte
@@ -462,7 +462,7 @@
   /* color gradient bar */
   div.bar {
     position: relative;
-    border-radius: var(--cbar-border-radius, 2pt);
+    border-radius: var(--cbar-border-radius, var(--border-radius));
     /* Use CSS variables set inline */
     width: var(--cbar-width);
     height: var(--cbar-height);

--- a/src/lib/plot/Histogram.svelte
+++ b/src/lib/plot/Histogram.svelte
@@ -926,6 +926,7 @@
     display: var(--histogram-display, flex);
     flex-direction: column;
     background: var(--histogram-bg, var(--plot-bg));
+    border-radius: var(--histogram-border-radius, var(--border-radius));
   }
   .histogram.fullscreen {
     position: fixed;

--- a/src/lib/plot/PlotLegend.svelte
+++ b/src/lib/plot/PlotLegend.svelte
@@ -178,7 +178,7 @@
     gap: 1px 6px; /* row-gap column-gap */
     background-color: var(--plot-legend-bg-color);
     border: var(--plot-legend-border);
-    border-radius: var(--plot-legend-border-radius, 3px);
+    border-radius: var(--plot-legend-border-radius, var(--border-radius));
     font-size: var(--plot-legend-font-size, 0.8em);
     max-width: var(--plot-legend-max-width);
     width: fit-content;

--- a/src/lib/plot/ScatterPlot.svelte
+++ b/src/lib/plot/ScatterPlot.svelte
@@ -69,6 +69,7 @@
     range_padding = 0.05,
     current_x_value = null,
     tooltip_point = $bindable(null),
+    selected_point = null,
     hovered = $bindable(false),
     tooltip,
     user_content,
@@ -102,6 +103,7 @@
     range_padding?: number
     current_x_value?: number | null
     tooltip_point?: InternalPoint | null
+    selected_point?: { series_idx: number; point_idx: number } | null
     hovered?: boolean
     tooltip?: Snippet<[ScatterHandlerProps]>
     user_content?: Snippet<[UserContentProps]>
@@ -1532,6 +1534,9 @@
                   is_hovered={tooltip_point !== null &&
                   point.series_idx === tooltip_point.series_idx &&
                   point.point_idx === tooltip_point.point_idx}
+                  is_selected={selected_point !== null &&
+                  point.series_idx === selected_point.series_idx &&
+                  point.point_idx === selected_point.point_idx}
                   style={{
                     ...point.point_style,
                     // When size_value is present, it should always determine the radius

--- a/src/lib/plot/ScatterPlot.svelte
+++ b/src/lib/plot/ScatterPlot.svelte
@@ -1766,6 +1766,7 @@
     display: var(--scatter-display, flex);
     flex-direction: column;
     background: var(--scatter-bg, var(--plot-bg));
+    border-radius: var(--scatter-border-radius, var(--border-radius));
   }
   div.scatter.fullscreen {
     position: fixed;
@@ -1846,7 +1847,7 @@
   .tooltip {
     color: var(--scatter-tooltip-color, light-dark(black, white));
     padding: var(--scatter-tooltip-padding, 1px 4px);
-    border-radius: var(--scatter-tooltip-border-radius, 3px);
+    border-radius: var(--scatter-tooltip-border-radius, var(--border-radius));
     font-size: var(--scatter-tooltip-font-size, 0.8em);
     /* Ensure background fits content width */
     width: var(--scatter-tooltip-width, max-content);

--- a/src/lib/plot/ScatterPoint.svelte
+++ b/src/lib/plot/ScatterPoint.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import type { HoverStyle, LabelStyle, Point } from '$lib/plot'
   import { type D3SymbolName, symbol_map } from '$lib/labels'
+  import type { HoverStyle, LabelStyle, Point } from '$lib/plot'
   import type { PointStyle, TweenedOptions, XyObj } from '$lib/plot/types'
   import { DEFAULTS } from '$lib/settings'
   import * as d3_symbols from 'd3-shape'
@@ -19,6 +19,7 @@
     point_tween,
     origin = { x: 0, y: 0 },
     is_hovered = false,
+    is_selected = false,
     ...rest
   }: Omit<SVGAttributes<SVGGElement>, `style` | `offset` | `origin` | `transform`> & {
     x: number
@@ -30,6 +31,7 @@
     point_tween?: TweenedOptions<XyObj>
     origin?: XyObj
     is_hovered?: boolean
+    is_selected?: boolean
   } = $props()
 
   // get the SVG path data as 'd' attribute
@@ -62,6 +64,13 @@
   style:--hover-brightness={hover.brightness ?? 1.2}
   {...rest}
 >
+  {#if is_selected}
+    <circle
+      r={(style.radius ?? 4) * 2.5}
+      class="selection-ring"
+      fill="var(--point-fill-color, {style.fill ?? `cornflowerblue`})"
+    />
+  {/if}
   <path
     d={marker_path}
     stroke={style.stroke ?? `transparent`}
@@ -97,6 +106,20 @@
     stroke: var(--hover-stroke);
     stroke-width: var(--hover-stroke-width);
     filter: brightness(var(--hover-brightness));
+  }
+  .selection-ring {
+    animation: pulse 1s ease-in-out infinite;
+    pointer-events: none;
+  }
+  @keyframes pulse {
+    0%, 100% {
+      opacity: 0.3;
+      transform: scale(1);
+    }
+    50% {
+      opacity: 0.7;
+      transform: scale(1.15);
+    }
   }
   .label-text {
     pointer-events: var(--scatter-point-label-pointer-events, none);

--- a/src/lib/plot/ScatterPoint.svelte
+++ b/src/lib/plot/ScatterPoint.svelte
@@ -67,8 +67,18 @@
   {#if is_selected}
     <circle
       r={(style.radius ?? 4) * 2.5}
-      class="selection-ring"
+      class="effect-ring selected"
       fill="var(--point-fill-color, {style.fill ?? `cornflowerblue`})"
+      stroke="var(--effect-ring-stroke, white)"
+      stroke-width="var(--effect-ring-stroke-width, 1)"
+    />
+  {:else if style.is_highlighted && style.highlight_effect?.match(/pulse|glow/)}
+    <circle
+      r={(style.radius ?? 4) * 2}
+      class="effect-ring {style.highlight_effect}"
+      fill={style.highlight_color ?? `#ff4444`}
+      stroke="var(--effect-ring-stroke, white)"
+      stroke-width="var(--effect-ring-stroke-width, 1)"
     />
   {/if}
   <path
@@ -107,18 +117,26 @@
     stroke-width: var(--hover-stroke-width);
     filter: brightness(var(--hover-brightness));
   }
-  .selection-ring {
-    animation: pulse 1s ease-in-out infinite;
+  .effect-ring {
     pointer-events: none;
+    animation: ring-pulse var(--effect-ring-duration, 1s) ease-in-out
+      var(--effect-ring-iterations, infinite);
   }
-  @keyframes pulse {
+  .effect-ring.pulse {
+    --effect-ring-duration: 1.2s;
+  }
+  .effect-ring.glow {
+    --effect-ring-duration: 1.5s;
+    filter: blur(3px);
+  }
+  @keyframes ring-pulse {
     0%, 100% {
       opacity: 0.3;
       transform: scale(1);
     }
     50% {
       opacity: 0.7;
-      transform: scale(1.15);
+      transform: scale(1.2);
     }
   }
   .label-text {

--- a/src/lib/plot/types.ts
+++ b/src/lib/plot/types.ts
@@ -40,7 +40,7 @@ export interface PointStyle {
   // Highlight support for phase diagrams and other use cases
   is_highlighted?: boolean
   highlight_color?: string
-  highlight_effect?: `pulse` | `glow` | `size` | `color`
+  highlight_effect?: `pulse` | `glow` | `size` | `color` | `both`
 }
 
 export interface HoverStyle {

--- a/src/lib/plot/types.ts
+++ b/src/lib/plot/types.ts
@@ -37,6 +37,10 @@ export interface PointStyle {
   symbol_size?: number | null // Optional override for marker size
   shape?: string // Add optional shape (string for flexibility)
   cursor?: string // Cursor style for the point
+  // Highlight support for phase diagrams and other use cases
+  is_highlighted?: boolean
+  highlight_color?: string
+  highlight_effect?: `pulse` | `glow` | `size` | `color`
 }
 
 export interface HoverStyle {

--- a/src/lib/structure/AtomLegend.svelte
+++ b/src/lib/structure/AtomLegend.svelte
@@ -303,7 +303,7 @@
   }
   .element-legend label {
     padding: var(--struct-legend-padding, 0 4pt);
-    border-radius: var(--struct-legend-radius, 3pt);
+    border-radius: var(--struct-legend-radius, var(--border-radius));
     line-height: var(--struct-legend-line-height, 1.3);
     display: inline-block;
     cursor: pointer;
@@ -392,7 +392,7 @@
     right: 0;
     margin-bottom: 0.25rem;
     background: var(--surface-bg);
-    border-radius: 4px;
+    border-radius: var(--border-radius);
     box-shadow: 0 8px 16px -4px rgba(0, 0, 0, 0.3), 0 4px 8px -2px rgba(0, 0, 0, 0.1);
     display: flex;
     flex-direction: column;
@@ -414,12 +414,12 @@
     font-size: 0.85rem;
   }
   .mode-option:first-child {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
+    border-top-left-radius: var(--border-radius);
+    border-top-right-radius: var(--border-radius);
   }
   .mode-option:last-child {
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-bottom-left-radius: var(--border-radius);
+    border-bottom-right-radius: var(--border-radius);
   }
   .mode-option:hover:not(.disabled) {
     background: var(--pane-btn-bg-hover, rgba(128, 128, 128, 0.1));
@@ -441,7 +441,7 @@
   }
   .category-label {
     padding: var(--struct-legend-padding, 0 4pt);
-    border-radius: var(--struct-legend-radius, 3pt);
+    border-radius: var(--struct-legend-radius, var(--border-radius));
     line-height: var(--struct-legend-line-height, 1.3);
     display: inline-block;
     white-space: nowrap;

--- a/src/lib/structure/CanvasTooltip.svelte
+++ b/src/lib/structure/CanvasTooltip.svelte
@@ -21,7 +21,7 @@
     width: max-content;
     box-sizing: border-box;
     text-align: var(--canvas-tooltip-text-align, left);
-    border-radius: var(--canvas-tooltip-border-radius, 5pt);
+    border-radius: var(--canvas-tooltip-border-radius, var(--border-radius));
     background: var(--canvas-tooltip-bg, var(--code-bg));
     padding: var(--canvas-tooltip-padding, 1pt 5pt);
     color: var(--canvas-tooltip-text-color);

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -870,7 +870,7 @@
     width: var(--struct-width, 100%);
     max-width: var(--struct-max-width, 100%);
     min-width: var(--struct-min-width, 300px);
-    border-radius: var(--struct-border-radius, 3pt);
+    border-radius: var(--struct-border-radius, var(--border-radius));
     background: var(--struct-bg-override, var(--struct-bg));
     color: var(--struct-text-color);
   }
@@ -934,7 +934,7 @@
     top: 115%;
     right: 0;
     background: var(--surface-bg);
-    border-radius: 4px;
+    border-radius: var(--border-radius);
     box-shadow: 0 8px 16px -4px rgba(0, 0, 0, 0.3), 0 4px 8px -2px rgba(0, 0, 0, 0.1);
     display: flex;
     flex-direction: column;
@@ -1004,7 +1004,7 @@
     background: var(--error-color, #ff6b6b);
     color: white;
     border: none;
-    border-radius: 4px;
+    border-radius: var(--border-radius);
     cursor: pointer;
     font-size: 0.9rem;
   }
@@ -1018,7 +1018,7 @@
     background: rgba(255, 165, 0, 0.95);
     color: #000;
     padding: 0.75rem 1rem;
-    border-radius: 6px;
+    border-radius: var(--border-radius);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
     display: flex;
     gap: 1rem;

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -916,7 +916,7 @@
   }
   .atom-label {
     background: var(--struct-atom-label-bg, rgba(0, 0, 0, 0.1));
-    border-radius: var(--struct-atom-label-border-radius, 3pt);
+    border-radius: var(--struct-atom-label-border-radius, var(--border-radius));
     padding: var(--struct-atom-label-padding, 0 3px);
     white-space: nowrap;
   }
@@ -941,7 +941,7 @@
   .measure-label {
     background: var(--measure-label-bg, var(--surface-bg));
     color: var(--measure-label-color, var(--text-color));
-    border-radius: 4px;
+    border-radius: var(--border-radius);
     padding: 0 5px;
     user-select: none;
     white-space: pre;

--- a/src/lib/structure/SupercellSelector.svelte
+++ b/src/lib/structure/SupercellSelector.svelte
@@ -123,7 +123,7 @@
     right: 0;
     background: var(--surface-bg, #222);
     padding: 4px 2px;
-    border-radius: 4px;
+    border-radius: var(--struct-border-radius, var(--border-radius));
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
     display: grid;
     grid-template-columns: 1fr 1fr;

--- a/src/lib/theme/ThemeControl.svelte
+++ b/src/lib/theme/ThemeControl.svelte
@@ -36,7 +36,7 @@
     background: var(--btn-bg);
     border: var(--pane-border);
     color: var(--text-color);
-    border-radius: var(--theme-control-border-radius, 5pt);
+    border-radius: var(--theme-control-border-radius, var(--border-radius));
     padding: var(--theme-control-padding, 1pt 2pt);
     backdrop-filter: blur(10px);
     transition: all 0.2s ease;

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -1206,14 +1206,13 @@
 
 <style>
   .trajectory {
-    --border-radius: 4px;
     --min-height: 500px;
     display: flex;
     flex-direction: column;
     height: var(--traj-height, 100%);
     position: relative;
     min-height: var(--traj-min-height, var(--min-height));
-    border-radius: var(--border-radius);
+    border-radius: var(--traj-border-radius, var(--border-radius));
     box-sizing: border-box;
     contain: layout;
     z-index: var(--traj-z-index, 1);
@@ -1347,7 +1346,7 @@
     align-items: center;
     white-space: nowrap;
     padding: var(--trajectory-filename-padding, 3pt 4pt);
-    border-radius: var(--trajectory-filename-border-radius, 2px);
+    border-radius: var(--trajectory-filename-border-radius, var(--border-radius));
     max-width: clamp(150px, 20cqw, 250px);
     overflow: hidden;
     text-overflow: ellipsis;

--- a/src/lib/trajectory/TrajectoryExportPane.svelte
+++ b/src/lib/trajectory/TrajectoryExportPane.svelte
@@ -295,7 +295,7 @@
 <style>
   .warning, .error-message {
     padding: 1ex;
-    border-radius: 4px;
+    border-radius: var(--traj-border-radius, var(--border-radius));
     font-size: 0.9em;
   }
   .warning {

--- a/src/routes/(demos)/plot/bar-plot/+page.md
+++ b/src/routes/(demos)/plot/bar-plot/+page.md
@@ -281,7 +281,7 @@ Add rich interactivity with custom tooltips, hover effects, and click handlers:
   }
 
   const info_style =
-    `margin: 1em 0; padding: 4pt 8pt; background: rgba(255,255,255,0.1); border-radius: 4px; font-size: 0.9em`
+    `margin: 1em 0; padding: 4pt 8pt; background: rgba(255,255,255,0.1); border-radius: var(--border-radius); font-size: 0.9em`
 </script>
 
 <BarPlot

--- a/src/routes/(demos)/plot/spacegroup-bar-plot/+page.md
+++ b/src/routes/(demos)/plot/spacegroup-bar-plot/+page.md
@@ -169,7 +169,7 @@ Simulated space group distributions from Materials Project database:
 </script>
 
 <div
-  style="margin-bottom: 1em; padding: 8pt; background: rgba(255, 255, 255, 0.05); border-radius: 4px; font-size: 0.9em"
+  style="margin-bottom: 1em; padding: 8pt; background: rgba(255, 255, 255, 0.05); border-radius: var(--border-radius); font-size: 0.9em"
 >
   <strong>Dataset:</strong> {materials_db.length} materials with distribution resembling
   real materials databases. Notice how certain space groups like 225 (Fm-3m), 62 (Pnma),

--- a/src/routes/(demos)/trajectory/+page.svelte
+++ b/src/routes/(demos)/trajectory/+page.svelte
@@ -28,7 +28,7 @@
       properties are currently displayed.
     </p>
     <strong
-      style="display: block; margin: 1em auto; padding: 1em; background: var(--surface-bg-hover); border-radius: 4px; font-family: monospace; font-size: 0.9em"
+      style="display: block; margin: 1em auto; padding: 1em; background: var(--surface-bg-hover); border-radius: var(--border-radius); font-family: monospace; font-size: 0.9em"
     >
       bind:visible_properties = {JSON.stringify(visible_props_cantor_qha)}
     </strong>

--- a/src/routes/test/bands-and-dos/+page.svelte
+++ b/src/routes/test/bands-and-dos/+page.svelte
@@ -69,7 +69,7 @@
 >
   <div
     class="custom-overlay"
-    style="position: absolute; top: 10px; right: 10px; background: rgba(255, 255, 255, 0.9); padding: 8px; border-radius: 4px; font-size: 12px; pointer-events: none"
+    style="position: absolute; top: 10px; right: 10px; background: rgba(255, 255, 255, 0.9); padding: 8px; border-radius: var(--border-radius); font-size: 12px; pointer-events: none"
   >
     Custom Overlay
   </div>

--- a/src/routes/test/brillouin-bands-dos/+page.svelte
+++ b/src/routes/test/brillouin-bands-dos/+page.svelte
@@ -193,7 +193,7 @@
   >
     <div
       class="custom-overlay"
-      style="position: absolute; top: 10px; right: 10px; background: rgba(255, 255, 255, 0.9); padding: 8px; border-radius: 4px; font-size: 12px; pointer-events: none; z-index: 10"
+      style="position: absolute; top: 10px; right: 10px; background: rgba(255, 255, 255, 0.9); padding: 8px; border-radius: var(--border-radius); font-size: 12px; pointer-events: none; z-index: 10"
     >
       Custom Overlay
     </div>

--- a/src/routes/test/brillouin-zone/+page.svelte
+++ b/src/routes/test/brillouin-zone/+page.svelte
@@ -140,6 +140,6 @@
     margin-bottom: 2em;
     padding: 1em;
     border: 1px solid var(--sms-border);
-    border-radius: 4px;
+    border-radius: var(--border-radius);
   }
 </style>

--- a/src/site/CompositionDemo.svelte
+++ b/src/site/CompositionDemo.svelte
@@ -110,7 +110,7 @@
     gap: 1pt;
     padding: 4pt 9pt;
     background: var(--card-bg, rgba(255, 255, 255, 0.05));
-    border-radius: var(--border-radius, 4px);
+    border-radius: var(--border-radius, var(--border-radius));
     border: 1px solid var(--card-border, rgba(255, 255, 255, 0.1));
   }
   .composition-card h4 {

--- a/src/site/CompositionDemo.svelte
+++ b/src/site/CompositionDemo.svelte
@@ -110,7 +110,7 @@
     gap: 1pt;
     padding: 4pt 9pt;
     background: var(--card-bg, rgba(255, 255, 255, 0.05));
-    border-radius: var(--border-radius, var(--border-radius));
+    border-radius: var(--border-radius);
     border: 1px solid var(--card-border, rgba(255, 255, 255, 0.1));
   }
   .composition-card h4 {

--- a/static/prism-syntax-highlight-theme-aware.css
+++ b/static/prism-syntax-highlight-theme-aware.css
@@ -53,12 +53,12 @@ pre[class*='language-'] {
   padding: 1em;
   margin: 0.5em 0;
   overflow: auto;
-  border-radius: 0.3em;
+  border-radius: var(--border-radius);
 }
 
 :not(pre) > code[class*='language-'] {
   padding: 0.1em 0.3em;
-  border-radius: 0.3em;
+  border-radius: var(--border-radius);
   white-space: normal;
 }
 

--- a/tests/playwright/phase-diagram/phase-diagram-3d.test.ts
+++ b/tests/playwright/phase-diagram/phase-diagram-3d.test.ts
@@ -43,6 +43,12 @@ test.describe(`PhaseDiagram3D (Ternary)`, () => {
       .toBeVisible()
     await expect(info.getByText(`Total entries in`, { exact: false })).toBeVisible()
     await expect(info.getByText(`Stability`)).toBeVisible()
+
+    // Regression: verify unstable phases > 0 (catches possible e_above_hull placeholder bugs)
+    const unstable_text = await info.getByTestId(`pd-unstable-phases`).textContent()
+    const unstable_match = unstable_text?.match(/(\d+)/)
+    const unstable_count = unstable_match ? parseInt(unstable_match[1], 10) : 0
+    expect(unstable_count).toBeGreaterThan(0)
   })
 
   test(`camera elevation/azimuth controls accept numeric changes`, async ({ page }) => {

--- a/tests/vitest/bands/helpers.test.ts
+++ b/tests/vitest/bands/helpers.test.ts
@@ -696,6 +696,20 @@ describe(`normalize_dos`, () => {
         expect(result.frequencies).toEqual([0, 5, 10, 15, 20])
       }
     })
+
+    it(`skips cm⁻¹→THz conversion when auto_convert_units: false`, () => {
+      const info_spy = spy_info()
+      const result = normalize_dos(
+        { frequencies: [0, 100, 200, 300, 400], densities: [0, 0.5, 1, 0.5, 0] },
+        { auto_convert_units: false },
+      )
+      if (result?.type === `phonon`) {
+        // Frequencies should remain unchanged (not converted)
+        expect(result.frequencies).toEqual([0, 100, 200, 300, 400])
+      }
+      expect(info_spy).not.toHaveBeenCalled()
+      info_spy.mockRestore()
+    })
   })
 
   describe(`electronic DOS`, () => {

--- a/tests/vitest/plot/ScatterPlot.test.ts
+++ b/tests/vitest/plot/ScatterPlot.test.ts
@@ -162,4 +162,19 @@ describe(`ScatterPlot`, () => {
       `Custom overlay content`,
     )
   })
+
+  test.each([
+    { selected_point: { series_idx: 0, point_idx: 2 }, desc: `middle point` },
+    { selected_point: { series_idx: 0, point_idx: 0 }, desc: `first point` },
+    { selected_point: { series_idx: 0, point_idx: 4 }, desc: `last point` },
+    { selected_point: null, desc: `null (no selection)` },
+  ])(`selected_point accepts $desc`, ({ selected_point }) => {
+    // Tests that ScatterPlot accepts selected_point prop without errors
+    mount(ScatterPlot, {
+      target: document.body,
+      props: { series: [basic], selected_point },
+    })
+    // Component should render without throwing
+    expect(document.querySelector(`.scatter`)).toBeTruthy()
+  })
 })

--- a/tests/vitest/plot/ScatterPoint.test.ts
+++ b/tests/vitest/plot/ScatterPoint.test.ts
@@ -200,6 +200,42 @@ describe(`ScatterPoint`, () => {
     expect(document.querySelector(`text`)).toBeFalsy()
   })
 
+  test(`renders selection ring when is_selected=true`, () => {
+    const target = doc_query(`div`)
+    mount(ScatterPoint, {
+      target,
+      props: { x: 100, y: 100, is_selected: true, style: { fill: `blue`, radius: 6 } },
+    })
+
+    const selection_ring = doc_query(`circle.selection-ring`)
+    expect(selection_ring).toBeTruthy()
+    expect(selection_ring.getAttribute(`r`)).toBe(`15`) // radius * 2.5 = 6 * 2.5 = 15
+    expect(selection_ring.classList.contains(`selection-ring`)).toBe(true)
+  })
+
+  test(`does not render selection ring when is_selected=false`, () => {
+    const target = doc_query(`div`)
+    mount(ScatterPoint, { target, props: { x: 100, y: 100, is_selected: false } })
+
+    expect(document.querySelector(`circle.selection-ring`)).toBeFalsy()
+  })
+
+  test(`selection ring defaults is_selected to false`, () => {
+    const target = doc_query(`div`)
+    mount(ScatterPoint, { target, props: { x: 100, y: 100 } })
+
+    expect(document.querySelector(`circle.selection-ring`)).toBeFalsy()
+  })
+
+  test(`selection ring uses default radius when style.radius not provided`, () => {
+    const target = doc_query(`div`)
+    mount(ScatterPoint, { target, props: { x: 100, y: 100, is_selected: true } })
+
+    const selection_ring = doc_query(`circle.selection-ring`)
+    expect(selection_ring).toBeTruthy()
+    expect(selection_ring.getAttribute(`r`)).toBe(`10`) // default radius 4 * 2.5 = 10
+  })
+
   test(`handles zero values correctly`, () => {
     const target = doc_query(`div`)
     mount(ScatterPoint, { target, props: { x: 0, y: 0 } })

--- a/tests/vitest/plot/ScatterPoint.test.ts
+++ b/tests/vitest/plot/ScatterPoint.test.ts
@@ -200,40 +200,34 @@ describe(`ScatterPoint`, () => {
     expect(document.querySelector(`text`)).toBeFalsy()
   })
 
-  test(`renders selection ring when is_selected=true`, () => {
+  test.each([
+    { is_selected: false, desc: `is_selected=false` },
+    { is_selected: undefined, desc: `is_selected omitted (defaults false)` },
+  ])(`no selection ring when $desc`, ({ is_selected }) => {
+    const target = doc_query(`div`)
+    mount(ScatterPoint, { target, props: { x: 100, y: 100, is_selected } })
+    expect(document.querySelector(`circle.selection-ring`)).toBeFalsy()
+  })
+
+  test.each([
+    { radius: 6, expected_r: `15`, desc: `custom radius 6` },
+    { radius: undefined, expected_r: `10`, desc: `default radius 4` },
+  ])(`selection ring radius = style.radius * 2.5 ($desc)`, ({ radius, expected_r }) => {
     const target = doc_query(`div`)
     mount(ScatterPoint, {
       target,
-      props: { x: 100, y: 100, is_selected: true, style: { fill: `blue`, radius: 6 } },
+      props: { x: 100, y: 100, is_selected: true, style: { radius } },
     })
 
-    const selection_ring = doc_query(`circle.selection-ring`)
-    expect(selection_ring).toBeTruthy()
-    expect(selection_ring.getAttribute(`r`)).toBe(`15`) // radius * 2.5 = 6 * 2.5 = 15
-    expect(selection_ring.classList.contains(`selection-ring`)).toBe(true)
-  })
+    const ring = doc_query(`circle.selection-ring`)
+    const marker = doc_query(`path.marker`)
+    const group = doc_query(`g`)
 
-  test(`does not render selection ring when is_selected=false`, () => {
-    const target = doc_query(`div`)
-    mount(ScatterPoint, { target, props: { x: 100, y: 100, is_selected: false } })
-
-    expect(document.querySelector(`circle.selection-ring`)).toBeFalsy()
-  })
-
-  test(`selection ring defaults is_selected to false`, () => {
-    const target = doc_query(`div`)
-    mount(ScatterPoint, { target, props: { x: 100, y: 100 } })
-
-    expect(document.querySelector(`circle.selection-ring`)).toBeFalsy()
-  })
-
-  test(`selection ring uses default radius when style.radius not provided`, () => {
-    const target = doc_query(`div`)
-    mount(ScatterPoint, { target, props: { x: 100, y: 100, is_selected: true } })
-
-    const selection_ring = doc_query(`circle.selection-ring`)
-    expect(selection_ring).toBeTruthy()
-    expect(selection_ring.getAttribute(`r`)).toBe(`10`) // default radius 4 * 2.5 = 10
+    expect(ring).toBeTruthy()
+    expect(ring.getAttribute(`r`)).toBe(expected_r)
+    // Ring must come before marker in DOM so it renders behind
+    const children = Array.from(group.children)
+    expect(children.indexOf(ring)).toBeLessThan(children.indexOf(marker))
   })
 
   test(`handles zero values correctly`, () => {

--- a/tests/vitest/plot/ScatterPoint.test.ts
+++ b/tests/vitest/plot/ScatterPoint.test.ts
@@ -203,23 +203,23 @@ describe(`ScatterPoint`, () => {
   test.each([
     { is_selected: false, desc: `is_selected=false` },
     { is_selected: undefined, desc: `is_selected omitted (defaults false)` },
-  ])(`no selection ring when $desc`, ({ is_selected }) => {
+  ])(`no effect ring when $desc`, ({ is_selected }) => {
     const target = doc_query(`div`)
     mount(ScatterPoint, { target, props: { x: 100, y: 100, is_selected } })
-    expect(document.querySelector(`circle.selection-ring`)).toBeFalsy()
+    expect(document.querySelector(`circle.effect-ring`)).toBeFalsy()
   })
 
   test.each([
     { radius: 6, expected_r: `15`, desc: `custom radius 6` },
     { radius: undefined, expected_r: `10`, desc: `default radius 4` },
-  ])(`selection ring radius = style.radius * 2.5 ($desc)`, ({ radius, expected_r }) => {
+  ])(`effect ring radius = style.radius * 2.5 ($desc)`, ({ radius, expected_r }) => {
     const target = doc_query(`div`)
     mount(ScatterPoint, {
       target,
       props: { x: 100, y: 100, is_selected: true, style: { radius } },
     })
 
-    const ring = doc_query(`circle.selection-ring`)
+    const ring = doc_query(`circle.effect-ring`)
     const marker = doc_query(`path.marker`)
     const group = doc_query(`g`)
 


### PR DESCRIPTION
was already supported in `PhaseDiagram(3|4)D` but missing in 2D due to different implementation

- Add externally controlled scatter-point selection with a selection ring and configurable pulse, glow, size, and color effects.
- Add unit-aware Bands/DOS frequency conversion with automatic conversion thresholds.