### PR TITLE
Fix all legacy type errors and run `svelte-check` as pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
         args: [--config, deno.jsonc, --permit-no-files, --fix]
       - id: svelte-check
         name: Svelte type check
-        entry: bash -c 'deno run -A npm:@sveltejs/kit sync && deno run -A npm:svelte-check --fail-on-warnings --threshold error'
+        entry: bash -c 'deno install && deno run -A --node-modules-dir npm:@sveltejs/kit sync && deno run -A --node-modules-dir npm:svelte-check --fail-on-warnings --threshold error'
         language: system
         types_or: [ts, svelte]
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,12 @@ repos:
         types_or: [file]
         language: system
         args: [--config, deno.jsonc, --permit-no-files, --fix]
+      - id: svelte-check
+        name: Svelte type check
+        entry: bash -c 'deno run -A npm:@sveltejs/kit sync && deno run -A npm:svelte-check --fail-on-warnings --threshold error'
+        language: system
+        types_or: [ts, svelte]
+        pass_filenames: false
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -31,6 +31,10 @@ export default [
     },
   },
   {
-    ignores: [`build/`, `.svelte-kit/`, `package/`],
+    files: [`**/*.d.ts`],
+    rules: {
+      '@stylistic/quotes': [`error`, `single`, { avoidEscape: true }],
+    },
   },
