### PR TITLE
Support tick labels inside + rounded bars on all plots, smarter default filtering of unstable PD entries

### DIFF
--- a/src/lib/phase-diagram/PhaseDiagram2D.svelte
+++ b/src/lib/phase-diagram/PhaseDiagram2D.svelte
@@ -237,7 +237,9 @@
     // eslint-disable-next-line svelte/prefer-svelte-reactivity -- local var in derived
     const by_x = new Map<number, PhaseDiagramEntry[]>()
     for (const entry of coords_entries) {
-      ;(by_x.get(entry.x) ?? by_x.set(entry.x, []).get(entry.x))!.push(entry)
+      const group = by_x.get(entry.x)
+      if (group) group.push(entry)
+      else by_x.set(entry.x, [entry])
     }
 
     const hull_input: HullVertex[] = [...by_x].map(([x_coord, entries]) => ({

--- a/src/lib/phase-diagram/PhaseDiagram2D.svelte
+++ b/src/lib/phase-diagram/PhaseDiagram2D.svelte
@@ -272,7 +272,7 @@
   ))
 
   // Initialize threshold to auto value on first load
-  let initialized = false
+  let initialized = $state(false)
   $effect(() => {
     if (!initialized && all_enriched_entries.length > 0) {
       initialized = true

--- a/src/lib/phase-diagram/PhaseDiagram3D.svelte
+++ b/src/lib/phase-diagram/PhaseDiagram3D.svelte
@@ -157,7 +157,7 @@
   ))
 
   // Initialize threshold to auto value on first load
-  let initialized = false
+  let initialized = $state(false)
   $effect(() => {
     if (!initialized && all_enriched_entries.length > 0) {
       initialized = true

--- a/src/lib/phase-diagram/PhaseDiagramControls.svelte
+++ b/src/lib/phase-diagram/PhaseDiagramControls.svelte
@@ -88,6 +88,10 @@
   pane_props={{
     ...pane_props,
     class: `phase-diagram-controls-pane ${pane_props?.class ?? ``}`,
+    style:
+      `--pane-min-height: 280px; --pane-max-height: max(350px, calc(100cqh - 40px)); ${
+        pane_props?.style ?? ``
+      }`,
   }}
   toggle_props={{
     title: controls_open ? `` : `Phase diagram controls`,
@@ -403,6 +407,10 @@
     align-items: center;
     gap: 8px;
     margin-bottom: 12px;
+  }
+  /* Remove bottom margin from last element to prevent blank scrollable space */
+  :global(.phase-diagram-controls-pane > :last-child) {
+    margin-bottom: 0;
   }
   .control-label {
     font-weight: 500;

--- a/src/lib/phase-diagram/PhaseDiagramStats.svelte
+++ b/src/lib/phase-diagram/PhaseDiagramStats.svelte
@@ -81,7 +81,7 @@
       phase_items.push({
         label: `Unary phases`,
         value: `${format_num(phase_stats.unary)} (${
-          format_num(phase_stats.unary / phase_stats.total, `.2~%`)
+          format_num(phase_stats.unary / phase_stats.total, `.1~%`)
         })`,
         key: `unary-phases`,
       })
@@ -90,7 +90,7 @@
       phase_items.push({
         label: `Binary phases`,
         value: `${format_num(phase_stats.binary)} (${
-          format_num(phase_stats.binary / phase_stats.total, `.2~%`)
+          format_num(phase_stats.binary / phase_stats.total, `.1~%`)
         })`,
         key: `binary-phases`,
       })
@@ -99,7 +99,7 @@
       phase_items.push({
         label: `Ternary phases`,
         value: `${format_num(phase_stats.ternary)} (${
-          format_num(phase_stats.ternary / phase_stats.total, `.2~%`)
+          format_num(phase_stats.ternary / phase_stats.total, `.1~%`)
         })`,
         key: `ternary-phases`,
       })
@@ -108,7 +108,7 @@
       phase_items.push({
         label: `Quaternary phases`,
         value: `${format_num(phase_stats.quaternary)} (${
-          format_num(phase_stats.quaternary / phase_stats.total, `.2~%`)
+          format_num(phase_stats.quaternary / phase_stats.total, `.1~%`)
         })`,
         key: `quaternary-phases`,
       })
@@ -126,14 +126,14 @@
         {
           label: `Stable phases`,
           value: `${format_num(phase_stats.stable)} (${
-            format_num(phase_stats.stable / phase_stats.total, `.2~%`)
+            format_num(phase_stats.stable / phase_stats.total, `.1~%`)
           })`,
           key: `stable-phases`,
         },
         {
           label: `Unstable phases`,
           value: `${format_num(phase_stats.unstable)} (${
-            format_num(phase_stats.unstable / phase_stats.total, `.2~%`)
+            format_num(phase_stats.unstable / phase_stats.total, `.1~%`)
           })`,
           key: `unstable-phases`,
         },

--- a/src/lib/phase-diagram/helpers.ts
+++ b/src/lib/phase-diagram/helpers.ts
@@ -75,39 +75,18 @@ export function calc_max_hull_dist_in_data(
   return Math.max(0.1, max_val)
 }
 
-// Thresholds for auto-adjusting max_hull_dist_show_phases based on entry count
-const AUTO_THRESHOLD_LOW_ENTRIES = 25 // Show all entries below this count
-const AUTO_THRESHOLD_HIGH_ENTRIES = 100 // Use static default above this count
-
-/**
- * Compute a smart threshold for showing unstable entries based on entry count.
- * For phase diagrams with very few entries, show all entries regardless of e_above_hull.
- * For well-sampled phase diagrams with many entries, use the static default to reduce clutter.
- * In between, linearly interpolate between showing all and the static default.
- *
- * @param n_entries - Total number of entries in the phase diagram
- * @param max_hull_dist_in_data - Maximum e_above_hull value in the dataset
- * @param static_default - The static default threshold (e.g., 0.1 for binary, 0.5 for ternary)
- * @returns The computed threshold for showing unstable entries
- */
+/** Smart threshold for showing unstable entries based on entry count.
+ * Few entries (≤25): show all. Many entries (≥100): use static default. Between: interpolate. */
 export function compute_auto_hull_dist_threshold(
   n_entries: number,
   max_hull_dist_in_data: number,
   static_default: number,
 ): number {
-  if (n_entries <= AUTO_THRESHOLD_LOW_ENTRIES) {
-    // For very few entries, show all by using max in data
-    return max_hull_dist_in_data
-  } else if (n_entries >= AUTO_THRESHOLD_HIGH_ENTRIES) {
-    // For many entries, use the static default
-    return static_default
-  } else {
-    // Linear interpolation between showing all and static default
-    const interpolation_factor = (n_entries - AUTO_THRESHOLD_LOW_ENTRIES) /
-      (AUTO_THRESHOLD_HIGH_ENTRIES - AUTO_THRESHOLD_LOW_ENTRIES)
-    return max_hull_dist_in_data * (1 - interpolation_factor) +
-      static_default * interpolation_factor
-  }
+  const [LOW, HIGH] = [25, 100]
+  if (n_entries <= LOW) return max_hull_dist_in_data
+  if (n_entries >= HIGH) return static_default
+  const t = (n_entries - LOW) / (HIGH - LOW)
+  return max_hull_dist_in_data * (1 - t) + static_default * t
 }
 
 // Build a tooltip text for any phase entry (shared)

--- a/src/lib/phase-diagram/helpers.ts
+++ b/src/lib/phase-diagram/helpers.ts
@@ -75,6 +75,41 @@ export function calc_max_hull_dist_in_data(
   return Math.max(0.1, max_val)
 }
 
+// Thresholds for auto-adjusting max_hull_dist_show_phases based on entry count
+const AUTO_THRESHOLD_LOW_ENTRIES = 25 // Show all entries below this count
+const AUTO_THRESHOLD_HIGH_ENTRIES = 100 // Use static default above this count
+
+/**
+ * Compute a smart threshold for showing unstable entries based on entry count.
+ * For phase diagrams with very few entries, show all entries regardless of e_above_hull.
+ * For well-sampled phase diagrams with many entries, use the static default to reduce clutter.
+ * In between, linearly interpolate between showing all and the static default.
+ *
+ * @param n_entries - Total number of entries in the phase diagram
+ * @param max_hull_dist_in_data - Maximum e_above_hull value in the dataset
+ * @param static_default - The static default threshold (e.g., 0.1 for binary, 0.5 for ternary)
+ * @returns The computed threshold for showing unstable entries
+ */
+export function compute_auto_hull_dist_threshold(
+  n_entries: number,
+  max_hull_dist_in_data: number,
+  static_default: number,
+): number {
+  if (n_entries <= AUTO_THRESHOLD_LOW_ENTRIES) {
+    // For very few entries, show all by using max in data
+    return max_hull_dist_in_data
+  } else if (n_entries >= AUTO_THRESHOLD_HIGH_ENTRIES) {
+    // For many entries, use the static default
+    return static_default
+  } else {
+    // Linear interpolation between showing all and static default
+    const interpolation_factor = (n_entries - AUTO_THRESHOLD_LOW_ENTRIES) /
+      (AUTO_THRESHOLD_HIGH_ENTRIES - AUTO_THRESHOLD_LOW_ENTRIES)
+    return max_hull_dist_in_data * (1 - interpolation_factor) +
+      static_default * interpolation_factor
+  }
+}
+
 // Build a tooltip text for any phase entry (shared)
 export function build_entry_tooltip_text(entry: PhaseData): string {
   const is_element = is_unary_entry(entry)

--- a/src/lib/plot/BarPlot.svelte
+++ b/src/lib/plot/BarPlot.svelte
@@ -91,7 +91,7 @@
     scale_type: `linear`,
     ticks: 5,
     label_shift: { y: 60 },
-    tick_label_shift: { x: 0, y: 0 }, // base offset handled in rendering
+    tick: { label: { shift: { x: 0, y: 0 } } }, // base offset handled in rendering
     range: [null, null],
     ...y2_axis,
   }
@@ -278,8 +278,8 @@
       )
       // Need space for: tick shift + tick width + gap (30px) + label space (20px if present)
       // When ticks are inside, they don't contribute to padding
-      const inside = y2_axis.tick_labels_inside ?? false
-      const tick_shift = inside ? 0 : (y2_axis.tick_label_shift?.x ?? 0) + 8
+      const inside = y2_axis.tick?.label?.inside ?? false
+      const tick_shift = inside ? 0 : (y2_axis.tick?.label?.shift?.x ?? 0) + 8
       const tick_width_contribution = inside ? 0 : y2_tick_width
       const label_space = y2_axis.label ? 20 : 0
       new_pad.r = Math.max(
@@ -621,10 +621,10 @@
         {#each ticks.x as tick (tick)}
           {@const tick_x = scales.x(tick as number)}
           {#if isFinite(tick_x)}
-            {@const rotation = x_axis.tick_rotation ?? 0}
-            {@const shift_x = x_axis.tick_label_shift?.x ?? 0}
-            {@const shift_y = x_axis.tick_label_shift?.y ?? 0}
-            {@const inside = x_axis.tick_labels_inside ?? false}
+            {@const rotation = x_axis.tick?.label?.rotation ?? 0}
+            {@const shift_x = x_axis.tick?.label?.shift?.x ?? 0}
+            {@const shift_y = x_axis.tick?.label?.shift?.y ?? 0}
+            {@const inside = x_axis.tick?.label?.inside ?? false}
             {@const base_y = inside ? -8 : (rotation !== 0 ? 8 : 18)}
             {@const text_y = base_y + shift_y}
             {@const text_anchor = rotation !== 0 ? (inside ? `end` : `start`) : `middle`}
@@ -686,10 +686,10 @@
         {#each ticks.y as tick (tick)}
           {@const tick_y = scales.y(tick as number)}
           {#if isFinite(tick_y)}
-            {@const rotation = y_axis.tick_rotation ?? 0}
-            {@const shift_x = y_axis.tick_label_shift?.x ?? 0}
-            {@const shift_y = y_axis.tick_label_shift?.y ?? 0}
-            {@const inside = y_axis.tick_labels_inside ?? false}
+            {@const rotation = y_axis.tick?.label?.rotation ?? 0}
+            {@const shift_x = y_axis.tick?.label?.shift?.x ?? 0}
+            {@const shift_y = y_axis.tick?.label?.shift?.y ?? 0}
+            {@const inside = y_axis.tick?.label?.inside ?? false}
             {@const base_x = inside ? 8 : -10}
             {@const text_x = base_x + shift_x}
             {@const text_anchor = inside ? `start` : `end`}
@@ -765,11 +765,11 @@
           {#each ticks.y2 as tick (tick)}
             {@const tick_y = scales.y2(tick as number)}
             {#if isFinite(tick_y)}
-              {@const rotation = y2_axis.tick_rotation ?? 0}
-              {@const inside = y2_axis.tick_labels_inside ?? false}
+              {@const rotation = y2_axis.tick?.label?.rotation ?? 0}
+              {@const inside = y2_axis.tick?.label?.inside ?? false}
               {@const base_x = inside ? -8 : 8}
-              {@const shift_x = (y2_axis.tick_label_shift?.x ?? 0) + base_x}
-              {@const shift_y = y2_axis.tick_label_shift?.y ?? 0}
+              {@const shift_x = (y2_axis.tick?.label?.shift?.x ?? 0) + base_x}
+              {@const shift_y = y2_axis.tick?.label?.shift?.y ?? 0}
               {@const text_anchor = inside ? `end` : `start`}
               <g class="tick" transform="translate({width - pad.r}, {tick_y})">
                 {#if display.y2_grid}
@@ -813,8 +813,8 @@
         )}
             {@const shift_x = y2_axis.label_shift?.x ?? 0}
             {@const shift_y = y2_axis.label_shift?.y ?? 0}
-            {@const inside = y2_axis.tick_labels_inside ?? false}
-            {@const tick_shift = inside ? 0 : (y2_axis.tick_label_shift?.x ?? 0) + 8}
+            {@const inside = y2_axis.tick?.label?.inside ?? false}
+            {@const tick_shift = inside ? 0 : (y2_axis.tick?.label?.shift?.x ?? 0) + 8}
             {@const tick_width_contribution = inside ? 0 : max_y2_tick_width}
             {@const y2_label_x = width - pad.r + tick_shift + tick_width_contribution +
           LABEL_GAP_DEFAULT +

--- a/src/lib/plot/BarPlot.svelte
+++ b/src/lib/plot/BarPlot.svelte
@@ -22,6 +22,7 @@
   import type { Snippet } from 'svelte'
   import type { HTMLAttributes } from 'svelte/elements'
   import { SvelteMap } from 'svelte/reactivity'
+  import { bar_path } from './svg'
   import { calc_auto_padding, LABEL_GAP_DEFAULT, measure_text_width } from './layout'
   import PlotTooltip from './PlotTooltip.svelte'
 
@@ -60,11 +61,6 @@
     ...rest
   }: HTMLAttributes<HTMLDivElement> & BasePlotProps & PlotConfig & {
     series?: BarSeries[]
-    hovered?: boolean
-    show_controls?: boolean
-    controls_open?: boolean
-    fullscreen?: boolean
-    fullscreen_toggle?: boolean
     // Component-specific props
     orientation?: Orientation
     mode?: BarMode
@@ -95,7 +91,7 @@
     scale_type: `linear`,
     ticks: 5,
     label_shift: { y: 60 },
-    tick_label_shift: { x: 8, y: 0 },
+    tick_label_shift: { x: 0, y: 0 }, // base offset handled in rendering
     range: [null, null],
     ...y2_axis,
   }
@@ -280,10 +276,16 @@
           measure_text_width(format_value(tick, y2_axis.format), `12px sans-serif`)
         ),
       )
-      // Need space for: tick shift (8px) + tick width + gap (30px) + label space (20px if present)
-      const tick_shift = y2_axis.tick_label_shift?.x ?? 8
+      // Need space for: tick shift + tick width + gap (30px) + label space (20px if present)
+      // When ticks are inside, they don't contribute to padding
+      const inside = y2_axis.tick_labels_inside ?? false
+      const tick_shift = inside ? 0 : (y2_axis.tick_label_shift?.x ?? 0) + 8
+      const tick_width_contribution = inside ? 0 : y2_tick_width
       const label_space = y2_axis.label ? 20 : 0
-      new_pad.r = Math.max(new_pad.r, tick_shift + y2_tick_width + 30 + label_space)
+      new_pad.r = Math.max(
+        new_pad.r,
+        tick_shift + tick_width_contribution + 30 + label_space,
+      )
     }
 
     // Only update if padding actually changed (prevents infinite loop)
@@ -622,8 +624,11 @@
             {@const rotation = x_axis.tick_rotation ?? 0}
             {@const shift_x = x_axis.tick_label_shift?.x ?? 0}
             {@const shift_y = x_axis.tick_label_shift?.y ?? 0}
-            {@const text_y = rotation !== 0 ? 8 + shift_y : 18 + shift_y}
-            {@const text_anchor = rotation !== 0 ? `start` : `middle`}
+            {@const inside = x_axis.tick_labels_inside ?? false}
+            {@const base_y = inside ? -8 : (rotation !== 0 ? 8 : 18)}
+            {@const text_y = base_y + shift_y}
+            {@const text_anchor = rotation !== 0 ? (inside ? `end` : `start`) : `middle`}
+            {@const dominant_baseline = inside ? `auto` : `hanging`}
             <g class="tick" transform="translate({tick_x}, {height - pad.b})">
               {#if display.x_grid}
                 <line
@@ -635,7 +640,7 @@
               {/if}
               <line
                 y1="0"
-                y2="5"
+                y2={inside ? -5 : 5}
                 stroke={x_axis.color || `var(--border-color, gray)`}
                 stroke-width="1"
               />
@@ -643,6 +648,7 @@
                 x={shift_x}
                 y={text_y}
                 text-anchor={text_anchor}
+                dominant-baseline={dominant_baseline}
                 fill={x_axis.color || `var(--text-color)`}
                 transform={rotation !== 0
                 ? `rotate(${rotation}, ${shift_x}, ${text_y})`
@@ -683,7 +689,10 @@
             {@const rotation = y_axis.tick_rotation ?? 0}
             {@const shift_x = y_axis.tick_label_shift?.x ?? 0}
             {@const shift_y = y_axis.tick_label_shift?.y ?? 0}
-            {@const text_x = -10 + shift_x}
+            {@const inside = y_axis.tick_labels_inside ?? false}
+            {@const base_x = inside ? 8 : -10}
+            {@const text_x = base_x + shift_x}
+            {@const text_anchor = inside ? `start` : `end`}
             <g class="tick" transform="translate({pad.l}, {tick_y})">
               {#if display.y_grid}
                 <line
@@ -694,15 +703,15 @@
                 />
               {/if}
               <line
-                x1="-5"
-                x2="0"
+                x1={inside ? 0 : -5}
+                x2={inside ? 5 : 0}
                 stroke={y_axis.color || `var(--border-color, gray)`}
                 stroke-width="1"
               />
               <text
                 x={text_x}
                 y={shift_y}
-                text-anchor="end"
+                text-anchor={text_anchor}
                 dominant-baseline="central"
                 fill={y_axis.color || `var(--text-color)`}
                 transform={rotation !== 0
@@ -757,8 +766,11 @@
             {@const tick_y = scales.y2(tick as number)}
             {#if isFinite(tick_y)}
               {@const rotation = y2_axis.tick_rotation ?? 0}
-              {@const shift_x = y2_axis.tick_label_shift?.x ?? 8}
+              {@const inside = y2_axis.tick_labels_inside ?? false}
+              {@const base_x = inside ? -8 : 8}
+              {@const shift_x = (y2_axis.tick_label_shift?.x ?? 0) + base_x}
               {@const shift_y = y2_axis.tick_label_shift?.y ?? 0}
+              {@const text_anchor = inside ? `end` : `start`}
               <g class="tick" transform="translate({width - pad.r}, {tick_y})">
                 {#if display.y2_grid}
                   <line
@@ -769,15 +781,15 @@
                   />
                 {/if}
                 <line
-                  x1="0"
-                  x2="5"
+                  x1={inside ? -5 : 0}
+                  x2={inside ? 0 : 5}
                   stroke={y2_axis.color || `var(--border-color, gray)`}
                   stroke-width="1"
                 />
                 <text
                   x={shift_x}
                   y={shift_y}
-                  text-anchor="start"
+                  text-anchor={text_anchor}
                   dominant-baseline="central"
                   fill={y2_axis.color || `var(--text-color)`}
                   transform={rotation !== 0
@@ -801,8 +813,10 @@
         )}
             {@const shift_x = y2_axis.label_shift?.x ?? 0}
             {@const shift_y = y2_axis.label_shift?.y ?? 0}
-            {@const tick_shift = y2_axis.tick_label_shift?.x ?? 8}
-            {@const y2_label_x = width - pad.r + tick_shift + max_y2_tick_width +
+            {@const inside = y2_axis.tick_labels_inside ?? false}
+            {@const tick_shift = inside ? 0 : (y2_axis.tick_label_shift?.x ?? 0) + 8}
+            {@const tick_width_contribution = inside ? 0 : max_y2_tick_width}
+            {@const y2_label_x = width - pad.r + tick_shift + tick_width_contribution +
           LABEL_GAP_DEFAULT +
           shift_x}
             {@const y2_label_y = pad.t + chart_height / 2 + shift_y}
@@ -990,13 +1004,20 @@
             ? [Math.max(1, Math.abs(c1 - c0)), Math.max(0, Math.abs(v1 - v0))]
             : [Math.max(1, Math.abs(v1 - v0)), Math.max(0, Math.abs(c1 - c0))]}
                   {#if (is_vertical ? rect_h : rect_w) > 0}
-                    <rect
-                      x={rect_x}
-                      y={rect_y}
-                      width={rect_w}
-                      height={rect_h}
+                    <path
+                      d={bar_path(
+                        rect_x,
+                        rect_y,
+                        rect_w,
+                        rect_h,
+                        Math.min(bar.border_radius ?? 0, rect_w / 2, rect_h / 2),
+                        is_vertical,
+                      )}
                       fill={color}
                       opacity={mode === `overlay` ? bar.opacity : 1}
+                      stroke={bar.stroke_color}
+                      stroke-opacity={bar.stroke_opacity}
+                      stroke-width={bar.stroke_width}
                       role="button"
                       tabindex="0"
                       aria-label={`bar ${bar_idx + 1} of ${srs.label ?? `series`}`}

--- a/src/lib/plot/Histogram.svelte
+++ b/src/lib/plot/Histogram.svelte
@@ -111,7 +111,7 @@
     scale_type: `linear` as const,
     ticks: 5,
     label_shift: { y: 60 },
-    tick_label_shift: { x: 0, y: 0 }, // base offset handled in rendering
+    tick: { label: { shift: { x: 0, y: 0 } } }, // base offset handled in rendering
     range: [null, null] as [number | null, number | null],
     ...y2_axis,
   })
@@ -277,9 +277,9 @@
           )
         ),
       )
-      const inside = final_y2_axis.tick_labels_inside ?? false
+      const inside = final_y2_axis.tick?.label?.inside ?? false
       // When ticks are inside, they don't contribute to padding
-      const tick_shift = inside ? 0 : (final_y2_axis.tick_label_shift?.x ?? 0) + 8
+      const tick_shift = inside ? 0 : (final_y2_axis.tick?.label?.shift?.x ?? 0) + 8
       const tick_width_contribution = inside ? 0 : y2_tick_width
       const label_thickness = Math.round(12 * 1.2)
       new_pad.r = Math.max(
@@ -587,9 +587,9 @@
       {#each ticks.x as tick (tick)}
         {@const tick_x = scales.x(tick as number)}
         {@const custom_label = get_tick_label(tick as number, final_x_axis.ticks)}
-        {@const inside = final_x_axis.tick_labels_inside ?? false}
-        {@const shift_x = final_x_axis.tick_label_shift?.x ?? 0}
-        {@const shift_y = final_x_axis.tick_label_shift?.y ?? 0}
+        {@const inside = final_x_axis.tick?.label?.inside ?? false}
+        {@const shift_x = final_x_axis.tick?.label?.shift?.x ?? 0}
+        {@const shift_y = final_x_axis.tick?.label?.shift?.y ?? 0}
         {@const base_y = inside ? -8 : 18}
         {@const text_y = base_y + shift_y}
         {@const dominant_baseline = inside ? `auto` : `hanging`}
@@ -644,9 +644,9 @@
       {#each ticks.y as tick (tick)}
         {@const tick_y = scales.y(tick as number)}
         {@const custom_label = get_tick_label(tick as number, final_y_axis.ticks)}
-        {@const inside = final_y_axis.tick_labels_inside ?? false}
-        {@const shift_x = final_y_axis.tick_label_shift?.x ?? 0}
-        {@const shift_y = final_y_axis.tick_label_shift?.y ?? 0}
+        {@const inside = final_y_axis.tick?.label?.inside ?? false}
+        {@const shift_x = final_y_axis.tick?.label?.shift?.x ?? 0}
+        {@const shift_y = final_y_axis.tick?.label?.shift?.y ?? 0}
         {@const base_x = inside ? 8 : -10}
         {@const text_x = base_x + shift_x}
         {@const text_anchor = inside ? `start` : `end`}
@@ -719,10 +719,10 @@
         {#each ticks.y2 as tick (tick)}
           {@const tick_y = scales.y2(tick as number)}
           {@const custom_label = get_tick_label(tick as number, final_y2_axis.ticks)}
-          {@const inside = final_y2_axis.tick_labels_inside ?? false}
+          {@const inside = final_y2_axis.tick?.label?.inside ?? false}
           {@const base_x = inside ? -8 : 8}
-          {@const shift_x = (final_y2_axis.tick_label_shift?.x ?? 0) + base_x}
-          {@const shift_y = final_y2_axis.tick_label_shift?.y ?? 0}
+          {@const shift_x = (final_y2_axis.tick?.label?.shift?.x ?? 0) + base_x}
+          {@const shift_y = final_y2_axis.tick?.label?.shift?.y ?? 0}
           {@const text_anchor = inside ? `end` : `start`}
           <g class="tick" transform="translate({width - pad.r}, {tick_y})">
             {#if display.y2_grid}
@@ -764,8 +764,8 @@
         )}
           {@const shift_x = final_y2_axis.label_shift?.x ?? 0}
           {@const shift_y = final_y2_axis.label_shift?.y ?? 0}
-          {@const inside = final_y2_axis.tick_labels_inside ?? false}
-          {@const tick_shift = inside ? 0 : (final_y2_axis.tick_label_shift?.x ?? 0) + 8}
+          {@const inside = final_y2_axis.tick?.label?.inside ?? false}
+          {@const tick_shift = inside ? 0 : (final_y2_axis.tick?.label?.shift?.x ?? 0) + 8}
           {@const tick_width_contribution = inside ? 0 : max_y2_tick_width}
           {@const y2_label_x = width - pad.r + tick_shift + tick_width_contribution +
           LABEL_GAP_DEFAULT +

--- a/src/lib/plot/Histogram.svelte
+++ b/src/lib/plot/Histogram.svelte
@@ -24,6 +24,7 @@
   import { untrack } from 'svelte'
   import type { HTMLAttributes } from 'svelte/elements'
   import PlotTooltip from './PlotTooltip.svelte'
+  import { bar_path } from './svg'
 
   type LegendConfig = ComponentProps<typeof PlotLegend>
 
@@ -62,11 +63,6 @@
     ...rest
   }: HTMLAttributes<HTMLDivElement> & BasePlotProps & PlotConfig & {
     series: DataSeries[]
-    hovered?: boolean
-    show_controls?: boolean
-    controls_open?: boolean
-    fullscreen?: boolean
-    fullscreen_toggle?: boolean
     // Component-specific props
     bins?: number
     show_legend?: boolean
@@ -115,7 +111,7 @@
     scale_type: `linear` as const,
     ticks: 5,
     label_shift: { y: 60 },
-    tick_label_shift: { x: 8, y: 0 },
+    tick_label_shift: { x: 0, y: 0 }, // base offset handled in rendering
     range: [null, null] as [number | null, number | null],
     ...y2_axis,
   })
@@ -281,11 +277,14 @@
           )
         ),
       )
-      const tick_shift = final_y2_axis.tick_label_shift?.x ?? 8
+      const inside = final_y2_axis.tick_labels_inside ?? false
+      // When ticks are inside, they don't contribute to padding
+      const tick_shift = inside ? 0 : (final_y2_axis.tick_label_shift?.x ?? 0) + 8
+      const tick_width_contribution = inside ? 0 : y2_tick_width
       const label_thickness = Math.round(12 * 1.2)
       new_pad.r = Math.max(
         new_pad.r,
-        y2_tick_width + LABEL_GAP_DEFAULT + tick_shift + label_thickness,
+        tick_width_contribution + LABEL_GAP_DEFAULT + tick_shift + label_thickness,
       )
     }
 
@@ -588,6 +587,12 @@
       {#each ticks.x as tick (tick)}
         {@const tick_x = scales.x(tick as number)}
         {@const custom_label = get_tick_label(tick as number, final_x_axis.ticks)}
+        {@const inside = final_x_axis.tick_labels_inside ?? false}
+        {@const shift_x = final_x_axis.tick_label_shift?.x ?? 0}
+        {@const shift_y = final_x_axis.tick_label_shift?.y ?? 0}
+        {@const base_y = inside ? -8 : 18}
+        {@const text_y = base_y + shift_y}
+        {@const dominant_baseline = inside ? `auto` : `hanging`}
         <g class="tick" transform="translate({tick_x}, {height - pad.b})">
           {#if display.x_grid}
             <line
@@ -601,13 +606,15 @@
           {/if}
           <line
             y1="0"
-            y2="5"
+            y2={inside ? -5 : 5}
             stroke={final_x_axis.color || `var(--border-color, gray)`}
             stroke-width="1"
           />
           <text
-            y="18"
+            x={shift_x}
+            y={text_y}
             text-anchor="middle"
+            dominant-baseline={dominant_baseline}
             fill={final_x_axis.color || `var(--text-color)`}
           >
             {custom_label ?? format_value(tick, final_x_axis.format)}
@@ -637,6 +644,12 @@
       {#each ticks.y as tick (tick)}
         {@const tick_y = scales.y(tick as number)}
         {@const custom_label = get_tick_label(tick as number, final_y_axis.ticks)}
+        {@const inside = final_y_axis.tick_labels_inside ?? false}
+        {@const shift_x = final_y_axis.tick_label_shift?.x ?? 0}
+        {@const shift_y = final_y_axis.tick_label_shift?.y ?? 0}
+        {@const base_x = inside ? 8 : -10}
+        {@const text_x = base_x + shift_x}
+        {@const text_anchor = inside ? `start` : `end`}
         <g class="tick" transform="translate({pad.l}, {tick_y})">
           {#if display.y_grid}
             <line
@@ -649,14 +662,15 @@
             />
           {/if}
           <line
-            x1="-5"
-            x2="0"
+            x1={inside ? 0 : -5}
+            x2={inside ? 5 : 0}
             stroke={final_y_axis.color || `var(--border-color, gray)`}
             stroke-width="1"
           />
           <text
-            x="-10"
-            text-anchor="end"
+            x={text_x}
+            y={shift_y}
+            text-anchor={text_anchor}
             dominant-baseline="central"
             fill={final_y_axis.color || `var(--text-color)`}
           >
@@ -705,6 +719,11 @@
         {#each ticks.y2 as tick (tick)}
           {@const tick_y = scales.y2(tick as number)}
           {@const custom_label = get_tick_label(tick as number, final_y2_axis.ticks)}
+          {@const inside = final_y2_axis.tick_labels_inside ?? false}
+          {@const base_x = inside ? -8 : 8}
+          {@const shift_x = (final_y2_axis.tick_label_shift?.x ?? 0) + base_x}
+          {@const shift_y = final_y2_axis.tick_label_shift?.y ?? 0}
+          {@const text_anchor = inside ? `end` : `start`}
           <g class="tick" transform="translate({width - pad.r}, {tick_y})">
             {#if display.y2_grid}
               <line
@@ -717,15 +736,15 @@
               />
             {/if}
             <line
-              x1="0"
-              x2="5"
+              x1={inside ? -5 : 0}
+              x2={inside ? 0 : 5}
               stroke={final_y2_axis.color || `var(--border-color, gray)`}
               stroke-width="1"
             />
             <text
-              x={final_y2_axis.tick_label_shift?.x ?? 8}
-              y={final_y2_axis.tick_label_shift?.y ?? 0}
-              text-anchor="start"
+              x={shift_x}
+              y={shift_y}
+              text-anchor={text_anchor}
               dominant-baseline="central"
               fill={final_y2_axis.color || `var(--text-color)`}
             >
@@ -745,8 +764,10 @@
         )}
           {@const shift_x = final_y2_axis.label_shift?.x ?? 0}
           {@const shift_y = final_y2_axis.label_shift?.y ?? 0}
-          {@const tick_shift = final_y2_axis.tick_label_shift?.x ?? 8}
-          {@const y2_label_x = width - pad.r + tick_shift + max_y2_tick_width +
+          {@const inside = final_y2_axis.tick_labels_inside ?? false}
+          {@const tick_shift = inside ? 0 : (final_y2_axis.tick_label_shift?.x ?? 0) + 8}
+          {@const tick_width_contribution = inside ? 0 : max_y2_tick_width}
+          {@const y2_label_x = width - pad.r + tick_shift + tick_width_contribution +
           LABEL_GAP_DEFAULT +
           shift_x}
           {@const y2_label_y = pad.t + (height - pad.t - pad.b) / 2 + shift_y}
@@ -806,11 +827,14 @@
           {@const bar_y = y_scale(bin.length)}
           {@const value = (bin.x0! + bin.x1!) / 2}
           {#if bar_height > 0}
-            <rect
-              x={bar_x}
-              y={bar_y}
-              width={bar_width}
-              height={bar_height}
+            <path
+              d={bar_path(
+                bar_x,
+                bar_y,
+                bar_width,
+                bar_height,
+                Math.min(final_bar.border_radius ?? 0, bar_width / 2, bar_height / 2),
+              )}
               fill={color}
               opacity={final_bar.opacity}
               stroke={final_bar.stroke_color}

--- a/src/lib/plot/ScatterPlot.svelte
+++ b/src/lib/plot/ScatterPlot.svelte
@@ -154,7 +154,7 @@
     format: ``,
     scale_type: `linear`,
     label_shift: { x: 0, y: -40 },
-    tick_label_shift: { x: 0, y: 0 }, // base offset handled in rendering
+    tick: { label: { shift: { x: 0, y: 0 } } }, // base offset handled in rendering
     range: [null, null],
     ...x_axis,
   }
@@ -162,7 +162,7 @@
     format: ``,
     scale_type: `linear`,
     label_shift: { x: 0, y: 0 },
-    tick_label_shift: { x: 0, y: 0 }, // base offset handled in rendering
+    tick: { label: { shift: { x: 0, y: 0 } } }, // base offset handled in rendering
     range: [null, null],
     ...y_axis,
   }
@@ -171,7 +171,7 @@
     scale_type: `linear`,
     ticks: 5,
     label_shift: { x: 0, y: 0 },
-    tick_label_shift: { x: 0, y: 0 }, // base offset handled in rendering
+    tick: { label: { shift: { x: 0, y: 0 } } }, // base offset handled in rendering
     range: [null, null],
     ...y2_axis,
   }
@@ -1211,7 +1211,7 @@
               // Check if tick position is finite
               {@const tick_pos = tick_pos_raw}
               {#if tick_pos >= pad.l && tick_pos <= width - pad.r}
-                {@const inside = x_axis.tick_labels_inside ?? false}
+                {@const inside = x_axis.tick?.label?.inside ?? false}
                 <g class="tick" transform="translate({tick_pos}, {height - pad.b})">
                   {#if display.x_grid}
                     <line
@@ -1225,7 +1225,7 @@
 
                   {#if tick >= x_min && tick <= x_max}
                     {@const base_y = inside ? -8 : 20}
-                    {@const shift = x_axis.tick_label_shift ?? { x: 0, y: 0 }}
+                    {@const shift = x_axis.tick?.label?.shift ?? { x: 0, y: 0 }}
                     {@const x = shift.x ?? 0}
                     {@const y = base_y + (shift.y ?? 0)}
                     {@const custom_label = get_tick_label(tick, x_axis.ticks)}
@@ -1285,7 +1285,7 @@
               // Check if tick position is finite
               {@const tick_pos = tick_pos_raw}
               {#if tick_pos >= pad.t && tick_pos <= height - pad.b}
-                {@const inside = y_axis.tick_labels_inside ?? false}
+                {@const inside = y_axis.tick?.label?.inside ?? false}
                 <g class="tick" transform="translate({pad.l}, {tick_pos})">
                   {#if display.y_grid}
                     <line
@@ -1303,7 +1303,7 @@
 
                   {#if tick >= y_min && tick <= y_max}
                     {@const base_x = inside ? 8 : -8}
-                    {@const shift = y_axis.tick_label_shift ?? { x: 0, y: 0 }}
+                    {@const shift = y_axis.tick?.label?.shift ?? { x: 0, y: 0 }}
                     {@const x = base_x + (shift.x ?? 0)}
                     {@const y = shift.y ?? 0}
                     {@const custom_label = get_tick_label(tick, y_axis.ticks)}
@@ -1350,7 +1350,7 @@
                 // Check if tick position is finite
                 {@const tick_pos = tick_pos_raw}
                 {#if tick_pos >= pad.t && tick_pos <= height - pad.b}
-                  {@const inside = y2_axis.tick_labels_inside ?? false}
+                  {@const inside = y2_axis.tick?.label?.inside ?? false}
                   <g class="tick" transform="translate({width - pad.r}, {tick_pos})">
                     {#if display.y2_grid}
                       <line
@@ -1368,7 +1368,7 @@
 
                     {#if tick >= y2_min && tick <= y2_max}
                       {@const base_x = inside ? -8 : 8}
-                      {@const shift = y2_axis.tick_label_shift ?? { x: 0, y: 0 }}
+                      {@const shift = y2_axis.tick?.label?.shift ?? { x: 0, y: 0 }}
                       {@const x = base_x + (shift.x ?? 0)}
                       {@const y = shift.y ?? 0}
                       {@const custom_label = get_tick_label(tick, y2_axis.ticks)}

--- a/src/lib/plot/ScatterPlot.svelte
+++ b/src/lib/plot/ScatterPlot.svelte
@@ -5,6 +5,7 @@
   import { format_value, symbol_names } from '$lib/labels'
   import * as math from '$lib/math'
   import type {
+    BasePlotProps,
     ControlsConfig,
     DataSeries,
     HoverConfig,
@@ -97,19 +98,15 @@
     header_controls,
     controls_extra,
     ...rest
-  }: HTMLAttributes<HTMLDivElement> & PlotConfig & {
+  }: HTMLAttributes<HTMLDivElement> & Omit<BasePlotProps, `change`> & PlotConfig & {
     series?: DataSeries[]
     styles?: StyleOverrides
     controls?: ControlsConfig
-    padding?: Sides
-    range_padding?: number
     current_x_value?: number | null
     tooltip_point?: InternalPoint | null
     selected_point?: { series_idx: number; point_idx: number } | null
-    hovered?: boolean
     tooltip?: Snippet<[ScatterHandlerProps]>
     user_content?: Snippet<[UserContentProps]>
-    children?: Snippet<[{ height: number; width: number; fullscreen: boolean }]>
     header_controls?: Snippet<
       [{ height: number; width: number; fullscreen: boolean }]
     >
@@ -146,8 +143,6 @@
     on_point_hover?: (data: ScatterHandlerEvent | null) => void
     selected_series_idx?: number
     wrapper?: HTMLDivElement
-    fullscreen?: boolean
-    fullscreen_toggle?: boolean
   } = $props()
 
   // Initialize style overrides with defaults (runs once to avoid infinite loop)
@@ -159,7 +154,7 @@
     format: ``,
     scale_type: `linear`,
     label_shift: { x: 0, y: -40 },
-    tick_label_shift: { x: 0, y: 20 },
+    tick_label_shift: { x: 0, y: 0 }, // base offset handled in rendering
     range: [null, null],
     ...x_axis,
   }
@@ -167,7 +162,7 @@
     format: ``,
     scale_type: `linear`,
     label_shift: { x: 0, y: 0 },
-    tick_label_shift: { x: -8, y: 0 },
+    tick_label_shift: { x: 0, y: 0 }, // base offset handled in rendering
     range: [null, null],
     ...y_axis,
   }
@@ -176,7 +171,7 @@
     scale_type: `linear`,
     ticks: 5,
     label_shift: { x: 0, y: 0 },
-    tick_label_shift: { x: 8, y: 0 },
+    tick_label_shift: { x: 0, y: 0 }, // base offset handled in rendering
     range: [null, null],
     ...y2_axis,
   }
@@ -1216,6 +1211,7 @@
               // Check if tick position is finite
               {@const tick_pos = tick_pos_raw}
               {#if tick_pos >= pad.l && tick_pos <= width - pad.r}
+                {@const inside = x_axis.tick_labels_inside ?? false}
                 <g class="tick" transform="translate({tick_pos}, {height - pad.b})">
                   {#if display.x_grid}
                     <line
@@ -1225,11 +1221,16 @@
                       {...(x_axis.grid_style ?? {})}
                     />
                   {/if}
+                  <line y1="0" y2={inside ? -5 : 5} stroke="var(--border-color, gray)" />
 
                   {#if tick >= x_min && tick <= x_max}
-                    {@const { x, y } = x_axis.tick_label_shift ?? { x: 0, y: 20 }}
+                    {@const base_y = inside ? -8 : 20}
+                    {@const shift = x_axis.tick_label_shift ?? { x: 0, y: 0 }}
+                    {@const x = shift.x ?? 0}
+                    {@const y = base_y + (shift.y ?? 0)}
                     {@const custom_label = get_tick_label(tick, x_axis.ticks)}
-                    <text {x} {y}>
+                    {@const dominant_baseline = inside ? `auto` : `hanging`}
+                    <text {x} {y} dominant-baseline={dominant_baseline}>
                       {custom_label ?? format_value(tick, x_axis.format ?? ``)}
                     </text>
                   {/if}
@@ -1284,6 +1285,7 @@
               // Check if tick position is finite
               {@const tick_pos = tick_pos_raw}
               {#if tick_pos >= pad.t && tick_pos <= height - pad.b}
+                {@const inside = y_axis.tick_labels_inside ?? false}
                 <g class="tick" transform="translate({pad.l}, {tick_pos})">
                   {#if display.y_grid}
                     <line
@@ -1293,11 +1295,20 @@
                       {...(y_axis.grid_style ?? {})}
                     />
                   {/if}
+                  <line
+                    x1={inside ? 0 : -5}
+                    x2={inside ? 5 : 0}
+                    stroke="var(--border-color, gray)"
+                  />
 
                   {#if tick >= y_min && tick <= y_max}
-                    {@const { x, y } = y_axis.tick_label_shift ?? { x: -8, y: 0 }}
+                    {@const base_x = inside ? 8 : -8}
+                    {@const shift = y_axis.tick_label_shift ?? { x: 0, y: 0 }}
+                    {@const x = base_x + (shift.x ?? 0)}
+                    {@const y = shift.y ?? 0}
                     {@const custom_label = get_tick_label(tick, y_axis.ticks)}
-                    <text {x} {y} text-anchor="end" fill={y_axis.color}>
+                    {@const text_anchor = inside ? `start` : `end`}
+                    <text {x} {y} text-anchor={text_anchor} fill={y_axis.color}>
                       {custom_label ?? format_value(tick, y_axis.format ?? ``)}
                       {#if y_axis.unit && idx === 0}
                         &zwnj;&ensp;{y_axis.unit}
@@ -1339,6 +1350,7 @@
                 // Check if tick position is finite
                 {@const tick_pos = tick_pos_raw}
                 {#if tick_pos >= pad.t && tick_pos <= height - pad.b}
+                  {@const inside = y2_axis.tick_labels_inside ?? false}
                   <g class="tick" transform="translate({width - pad.r}, {tick_pos})">
                     {#if display.y2_grid}
                       <line
@@ -1348,11 +1360,20 @@
                         {...(y2_axis.grid_style ?? {})}
                       />
                     {/if}
+                    <line
+                      x1={inside ? -5 : 0}
+                      x2={inside ? 0 : 5}
+                      stroke="var(--border-color, gray)"
+                    />
 
                     {#if tick >= y2_min && tick <= y2_max}
-                      {@const { x, y } = y2_axis.tick_label_shift ?? { x: 8, y: 0 }}
+                      {@const base_x = inside ? -8 : 8}
+                      {@const shift = y2_axis.tick_label_shift ?? { x: 0, y: 0 }}
+                      {@const x = base_x + (shift.x ?? 0)}
+                      {@const y = shift.y ?? 0}
                       {@const custom_label = get_tick_label(tick, y2_axis.ticks)}
-                      <text {x} {y} text-anchor="start" fill={y2_axis.color}>
+                      {@const text_anchor = inside ? `end` : `start`}
+                      <text {x} {y} text-anchor={text_anchor} fill={y2_axis.color}>
                         {custom_label ?? format_value(tick, y2_axis.format ?? ``)}
                         {#if y2_axis.unit && idx === 0}
                           &zwnj;&ensp;{y2_axis.unit}

--- a/src/lib/plot/SpacegroupBarPlot.svelte
+++ b/src/lib/plot/SpacegroupBarPlot.svelte
@@ -139,7 +139,7 @@
       label: x_axis.label ?? `International Spacegroup Number`,
       range: x_range,
       ticks: x_axis_ticks,
-      tick_rotation: x_axis.tick_rotation ?? 90, // Rotate ticks 90° to avoid overlap
+      tick: { label: { rotation: x_axis.tick?.label?.rotation ?? 90 } }, // Rotate ticks 90° to avoid overlap
       label_shift: { x: 0, y: 20, ...x_axis.label_shift }, // Move label down for rotated ticks
     },
   )
@@ -151,7 +151,7 @@
         label: y_axis.label ?? `International Spacegroup Number`,
         range: x_range,
         ticks: x_axis_ticks,
-        tick_rotation: y_axis.tick_rotation ?? 0,
+        tick: { label: { rotation: y_axis.tick?.label?.rotation ?? 0 } },
       }
       : { ...y_axis, label: y_axis.label ?? `Counts` },
   )

--- a/src/lib/plot/SpacegroupBarPlot.svelte
+++ b/src/lib/plot/SpacegroupBarPlot.svelte
@@ -1,12 +1,21 @@
 <script lang="ts">
   import { type BarHandlerProps, type BarSeries, format_num } from '$lib'
   import { format_value } from '$lib/labels'
-  import { BarPlot } from '$lib/plot'
+  import { BarPlot, type TickConfig } from '$lib/plot'
   import type { CrystalSystem } from '$lib/symmetry'
   import * as symmetry from '$lib/symmetry'
   import * as spg from '$lib/symmetry/spacegroups'
   import type { ComponentProps } from 'svelte'
   import { SvelteMap } from 'svelte/reactivity'
+
+  /** Merge tick config with default rotation, preserving user overrides */
+  const with_rotation = (
+    tick: TickConfig | undefined,
+    default_rot: number,
+  ): TickConfig => ({
+    ...tick,
+    label: { ...tick?.label, rotation: tick?.label?.rotation ?? default_rot },
+  })
 
   const MAX_SPACEGROUP = 230
   let {
@@ -139,7 +148,7 @@
       label: x_axis.label ?? `International Spacegroup Number`,
       range: x_range,
       ticks: x_axis_ticks,
-      tick: { label: { rotation: x_axis.tick?.label?.rotation ?? 90 } }, // Rotate ticks 90° to avoid overlap
+      tick: with_rotation(x_axis.tick, 90), // Rotate ticks 90° to avoid overlap
       label_shift: { x: 0, y: 20, ...x_axis.label_shift }, // Move label down for rotated ticks
     },
   )
@@ -151,7 +160,7 @@
         label: y_axis.label ?? `International Spacegroup Number`,
         range: x_range,
         ticks: x_axis_ticks,
-        tick: { label: { rotation: y_axis.tick?.label?.rotation ?? 0 } },
+        tick: with_rotation(y_axis.tick, 0),
       }
       : { ...y_axis, label: y_axis.label ?? `Counts` },
   )

--- a/src/lib/plot/index.ts
+++ b/src/lib/plot/index.ts
@@ -7,6 +7,7 @@ export interface TweenedOptions<T> {
   interpolate?: (a: T, b: T) => (t: number) => T
 }
 
+export * from './svg'
 export { default as BarPlot } from './BarPlot.svelte'
 export { default as BarPlotControls } from './BarPlotControls.svelte'
 export { default as ColorBar } from './ColorBar.svelte'

--- a/src/lib/plot/svg.ts
+++ b/src/lib/plot/svg.ts
@@ -1,0 +1,26 @@
+/**
+ * SVG path and rendering utilities for plot components.
+ */
+
+/**
+ * Generate SVG path for a bar with rounded corners on the "free" end (away from axis).
+ * For vertical bars, rounds top corners. For horizontal bars, rounds right corners.
+ */
+export function bar_path(
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  r: number,
+  vertical: boolean = true,
+): string {
+  if (r <= 0) return `M${x},${y}h${w}v${h}h${-w}Z`
+
+  return vertical
+    ? `M${x},${y + h}V${y + r}A${r},${r} 0 0 1 ${x + r},${y}H${
+      x + w - r
+    }A${r},${r} 0 0 1 ${x + w},${y + r}V${y + h}Z`
+    : `M${x},${y}H${x + w - r}A${r},${r} 0 0 1 ${x + w},${y + r}V${
+      y + h - r
+    }A${r},${r} 0 0 1 ${x + w - r},${y + h}H${x}Z`
+}

--- a/src/lib/plot/types.ts
+++ b/src/lib/plot/types.ts
@@ -66,9 +66,9 @@ export interface BarStyle {
   stroke_width?: number
   stroke_color?: string
   stroke_opacity?: number
-  border_radius?: number // SVG rx/ry for rounded corners (applied to both x and y)
-  rx?: number // SVG rx attribute for horizontal corner radius
-  ry?: number // SVG ry attribute for vertical corner radius
+  border_radius?: number // Shorthand: sets both rx and ry to this value (lower priority than explicit rx/ry)
+  rx?: number // SVG rx attribute for horizontal corner radius (overrides border_radius)
+  ry?: number // SVG ry attribute for vertical corner radius (overrides border_radius)
   [key: string]: unknown
 }
 

--- a/src/lib/plot/types.ts
+++ b/src/lib/plot/types.ts
@@ -406,7 +406,7 @@ export interface BasePlotProps {
   fullscreen?: boolean
   fullscreen_toggle?: boolean // default: true
   // Callbacks
-  change?: (...args: unknown[]) => void
+  change?: (data: Record<string, unknown> | null) => void
   // Children
   children?: Snippet<[{ height: number; width: number; fullscreen?: boolean }]>
 }

--- a/src/lib/plot/types.ts
+++ b/src/lib/plot/types.ts
@@ -288,18 +288,28 @@ export interface BarSeries {
   }
 }
 
+// Tick label configuration
+export interface TickLabelConfig {
+  inside?: boolean // Render tick labels inside the plot area (default: false/outside)
+  shift?: { x?: number; y?: number }
+  rotation?: number // Rotation angle in degrees
+}
+
+// Tick configuration
+export interface TickConfig {
+  label?: TickLabelConfig
+}
+
 // Axis configuration type for grouping related axis properties
 export interface AxisConfig {
   label?: string
   format?: string
   ticks?: TicksOption
+  tick?: TickConfig
   scale_type?: ScaleType
   range?: [number | null, number | null]
   unit?: string
   label_shift?: { x?: number; y?: number }
-  tick_label_shift?: { x?: number; y?: number }
-  tick_rotation?: number // Rotation angle in degrees for tick labels
-  tick_labels_inside?: boolean // Render tick labels inside the plot area (default: false/outside)
   grid_style?: HTMLAttributes<SVGLineElement>
   color?: string | null // Color for axis label, tick labels, and axis line
 }

--- a/src/lib/plot/types.ts
+++ b/src/lib/plot/types.ts
@@ -65,6 +65,9 @@ export interface BarStyle {
   stroke_width?: number
   stroke_color?: string
   stroke_opacity?: number
+  border_radius?: number // SVG rx/ry for rounded corners (applied to both x and y)
+  rx?: number // SVG rx attribute for horizontal corner radius
+  ry?: number // SVG ry attribute for vertical corner radius
   [key: string]: unknown
 }
 
@@ -296,6 +299,7 @@ export interface AxisConfig {
   label_shift?: { x?: number; y?: number }
   tick_label_shift?: { x?: number; y?: number }
   tick_rotation?: number // Rotation angle in degrees for tick labels
+  tick_labels_inside?: boolean // Render tick labels inside the plot area (default: false/outside)
   grid_style?: HTMLAttributes<SVGLineElement>
   color?: string | null // Color for axis label, tick labels, and axis line
 }
@@ -379,13 +383,19 @@ export interface BasePlotProps {
   y_range?: [number | null, number | null]
   y2_range?: [number | null, number | null]
   range_padding?: number // Factor to pad auto-detected ranges before nicing (e.g. 0.05 = 5%)
-  // Layout (non-bindable)
   padding?: Sides
-  // Callbacks (non-bindable)
-  change?: (...args: unknown[]) => void // Callback when hovered item changes
-  // Control pane component props (non-bindable)
+  // State
+  hovered?: boolean
+  // Controls
+  show_controls?: boolean
+  controls_open?: boolean
   controls_toggle_props?: ComponentProps<typeof DraggablePane>[`toggle_props`]
   controls_pane_props?: ComponentProps<typeof DraggablePane>[`pane_props`]
+  // Fullscreen
+  fullscreen?: boolean
+  fullscreen_toggle?: boolean // default: true
+  // Callbacks
+  change?: (...args: unknown[]) => void
   // Children
   children?: Snippet<[{ height: number; width: number; fullscreen?: boolean }]>
 }

--- a/src/lib/plot/types.ts
+++ b/src/lib/plot/types.ts
@@ -17,6 +17,7 @@ export interface TweenedOptions<T> {
 }
 
 export type XyObj = { x: number; y: number }
+export type XyShift = { x?: number; y?: number } // For optional shift/offset values
 export type Sides = { t?: number; b?: number; l?: number; r?: number }
 
 export type Point = {
@@ -291,7 +292,7 @@ export interface BarSeries {
 // Tick label configuration
 export interface TickLabelConfig {
   inside?: boolean // Render tick labels inside the plot area (default: false/outside)
-  shift?: { x?: number; y?: number }
+  shift?: XyShift
   rotation?: number // Rotation angle in degrees
 }
 
@@ -309,7 +310,7 @@ export interface AxisConfig {
   scale_type?: ScaleType
   range?: [number | null, number | null]
   unit?: string
-  label_shift?: { x?: number; y?: number }
+  label_shift?: XyShift
   grid_style?: HTMLAttributes<SVGLineElement>
   color?: string | null // Color for axis label, tick labels, and axis line
 }

--- a/src/routes/(demos)/plot/bar-plot/+page.md
+++ b/src/routes/(demos)/plot/bar-plot/+page.md
@@ -2,7 +2,7 @@
 
 ## Crystal Structure Analysis
 
-A simple bar plot showing lattice parameters across different crystal systems. Use the controls (gear icon) to toggle orientation, modes, and grid display:
+A simple bar plot showing lattice parameters across different crystal systems. Use the controls (gear icon) to toggle orientation, modes, and grid display. This example also demonstrates rounded corners (`border_radius`) and bar borders (`stroke_color`, `stroke_width`):
 
 ```svelte example
 <script>
@@ -21,6 +21,7 @@ A simple bar plot showing lattice parameters across different crystal systems. U
 
 <BarPlot
   series={lattice_params}
+  bar={{ border_radius: 4, stroke_color: `#364fc7`, stroke_width: 1.5 }}
   x_axis={{ label: `Crystal System` }}
   y_axis={{ label: `Lattice Parameter (Å)` }}
   style="height: 400px"
@@ -181,7 +182,7 @@ A classic business use case: comparing raw sales (bars, left axis) with profit m
 
 ## Element Abundance in Earth's Crust
 
-Horizontal bar charts work well for categorical data with long labels:
+Horizontal bar charts work well for categorical data with long labels. This example demonstrates `tick_labels_inside` which positions tick labels inside the plot area for a more compact design:
 
 ```svelte example
 <script>
@@ -207,9 +208,10 @@ Horizontal bar charts work well for categorical data with long labels:
   ]
 
   let orientation = $state(`horizontal`)
+  let tick_labels_inside = $state(false)
 </script>
 
-<label style="margin-bottom: 1em; display: block">
+<label style="margin-bottom: 1em; display: inline-block">
   <input
     type="checkbox"
     checked={orientation === `horizontal`}
@@ -217,12 +219,16 @@ Horizontal bar charts work well for categorical data with long labels:
   />
   Horizontal Orientation
 </label>
+<label style="margin-bottom: 1em; display: inline-block; margin-left: 2em">
+  <input type="checkbox" bind:checked={tick_labels_inside} />
+  Tick Labels Inside
+</label>
 
 <BarPlot
   series={abundances}
   {orientation}
-  x_axis={{ label: `Abundance (ppm)`, format: `~s` }}
-  y_axis={{ label: `Element`, format: `~s` }}
+  x_axis={{ label: `Abundance (ppm)`, format: `~s`, tick_labels_inside }}
+  y_axis={{ label: `Element`, format: `~s`, tick_labels_inside }}
   style="height: 400px"
 />
 ```

--- a/src/routes/(demos)/plot/bar-plot/+page.md
+++ b/src/routes/(demos)/plot/bar-plot/+page.md
@@ -182,7 +182,7 @@ A classic business use case: comparing raw sales (bars, left axis) with profit m
 
 ## Element Abundance in Earth's Crust
 
-Horizontal bar charts work well for categorical data with long labels. This example demonstrates `tick_labels_inside` which positions tick labels inside the plot area for a more compact design:
+Horizontal bar charts work well for categorical data with long labels. This example demonstrates `tick.label.inside` which positions tick labels inside the plot area for a more compact design:
 
 ```svelte example
 <script>
@@ -208,7 +208,7 @@ Horizontal bar charts work well for categorical data with long labels. This exam
   ]
 
   let orientation = $state(`horizontal`)
-  let tick_labels_inside = $state(false)
+  let inside = $state(false)
 </script>
 
 <label style="margin-bottom: 1em; display: inline-block">
@@ -220,15 +220,15 @@ Horizontal bar charts work well for categorical data with long labels. This exam
   Horizontal Orientation
 </label>
 <label style="margin-bottom: 1em; display: inline-block; margin-left: 2em">
-  <input type="checkbox" bind:checked={tick_labels_inside} />
+  <input type="checkbox" bind:checked={inside} />
   Tick Labels Inside
 </label>
 
 <BarPlot
   series={abundances}
   {orientation}
-  x_axis={{ label: `Abundance (ppm)`, format: `~s`, tick_labels_inside }}
-  y_axis={{ label: `Element`, format: `~s`, tick_labels_inside }}
+  x_axis={{ label: `Abundance (ppm)`, format: `~s`, tick: { label: { inside } } }}
+  y_axis={{ label: `Element`, format: `~s`, tick: { label: { inside } } }}
   style="height: 400px"
 />
 ```

--- a/src/routes/(demos)/plot/histogram/+page.md
+++ b/src/routes/(demos)/plot/histogram/+page.md
@@ -2,6 +2,8 @@
 
 ## Basic Histogram
 
+This example demonstrates bar styling options including `border_radius` for rounded corners and `stroke_color`/`stroke_width` for bar borders:
+
 ```svelte example
 <script>
   import { format_num, Histogram } from 'matterviz'
@@ -10,6 +12,7 @@
   let bins = $state(50)
   let sample_size = $state(1000)
   let show_controls = $state(true)
+  let border_radius = $state(2)
   let hover_info = $state('Hover over a bar to see details')
   let click_info = $state('Click on a bar to select it')
 
@@ -45,6 +48,12 @@
   <input type="range" bind:value={sample_size} min="100" max="10000" step="100" />
 </label>
 <label><input type="checkbox" bind:checked={show_controls} />Controls</label>
+<label>Radius: {border_radius}<input
+    type="range"
+    bind:value={border_radius}
+    min="0"
+    max="8"
+  /></label>
 
 {#snippet tooltip({ value, count })}
   Value: {value.toFixed(1)}<br>Count: {count}<br>
@@ -55,6 +64,7 @@
   series={[data]}
   {bins}
   {show_controls}
+  bar={{ border_radius, stroke_color: `#364fc7`, stroke_width: 0.5 }}
   on_bar_hover={handle_bar_hover}
   on_bar_click={handle_bar_click}
   {tooltip}

--- a/src/routes/(demos)/plot/scatter-plot/+page.md
+++ b/src/routes/(demos)/plot/scatter-plot/+page.md
@@ -475,7 +475,7 @@ This example shows categorized data with color coding, custom tick intervals, an
 
 ## Time-Based Data with Custom Formatting
 
-Using time data on the x-axis with custom formatting:
+Using time data on the x-axis with custom formatting. This example also demonstrates `tick_labels_inside` which positions tick labels inside the plot area for a more compact design:
 
 ```svelte example
 <script>
@@ -510,8 +510,9 @@ Using time data on the x-axis with custom formatting:
   ]
 
   // Format options
-  let date_format = '%b %d'
-  let y_format = '.1f'
+  let date_format = $state('%b %d')
+  let y_format = $state('.1f')
+  let tick_labels_inside = $state(false)
 </script>
 
 <div>
@@ -540,11 +541,15 @@ Using time data on the x-axis with custom formatting:
       {/each}
     </select>
   </label>
+  <label style="margin-left: 1em">
+    <input type="checkbox" bind:checked={tick_labels_inside} />
+    Tick Labels Inside
+  </label>
 
   <ScatterPlot
     series={time_series.map((srs) => ({ ...srs, markers: 'line+points' }))}
-    x_axis={{ format: date_format, ticks: -7, label: 'Date' }}
-    y_axis={{ format: y_format, ticks: 5, label: 'Value' }}
+    x_axis={{ format: date_format, ticks: -7, label: 'Date', tick_labels_inside }}
+    y_axis={{ format: y_format, ticks: 5, label: 'Value', tick_labels_inside }}
     style="height: 350px"
     legend={{
       layout: `horizontal`,

--- a/src/routes/(demos)/plot/scatter-plot/+page.md
+++ b/src/routes/(demos)/plot/scatter-plot/+page.md
@@ -475,7 +475,7 @@ This example shows categorized data with color coding, custom tick intervals, an
 
 ## Time-Based Data with Custom Formatting
 
-Using time data on the x-axis with custom formatting. This example also demonstrates `tick_labels_inside` which positions tick labels inside the plot area for a more compact design:
+Using time data on the x-axis with custom formatting. This example also demonstrates `tick.label.inside` which positions tick labels inside the plot area for a more compact design:
 
 ```svelte example
 <script>
@@ -512,7 +512,7 @@ Using time data on the x-axis with custom formatting. This example also demonstr
   // Format options
   let date_format = $state('%b %d')
   let y_format = $state('.1f')
-  let tick_labels_inside = $state(false)
+  let inside = $state(false)
 </script>
 
 <div>
@@ -542,14 +542,14 @@ Using time data on the x-axis with custom formatting. This example also demonstr
     </select>
   </label>
   <label style="margin-left: 1em">
-    <input type="checkbox" bind:checked={tick_labels_inside} />
+    <input type="checkbox" bind:checked={inside} />
     Tick Labels Inside
   </label>
 
   <ScatterPlot
     series={time_series.map((srs) => ({ ...srs, markers: 'line+points' }))}
-    x_axis={{ format: date_format, ticks: -7, label: 'Date', tick_labels_inside }}
-    y_axis={{ format: y_format, ticks: 5, label: 'Value', tick_labels_inside }}
+    x_axis={{ format: date_format, ticks: -7, label: 'Date', tick: { label: { inside } } }}
+    y_axis={{ format: y_format, ticks: 5, label: 'Value', tick: { label: { inside } } }}
     style="height: 350px"
     legend={{
       layout: `horizontal`,

--- a/tests/vitest/phase-diagram/PhaseDiagramStats.test.ts
+++ b/tests/vitest/phase-diagram/PhaseDiagramStats.test.ts
@@ -85,7 +85,7 @@ describe(`PhaseDiagramStats`, () => {
     expect(text).toContain(`150`)
     expect(text).toContain(`Stable phases`)
     expect(text).toContain(`25`)
-    for (const val of [`2.567`, `0.123`, `1.234`, `0.456`, `0.089`]) {
+    for (const val of [`−2.567`, `0.123`, `−1.234`, `0.456`, `0.089`]) {
       expect(text).toContain(val)
     }
   })

--- a/tests/vitest/phase-diagram/PhaseDiagramStats.test.ts
+++ b/tests/vitest/phase-diagram/PhaseDiagramStats.test.ts
@@ -1,0 +1,209 @@
+import { PhaseDiagramStats } from '$lib/phase-diagram'
+import type { PhaseDiagramEntry, PhaseStats } from '$lib/phase-diagram/types'
+import { flushSync, mount } from 'svelte'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { doc_query } from '../setup'
+
+const mock_stats = (overrides: Partial<PhaseStats> = {}): PhaseStats => ({
+  total: 100,
+  unary: 3,
+  binary: 20,
+  ternary: 50,
+  quaternary: 27,
+  stable: 15,
+  unstable: 85,
+  elements: 4,
+  chemical_system: `Li-Fe-P-O`,
+  energy_range: { min: -2.5, max: 0.5, avg: -0.8 },
+  hull_distance: { max: 0.4, avg: 0.12 },
+  ...overrides,
+})
+
+const mock_entry = (overrides: Partial<PhaseDiagramEntry> = {}): PhaseDiagramEntry => ({
+  composition: { Li: 1, Fe: 1, P: 1, O: 4 },
+  energy: -50,
+  e_form_per_atom: -0.5,
+  e_above_hull: 0.1,
+  is_stable: false,
+  is_element: false,
+  x: 0.25,
+  y: 0.25,
+  z: 0.25,
+  visible: true,
+  ...overrides,
+})
+
+type Props = {
+  phase_stats: PhaseStats | null
+  stable_entries: PhaseDiagramEntry[]
+  unstable_entries: PhaseDiagramEntry[]
+}
+const mount_stats = (props: Partial<Props> = {}) =>
+  mount(PhaseDiagramStats, {
+    target: document.body,
+    props: {
+      phase_stats: mock_stats(),
+      stable_entries: [],
+      unstable_entries: [],
+      ...props,
+    },
+  })
+
+describe(`PhaseDiagramStats`, () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  test(`renders header and all phase type counts`, () => {
+    mount_stats({
+      phase_stats: mock_stats({ unary: 4, binary: 20, ternary: 50, quaternary: 26 }),
+    })
+    const text = document.body.textContent ?? ``
+    expect(doc_query(`h4`).textContent).toContain(`Phase Diagram Stats`)
+    for (
+      const [type, count] of [[`Unary`, 4], [`Binary`, 20], [`Ternary`, 50], [
+        `Quaternary`,
+        26,
+      ]] as const
+    ) {
+      expect(text).toContain(`${type} phases`)
+      expect(text).toContain(`${count}`)
+    }
+  })
+
+  test(`displays chemical system, stability counts, energy and hull stats`, () => {
+    mount_stats({
+      phase_stats: mock_stats({
+        chemical_system: `Li-Fe-P-O`,
+        total: 150,
+        stable: 25,
+        unstable: 125,
+        energy_range: { min: -2.567, max: 0.123, avg: -1.234 },
+        hull_distance: { max: 0.456, avg: 0.089 },
+      }),
+    })
+    const text = document.body.textContent ?? ``
+    expect(text).toContain(`Total entries in Li-Fe-P-O`)
+    expect(text).toContain(`150`)
+    expect(text).toContain(`Stable phases`)
+    expect(text).toContain(`25`)
+    for (const val of [`2.567`, `0.123`, `1.234`, `0.456`, `0.089`]) {
+      expect(text).toContain(val)
+    }
+  })
+
+  test.each([
+    [`click`, (el: HTMLElement) => el.click()],
+    [
+      `Enter key`,
+      (el: HTMLElement) =>
+        el.dispatchEvent(new KeyboardEvent(`keydown`, { key: `Enter`, bubbles: true })),
+    ],
+  ])(`copies stat item on %s`, (_, trigger) => {
+    mount_stats()
+    trigger(doc_query(`[data-testid="pd-total-entries"]`))
+    flushSync()
+    expect(navigator.clipboard.writeText).toHaveBeenCalled()
+  })
+
+  test.each([
+    { name: `energy histogram`, entries: [mock_entry({ e_form_per_atom: -0.5 })] },
+    { name: `hull histogram`, entries: [mock_entry({ e_above_hull: 0.1 })] },
+  ])(`renders $name when entries have data`, ({ entries }) => {
+    mount_stats({ stable_entries: entries })
+    expect(document.querySelectorAll(`.histogram`).length).toBeGreaterThanOrEqual(1)
+  })
+
+  test.each([
+    {
+      system: `Li-Fe`,
+      ternary: 0,
+      quaternary: 0,
+      shown: [`Binary`],
+      hidden: [`Ternary`, `Quaternary`],
+    },
+    {
+      system: `Li-Fe-O`,
+      ternary: 10,
+      quaternary: 0,
+      shown: [`Ternary`],
+      hidden: [`Quaternary`],
+    },
+  ])(
+    `conditional phase display for $system system`,
+    ({ system, ternary, quaternary, shown, hidden }) => {
+      mount_stats({
+        phase_stats: mock_stats({ chemical_system: system, ternary, quaternary }),
+      })
+      const text = document.body.textContent ?? ``
+      for (const type of shown) expect(text).toContain(`${type} phases`)
+      for (const type of hidden) expect(text).not.toContain(`${type} phases`)
+    },
+  )
+
+  test(`renders empty stat items when phase_stats is null`, () => {
+    mount_stats({ phase_stats: null })
+    expect(doc_query(`.phase-diagram-stats`).querySelectorAll(`.stat-item`).length).toBe(
+      0,
+    )
+  })
+
+  test(`energy_per_atom fallback renders both histograms`, () => {
+    mount_stats({
+      stable_entries: [
+        mock_entry({
+          e_form_per_atom: undefined,
+          energy_per_atom: -0.3,
+          e_above_hull: 0.1,
+        }),
+      ],
+    })
+    expect(document.querySelectorAll(`.histogram`).length).toBe(2)
+  })
+
+  test.each([
+    { desc: `zero totals`, stats: { total: 0, stable: 0, unstable: 0 }, entries: [] },
+    {
+      desc: `missing energy`,
+      stats: {},
+      entries: [mock_entry({ e_form_per_atom: undefined, energy_per_atom: undefined })],
+    },
+    {
+      desc: `non-finite values`,
+      stats: {},
+      entries: [
+        mock_entry({ e_form_per_atom: NaN }),
+        mock_entry({ e_form_per_atom: Infinity }),
+      ],
+    },
+  ])(`handles edge case: $desc`, ({ stats, entries }) => {
+    mount_stats({ phase_stats: mock_stats(stats), stable_entries: entries })
+    expect(doc_query(`.phase-diagram-stats`)).toBeTruthy()
+  })
+
+  test(`stat items have accessibility attributes and copy hint`, () => {
+    mount_stats()
+    const items = Array.from(document.querySelectorAll(`.stat-item`))
+    for (const item of items) {
+      expect(item.getAttribute(`role`)).toBe(`button`)
+      expect(item.getAttribute(`tabindex`)).toBe(`0`)
+    }
+    expect(doc_query(`[data-testid="pd-total-entries"]`).getAttribute(`title`)).toContain(
+      `Click to copy`,
+    )
+  })
+
+  test(`passes through HTML attributes`, () => {
+    mount(PhaseDiagramStats, {
+      target: document.body,
+      props: {
+        phase_stats: mock_stats(),
+        stable_entries: [],
+        unstable_entries: [],
+        class: `custom-class`,
+        style: `background: red;`,
+      },
+    })
+    const container = doc_query(`.phase-diagram-stats`)
+    expect(container.classList.contains(`custom-class`)).toBe(true)
+    expect(container.getAttribute(`style`)).toContain(`background: red`)
+  })
+})

--- a/tests/vitest/plot/svg.test.ts
+++ b/tests/vitest/plot/svg.test.ts
@@ -1,0 +1,51 @@
+import { bar_path } from '$lib/plot/svg'
+import { describe, expect, it } from 'vitest'
+
+describe(`bar_path`, () => {
+  it.each([
+    [0, 0, 10, 20, 0, true, `M0,0h10v20h-10Z`],
+    [5, 10, 20, 30, 0, false, `M5,10h20v30h-20Z`],
+    [0, 0, 10, 20, -5, true, `M0,0h10v20h-10Z`],
+  ])(
+    `returns simple rect path when radius is 0 or negative (x=%d, y=%d, w=%d, h=%d, r=%d, vertical=%s)`,
+    (x, y, w, h, r, vertical, expected) => {
+      expect(bar_path(x, y, w, h, r, vertical)).toBe(expected)
+    },
+  )
+
+  it(`returns vertical bar path with rounded top corners`, () => {
+    const path = bar_path(10, 20, 40, 60, 5, true)
+    // Path should: start bottom-left, go up, arc top-left, horizontal across, arc top-right, go down, close
+    expect(path).toBe(
+      `M10,80V25A5,5 0 0 1 15,20H45A5,5 0 0 1 50,25V80Z`,
+    )
+  })
+
+  it(`returns horizontal bar path with rounded right corners`, () => {
+    const path = bar_path(10, 20, 40, 60, 5, false)
+    // Path should: start top-left, go right, arc top-right, go down, arc bottom-right, go left, close
+    expect(path).toBe(
+      `M10,20H45A5,5 0 0 1 50,25V75A5,5 0 0 1 45,80H10Z`,
+    )
+  })
+
+  it(`defaults to vertical orientation when not specified`, () => {
+    const explicit = bar_path(0, 0, 10, 20, 3, true)
+    const implicit = bar_path(0, 0, 10, 20, 3)
+    expect(implicit).toBe(explicit)
+  })
+
+  it.each([
+    [0, 0, 10, 20, 5, true],
+    [100, 200, 50, 100, 10, false],
+  ])(
+    `path is valid SVG (x=%d, y=%d, w=%d, h=%d, r=%d, vertical=%s)`,
+    (x, y, w, h, r, vertical) => {
+      const path = bar_path(x, y, w, h, r, vertical)
+      // Basic SVG path validation: starts with M, ends with Z, contains expected commands
+      expect(path).toMatch(/^M[\d.,-]+/)
+      expect(path).toMatch(/Z$/)
+      expect(path).toContain(`A${r},${r}`)
+    },
+  )
+})


### PR DESCRIPTION
- Automatically choose a phase-diagram threshold for displaying unstable entries and improve threshold/reset defaults.
- Improve phase visibility plus selection and hover behavior, and show phase-stat percentages to one decimal place.
- Add rounded corners and stroke controls to bars and histograms.
- Allow tick labels inside plot areas and expose controls for bar radius and tick placement.