### PR TITLE
Fix code smells

### DIFF
--- a/src/lib/colors/index.ts
+++ b/src/lib/colors/index.ts
@@ -168,7 +168,7 @@ export function is_dark_mode(): boolean {
   try {
     const stored = localStorage.getItem(`theme`)
     if (stored === `dark` || stored === `light`) return stored === `dark`
-  } catch { /* localStorage may throw in private browsing */ }
+  } catch { /* localStorage throws in private browsing mode */ }
   return globalThis.matchMedia?.(`(prefers-color-scheme: dark)`).matches ?? false
 }
 

--- a/src/lib/composition/parse.ts
+++ b/src/lib/composition/parse.ts
@@ -545,7 +545,7 @@ export function matches_formula_wildcard(
       if (token.element === null) {
         wildcard_counts.push(token.count)
       } else {
-        // Merge counts for same element (e.g., "LiLi" -> Li with count 2)
+        // Merge counts for same element (e.g. "LiLi" -> Li with count 2)
         const existing = explicit_requirements.find((req) =>
           req.element === token.element
         )

--- a/src/lib/composition/parse.ts
+++ b/src/lib/composition/parse.ts
@@ -9,8 +9,7 @@ export const SYMBOL_TO_ATOMIC_NUMBER: Partial<CompositionType> = {}
 export const ATOMIC_WEIGHTS = new Map<ElementSymbol, number>()
 export const ELEMENT_ELECTRONEGATIVITY_MAP = new Map<ElementSymbol, number>()
 export const ELEM_NAME_TO_SYMBOL: Record<string, ElementSymbol> = {}
-// @ts-expect-error - record gets built in for loop
-export const ELEM_SYMBOL_TO_NAME: Record<ElementSymbol, string> = {}
+export const ELEM_SYMBOL_TO_NAME: Partial<Record<ElementSymbol, string>> = {}
 
 // Populate maps at module load time
 for (const element of element_data) {
@@ -398,6 +397,7 @@ export const normalize_element_symbols = <T extends string>(
   all_symbols?: T[],
 ): T[] => {
   const input_set = new Set(csv.split(`,`).map((sym) => sym.trim()).filter(Boolean))
+  // Cast needed: ELEM_SYMBOLS is readonly const tuple, T is generic string subtype
   return (all_symbols ?? (ELEM_SYMBOLS as unknown as T[])).filter((sym) =>
     input_set.has(sym)
   )

--- a/src/lib/convex-hull/ConvexHull2D.svelte
+++ b/src/lib/convex-hull/ConvexHull2D.svelte
@@ -526,8 +526,8 @@
   let last_clicked_entry: ConvexHullEntry | null = null
   let last_click_time = 0
 
-  function handle_point_click_internal(data: ScatterHandlerEvent) {
-    const entry = data.metadata as unknown as ConvexHullEntry
+  function handle_point_click_internal(data: ScatterHandlerEvent<ConvexHullEntry>) {
+    const { metadata: entry, event } = data
     if (!entry) return
 
     const now = Date.now()
@@ -536,10 +536,7 @@
 
     if (is_double_click) {
       // Double-click: copy to clipboard
-      copy_entry_data(entry, {
-        x: data.event.clientX,
-        y: data.event.clientY,
-      })
+      copy_entry_data(entry, { x: event.clientX, y: event.clientY })
       last_clicked_entry = null
       last_click_time = 0
     } else {
@@ -554,13 +551,13 @@
           const structure = extract_structure_from_entry(entry)
           if (structure) {
             const viewport_width = globalThis.innerWidth
-            const click_x = data.event.clientX
+            const click_x = event.clientX
             const space_on_right = viewport_width - click_x
             const space_on_left = click_x
             const place_right = space_on_right >= space_on_left
 
             structure_popup = { open: true, structure, entry, place_right }
-            data.event.stopPropagation()
+            event.stopPropagation()
           }
         }
       }
@@ -590,8 +587,8 @@
 />
 
 <!-- Hover tooltip matching 3D/4D style (content only; container handled by ScatterPlot) -->
-{#snippet tooltip(point: ScatterHandlerProps)}
-  {@const entry = point.metadata as unknown as ConvexHullEntry}
+{#snippet tooltip(point: ScatterHandlerProps<ConvexHullEntry>)}
+  {@const entry = point.metadata}
   {@const entry_highlight = entry && is_highlighted(entry)
     ? merged_highlight_style
     : undefined}
@@ -710,18 +707,15 @@
     header_controls={pd_header_controls}
     selected_point={selected_scatter_point}
     on_point_click={handle_point_click_internal}
-    on_point_hover={(data: ScatterHandlerEvent | null) => {
+    on_point_hover={(data: ScatterHandlerEvent<ConvexHullEntry> | null) => {
       if (!data) {
         hover_data = null
         on_point_hover?.(null)
         return
       }
-      const entry = data.metadata as unknown as ConvexHullEntry
+      const { metadata: entry, event } = data
       hover_data = entry
-        ? {
-          entry,
-          position: { x: data.event.clientX, y: data.event.clientY },
-        }
+        ? { entry, position: { x: event.clientX, y: event.clientY } }
         : null
       on_point_hover?.(hover_data)
     }}

--- a/src/lib/convex-hull/ConvexHull2D.svelte
+++ b/src/lib/convex-hull/ConvexHull2D.svelte
@@ -315,10 +315,8 @@
   })
 
   let reset_counter = $state(0)
-
   // Drag and drop state (to match 3D/4D components)
   let drag_over = $state(false)
-
   // Copy feedback state
   let copy_feedback = $state({ visible: false, position: { x: 0, y: 0 } })
 

--- a/src/lib/convex-hull/helpers.ts
+++ b/src/lib/convex-hull/helpers.ts
@@ -22,6 +22,7 @@ export function get_energy_color_scale(
   const lo = Math.min(...hull_distances)
   const hi_raw = Math.max(...hull_distances, 0.1)
   const hi = Math.max(hi_raw, lo + 1e-6)
+  // Cast needed: d3-scale-chromatic module has non-interpolator exports (e.g. `default`)
   const interpolator =
     (d3_sc as unknown as Record<string, (t: number) => string>)[color_scale] ||
     d3_sc.interpolateViridis

--- a/src/lib/convex-hull/helpers.ts
+++ b/src/lib/convex-hull/helpers.ts
@@ -419,7 +419,7 @@ function apply_alpha_to_color(color: string, alpha: number): string {
   const hex_match = color.match(/^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/) // Convert hex to rgba
   if (hex_match) {
     let hex = hex_match[1]
-    // Expand short form (e.g., "03F") to full form (e.g., "0033FF")
+    // Expand short form (e.g. "03F") to full form (e.g. "0033FF")
     if (hex.length === 3) hex = [...hex].map((char) => char + char).join(``)
 
     const red = parseInt(hex.slice(0, 2), 16)
@@ -523,7 +523,7 @@ export function create_marker_path(
   size: number,
   marker: MarkerSymbol = `circle`,
 ): Path2D {
-  // Capitalize first letter to get D3 symbol name (e.g., 'circle' -> 'Circle')
+  // Capitalize first letter to get D3 symbol name (e.g. 'circle' -> 'Circle')
   const d3_name = marker.charAt(0).toUpperCase() + marker.slice(1)
   const symbol_type = symbol_map[d3_name as keyof typeof symbol_map]
 

--- a/src/lib/coordination/CoordinationBarPlot.svelte
+++ b/src/lib/coordination/CoordinationBarPlot.svelte
@@ -19,6 +19,11 @@
   import { calc_coordination_nums, type CoordinationData } from './calc-coordination'
   import type { SplitMode } from './index'
 
+  type CoordinationMetadata = {
+    element?: string
+    structure_label?: string
+  } & Record<string, unknown>
+
   interface StructureEntry {
     label: string
     structure: AnyStructure
@@ -38,7 +43,7 @@
     loading = $bindable(false),
     error_msg = $bindable(),
     ...rest
-  }: ComponentProps<typeof BarPlot> & {
+  }: Omit<ComponentProps<typeof BarPlot>, `series`> & {
     structures:
       | AnyStructure
       | Record<string, AnyStructure | { structure: AnyStructure; color?: string }>
@@ -111,7 +116,7 @@
   })
 
   // Build BarPlot series based on split_mode
-  const bar_series = $derived.by<BarSeries[]>(() => {
+  const bar_series = $derived.by<BarSeries<CoordinationMetadata>[]>(() => {
     if (split_mode === `by_element`) {
       // One series per element across all structures
       const element_series_map = new SvelteMap<string, Map<number, number>>()
@@ -270,11 +275,11 @@
     : `No coordination data to display`}
   />
 {:else}
-  {#snippet tooltip(info: BarHandlerProps)}
+  {#snippet tooltip(info: BarHandlerProps<CoordinationMetadata>)}
     {@const cn = info.x}
     {@const count = info.y}
-    {@const element = info.metadata?.element as string | undefined}
-    {@const structure_label = info.metadata?.structure_label as string | undefined}
+    {@const element = info.metadata?.element}
+    {@const structure_label = info.metadata?.structure_label}
     {#if element}
       {element} —
     {/if}

--- a/src/lib/fermi-surface/FermiSurfaceControls.svelte
+++ b/src/lib/fermi-surface/FermiSurfaceControls.svelte
@@ -92,9 +92,10 @@
   $effect(() => {
     const bands_changed = available_bands.length !== prev_available_bands.length ||
       available_bands.some((band, idx) => band !== prev_available_bands[idx])
-    if (bands_changed && available_bands.length > 0) {
-      selected_bands = [...available_bands]
+    if (bands_changed) { // Always update tracking variable to avoid stale comparisons
       prev_available_bands = [...available_bands]
+      // Only reset selected_bands when there are bands to select
+      if (available_bands.length > 0) selected_bands = [...available_bands]
     }
   })
 

--- a/src/lib/fermi-surface/FermiSurfaceScene.svelte
+++ b/src/lib/fermi-surface/FermiSurfaceScene.svelte
@@ -268,7 +268,7 @@
       if (face.length < 3) continue
 
       // Fan triangulation: for polygon with N vertices, create N-2 triangles
-      // E.g., quad [0,1,2,3] becomes triangles [0,1,2] and [0,2,3]
+      // e.g. quad [0,1,2,3] becomes triangles [0,1,2] and [0,2,3]
       for (let fan_idx = 1; fan_idx < face.length - 1; fan_idx++) {
         const idx0 = face[0]
         const idx1 = face[fan_idx]

--- a/src/lib/fermi-surface/compute.ts
+++ b/src/lib/fermi-surface/compute.ts
@@ -26,12 +26,11 @@ import type {
 function catmull_rom_coeffs(t: number): [number, number, number, number] {
   const t2 = t * t
   const t3 = t2 * t
-  return [
-    0.5 * (-t + 2 * t2 - t3),
-    0.5 * (2 - 5 * t2 + 3 * t3),
-    0.5 * (t + 4 * t2 - 3 * t3),
-    0.5 * (-t2 + t3),
-  ]
+  const c1 = 0.5 * (-t + 2 * t2 - t3)
+  const c2 = 0.5 * (2 - 5 * t2 + 3 * t3)
+  const c3 = 0.5 * (t + 4 * t2 - 3 * t3)
+  const c4 = 0.5 * (-t2 + t3)
+  return [c1, c2, c3, c4]
 }
 
 // Tricubic interpolation with cached wrap indices and precomputed coefficients

--- a/src/lib/fermi-surface/parse.ts
+++ b/src/lib/fermi-surface/parse.ts
@@ -58,7 +58,7 @@ function parse_bxsf(content: string): BandGridData {
     throw new Error(`BXSF file missing BEGIN_BLOCK_BANDGRID_3D`)
   }
 
-  // Skip block identifier line (e.g., "band_energies")
+  // Skip block identifier line (e.g. "band_energies")
   next_line()
 
   // Parse BEGIN_BANDGRID_3D or BANDGRID_3D_BANDS (both variants exist)
@@ -217,7 +217,7 @@ function parse_frmsf(content: string): BandGridData {
 
   // Parse band energies for each spin and band
   // FRMSF format: one energy value per line per grid point. Any additional columns
-  // (e.g., auxiliary color/velocity data) are ignored to prevent grid corruption.
+  // (e.g. auxiliary color/velocity data) are ignored to prevent grid corruption.
   const energies: EnergyGrid5D = []
   for (let spin_idx = 0; spin_idx < n_spins; spin_idx++) {
     energies[spin_idx] = []
@@ -348,7 +348,7 @@ function parse_fermi_json(
     return data as BandGridData
   }
 
-  // Try to extract from nested structure (e.g., IFermi output)
+  // Try to extract from nested structure (e.g. IFermi output)
   if (data.fermi_surface) {
     return data.fermi_surface as FermiSurfaceData
   }

--- a/src/lib/fermi-surface/types.ts
+++ b/src/lib/fermi-surface/types.ts
@@ -21,8 +21,8 @@ export interface Isosurface {
   vertices: Vec3[]
   faces: number[][] // triangle indices (each array has 3 indices)
   normals: Vec3[] // per-vertex normals
-  properties?: number[] // per-vertex scalar values (e.g., Fermi velocity magnitude)
-  vector_properties?: Vec3[] // per-vertex vector values (e.g., spin texture)
+  properties?: number[] // per-vertex scalar values (e.g. Fermi velocity magnitude)
+  vector_properties?: Vec3[] // per-vertex vector values (e.g. spin texture)
   band_index: number
   spin: SpinChannel
   // Analysis results (computed on demand)
@@ -46,7 +46,7 @@ export interface FermiSurfaceMetadata {
   n_bands: number
   n_surfaces: number
   total_area: number // total surface area in Å⁻²
-  source_format?: string // e.g., 'bxsf', 'frmsf', 'json'
+  source_format?: string // e.g. 'bxsf', 'frmsf', 'json'
   source_file?: string
   has_spin?: boolean
   has_velocities?: boolean

--- a/src/lib/labels.ts
+++ b/src/lib/labels.ts
@@ -27,9 +27,8 @@ export const symbol_names = (
     .map(name_for_symbol).filter((n): n is D3SymbolName => n !== null)
 ) as D3SymbolName[]
 
-const symbols_index = d3_symbols as unknown as Record<string, SymbolType>
-export const symbol_map = Object.fromEntries(
-  symbol_names.map((name) => [name, symbols_index[`symbol${name}`]]),
+export const symbol_map = Object.fromEntries( // Symbol lookup from d3-shape
+  symbol_names.map((name) => [name, d3_symbols[`symbol${name}`]]),
 ) as Record<D3SymbolName, SymbolType>
 
 // Format a value for display with optional time formatting
@@ -145,18 +144,15 @@ const BYTE_UNITS = [`B`, `KiB`, `MiB`, `GiB`, `TiB`, `PiB`] as const
 export const format_bytes = (bytes?: number): string => {
   if (bytes === undefined || !Number.isFinite(bytes)) return `Unknown`
 
-  let val = bytes
-  let idx = 0
-
+  let [val, idx] = [bytes, 0]
   while (Math.abs(val) >= 1024 && idx < BYTE_UNITS.length - 1) {
     val /= 1024
     idx++
   }
-
   return idx === 0 ? `${val} B` : `${val.toFixed(2)} ${BYTE_UNITS[idx]}`
 }
 
-// Replace common fractional values with unicode glyphs (e.g., 1/2 → ½)
+// Replace common fractional values with unicode glyphs (e.g. 1/2 → ½)
 export function format_fractional(value: number): string {
   if (!Number.isFinite(value)) return String(value)
   const x = ((value % 1) + 1) % 1 // wrap into [0,1)
@@ -179,7 +175,7 @@ export function parse_si_float<T extends string | number | null | undefined>(
   // Remove whitespace and commas
   const cleaned = value.trim().replace(/(\d),(\d)/g, `$1$2`)
 
-  // Check if the value is a SI-formatted number (e.g., "1.23k", "4.56M", "789µ", "12n")
+  // Check if the value is a SI-formatted number (e.g. "1.23k", "4.56M", "789µ", "12n")
   const match = cleaned.match(/^([-+]?\d*\.?\d+)\s*([yzafpnµmkMGTPEZY])?$/i)
   if (match) {
     const [, num_part, suffix] = match

--- a/src/lib/math.ts
+++ b/src/lib/math.ts
@@ -294,13 +294,17 @@ export const transpose_3x3_matrix = (matrix: Matrix3x3): Matrix3x3 => [
   [matrix[0][2], matrix[1][2], matrix[2][2]],
 ]
 
-// Convert fractional (abc) coordinates to Cartesian (xyz) using lattice matrix
-export const frac_to_cart = (frac: Vec3, lattice: Matrix3x3): Vec3 =>
-  mat3x3_vec3_multiply(transpose_3x3_matrix(lattice), frac)
+// Curried fractional→Cartesian converter (caches transposed matrix)
+export const create_frac_to_cart = (lattice: Matrix3x3) => {
+  const transposed = transpose_3x3_matrix(lattice)
+  return (frac: Vec3) => mat3x3_vec3_multiply(transposed, frac)
+}
 
-// Convert Cartesian (xyz) coordinates to fractional (abc) using lattice matrix
-export const cart_to_frac = (cart: Vec3, lattice: Matrix3x3): Vec3 =>
-  mat3x3_vec3_multiply(matrix_inverse_3x3(transpose_3x3_matrix(lattice)), cart)
+// Curried Cartesian→fractional converter (caches inverse transpose)
+export const create_cart_to_frac = (lattice: Matrix3x3) => {
+  const inv_t = matrix_inverse_3x3(transpose_3x3_matrix(lattice))
+  return (cart: Vec3) => mat3x3_vec3_multiply(inv_t, cart)
+}
 
 // Convert unit cell parameters to lattice matrix (crystallographic convention)
 export function cell_to_lattice_matrix(

--- a/src/lib/math.ts
+++ b/src/lib/math.ts
@@ -294,6 +294,14 @@ export const transpose_3x3_matrix = (matrix: Matrix3x3): Matrix3x3 => [
   [matrix[0][2], matrix[1][2], matrix[2][2]],
 ]
 
+// Convert fractional (abc) coordinates to Cartesian (xyz) using lattice matrix
+export const frac_to_cart = (frac: Vec3, lattice: Matrix3x3): Vec3 =>
+  mat3x3_vec3_multiply(transpose_3x3_matrix(lattice), frac)
+
+// Convert Cartesian (xyz) coordinates to fractional (abc) using lattice matrix
+export const cart_to_frac = (cart: Vec3, lattice: Matrix3x3): Vec3 =>
+  mat3x3_vec3_multiply(matrix_inverse_3x3(transpose_3x3_matrix(lattice)), cart)
+
 // Convert unit cell parameters to lattice matrix (crystallographic convention)
 export function cell_to_lattice_matrix(
   a: number,

--- a/src/lib/plot/BarPlot.svelte
+++ b/src/lib/plot/BarPlot.svelte
@@ -11,14 +11,12 @@
     BarSeries,
     BarStyle,
     BasePlotProps,
-    HoverStyle,
     InternalPoint,
     LegendConfig,
     LegendItem,
     LineStyle,
     Orientation,
     PlotConfig,
-    PointStyle,
     ScaleType,
     TweenedOptions,
     UserContentProps,
@@ -535,7 +533,7 @@
 
   // Legend data and handlers
   let legend_data = $derived.by<LegendItem[]>(() =>
-    series.map((srs: BarSeries, idx: number) => {
+    series.map((srs: BarSeries<Metadata>, idx: number) => {
       const is_line = srs.render_mode === `line`
       const series_markers = srs.markers ?? DEFAULT_MARKERS
       const has_line = series_markers === `line` || series_markers === `line+points`
@@ -698,7 +696,7 @@
     const y2_pos_acc = Array.from({ length: max_len }, () => 0)
     const y2_neg_acc = Array.from({ length: max_len }, () => 0)
 
-    series.forEach((srs: BarSeries, series_idx: number) => {
+    series.forEach((srs: BarSeries<Metadata>, series_idx: number) => {
       if (!(srs?.visible ?? true) || srs.render_mode === `line`) return
 
       const use_y2 = srs.y_axis === `y2`
@@ -719,7 +717,7 @@
   let group_info = $derived.by(() => {
     if (mode !== `grouped`) return { bar_series_count: 0, bar_series_indices: [] }
     const bar_series_indices = series
-      .map((srs: BarSeries, idx: number) =>
+      .map((srs: BarSeries<Metadata>, idx: number) =>
         (srs?.visible ?? true) && srs.render_mode !== `line` ? idx : -1
       )
       .filter((idx) => idx >= 0)
@@ -1148,7 +1146,7 @@
                   {@const fill = (pt: LineSeriesPoint) =>
             pt.color_value != null
               ? color_scale_fn(pt.color_value)
-              : (pt.point_style as PointStyle)?.fill ?? color}
+              : pt.point_style?.fill ?? color}
                   {@const set_hover = (
             pt: LineSeriesPoint | null,
             evt: MouseEvent | FocusEvent,
@@ -1208,7 +1206,7 @@
                     }}
                   >
                     {#each points as pt (pt.idx)}
-                      {@const sty = pt.point_style as PointStyle}
+                      {@const sty = pt.point_style}
                       {@const fl = fill(pt)}
                       {@const rad = pt.size_value != null
               ? size_scale_fn(pt.size_value)
@@ -1230,7 +1228,7 @@
                           stroke_opacity: sty?.stroke_opacity ?? 1,
                           cursor: clickable ? `pointer` : undefined,
                         }}
-                        hover={pt.point_hover as HoverStyle ?? {}}
+                        hover={pt.point_hover ?? {}}
                         label={pt.point_label ?? {}}
                         offset={pt.point_offset ?? { x: 0, y: 0 }}
                         origin={{ x: plot_center_x, y: plot_center_y }}

--- a/src/lib/plot/ColorBar.svelte
+++ b/src/lib/plot/ColorBar.svelte
@@ -161,7 +161,7 @@
           !power_of_10_ticks.includes(nice_max)
         ) power_of_10_ticks.push(nice_max)
 
-        // If no powers of 10 are within range (e.g., [0.1, 0.9]), fall back to D3 ticks?
+        // If no powers of 10 are within range (e.g. [0.1, 0.9]), fall back to D3 ticks?
         // Or just return filtered list which might be empty?
         // For now, let's stick with only powers of 10.
         // If list is empty maybe return domain ends?

--- a/src/lib/plot/PlotControls.svelte
+++ b/src/lib/plot/PlotControls.svelte
@@ -26,11 +26,8 @@
   }: PlotControlsProps = $props()
 
   // Range input state
-  let range_inputs = $state(
-    { x: [null, null], y: [null, null], y2: [null, null] } as Record<
-      `x` | `y` | `y2`,
-      [number | null, number | null]
-    >,
+  let range_inputs: Record<`x` | `y` | `y2`, [number | null, number | null]> = $state(
+    { x: [null, null], y: [null, null], y2: [null, null] },
   )
   let range_els = $state<Record<string, HTMLInputElement>>({})
 

--- a/src/lib/plot/ScatterPlot.svelte
+++ b/src/lib/plot/ScatterPlot.svelte
@@ -16,7 +16,6 @@
     LegendConfig,
     PlotConfig,
     Point,
-    PointStyle,
     ScaleType,
     ScatterHandlerEvent,
     ScatterHandlerProps,
@@ -290,7 +289,7 @@
   // Compute data color values for color scaling
   let all_color_values = $derived(
     series_with_ids.filter(Boolean).flatMap((srs: DataSeries) =>
-      srs.color_values?.filter((val) => val != null) || []
+      srs.color_values?.filter((val): val is number => val != null) ?? []
     ),
   )
 
@@ -410,8 +409,8 @@
     series_with_ids
       .filter(Boolean)
       .flatMap(({ size_values }: DataSeries) =>
-        size_values?.filter((val) => val != null) || []
-      ) as (number | null)[],
+        size_values?.filter((val): val is number => val != null) ?? []
+      ),
   )
 
   // Size scale function (using shared utility)
@@ -563,8 +562,8 @@
 
         // Check point_style (could be object or array)
         const first_point_style = Array.isArray(data_series?.point_style)
-          ? (data_series.point_style[0] as PointStyle | undefined) // Handle potential undefined
-          : (data_series?.point_style as PointStyle | undefined) // Handle potential undefined
+          ? data_series.point_style[0]
+          : data_series?.point_style
 
         if (series_markers?.includes(`points`)) {
           if (first_point_style) {
@@ -1696,12 +1695,12 @@
         on_drag_end={handle_legend_drag_end}
         draggable={legend?.draggable ?? true}
         {...legend}
-        on_toggle={(legend?.on_toggle as ((series_idx: number) => void) | undefined) ??
-        ((series_idx: number) => {
+        on_toggle={legend?.on_toggle ??
+        ((series_idx) => {
           series = toggle_series_visibility(series, series_idx)
         })}
-        on_double_click={(legend?.on_double_click as ((series_idx: number) => void) | undefined) ??
-        ((double_clicked_idx: number) => {
+        on_double_click={legend?.on_double_click ??
+        ((double_clicked_idx) => {
           const result = handle_legend_double_click(
             series,
             double_clicked_idx,
@@ -1710,10 +1709,8 @@
           series = result.series
           previous_series_visibility = result.previous_visibility
         })}
-        on_group_toggle={(legend?.on_group_toggle as
-        | ((group_name: string, series_indices: number[]) => void)
-        | undefined) ??
-        ((_group_name: string, series_indices: number[]) => {
+        on_group_toggle={legend?.on_group_toggle ??
+        ((_group_name, series_indices) => {
           series = toggle_group_visibility(series, series_indices)
         })}
         wrapper_style={`

--- a/src/lib/plot/ScatterPlot.svelte
+++ b/src/lib/plot/ScatterPlot.svelte
@@ -947,12 +947,7 @@
       tooltip_point = closest_point
       // Construct object matching change signature
       const { x, y, metadata } = closest_point
-      change({
-        x,
-        y,
-        metadata: metadata as Metadata | undefined,
-        series: closest_series,
-      })
+      change({ x, y, metadata, series: closest_series })
       // Call hover handler with synchronously constructed props
       if (evt && props) {
         on_point_hover?.({ ...props, event: evt, point: closest_point })
@@ -1090,7 +1085,7 @@
     return {
       ...coords,
       fullscreen,
-      metadata: (metadata ?? null) as Metadata | null,
+      metadata,
       label: hovered_series.label ?? null,
       series_idx,
       x_formatted: format_value(x, final_x_axis.format || `.3~s`),
@@ -1703,9 +1698,7 @@
         {...legend}
         on_toggle={(legend?.on_toggle as ((series_idx: number) => void) | undefined) ??
         ((series_idx: number) => {
-          series = toggle_series_visibility(series, series_idx) as DataSeries<
-            Metadata
-          >[]
+          series = toggle_series_visibility(series, series_idx)
         })}
         on_double_click={(legend?.on_double_click as ((series_idx: number) => void) | undefined) ??
         ((double_clicked_idx: number) => {
@@ -1714,16 +1707,14 @@
             double_clicked_idx,
             previous_series_visibility,
           )
-          series = result.series as DataSeries<Metadata>[]
+          series = result.series
           previous_series_visibility = result.previous_visibility
         })}
         on_group_toggle={(legend?.on_group_toggle as
         | ((group_name: string, series_indices: number[]) => void)
         | undefined) ??
         ((_group_name: string, series_indices: number[]) => {
-          series = toggle_group_visibility(series, series_indices) as DataSeries<
-            Metadata
-          >[]
+          series = toggle_group_visibility(series, series_indices)
         })}
         wrapper_style={`
           position: absolute;

--- a/src/lib/plot/ScatterPlot3D.svelte
+++ b/src/lib/plot/ScatterPlot3D.svelte
@@ -191,7 +191,7 @@
   // Collect all color values for color bar
   let all_color_values = $derived(
     series.filter(Boolean).flatMap((srs) =>
-      srs.color_values?.filter((val): val is number => val != null) || []
+      srs.color_values?.filter((val): val is number => val != null) ?? []
     ),
   )
 

--- a/src/lib/plot/ScatterPlot3D.svelte
+++ b/src/lib/plot/ScatterPlot3D.svelte
@@ -1,4 +1,7 @@
-<script lang="ts">
+<script
+  lang="ts"
+  generics="Metadata extends Record<string, unknown> = Record<string, unknown>"
+>
   import type { D3ColorSchemeName, D3InterpolateName } from '$lib/colors'
   import { FullscreenToggle } from '$lib/layout'
   import type { Vec3 } from '$lib/math'
@@ -98,7 +101,7 @@
     controls_extra,
     ...rest
   }: HTMLAttributes<HTMLDivElement> & {
-    series?: DataSeries3D[]
+    series?: DataSeries3D<Metadata>[]
     surfaces?: Surface3DConfig[]
     x_axis?: AxisConfig3D
     y_axis?: AxisConfig3D
@@ -133,9 +136,9 @@
     gizmo?: boolean | ComponentProps<typeof extras.Gizmo>
     controls?: ControlsConfig3D
     hovered?: boolean
-    tooltip_point?: InternalPoint3D | null
-    on_point_click?: (data: Scatter3DHandlerEvent) => void
-    on_point_hover?: (data: Scatter3DHandlerEvent | null) => void
+    tooltip_point?: InternalPoint3D<Metadata> | null
+    on_point_click?: (data: Scatter3DHandlerEvent<Metadata>) => void
+    on_point_hover?: (data: Scatter3DHandlerEvent<Metadata> | null) => void
     on_series_visibility_change?: (series_idx: number, visible: boolean) => void
     fullscreen?: boolean
     fullscreen_toggle?: boolean
@@ -143,7 +146,7 @@
     scene?: Scene
     camera?: Camera
     orbit_controls?: ComponentProps<typeof extras.OrbitControls>[`ref`]
-    tooltip?: Snippet<[Scatter3DHandlerEvent]>
+    tooltip?: Snippet<[Scatter3DHandlerEvent<Metadata>]>
     children?: Snippet<[{ height: number; width: number; fullscreen: boolean }]>
     header_controls?: Snippet<
       [{ height: number; width: number; fullscreen: boolean }]
@@ -251,7 +254,7 @@
   }
 
   // Handle point hover
-  function handle_point_hover(data: Scatter3DHandlerEvent | null) {
+  function handle_point_hover(data: Scatter3DHandlerEvent<Metadata> | null) {
     hovered = data !== null
     tooltip_point = data?.point ?? null
     on_point_hover?.(data)

--- a/src/lib/plot/ScatterPlot3DScene.svelte
+++ b/src/lib/plot/ScatterPlot3DScene.svelte
@@ -507,6 +507,7 @@
   // Axis configuration for rendering
   const tick_length = 0.15
   type AxisKey = `x` | `y` | `z`
+  const AXIS_KEYS: readonly AxisKey[] = [`x`, `y`, `z`]
 
   // Main axis line geometries - updated when backside positions change
   let axis_geometries: Record<AxisKey, THREE.BufferGeometry> = $state({
@@ -519,7 +520,7 @@
     // Capture pos values for dependency tracking
     const { x: px, y: py, z: pz } = pos
     untrack(() => {
-      for (const key of [`x`, `y`, `z`] as AxisKey[]) axis_geometries[key].dispose()
+      for (const key of AXIS_KEYS) axis_geometries[key].dispose()
     })
     // X-axis: spans full X, positioned at backside Y and Z
     axis_geometries.x = create_line_geometry([-half_x, py, pz], [half_x, py, pz])
@@ -620,9 +621,9 @@
     const config = axes_config
     // Dispose old geometries (untracked to avoid dependency cycle)
     untrack(() => {
-      for (const key of [`x`, `y`, `z`] as AxisKey[]) {
-        axis_geom_data[key].tick_geoms.forEach((g) => g.dispose())
-        axis_geom_data[key].grid_geoms.flat().forEach((g) => g.dispose())
+      for (const key of AXIS_KEYS) {
+        axis_geom_data[key].tick_geoms.forEach((geom) => geom.dispose())
+        axis_geom_data[key].grid_geoms.flat().forEach((geom) => geom.dispose())
       }
     })
     for (const { key, ticks, get_tick_pos, get_tick_end, get_grid_lines } of config) {

--- a/src/lib/plot/ScatterPlot3DScene.svelte
+++ b/src/lib/plot/ScatterPlot3DScene.svelte
@@ -1,4 +1,7 @@
-<script lang="ts">
+<script
+  lang="ts"
+  generics="Metadata extends Record<string, unknown> = Record<string, unknown>"
+>
   import type { D3ColorSchemeName, D3InterpolateName } from '$lib/colors'
   import { format_num } from '$lib/labels'
   import type { Vec3 } from '$lib/math'
@@ -61,7 +64,7 @@
     width = 0,
     height = 0,
   }: {
-    series?: DataSeries3D[]
+    series?: DataSeries3D<Metadata>[]
     series_visibility?: boolean[]
     x_axis?: AxisConfig3D
     y_axis?: AxisConfig3D
@@ -93,10 +96,10 @@
     directional_light?: number
     sphere_segments?: number
     gizmo?: boolean | ComponentProps<typeof extras.Gizmo>
-    hovered_point?: InternalPoint3D | null
-    on_point_click?: (data: Scatter3DHandlerEvent) => void
-    on_point_hover?: (data: Scatter3DHandlerEvent | null) => void
-    tooltip?: Snippet<[Scatter3DHandlerEvent]>
+    hovered_point?: InternalPoint3D<Metadata> | null
+    on_point_click?: (data: Scatter3DHandlerEvent<Metadata>) => void
+    on_point_hover?: (data: Scatter3DHandlerEvent<Metadata> | null) => void
+    tooltip?: Snippet<[Scatter3DHandlerEvent<Metadata>]>
     scene?: Scene
     camera?: Camera
     orbit_controls?: ComponentProps<typeof extras.OrbitControls>[`ref`]
@@ -271,7 +274,7 @@
   // Process points with normalized positions
   // Swap Y/Z for Three.js: user Z → Three.js Y (vertical), user Y → Three.js Z (depth)
   let processed_points = $derived(
-    all_points.map((pt): InternalPoint3D => ({
+    all_points.map((pt): InternalPoint3D<Metadata> => ({
       ...pt,
       x: normalize_x(pt.x), // user X → Three.js X
       y: normalize_z(pt.z), // user Z → Three.js Y (vertical)
@@ -280,7 +283,11 @@
   )
 
   // Group points by radius, with per-instance colors
-  type RadiusGroup = { radius: number; points: InternalPoint3D[]; colors: string[] }
+  type RadiusGroup = {
+    radius: number
+    points: InternalPoint3D<Metadata>[]
+    colors: string[]
+  }
 
   let radius_groups = $derived.by((): RadiusGroup[] => {
     const groups: Record<string, RadiusGroup> = {}
@@ -428,9 +435,9 @@
 
   // Build event data for point interactions
   function make_event_data(
-    point: InternalPoint3D,
+    point: InternalPoint3D<Metadata>,
     event: MouseEvent,
-  ): Scatter3DHandlerEvent | null {
+  ): Scatter3DHandlerEvent<Metadata> | null {
     const orig = all_points.find(
       (pt) => pt.series_idx === point.series_idx && pt.point_idx === point.point_idx,
     )
@@ -455,7 +462,7 @@
     }
   }
 
-  function handle_point_enter(point: InternalPoint3D) {
+  function handle_point_enter(point: InternalPoint3D<Metadata>) {
     hovered_point = point
     const data = make_event_data(point, new MouseEvent(`pointerenter`))
     if (data) on_point_hover?.(data)
@@ -466,7 +473,7 @@
     on_point_hover?.(null)
   }
 
-  function handle_point_click(point: InternalPoint3D, event: MouseEvent) {
+  function handle_point_click(point: InternalPoint3D<Metadata>, event: MouseEvent) {
     const data = make_event_data(point, event)
     if (data) on_point_click?.(data)
   }

--- a/src/lib/plot/types.ts
+++ b/src/lib/plot/types.ts
@@ -21,10 +21,10 @@ export type XyObj = { x: number; y: number }
 export type XyShift = { x?: number; y?: number } // For optional shift/offset values
 export type Sides = { t?: number; b?: number; l?: number; r?: number }
 
-export type Point = {
+export type Point<Metadata = Record<string, unknown>> = {
   x: number
   y: number
-  metadata?: { [key: string]: unknown }
+  metadata?: Metadata
   offset?: XyObj
 }
 
@@ -81,9 +81,8 @@ export interface LineStyle {
 }
 
 // Extend the base Point type to include optional styling and metadata
-export interface PlotPoint extends Point {
+export interface PlotPoint<Metadata = Record<string, unknown>> extends Point<Metadata> {
   color_value?: number | null
-  metadata?: Record<string, unknown>
   point_style?: PointStyle
   point_hover?: HoverStyle
   point_label?: LabelStyle
@@ -94,7 +93,7 @@ export interface PlotPoint extends Point {
 export type Markers = `line` | `points` | `line+points` | `none`
 
 // Define the structure for a data series in the plot
-export interface DataSeries {
+export interface DataSeries<Metadata = Record<string, unknown>> {
   id?: string | number // Optional stable identifier for the series (used for keying)
   x: readonly number[]
   y: readonly number[]
@@ -104,7 +103,7 @@ export interface DataSeries {
   y_axis?: `y1` | `y2`
   color_values?: (number | null)[] | null
   size_values?: readonly (number | null)[] | null
-  metadata?: Record<string, unknown>[] | Record<string, unknown> // Can be array or single object
+  metadata?: Metadata[] | Metadata // Can be array or single object
   point_style?: PointStyle[] | PointStyle // Can be array or single object
   point_hover?: HoverStyle[] | HoverStyle // Can be array or single object
   point_label?: LabelStyle[] | LabelStyle // Can be array or single object
@@ -123,13 +122,14 @@ export interface DataSeries {
     line_dash?: string
   }
   // Internal fields used after processing (not provided by users)
-  filtered_data?: InternalPoint[]
+  filtered_data?: InternalPoint<Metadata>[]
   _id?: string | number
   orig_series_idx?: number // Original series index for consistent auto-cycling colors/symbols
 }
 
 // Represents the internal structure used within ScatterPlot, merging series-level and point-level data
-export interface InternalPoint extends PlotPoint {
+export interface InternalPoint<Metadata = Record<string, unknown>>
+  extends PlotPoint<Metadata> {
   series_idx: number // Index of the series this point belongs to
   point_idx: number // Index of the point within its series
   size_value?: number | null // Size value for the point
@@ -171,7 +171,7 @@ export interface ScatterHandlerProps<Metadata = Record<string, unknown>>
 }
 export type ScatterHandlerEvent<Metadata = Record<string, unknown>> =
   & ScatterHandlerProps<Metadata>
-  & { event: MouseEvent; point: InternalPoint }
+  & { event: MouseEvent; point: InternalPoint<Metadata> }
 
 export interface BarHandlerProps<Metadata = Record<string, unknown>>
   extends HandlerProps<Metadata> {
@@ -200,11 +200,12 @@ export type QuadrantCounts = {
 }
 
 // Type for nodes used in the d3-force simulation for label placement
-export interface LabelNode extends SimulationNodeDatum {
+export interface LabelNode<Metadata = Record<string, unknown>>
+  extends SimulationNodeDatum {
   id: string // unique identifier, e.g. series_idx-point_idx
   anchor_x: number // Original x coordinate of the point (scaled)
   anchor_y: number // Original y coordinate of the point (scaled)
-  point_node: InternalPoint // Reference to the original data point
+  point_node: InternalPoint<Metadata> // Reference to the original data point
   label_width: number // Estimated width for collision
   label_height: number // Estimated height for collision
   // x, y, vx, vy are added by d3-force
@@ -492,27 +493,28 @@ export const DEFAULT_SERIES_SYMBOLS = [
 export type XyzObj = { x: number; y: number; z: number }
 
 // 3D point extending base Point with z coordinate (prefixed to avoid conflict with convex-hull)
-export interface ScatterPoint3D extends Point {
+export interface ScatterPoint3D<Metadata = Record<string, unknown>>
+  extends Point<Metadata> {
   z: number
 }
 
 // 3D data series extending DataSeries with z array
 // Omit filtered_data since it uses 2D InternalPoint type, redeclare with 3D type
-export interface DataSeries3D
-  extends Omit<DataSeries, `x` | `y` | `y_axis` | `filtered_data`> {
+export interface DataSeries3D<Metadata = Record<string, unknown>>
+  extends Omit<DataSeries<Metadata>, `x` | `y` | `y_axis` | `filtered_data`> {
   x: readonly number[]
   y: readonly number[]
   z: readonly number[]
-  filtered_data?: InternalPoint3D[]
+  filtered_data?: InternalPoint3D<Metadata>[]
 }
 
 // Internal 3D point for processing within ScatterPlot3D
-export interface InternalPoint3D extends ScatterPoint3D {
+export interface InternalPoint3D<Metadata = Record<string, unknown>>
+  extends ScatterPoint3D<Metadata> {
   series_idx: number
   point_idx: number
   color_value?: number | null
   size_value?: number | null
-  metadata?: Record<string, unknown>
   point_style?: PointStyle
 }
 
@@ -584,7 +586,7 @@ export interface Scatter3DHandlerProps<Metadata = Record<string, unknown>> {
 
 export type Scatter3DHandlerEvent<Metadata = Record<string, unknown>> =
   & Scatter3DHandlerProps<Metadata>
-  & { event: MouseEvent; point: InternalPoint3D }
+  & { event: MouseEvent; point: InternalPoint3D<Metadata> }
 
 // Camera projection types for 3D
 export type CameraProjection3D = `perspective` | `orthographic`

--- a/src/lib/plot/types.ts
+++ b/src/lib/plot/types.ts
@@ -116,7 +116,7 @@ export interface DataSeries {
   // are displayed together under a collapsible header. Click the header to toggle
   // visibility of all series in the group, or the chevron to collapse/expand.
   legend_group?: string
-  unit?: string // Optional unit for the series (e.g., "eV", "eV/Å", "GPa")
+  unit?: string // Optional unit for the series (e.g. "eV", "eV/Å", "GPa")
   line_style?: {
     stroke?: string
     stroke_width?: number
@@ -201,7 +201,7 @@ export type QuadrantCounts = {
 
 // Type for nodes used in the d3-force simulation for label placement
 export interface LabelNode extends SimulationNodeDatum {
-  id: string // unique identifier, e.g., series_idx-point_idx
+  id: string // unique identifier, e.g. series_idx-point_idx
   anchor_x: number // Original x coordinate of the point (scaled)
   anchor_y: number // Original y coordinate of the point (scaled)
   point_node: InternalPoint // Reference to the original data point

--- a/src/lib/plot/types.ts
+++ b/src/lib/plot/types.ts
@@ -278,7 +278,7 @@ export type UserContentProps = {
 export type Orientation = `vertical` | `horizontal`
 export type BarMode = `overlay` | `stacked` | `grouped`
 
-export interface BarSeries {
+export interface BarSeries<Metadata = Record<string, unknown>> {
   id?: string | number // Optional stable identifier for the series (used for keying)
   x: readonly number[]
   y: readonly number[]
@@ -290,7 +290,7 @@ export interface BarSeries {
   color?: string
   bar_width?: number | readonly number[]
   visible?: boolean
-  metadata?: Record<string, unknown>[] | Record<string, unknown>
+  metadata?: Metadata[] | Metadata
   labels?: readonly (string | null | undefined)[]
   render_mode?: `bar` | `line` // Render as bars (default) or as a line
   // Specify which y-axis to use: 'y1' (left, default) or 'y2' (right)

--- a/src/lib/plot/utils/label-placement.ts
+++ b/src/lib/plot/utils/label-placement.ts
@@ -1,20 +1,9 @@
 import type { AxisConfig, DataSeries, XyObj } from '$lib/plot'
-import type { InternalPoint, LabelPlacementConfig } from '$lib/plot/types'
+import type { LabelNode, LabelPlacementConfig } from '$lib/plot/types'
 import { forceCollide, forceLink, forceManyBody, forceSimulation } from 'd3-force'
 import type { ScaleContinuousNumeric, ScaleTime } from 'd3-scale'
 
 type ScaleFn = ScaleContinuousNumeric<number, number> | ScaleTime<number, number>
-
-export interface LabelNode {
-  id: string
-  anchor_x: number
-  anchor_y: number
-  point_node: InternalPoint
-  label_width: number
-  label_height: number
-  x?: number
-  y?: number
-}
 
 export interface AnchorNode {
   id: string

--- a/src/lib/plot/utils/series-visibility.ts
+++ b/src/lib/plot/utils/series-visibility.ts
@@ -1,17 +1,22 @@
 import type { DataSeries } from '$lib/plot/types'
 
-export function have_compatible_units(series1: DataSeries, series2: DataSeries): boolean {
+export type StrRecord = Record<string, unknown>
+
+export function have_compatible_units<Metadata extends StrRecord = StrRecord>(
+  series1: DataSeries<Metadata>,
+  series2: DataSeries<Metadata>,
+): boolean {
   if (!series1.unit || !series2.unit) return true
   return series1.unit === series2.unit
 }
 
-export function toggle_series_visibility(
-  series: DataSeries[],
+export function toggle_series_visibility<Metadata extends StrRecord = StrRecord>(
+  series: DataSeries<Metadata>[],
   series_idx: number,
-): DataSeries[] {
+): DataSeries<Metadata>[] {
   if (series_idx < 0 || series_idx >= series.length || !series[series_idx]) return series
 
-  const toggled = series[series_idx] as DataSeries
+  const toggled = series[series_idx]
   const new_visibility = !(toggled.visible ?? true)
   const target_axis = toggled.y_axis ?? `y1`
 
@@ -31,10 +36,10 @@ export function toggle_series_visibility(
   })
 }
 
-export function toggle_group_visibility(
-  series: DataSeries[],
+export function toggle_group_visibility<Metadata extends StrRecord = StrRecord>(
+  series: DataSeries<Metadata>[],
   series_indices: number[],
-): DataSeries[] {
+): DataSeries<Metadata>[] {
   // Filter to valid indices upfront
   const valid_indices = series_indices.filter((idx) => idx >= 0 && idx < series.length)
   if (valid_indices.length === 0) return series
@@ -52,11 +57,11 @@ export function toggle_group_visibility(
   )
 }
 
-export function handle_legend_double_click(
-  series: DataSeries[],
+export function handle_legend_double_click<Metadata extends StrRecord = StrRecord>(
+  series: DataSeries<Metadata>[],
   idx: number,
   prev_visibility: boolean[] | null,
-): { series: DataSeries[]; previous_visibility: boolean[] | null } {
+): { series: DataSeries<Metadata>[]; previous_visibility: boolean[] | null } {
   if (idx < 0 || idx >= series.length) {
     return { series, previous_visibility: prev_visibility }
   }
@@ -65,17 +70,17 @@ export function handle_legend_double_click(
   const current = series.map((srs) => srs.visible ?? true)
   // Only check original series (ignore new ones added after isolation)
   const check_series = prev_visibility ? series.slice(0, prev_visibility.length) : series
-  const is_isolated = check_series.every((s, i) => {
-    const in_group = label ? s.label === label : i === idx
-    return in_group ? s.visible ?? true : !(s.visible ?? true)
+  const is_isolated = check_series.every((srs, srs_idx) => {
+    const in_group = label ? srs.label === label : srs_idx === idx
+    return in_group ? srs.visible ?? true : !(srs.visible ?? true)
   })
 
   // Restore from isolation
   if (is_isolated && prev_visibility) {
     return {
-      series: series.map((srs, idx) =>
-        idx < prev_visibility.length && current[idx] !== prev_visibility[idx]
-          ? { ...srs, visible: prev_visibility[idx] }
+      series: series.map((srs, srs_idx) =>
+        srs_idx < prev_visibility.length && current[srs_idx] !== prev_visibility[srs_idx]
+          ? { ...srs, visible: prev_visibility[srs_idx] }
           : srs
       ),
       previous_visibility: null,

--- a/src/lib/rdf/index.ts
+++ b/src/lib/rdf/index.ts
@@ -13,7 +13,7 @@ export interface RdfEntry {
   label: string
   pattern: RdfPattern
   color?: string
-  legend_group?: string // Group name for legend grouping (e.g., structure name)
+  legend_group?: string // Group name for legend grouping (e.g. structure name)
 }
 
 export interface RdfOptions {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -409,7 +409,7 @@ export const SETTINGS_CONFIG: SettingsConfig = {
     atom_color_scale: {
       value: `interpolateViridis`,
       description:
-        `D3 color scale for property-based coloring (e.g., interpolateViridis, interpolatePlasma)`,
+        `D3 color scale for property-based coloring (e.g. interpolateViridis, interpolatePlasma)`,
     },
     atom_color_scale_type: {
       value: `continuous`,
@@ -980,7 +980,7 @@ export const SETTINGS_CONFIG: SettingsConfig = {
       },
       dash: {
         value: `solid`,
-        description: `Line dash pattern for scatter plots (e.g., "4,4" for dashed)`,
+        description: `Line dash pattern for scatter plots (e.g. "4,4" for dashed)`,
       },
     },
   },

--- a/src/lib/structure/AtomLegend.svelte
+++ b/src/lib/structure/AtomLegend.svelte
@@ -49,8 +49,8 @@
     show_amounts?: boolean // Whether to show element amounts
     get_element_label?: (element: string, amount: number) => string // Custom label function
     hidden_elements?: Set<ElementSymbol>
-    hidden_prop_vals?: Set<number | string> // Track hidden property values (e.g., Wyckoff positions, coordination numbers)
-    // Element remapping: maps original element symbols to new ones (e.g., {'H': 'Na', 'He': 'Cl'})
+    hidden_prop_vals?: Set<number | string> // Track hidden property values (e.g. Wyckoff positions, coordination numbers)
+    // Element remapping: maps original element symbols to new ones (e.g. {'H': 'Na', 'He': 'Cl'})
     element_mapping?: Partial<Record<ElementSymbol, ElementSymbol>>
     title?: string
     sym_data?: MoyoDataset | null

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -92,13 +92,13 @@
     displayed_structure = $bindable<AnyStructure | undefined>(undefined),
     // Track hidden elements across component lifecycle
     hidden_elements = $bindable(new Set<ElementSymbol>()),
-    // Track hidden property values (e.g., Wyckoff positions, coordination numbers)
+    // Track hidden property values (e.g. Wyckoff positions, coordination numbers)
     hidden_prop_vals = $bindable(new Set<number | string>()),
     // Symmetry analysis data (bindable for external access)
     sym_data = $bindable<MoyoDataset | null>(null),
     // Symmetry analysis settings (bindable for external control)
     symmetry_settings = $bindable(symmetry.default_sym_settings),
-    // Map element symbols to different elements (e.g., {'H': 'Na', 'He': 'Cl'})
+    // Map element symbols to different elements (e.g. {'H': 'Na', 'He': 'Cl'})
     // Useful for LAMMPS files where atom types are mapped to H, He, Li by default
     element_mapping = $bindable<
       Partial<Record<ElementSymbol, ElementSymbol>> | undefined
@@ -157,13 +157,13 @@
       displayed_structure?: AnyStructure
       // Track which elements are hidden (bindable across frames in trajectories)
       hidden_elements?: Set<ElementSymbol>
-      // Track which property values are hidden (e.g., Wyckoff positions, coordination numbers)
+      // Track which property values are hidden (e.g. Wyckoff positions, coordination numbers)
       hidden_prop_vals?: Set<number | string>
       // Symmetry analysis data (bindable for external access)
       sym_data?: MoyoDataset | null
       // Symmetry analysis settings (bindable for external control)
       symmetry_settings?: Partial<SymmetrySettings>
-      // Map element symbols to different elements (e.g., {'H': 'Na', 'He': 'Cl'})
+      // Map element symbols to different elements (e.g. {'H': 'Na', 'He': 'Cl'})
       element_mapping?: Partial<Record<ElementSymbol, ElementSymbol>>
       // Cell type: original, conventional, or primitive (requires symmetry analysis)
       cell_type?: CellType

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -174,14 +174,14 @@
     active_sites?: number[]
     active_highlight_color?: string
     rotation?: Vec3 // rotation control prop
-    // Expose scene and camera for external use (e.g., export pane)
+    // Expose scene and camera for external use (e.g. export pane)
     scene?: Scene
     camera?: Camera
     orbit_controls?: ComponentProps<typeof extras.OrbitControls>[`ref`] // OrbitControls instance
     rotation_target_ref?: Vec3 // Expose rotation target for reset
     initial_computed_zoom?: number // Expose initial zoom for reset
     hidden_elements?: Set<ElementSymbol>
-    hidden_prop_vals?: Set<number | string> // Track hidden property values (e.g., Wyckoff positions, coordination numbers)
+    hidden_prop_vals?: Set<number | string> // Track hidden property values (e.g. Wyckoff positions, coordination numbers)
     atom_color_config?: Partial<AtomColorConfig> // Atom coloring configuration
     sym_data?: MoyoDataset | null // Symmetry data for Wyckoff coloring
   } = $props()
@@ -384,7 +384,7 @@
         0,
       ) * atom_radius
 
-      // Use property color if available (e.g., coordination number, Wyckoff position)
+      // Use property color if available (e.g. coordination number, Wyckoff position)
       // Otherwise, each species gets its own element color (important for disordered sites)
       const site_property_color = property_colors?.colors[orig_idx]
 

--- a/src/lib/symmetry/index.ts
+++ b/src/lib/symmetry/index.ts
@@ -45,7 +45,7 @@ let initialized = false
 export async function ensure_moyo_wasm_ready(wasm_url?: string) {
   if (initialized) return
 
-  // Use provided URL (e.g., from VSCode webview data), otherwise use Vite-bundled URL
+  // Use provided URL (e.g. from VSCode webview data), otherwise use Vite-bundled URL
   const url = wasm_url ?? moyo_wasm_url
 
   await init({ module_or_path: url })

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -131,18 +131,18 @@
       | `structure+histogram`
     // step labels configuration for slider
     // - positive number: number of evenly spaced ticks
-    // - negative number: spacing between ticks (e.g., -10 = every 10th step)
+    // - negative number: spacing between ticks (e.g. -10 = every 10th step)
     // - array: exact step indices to label
     // - undefined: no labels
     step_labels?: number | number[]
     // visible properties - bindable array of property keys currently shown in the plot
-    // - controls which trajectory properties are plotted (e.g., ['energy', 'volume', 'force_max'])
+    // - controls which trajectory properties are plotted (e.g. ['energy', 'volume', 'force_max'])
     // - bindable: reflects current visibility state and can be used for external control
     // - if not provided, uses default visible properties (energy, force_max, stress_frobenius)
     // - if specified properties don't exist in data, falls back to automatic selection
     visible_properties?: string[]
     // custom labels for trajectory properties - maps property keys to display labels
-    // - e.g., {energy: 'Total Energy', volume: 'Cell Volume', force_max: 'Max Force'}
+    // - e.g. {energy: 'Total Energy', volume: 'Cell Volume', force_max: 'Max Force'}
     // - merged with built-in trajectory_property_config
     ELEM_PROPERTY_LABELS?: Record<string, string>
     // units configuration - developers can override these (deprecated - use ELEM_PROPERTY_LABELS instead)
@@ -166,7 +166,7 @@
     fps?: number // frame rate for playback
     // Loading options for large files
     loading_options?: LoadingOptions
-    // Map LAMMPS atom types to element symbols (e.g., {1: 'Na', 2: 'Cl'})
+    // Map LAMMPS atom types to element symbols (e.g. {1: 'Na', 2: 'Cl'})
     atom_type_mapping?: AtomTypeMapping
     // Disable plot skimming (mouse over plot doesn't update structure/step slider)
     plot_skimming?: boolean

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -224,7 +224,6 @@
   // Update current frame when step changes
   $effect(() => {
     if (trajectory && current_step_idx >= 0 && current_step_idx < total_frames) {
-      // @ts-expect-error - frame_loader is added dynamically for indexed/streaming trajectories
       if (trajectory.frame_loader) {
         // Load frame on demand (works for both indexed files and external streaming)
         load_frame_on_demand(current_step_idx)
@@ -239,11 +238,9 @@
 
   // Load frame on demand - works for both indexed files and external streaming
   async function load_frame_on_demand(frame_idx: number) {
-    // @ts-expect-error - frame_loader is added dynamically for indexed/streaming trajectories
     if (!trajectory?.frame_loader) return
 
     try {
-      // @ts-expect-error - frame_loader is added dynamically for indexed/streaming trajectories
       const frame = await trajectory.frame_loader.load_frame(
         orig_data || ``, // Use original_data for indexed files, empty string for external streaming
         frame_idx,
@@ -723,7 +720,6 @@
 
       // Attach frame loader and original data directly to trajectory for unified access
       orig_data = data
-      // @ts-expect-error - dynamically adding frame_loader for indexed trajectories
       trajectory.frame_loader = create_frame_loader(filename)
     } catch (error) {
       console.error(`Indexed loading failed:`, error)

--- a/src/lib/trajectory/index.ts
+++ b/src/lib/trajectory/index.ts
@@ -43,6 +43,8 @@ export interface TrajectoryType {
   indexed_frames?: FrameIndex[]
   plot_metadata?: TrajectoryMetadata[]
   is_indexed?: boolean
+  // On-demand frame loading for large/indexed trajectories
+  frame_loader?: FrameLoader
 }
 
 // Unified handler data interface

--- a/src/lib/trajectory/index.ts
+++ b/src/lib/trajectory/index.ts
@@ -43,8 +43,8 @@ export interface TrajectoryType {
   indexed_frames?: FrameIndex[]
   plot_metadata?: TrajectoryMetadata[]
   is_indexed?: boolean
-  // On-demand frame loading for large/indexed trajectories
-  frame_loader?: FrameLoader
+  // On-demand frame loading for large/indexed trajectories.
+  frame_loader?: FrameLoader // When present, enables lazy loading of frames instead of loading all frames into memory.
 }
 
 // Unified handler data interface

--- a/src/lib/xrd/XrdPlot.svelte
+++ b/src/lib/xrd/XrdPlot.svelte
@@ -35,7 +35,7 @@
 
   function format_hkl(hkl: Hkl, format: HklFormat): string {
     if (format === `compact`) {
-      // Use crystallographic overbar notation for negative indices (e.g., 1̄ instead of -1)
+      // Use crystallographic overbar notation for negative indices (e.g. 1̄ instead of -1)
       // Note: Requires font support for Unicode combining characters (U+0305)
       return hkl
         .map((val) => {

--- a/src/lib/xrd/XrdPlot.svelte
+++ b/src/lib/xrd/XrdPlot.svelte
@@ -484,13 +484,15 @@
       />
     {:else}
       <!-- Discrete Stick View -->
-      {#snippet tooltip(info: BarHandlerProps)}
+      {#snippet tooltip(
+    info: BarHandlerProps<{ label?: string; hkls?: Hkl[]; d?: number }>,
+  )}
         {@const angle_text = `${format_value(info.x, `.2f`)}°`}
         {@const intensity_text = `${format_value(info.y, `.1f`)}`}
-        {@const hkls = info.metadata?.hkls as Hkl[] | undefined}
-        {@const d = info.metadata?.d as number | undefined}
+        {@const hkls = info.metadata?.hkls}
+        {@const d = info.metadata?.d}
         {@const hkl_text = hkls && hkl_format
-      ? hkls.map((h) => format_hkl(h, hkl_format)).join(`, `)
+      ? hkls.map((hkl: Hkl) => format_hkl(hkl, hkl_format)).join(`, `)
       : ``}
         {@const d_text = d != null ? `${format_value(d, `.3f`)} Å` : ``}
         {@html info.metadata?.label ?? ``}<br />

--- a/src/lib/xrd/broadening.ts
+++ b/src/lib/xrd/broadening.ts
@@ -109,7 +109,7 @@ export function compute_broadened_pattern(
 
     const fwhm = caglioti_fwhm(x0, U, V, W)
 
-    // Define window for calculation (e.g., +/- 10 * FWHM or fixed reasonable range)
+    // Define window for calculation (e.g. +/- 10 * FWHM or fixed reasonable range)
     // Lorentzian tails are long, so we need a decent window.
     // 20 * FWHM is usually sufficient for visual purposes.
     const window = 20 * fwhm

--- a/src/lib/xrd/calc-xrd.ts
+++ b/src/lib/xrd/calc-xrd.ts
@@ -186,6 +186,7 @@ export function compute_xrd_pattern(
       if (ELEMENT_Z[element_symbol] === undefined) {
         throw new Error(`Unknown atomic number for element ${element_symbol}`)
       }
+      // Cast needed: imported JSON has different type structure than our union type
       const raw_coeff = (
         ATOMIC_SCATTERING_PARAMS as unknown as Partial<
           Record<

--- a/src/lib/xrd/parse.ts
+++ b/src/lib/xrd/parse.ts
@@ -438,7 +438,7 @@ export async function parse_xrd_file(
 export const XRD_FILE_EXTENSIONS = [`xy`, `xye`, `xrdml`, `brml`] as const
 
 // Check if a filename represents a supported XRD data file format.
-// Recognizes both plain and gzipped versions (e.g., .xy and .xy.gz)
+// Recognizes both plain and gzipped versions (e.g. .xy and .xy.gz)
 export function is_xrd_data_file(filename: string): boolean {
   // Strip .gz suffix if present to get base extension
   const base_name = filename.toLowerCase().replace(/\.gz$/, ``)

--- a/src/routes/(demos)/plot/color-bar/+page.md
+++ b/src/routes/(demos)/plot/color-bar/+page.md
@@ -191,7 +191,7 @@ You can format tick labels for date/time ranges by providing a D3 format string 
 <script>
   import { ColorBar } from 'matterviz'
 
-  // Example date range (e.g., start and end of 2024)
+  // Example date range (e.g. start and end of 2024)
   const date_range = [
     new Date(2024, 0, 1).getTime(), // Jan 1, 2024
     new Date(2024, 11, 31).getTime(), // Dec 31, 2024

--- a/src/routes/(demos)/plot/scatter-plot/+page.md
+++ b/src/routes/(demos)/plot/scatter-plot/+page.md
@@ -1097,7 +1097,7 @@ This example demonstrates how the color bar automatically positions itself in on
     for (let idx = 0; idx < count; idx++) {
       const x_val = x_range[0] + Math.random() * (x_range[1] - x_range[0])
       const y_val = y_range[0] + Math.random() * (y_range[1] - y_range[0])
-      // Assign a color value (e.g., based on distance from origin)
+      // Assign a color value (e.g. based on distance from origin)
       const color_val = Math.sqrt(
         Math.pow(x_range[0] + (x_range[1] - x_range[0]) / 2, 2) +
           Math.pow(y_range[0] + (y_range[1] - y_range[0]) / 2, 2),

--- a/src/routes/(demos)/reciprocal/bands/+page.md
+++ b/src/routes/(demos)/reciprocal/bands/+page.md
@@ -181,7 +181,7 @@ When comparing multiple band structures, each can have its own `band_widths`. Th
 - **High-symmetry points**: Automatic labeling with Greek letters (Γ, Δ, Σ)
 - **Acoustic vs optical**: Different styling for phonon mode types
 - **Fat bands**: Visualize band-resolved quantities like electron-phonon coupling λ<sub>nk</sub>
-- **Shaded regions**: Highlight specific frequency ranges (e.g., imaginary modes)
+- **Shaded regions**: Highlight specific frequency ranges (e.g. imaginary modes)
 - **Path modes**: When plotting multiple bands, choose from different path resolutions (union/intersection/strict = error on mismatch)
 - **Interactive**: Zoom, pan, hover tooltips
 - **Responsive**: Adapts to container size

--- a/src/routes/test/scatter-plot/+page.svelte
+++ b/src/routes/test/scatter-plot/+page.svelte
@@ -301,7 +301,7 @@
     for (let idx = 0; idx < count; idx++) {
       const x_val = x_range[0] + Math.random() * (x_range[1] - x_range[0])
       const y_val = y_range[0] + Math.random() * (y_range[1] - y_range[0])
-      // Assign a color value (e.g., based on distance from origin)
+      // Assign a color value (e.g. based on distance from origin)
       const center_x = x_range[0] + (x_range[1] - x_range[0]) / 2
       const center_y = y_range[0] + (y_range[1] - y_range[0]) / 2
       const color_val = Math.hypot(center_x, center_y) * Math.random() * 2 // Add some variation

--- a/src/site/CompositionDemo.svelte
+++ b/src/site/CompositionDemo.svelte
@@ -71,7 +71,7 @@
     }):
     <input
       bind:value={formula}
-      placeholder={`e.g., Fe2O3, H2O, or {Fe: 2, O: 3}`}
+      placeholder={`e.g. Fe2O3, H2O, or {Fe: 2, O: 3}`}
       style="display: block; margin: 1em auto; padding: 2pt 6pt; font-size: 1.2em"
     />
   </label>

--- a/src/site/electronic/bands/index.ts
+++ b/src/site/electronic/bands/index.ts
@@ -7,7 +7,7 @@ const imports = import.meta.glob<BaseBandStructure>(
   { eager: true, import: `default` },
 )
 
-// Export with IDs extracted from filenames (e.g., ./cao-2605-bands.json -> cao_2605)
+// Export with IDs extracted from filenames (e.g. ./cao-2605-bands.json -> cao_2605)
 export const electronic_bands = Object.fromEntries(
   Object.entries(imports).map(([path, data]) => [
     path.match(/\/([^/]+)-bands\.json(?:\.gz)?$/)?.[1]?.replace(/-/g, `_`) ?? path,

--- a/src/site/phonons/index.ts
+++ b/src/site/phonons/index.ts
@@ -1,7 +1,7 @@
 // Extract phonon band structures and DOS from full phonon objects
 
-import type { Branch, PhononBandStructure, PhononDos, QPoint } from '$lib/spectral'
 import * as math from '$lib/math'
+import type { Branch, PhononBandStructure, PhononDos, QPoint } from '$lib/spectral'
 
 interface RawPhononBandStructure {
   recip_lattice: { matrix: math.Matrix3x3 }
@@ -58,7 +58,7 @@ function transform_band_structure(raw: RawPhononBandStructure): PhononBandStruct
   })
 
   // Find labeled points by matching coordinates with labels_dict
-  // Note: A label like GAMMA can appear multiple times in the path (e.g., Γ→X→Γ→L)
+  // Note: A label like GAMMA can appear multiple times in the path (e.g. Γ→X→Γ→L)
   const LABEL_MATCH_EPS = 1e-5
   const labeled_indices = new Map<number, string>()
   for (const [label, coords] of Object.entries(labels_dict)) {

--- a/tests/playwright/plot/spacegroup-bar-plot.test.ts
+++ b/tests/playwright/plot/spacegroup-bar-plot.test.ts
@@ -359,7 +359,7 @@ test.describe(`SpacegroupBarPlot Component Tests`, () => {
     const percentages = annotation_texts.filter((text) => text.includes(`%`))
     expect(percentages.length).toBeGreaterThan(0)
 
-    // Percentages should be formatted properly (e.g., "10.5%", "23%")
+    // Percentages should be formatted properly (e.g. "10.5%", "23%")
     for (const pct_text of percentages) {
       expect(pct_text).toMatch(/\d+\.?\d*\s*%/)
     }

--- a/tests/vitest/composition/FormulaFilter.svelte.test.ts
+++ b/tests/vitest/composition/FormulaFilter.svelte.test.ts
@@ -287,7 +287,7 @@ describe(`FormulaFilter`, () => {
     await tick()
     expect(mode).toBe(`exact`) // Initial inference
 
-    // Simulate parent updating value prop (e.g., from URL change)
+    // Simulate parent updating value prop (e.g. from URL change)
     value = `Fe,Li,O`
     await tick()
     expect(mode).toBe(`elements`) // Should re-infer from new value format

--- a/tests/vitest/math.test.ts
+++ b/tests/vitest/math.test.ts
@@ -1574,7 +1574,7 @@ describe(`compute_bounding_box`, () => {
   })
 })
 
-describe(`frac_to_cart and cart_to_frac`, () => {
+describe(`create_frac_to_cart and create_cart_to_frac`, () => {
   const cubic: math.Matrix3x3 = [[5, 0, 0], [0, 5, 0], [0, 0, 5]]
   const triclinic: math.Matrix3x3 = [[5, 0, 0], [2.5, 4.33, 0], [1, 1, 4]]
   const hexagonal: math.Matrix3x3 = [[4, 0, 0], [2, 3.464, 0], [0, 0, 8]]
@@ -1600,8 +1600,9 @@ describe(`frac_to_cart and cart_to_frac`, () => {
       expected: [8.5, 5.33, 4],
       desc: `triclinic corner`,
     },
-  ])(`frac_to_cart: $desc`, ({ frac, lattice, expected }) => {
-    const result = math.frac_to_cart(frac as Vec3, lattice)
+  ])(`create_frac_to_cart: $desc`, ({ frac, lattice, expected }) => {
+    const frac_to_cart = math.create_frac_to_cart(lattice)
+    const result = frac_to_cart(frac as Vec3)
     result.forEach((val, idx) => expect(val).toBeCloseTo(expected[idx], 2))
   })
 
@@ -1610,9 +1611,11 @@ describe(`frac_to_cart and cart_to_frac`, () => {
     { lattice: triclinic, name: `triclinic` },
     { lattice: hexagonal, name: `hexagonal` },
   ])(`round-trip frac→cart→frac for $name`, ({ lattice }) => {
+    const frac_to_cart = math.create_frac_to_cart(lattice)
+    const cart_to_frac = math.create_cart_to_frac(lattice)
     const frac: Vec3 = [0.25, 0.5, 0.75]
-    const cart = math.frac_to_cart(frac, lattice)
-    const recovered = math.cart_to_frac(cart, lattice)
+    const cart = frac_to_cart(frac)
+    const recovered = cart_to_frac(cart)
     recovered.forEach((val, idx) => expect(val).toBeCloseTo(frac[idx], 10))
   })
 
@@ -1621,9 +1624,11 @@ describe(`frac_to_cart and cart_to_frac`, () => {
     { lattice: triclinic, name: `triclinic` },
     { lattice: hexagonal, name: `hexagonal` },
   ])(`round-trip cart→frac→cart for $name`, ({ lattice }) => {
+    const frac_to_cart = math.create_frac_to_cart(lattice)
+    const cart_to_frac = math.create_cart_to_frac(lattice)
     const cart: Vec3 = [2.5, 3.5, 1.5]
-    const frac = math.cart_to_frac(cart, lattice)
-    const recovered = math.frac_to_cart(frac, lattice)
+    const frac = cart_to_frac(cart)
+    const recovered = frac_to_cart(frac)
     recovered.forEach((val, idx) => expect(val).toBeCloseTo(cart[idx], 10))
   })
 })

--- a/tests/vitest/math.test.ts
+++ b/tests/vitest/math.test.ts
@@ -1573,3 +1573,57 @@ describe(`compute_bounding_box`, () => {
     expect(result).toEqual({ min: [-10, -20, -30], max: [-5, -10, -15] })
   })
 })
+
+describe(`frac_to_cart and cart_to_frac`, () => {
+  const cubic: math.Matrix3x3 = [[5, 0, 0], [0, 5, 0], [0, 0, 5]]
+  const triclinic: math.Matrix3x3 = [[5, 0, 0], [2.5, 4.33, 0], [1, 1, 4]]
+  const hexagonal: math.Matrix3x3 = [[4, 0, 0], [2, 3.464, 0], [0, 0, 8]]
+
+  test.each([
+    { frac: [0, 0, 0], lattice: cubic, expected: [0, 0, 0], desc: `origin` },
+    { frac: [1, 0, 0], lattice: cubic, expected: [5, 0, 0], desc: `a-vector` },
+    {
+      frac: [0.5, 0.5, 0.5],
+      lattice: cubic,
+      expected: [2.5, 2.5, 2.5],
+      desc: `body center`,
+    },
+    {
+      frac: [0.5, 0.5, 0],
+      lattice: hexagonal,
+      expected: [3, 1.732, 0],
+      desc: `hexagonal face`,
+    },
+    {
+      frac: [1, 1, 1],
+      lattice: triclinic,
+      expected: [8.5, 5.33, 4],
+      desc: `triclinic corner`,
+    },
+  ])(`frac_to_cart: $desc`, ({ frac, lattice, expected }) => {
+    const result = math.frac_to_cart(frac as Vec3, lattice)
+    result.forEach((val, idx) => expect(val).toBeCloseTo(expected[idx], 2))
+  })
+
+  test.each([
+    { lattice: cubic, name: `cubic` },
+    { lattice: triclinic, name: `triclinic` },
+    { lattice: hexagonal, name: `hexagonal` },
+  ])(`round-trip frac→cart→frac for $name`, ({ lattice }) => {
+    const frac: Vec3 = [0.25, 0.5, 0.75]
+    const cart = math.frac_to_cart(frac, lattice)
+    const recovered = math.cart_to_frac(cart, lattice)
+    recovered.forEach((val, idx) => expect(val).toBeCloseTo(frac[idx], 10))
+  })
+
+  test.each([
+    { lattice: cubic, name: `cubic` },
+    { lattice: triclinic, name: `triclinic` },
+    { lattice: hexagonal, name: `hexagonal` },
+  ])(`round-trip cart→frac→cart for $name`, ({ lattice }) => {
+    const cart: Vec3 = [2.5, 3.5, 1.5]
+    const frac = math.cart_to_frac(cart, lattice)
+    const recovered = math.frac_to_cart(frac, lattice)
+    recovered.forEach((val, idx) => expect(val).toBeCloseTo(cart[idx], 10))
+  })
+})

--- a/tests/vitest/plot/BarPlot.test.ts
+++ b/tests/vitest/plot/BarPlot.test.ts
@@ -111,7 +111,7 @@ describe(`BarPlot`, () => {
     { render_mode: `line` as const, color: `red`, label: `Line` },
     { render_mode: `line` as const, line_style: { stroke_width: 4, line_dash: `10,5` } },
     // Regression: .filter(Boolean) incorrectly removed 0 from auto-range calculation
-    // Zero is a valid value for color/size scales (e.g., minimum on a gradient)
+    // Zero is a valid value for color/size scales (e.g. minimum on a gradient)
     {
       render_mode: `line` as const,
       markers: `line+points` as const,

--- a/tests/vitest/plot/ColorBar.test.ts
+++ b/tests/vitest/plot/ColorBar.test.ts
@@ -327,7 +327,7 @@ describe(`ColorBar Date/Time Formatting`, () => {
 })
 
 describe(`ColorBar Numeric Formatting`, () => {
-  test(`formats ticks correctly using numeric d3-format (e.g., '.1f')`, () => {
+  test(`formats ticks correctly using numeric d3-format (e.g. '.1f')`, () => {
     mount(ColorBar, {
       target: document.body,
       props: {

--- a/tests/vitest/plot/ScatterPlot.test.ts
+++ b/tests/vitest/plot/ScatterPlot.test.ts
@@ -82,8 +82,7 @@ describe(`ScatterPlot`, () => {
           point_style: { fill: `steelblue`, radius: 5 },
         }],
         x_axis: { label: `Time (s)` },
-        y_labels: { label: `Speed` },
-        y_unit: `m/s`,
+        y_axis: { label: `Speed`, unit: `m/s` },
         tooltip_point: { x: 3, y: 30, series_idx: 0, point_idx: 2 },
         hovered: true,
       },
@@ -103,25 +102,25 @@ describe(`ScatterPlot`, () => {
     ] as DataSeries[]
     mount(ScatterPlot, {
       target: document.body,
-      props: { series: invalid, markers: `line+points` },
+      props: { series: invalid },
     })
     mount(ScatterPlot, {
       target: document.body,
       props: {
         series: [{ x: [1, 2, 3], y: [4, 5, 6] }],
-        x_lim: [100, 200],
-        y_lim: [100, 200],
+        x_axis: { range: [100, 200] },
+        y_axis: { range: [100, 200] },
       },
     })
   })
 
   test.each([
-    { y: [-10, -5, 0, 5, 10], y_lim: [-15, 15] as const },
-    { y: [5, 10, 15, 20, 25], y_lim: [0, 30] as const },
-  ])(`zero lines`, ({ y, y_lim }) => {
+    { y: [-10, -5, 0, 5, 10], y_range: [-15, 15] as [number, number] },
+    { y: [5, 10, 15, 20, 25], y_range: [0, 30] as [number, number] },
+  ])(`zero lines`, ({ y, y_range }) => {
     mount(ScatterPlot, {
       target: document.body,
-      props: { series: [{ x: [1, 2, 3, 4, 5], y }], y_lim },
+      props: { series: [{ x: [1, 2, 3, 4, 5], y }], y_axis: { range: y_range } },
     })
   })
 

--- a/tests/vitest/structure/AtomLegend.test.ts
+++ b/tests/vitest/structure/AtomLegend.test.ts
@@ -567,7 +567,7 @@ describe(`AtomLegend Component`, () => {
       const labels = document.querySelectorAll(`.category-label`)
       const label_texts = Array.from(labels).map((l) => l.textContent?.trim())
 
-      // Format: Element:count+wyckoff (e.g., Fe:24e, O:12a)
+      // Format: Element:count+wyckoff (e.g. Fe:24e, O:12a)
       expect(label_texts).toContain(`Fe:24e`)
       expect(label_texts).toContain(`O:12a`)
     })

--- a/tests/vitest/xrd/XrdPlot.test.ts
+++ b/tests/vitest/xrd/XrdPlot.test.ts
@@ -82,7 +82,7 @@ describe(`XrdPlot`, () => {
 
   test(`overbar notation on multi-digit negative indices`, async () => {
     // Regression test for overbar notation bug: multi-digit negative indices
-    // should have overbar on all digits (e.g., -10 → 1̄0̄, not 10̄)
+    // should have overbar on all digits (e.g. -10 → 1̄0̄, not 10̄)
     const pattern_with_negatives: XrdPattern = {
       x: [15, 25, 35],
       y: [100, 200, 150],


### PR DESCRIPTION
- Add on-demand frame loading for large trajectories through `frame_loader`.
- Cache and unify fractional/Cartesian coordinate conversion across trajectory parsing and exports.
- Prevent unintended band-availability resets, harden instanced-mesh handling, and propagate per-point metadata consistently through plot components.