+  { ignores: [`build/`, `.svelte-kit/`, `package/`] },
 ]

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,7 +32,7 @@ export default [
   },
   {
     files: [`**/*.d.ts`],
-    rules: {
+    rules: { // Force single quotes in .d.ts files as TypeScript requires for imports
       '@stylistic/quotes': [`error`, `single`, { avoidEscape: true }],
     },
   },

--- a/extensions/vscode/tests/vscode-mock.ts
+++ b/extensions/vscode/tests/vscode-mock.ts
@@ -1,4 +1,6 @@
-export function mock_vscode() {
+import type { Plugin } from 'vite'
+
+export function mock_vscode(): Plugin {
   return {
     name: `vscode-mock`,
     enforce: `pre`,

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -10,12 +10,6 @@ declare module '*-colors.yml' {
   export default content
 }
 
-// type mdsvex markdown files as Svelte components
-declare module '*.md' {
-  const component: import('svelte').Component
-  export default component
-}
-
 // Global type declarations for theme system
 declare global {
   interface Window {

--- a/src/lib/composition/Composition.svelte
+++ b/src/lib/composition/Composition.svelte
@@ -3,8 +3,8 @@
   import { ContextMenu } from '$lib'
   import { export_svg_as_png, export_svg_as_svg } from '$lib/io/export'
   import type { SVGAttributes } from 'svelte/elements'
-  import { BarChart, BubbleChart, PieChart } from './index'
   import { get_electro_neg_formula } from './format'
+  import { BarChart, BubbleChart, PieChart } from './index'
   import { parse_composition } from './parse'
 
   type CompositionChartMode = `pie` | `bubble` | `bar`
@@ -19,6 +19,8 @@
     mode?: CompositionChartMode
     on_composition_change?: (composition: CompositionType) => void
     color_scheme?: ColorSchemeName
+    size?: number
+    interactive?: boolean
   } = $props()
 
   // Make these reactive so context menu changes propagate

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,7 +1,7 @@
 // MatterViz settings schema - single source of truth for all MatterViz settings
 // Used by both main package and VSCode extension
 
-import type { ColorScaleType } from '$lib/colors'
+import type { ColorScaleType, D3InterpolateName } from '$lib/colors'
 import type { D3SymbolName } from '$lib/labels'
 import { symbol_names } from '$lib/labels'
 import type { Vec3 } from '$lib/math'
@@ -119,7 +119,7 @@ export interface SettingsConfig {
     bond_color: SettingType<string>
     bonding_strategy: SettingType<BondingStrategy>
     atom_color_mode: SettingType<AtomColorMode>
-    atom_color_scale: SettingType<string>
+    atom_color_scale: SettingType<D3InterpolateName>
     atom_color_scale_type: SettingType<ColorScaleType>
 
     // Camera & Controls

--- a/src/lib/structure/AtomLegend.svelte
+++ b/src/lib/structure/AtomLegend.svelte
@@ -18,7 +18,7 @@
   let {
     atom_color_config = $bindable({
       mode: `element`,
-      scale: ``,
+      scale: undefined,
       scale_type: `continuous`,
     }),
     property_colors = null,

--- a/src/lib/structure/StructureControls.svelte
+++ b/src/lib/structure/StructureControls.svelte
@@ -7,7 +7,7 @@
     Lattice,
     SettingsSection,
   } from '$lib'
-  import type { ColorSchemeName } from '$lib/colors'
+  import type { ColorSchemeName, D3InterpolateName } from '$lib/colors'
   import { AXIS_COLORS, ELEMENT_COLOR_SCHEMES } from '$lib/colors'
   import { to_degrees, to_radians } from '$lib/math'
   import { DEFAULTS, SETTINGS_CONFIG } from '$lib/settings'
@@ -72,7 +72,7 @@
   })
 
   // Atom color config selection state
-  let color_scale_selected = $state([
+  let color_scale_selected = $state<D3InterpolateName[]>([
     atom_color_config.scale || DEFAULTS.structure.atom_color_scale,
   ])
 

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { AnyStructure, BondPair, ElementSymbol, Site, Vec3 } from '$lib'
   import { atomic_radii, AXIS_COLORS, element_data, NEG_AXIS_COLORS } from '$lib'
+  import type { D3InterpolateName } from '$lib/colors'
   import { format_num } from '$lib/labels'
   import * as math from '$lib/math'
   import { type CameraProjection, DEFAULTS, type ShowBonds } from '$lib/settings'
@@ -108,7 +109,7 @@
     hidden_prop_vals = $bindable(new Set<number | string>()),
     atom_color_config = {
       mode: DEFAULTS.structure.atom_color_mode,
-      scale: DEFAULTS.structure.atom_color_scale,
+      scale: DEFAULTS.structure.atom_color_scale as D3InterpolateName,
       scale_type: DEFAULTS.structure.atom_color_scale_type,
     },
     sym_data = null,

--- a/src/lib/structure/atom-properties.ts
+++ b/src/lib/structure/atom-properties.ts
@@ -12,7 +12,7 @@ import * as d3_sc from 'd3-scale-chromatic'
 
 export interface AtomColorConfig {
   mode: AtomColorMode
-  scale: string | D3InterpolateName
+  scale: D3InterpolateName
   scale_type: ColorScaleType
   color_fn?: (site: Site, idx: number) => number | string
 }

--- a/src/lib/structure/atom-properties.ts
+++ b/src/lib/structure/atom-properties.ts
@@ -12,7 +12,7 @@ import * as d3_sc from 'd3-scale-chromatic'
 
 export interface AtomColorConfig {
   mode: AtomColorMode
-  scale: D3InterpolateName
+  scale?: D3InterpolateName
   scale_type: ColorScaleType
   color_fn?: (site: Site, idx: number) => number | string
 }

--- a/src/routes/(demos)/(hide)/bohr-atoms/+page.svelte
+++ b/src/routes/(demos)/(hide)/bohr-atoms/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { BohrAtom, element_data } from 'matterviz/element'
+  // @ts-expect-error - relative markdown import resolution
   import Description from './bohr-atoms.md'
 
   let orbital_period = $state(2)

--- a/src/routes/contributing/+page.svelte
+++ b/src/routes/contributing/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  // @ts-expect-error - markdown import resolution with alias
   import Contributing from '$root/contributing.md'
 </script>
 

--- a/tests/vitest/DraggablePane.test.svelte.ts
+++ b/tests/vitest/DraggablePane.test.svelte.ts
@@ -1,11 +1,13 @@
 import { DraggablePane } from '$lib'
-import { mount, tick } from 'svelte'
+import { createRawSnippet, mount, tick } from 'svelte'
 import type { HTMLAttributes } from 'svelte/elements'
 import { describe, expect, test, vi } from 'vitest'
 import { doc_query } from './setup'
 
 describe(`DraggablePane`, () => {
-  const default_props = { children: () => `Pane Content` }
+  const default_props = {
+    children: createRawSnippet(() => ({ render: () => `Pane Content` })),
+  }
   const click = (el: Element) => {
     el.dispatchEvent(new MouseEvent(`click`, { bubbles: true, cancelable: true }))
   }

--- a/tests/vitest/SettingsSection.test.ts
+++ b/tests/vitest/SettingsSection.test.ts
@@ -1,7 +1,9 @@
 import { SettingsSection } from '$lib'
-import { mount } from 'svelte'
+import { createRawSnippet, mount } from 'svelte'
 import { describe, expect, test, vi } from 'vitest'
 import { doc_query } from './setup'
+
+const snippet = (content: string) => createRawSnippet(() => ({ render: () => content }))
 
 describe(`SettingsSection`, () => {
   const base_props = {
@@ -12,7 +14,7 @@ describe(`SettingsSection`, () => {
   test(`renders title correctly`, () => {
     mount(SettingsSection, {
       target: document.body,
-      props: { ...base_props, children: () => `Test content` },
+      props: { ...base_props, children: snippet(`Test content`) },
     })
     expect(doc_query(`h4`).textContent?.trim()).toBe(`Test Section`)
   })
@@ -20,11 +22,11 @@ describe(`SettingsSection`, () => {
   test(`title is required and h4 is always present`, () => {
     mount(SettingsSection, {
       target: document.body,
-      props: { ...base_props, children: () => `Test content` },
+      props: { ...base_props, children: snippet(`Test content`) },
     })
     // h4 should always be present since title is required
     expect(doc_query(`h4`).textContent?.trim()).toBe(`Test Section`)
-    expect(doc_query(`section`).textContent?.trim()).toBe(``)
+    expect(doc_query(`section`).textContent?.trim()).toBe(`Test content`)
   })
 
   test(`does not show reset button initially when values match reference`, () => {
@@ -35,7 +37,7 @@ describe(`SettingsSection`, () => {
         title: `Test Settings`,
         current_values: { setting1: `value` },
         on_reset: vi.fn(),
-        children: () => `Settings content`,
+        children: snippet(`Settings content`),
       },
     })
 
@@ -50,7 +52,7 @@ describe(`SettingsSection`, () => {
         title: `Test Settings`,
         current_values: { setting1: [`a`, `b`, `c`] },
         on_reset: vi.fn(),
-        children: () => `Settings content`,
+        children: snippet(`Settings content`),
       },
     })
 
@@ -65,7 +67,7 @@ describe(`SettingsSection`, () => {
         title: `Test Settings`,
         current_values: { setting1: [{ key: `value1` }, { key: `value2` }] },
         on_reset: vi.fn(),
-        children: () => `Settings content`,
+        children: snippet(`Settings content`),
       },
     })
 
@@ -80,7 +82,7 @@ describe(`SettingsSection`, () => {
         title: `Test Settings`,
         current_values: { setting1: undefined, setting2: null },
         on_reset: vi.fn(),
-        children: () => `Settings content`,
+        children: snippet(`Settings content`),
       },
     })
 
@@ -95,7 +97,7 @@ describe(`SettingsSection`, () => {
         title: `Test Settings`,
         current_values: { setting1: [] },
         on_reset: vi.fn(),
-        children: () => `Settings content`,
+        children: snippet(`Settings content`),
       },
     })
 

--- a/tests/vitest/composition/BarChart.test.ts
+++ b/tests/vitest/composition/BarChart.test.ts
@@ -3,7 +3,7 @@ import {
   count_atoms_in_composition,
   fractional_composition,
 } from '$lib/composition'
-import { mount } from 'svelte'
+import { createRawSnippet, mount } from 'svelte'
 import { describe, expect, test } from 'vitest'
 import { doc_query } from '../setup'
 
@@ -233,11 +233,9 @@ describe(`BarChart component`, () => {
       target: document.body,
       props: {
         composition: { H: 2, O: 1 },
-        children: () => {
-          const elem = document.createElement(`div`)
-          elem.className = `custom-child`
-          document.body.appendChild(elem)
-        },
+        children: createRawSnippet(() => ({
+          render: () => `<div class="custom-child"></div>`,
+        })),
       },
     })
 

--- a/tests/vitest/composition/BubbleChart.test.ts
+++ b/tests/vitest/composition/BubbleChart.test.ts
@@ -1,5 +1,5 @@
 import { BubbleChart, count_atoms_in_composition } from '$lib/composition'
-import { mount } from 'svelte'
+import { createRawSnippet, mount } from 'svelte'
 import { describe, expect, test } from 'vitest'
 
 describe(`BubbleChart component`, () => {
@@ -38,11 +38,9 @@ describe(`BubbleChart component`, () => {
       target: document.body,
       props: {
         composition: { H: 2, O: 1 },
-        children: () => {
-          const elem = document.createElement(`div`)
-          elem.className = `custom-child`
-          document.body.appendChild(elem)
-        },
+        children: createRawSnippet(() => ({
+          render: () => `<div class="custom-child"></div>`,
+        })),
       },
     })
 

--- a/tests/vitest/composition/PieChart.test.ts
+++ b/tests/vitest/composition/PieChart.test.ts
@@ -3,7 +3,7 @@ import {
   fractional_composition,
   PieChart,
 } from '$lib/composition'
-import { mount } from 'svelte'
+import { createRawSnippet, mount } from 'svelte'
 import { describe, expect, test } from 'vitest'
 
 describe(`PieChart component`, () => {
@@ -43,11 +43,9 @@ describe(`PieChart component`, () => {
       target: document.body,
       props: {
         composition: { H: 2, O: 1 },
-        children: () => {
-          const elem = document.createElement(`div`)
-          elem.className = `custom-child`
-          document.body.appendChild(elem)
-        },
+        children: createRawSnippet(() => ({
+          render: () => `<div class="custom-child"></div>`,
+        })),
       },
     })
 

--- a/tests/vitest/io/index.test.ts
+++ b/tests/vitest/io/index.test.ts
@@ -4,7 +4,10 @@ import { beforeEach, describe, expect, test, vi } from 'vitest'
 globalThis.fetch = vi.fn()
 
 describe(`handle_url_drop`, () => {
-  let callback: ReturnType<typeof vi.fn>
+  let callback: (
+    content: string | ArrayBuffer,
+    filename: string,
+  ) => void | Promise<void>
   let get_data: ReturnType<typeof vi.fn>
   let drag_event: DragEvent
 

--- a/tests/vitest/periodic-table/PeriodicTable.test.svelte.ts
+++ b/tests/vitest/periodic-table/PeriodicTable.test.svelte.ts
@@ -1,7 +1,7 @@
 import type { ChemicalElement, ElementCategory } from '$lib'
 import { element_data, PeriodicTable, PropertySelect } from '$lib'
 import { CATEGORY_COUNTS, ELEM_HEATMAP_LABELS } from '$lib/labels'
-import { mount, tick } from 'svelte'
+import { createRawSnippet, mount, tick } from 'svelte'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import { doc_query } from '../setup'
 
@@ -176,7 +176,10 @@ describe(`PeriodicTable`, () => {
   )(
     `active_elements=%s highlights %s tiles (%s)`,
     (active_elements, expected_active, _description) => {
-      mount(PeriodicTable, { target: document.body, props: { active_elements } })
+      mount(PeriodicTable, {
+        target: document.body,
+        props: { active_elements: [...active_elements] },
+      })
       const active_tiles = document.querySelectorAll(`.element-tile.active`)
       expect(active_tiles.length).toBe(expected_active)
     },
@@ -299,7 +302,7 @@ describe(`PeriodicTable`, () => {
       [null, `DIV`, null],
     ] as const,
   )(`links=%o -> %s tag, %s href`, (links, expected_tag, expected_href) => {
-    mount(PeriodicTable, { target: document.body, props: { links } })
+    mount(PeriodicTable, { target: document.body, props: { links: links as never } })
     const hydrogen_tile = document.querySelector(
       `.element-tile`,
     ) as HTMLElement
@@ -617,7 +620,13 @@ describe(`PeriodicTable`, () => {
       let rendered = false
       mount(PeriodicTable, {
         target: document.body,
-        props: { heatmap_values: [1, 2, 3], inset: () => (rendered = true, ``) },
+        props: {
+          heatmap_values: [1, 2, 3],
+          inset: createRawSnippet(() => {
+            rendered = true
+            return { render: () => `<div></div>` }
+          }),
+        },
       })
 
       expect(document.querySelector(`.colorbar`)).toBeNull()

--- a/tests/vitest/phase-diagram/helpers.test.ts
+++ b/tests/vitest/phase-diagram/helpers.test.ts
@@ -132,7 +132,7 @@ describe(`helpers: thresholds and tooltips`, () => {
           e_above_hull: 0.2,
           energy_per_atom: -1,
         },
-      ] as PhaseData[],
+      ] as unknown as PhaseData[],
       expected: {
         total: 2,
         unary: 1,

--- a/tests/vitest/phase-diagram/helpers.test.ts
+++ b/tests/vitest/phase-diagram/helpers.test.ts
@@ -1,4 +1,4 @@
-import type { CompositionType, ElementSymbol } from '$lib'
+import type { ElementSymbol } from '$lib'
 import type { D3InterpolateName } from '$lib/colors'
 import * as helpers from '$lib/phase-diagram/helpers'
 import { get_phase_diagram_stats } from '$lib/phase-diagram/thermodynamics'
@@ -122,17 +122,17 @@ describe(`helpers: thresholds and tooltips`, () => {
     },
     {
       name: `quaternary stats counts quaternary entries`,
-      elements: [`A`, `B`, `C`, `D`] as unknown as ElementSymbol[],
+      elements: [`H`, `He`, `Li`, `Be`],
       max_arity: 4 as const,
       entries: [
-        { composition: { A: 1 }, energy: 0, e_above_hull: 0, energy_per_atom: 0 },
+        { composition: { H: 1 }, energy: 0, e_above_hull: 0, energy_per_atom: 0 },
         {
-          composition: { A: 1, B: 1, C: 1, D: 1 },
+          composition: { H: 1, He: 1, Li: 1, Be: 1 },
           energy: -4,
           e_above_hull: 0.2,
           energy_per_atom: -1,
         },
-      ] as unknown as PhaseData[],
+      ] satisfies PhaseData[],
       expected: {
         total: 2,
         unary: 1,
@@ -140,11 +140,11 @@ describe(`helpers: thresholds and tooltips`, () => {
         ternary: 0,
         quaternary: 1,
         elements: 4,
-        system: `A-D-B-C`,
+        system: `He-Li-Be-H`,
       },
-    },
+    } as const,
   ])(`get_phase_diagram_stats: $name`, ({ elements, max_arity, entries, expected }) => {
-    const stats = get_phase_diagram_stats(entries, elements, max_arity)
+    const stats = get_phase_diagram_stats(entries, [...elements], max_arity)
     expect(stats).not.toBeNull()
     if (!stats) return
     expect(stats.total).toBe(expected.total)
@@ -163,25 +163,21 @@ describe(`helpers: energy range preserves zero formation energy`, () => {
   test(`zero e_form_per_atom is not dropped in energy range`, () => {
     const entries: PhaseData[] = [
       {
-        composition: { A: 1 } as unknown as CompositionType,
+        composition: { H: 1 },
         energy: 0,
         energy_per_atom: -1, // differs from e_form_per_atom to ensure we pick 0 over -1
         e_form_per_atom: 0, // critical zero value
         e_above_hull: 0,
       },
       {
-        composition: { B: 1 } as unknown as CompositionType,
+        composition: { He: 1 },
         energy: -2,
         energy_per_atom: -2,
         e_form_per_atom: -2,
         e_above_hull: 0,
       },
     ]
-    const stats = get_phase_diagram_stats(
-      entries,
-      [`A`, `B`] as unknown as ElementSymbol[],
-      3,
-    )
+    const stats = get_phase_diagram_stats(entries, [`H`, `He`], 3)
     // min should be -2, max should be 0, proving 0 was retained (not replaced by -1)
     expect(stats?.energy_range.min).toBeCloseTo(-2)
     expect(stats?.energy_range.max).toBeCloseTo(0)

--- a/tests/vitest/plot/BarPlot.test.ts
+++ b/tests/vitest/plot/BarPlot.test.ts
@@ -1,6 +1,6 @@
 import { BarPlot } from '$lib'
 import type { BarHandlerProps, BarMode, BarSeries, Orientation } from '$lib/plot'
-import { mount } from 'svelte'
+import { createRawSnippet, mount } from 'svelte'
 import { describe, expect, test, vi } from 'vitest'
 
 const basic: BarSeries = {
@@ -170,12 +170,10 @@ describe(`BarPlot`, () => {
       target: document.body,
       props: {
         series: [basic],
-        tooltip: (data: BarHandlerProps) => {
-          const div_el = document.createElement(`div`)
-          div_el.className = `custom-tooltip`
-          div_el.textContent = `x: ${data.x}, y: ${data.y}`
-          document.body.appendChild(div_el)
-        },
+        tooltip: createRawSnippet<[BarHandlerProps]>((data) => ({
+          render: () =>
+            `<div class="custom-tooltip">x: ${data().x}, y: ${data().y}</div>`,
+        })),
         hovered: true,
       },
     })
@@ -187,13 +185,12 @@ describe(`BarPlot`, () => {
       target: document.body,
       props: {
         series: [basic],
-        children: () => {
+        children: createRawSnippet(() => {
           called = true
-          const div_el = document.createElement(`div`)
-          div_el.className = `custom-bar-child`
-          div_el.textContent = `Custom bar overlay`
-          document.body.appendChild(div_el)
-        },
+          return {
+            render: () => `<div class="custom-bar-child">Custom bar overlay</div>`,
+          }
+        }),
       },
     })
     expect(called).toBe(true)

--- a/tests/vitest/plot/PlotTooltip.test.ts
+++ b/tests/vitest/plot/PlotTooltip.test.ts
@@ -1,16 +1,14 @@
 // @vitest-environment happy-dom
 import { PlotTooltip } from '$lib/plot'
-import { mount } from 'svelte'
+import { createRawSnippet, mount } from 'svelte'
 import { describe, expect, test } from 'vitest'
 import { doc_query } from '../setup'
 
 /** Helper to create a simple children snippet for testing. */
 function make_children(text: string = `Test`) {
-  return ($$anchor: Comment) => {
-    const span = document.createElement(`span`)
-    span.textContent = text
-    $$anchor.before(span)
-  }
+  return createRawSnippet(() => ({
+    render: () => `<span>${text}</span>`,
+  }))
 }
 
 describe(`PlotTooltip`, () => {
@@ -118,12 +116,10 @@ describe(`PlotTooltip`, () => {
       props: {
         x: 0,
         y: 0,
-        children: ($$anchor: Comment) => {
-          const div = document.createElement(`div`)
-          div.className = `tooltip-content`
-          div.innerHTML = `<strong>Label:</strong> Value`
-          $$anchor.before(div)
-        },
+        children: createRawSnippet(() => ({
+          render: () =>
+            `<div class="tooltip-content"><strong>Label:</strong> Value</div>`,
+        })),
       },
     })
 

--- a/tests/vitest/plot/ScatterPlot.test.ts
+++ b/tests/vitest/plot/ScatterPlot.test.ts
@@ -1,6 +1,6 @@
 import { ScatterPlot } from '$lib'
 import type { DataSeries } from '$lib/plot'
-import { mount } from 'svelte'
+import { createRawSnippet, mount } from 'svelte'
 import { describe, expect, test } from 'vitest'
 
 const basic = {
@@ -148,13 +148,13 @@ describe(`ScatterPlot`, () => {
       target: document.body,
       props: {
         series: [basic],
-        children: () => {
+        children: createRawSnippet(() => {
           called = true
-          const div_el = document.createElement(`div`)
-          div_el.className = `custom-scatter-child`
-          div_el.textContent = `Custom overlay content`
-          document.body.appendChild(div_el)
-        },
+          return {
+            render: () =>
+              `<div class="custom-scatter-child">Custom overlay content</div>`,
+          }
+        }),
       },
     })
     expect(called).toBe(true)

--- a/tests/vitest/rdf/RdfPlot.test.ts
+++ b/tests/vitest/rdf/RdfPlot.test.ts
@@ -2,7 +2,7 @@ import { RdfPlot } from '$lib'
 import type { RdfPattern } from '$lib/rdf'
 import type { Pbc, PymatgenStructure } from '$lib/structure'
 import { structure_map } from '$site/structures'
-import { mount } from 'svelte'
+import { createRawSnippet, mount } from 'svelte'
 import { describe, test } from 'vitest'
 
 const nacl_structure = structure_map.get(`mp-1234`)
@@ -103,7 +103,7 @@ describe(`RdfPlot`, () => {
       target: document.body,
       props: {
         patterns: { label: `Test`, pattern: create_synthetic_pattern() },
-        children: () => {},
+        children: createRawSnippet(() => ({ render: () => `<div></div>` })),
       },
     })
   })

--- a/tests/vitest/structure/AtomLegend.test.ts
+++ b/tests/vitest/structure/AtomLegend.test.ts
@@ -255,7 +255,7 @@ describe(`AtomLegend Component`, () => {
     test(`switches mode when option is clicked`, async () => {
       const atom_color_config = {
         mode: `element` as const,
-        scale: ``,
+        scale: `interpolateViridis` as const,
         scale_type: `continuous` as const,
       }
       mount(AtomLegend, {
@@ -779,7 +779,7 @@ describe(`Disordered Site Color Assignment`, () => {
     }))
 
   const create_species = (element: string, occu: number): Species => ({
-    element,
+    element: element as ElementSymbol,
     occu,
     oxidation_state: 0,
   })

--- a/tests/vitest/symmetry/WyckoffTable.test.ts
+++ b/tests/vitest/symmetry/WyckoffTable.test.ts
@@ -3,10 +3,13 @@ import { mount } from 'svelte'
 import { describe, expect, test } from 'vitest'
 
 describe(`WyckoffTable`, () => {
-  test.each([[], null, undefined])(
+  test.each([[], null, undefined] as const)(
     `renders nothing when wyckoff_positions is %s`,
     (wyckoff_positions) => {
-      mount(WyckoffTable, { target: document.body, props: { wyckoff_positions } })
+      mount(WyckoffTable, {
+        target: document.body,
+        props: { wyckoff_positions: wyckoff_positions as never },
+      })
       expect(document.querySelector(`table`)).toBeFalsy()
     },
   )

--- a/tests/vitest/xrd/XrdPlot.test.ts
+++ b/tests/vitest/xrd/XrdPlot.test.ts
@@ -1,6 +1,6 @@
 import { XrdPlot } from '$lib'
 import type { XrdPattern } from '$lib/xrd'
-import { type ComponentProps, mount } from 'svelte'
+import { type ComponentProps, createRawSnippet, mount } from 'svelte'
 import { describe, expect, test } from 'vitest'
 
 const pattern: XrdPattern = {
@@ -66,13 +66,12 @@ describe(`XrdPlot`, () => {
       target: document.body,
       props: {
         patterns: pattern,
-        children: () => {
+        children: createRawSnippet(() => {
           called = true
-          const div_el = document.createElement(`div`)
-          div_el.className = `custom-xrd-child`
-          div_el.textContent = `Custom XRD overlay`
-          document.body.appendChild(div_el)
-        },
+          return {
+            render: () => `<div class="custom-xrd-child">Custom XRD overlay</div>`,
+          }
+        }),
       },
     })
     expect(called).toBe(true)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,8 @@
     "sourceMap": true,
 
     "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true
-  }
+    "resolveJsonModule": true,
+    "skipLibCheck": true
+  },
+  "exclude": ["src/scripts", "extensions"]
 }


### PR DESCRIPTION
- Fix legacy Svelte and TypeScript errors and run `svelte-check` in the pre-commit workflow.
- Add `size` and interactive props to `Composition`.