### PR TITLE
Fix CIF parser for compound symmetry operations

### DIFF
--- a/extensions/vscode/tests/vscode-mock.ts
+++ b/extensions/vscode/tests/vscode-mock.ts
@@ -1,13 +1,12 @@
 import type { Plugin } from 'vite'
 
-export function mock_vscode(): Plugin {
-  return {
-    name: `vscode-mock`,
-    enforce: `pre`,
-    resolveId: (module_id) => (module_id === `vscode` ? `\0vscode-mock` : null),
-    load: (module_id) =>
-      module_id === `\0vscode-mock`
-        ? `
+export const mock_vscode = (): Plugin => ({
+  name: `vscode-mock`,
+  enforce: `pre`,
+  resolveId: (module_id) => (module_id === `vscode` ? `\0vscode-mock` : null),
+  load: (module_id) =>
+    module_id === `\0vscode-mock`
+      ? `
 export const __noop = () => undefined
 const __proxy = new Proxy(function(){}, { get: () => __proxy, apply: () => undefined, construct: () => ({}) })
 export const window = __proxy
@@ -15,6 +14,5 @@ export const commands = __proxy
 export const workspace = __proxy
 export default { window, commands, workspace }
 `
-        : null,
-  }
-}
+      : null,
+})

--- a/src/lib/composition/parse.ts
+++ b/src/lib/composition/parse.ts
@@ -419,9 +419,7 @@ export type ChemsysWithWildcards = {
 
 // Check if input contains wildcard elements (*).
 // Works for both chemsys format (Li-Fe-*-*) and exact formula format (LiFe*2*).
-export function has_wildcards(input: string): boolean {
-  return input.includes(`*`)
-}
+export const has_wildcards = (input: string): boolean => input.includes(`*`)
 
 // Parse chemsys format with wildcards: "Li-Fe-*-*" -> { elements: ["Li", "Fe"], wildcard_count: 2 }
 // Accepts both hyphen and comma separators.

--- a/src/lib/convex-hull/barycentric-coords.ts
+++ b/src/lib/convex-hull/barycentric-coords.ts
@@ -66,13 +66,15 @@ export function calculate_face_normal(p1: Point3D, p2: Point3D, p3: Point3D): Po
   return { x: nx / magnitude, y: ny / magnitude, z: nz / magnitude }
 }
 
-export function calculate_face_centroid(p1: Point3D, p2: Point3D, p3: Point3D): Point3D {
-  return {
-    x: (p1.x + p2.x + p3.x) / 3,
-    y: (p1.y + p2.y + p3.y) / 3,
-    z: (p1.z + p2.z + p3.z) / 3,
-  }
-}
+export const calculate_face_centroid = (
+  p1: Point3D,
+  p2: Point3D,
+  p3: Point3D,
+): Point3D => ({
+  x: (p1.x + p2.x + p3.x) / 3,
+  y: (p1.y + p2.y + p3.y) / 3,
+  z: (p1.z + p2.z + p3.z) / 3,
+})
 
 export function get_ternary_3d_coordinates(
   entries: PhaseData[],

--- a/src/lib/convex-hull/helpers.ts
+++ b/src/lib/convex-hull/helpers.ts
@@ -251,11 +251,9 @@ export const DEFAULT_HIGHLIGHT_STYLE: Required<HighlightStyle> = {
   pulse_speed: 3, // Smooth pulsing
 }
 
-export function merge_highlight_style(
+export const merge_highlight_style = (
   custom_style: HighlightStyle | undefined,
-): Required<HighlightStyle> {
-  return { ...DEFAULT_HIGHLIGHT_STYLE, ...custom_style }
-}
+): Required<HighlightStyle> => ({ ...DEFAULT_HIGHLIGHT_STYLE, ...custom_style })
 
 export function is_entry_highlighted<T extends { entry_id?: string }>(
   entry: T,

--- a/src/lib/convex-hull/thermodynamics.ts
+++ b/src/lib/convex-hull/thermodynamics.ts
@@ -482,50 +482,56 @@ export function interpolate_hull_2d(hull: Point2D[], x: number): number | null {
 
 const EPS = 1e-9
 
-const subtract = (a: Point3D, b: Point3D): Point3D => ({
-  x: a.x - b.x,
-  y: a.y - b.y,
-  z: a.z - b.z,
+const subtract = (pt1: Point3D, pt2: Point3D): Point3D => ({
+  x: pt1.x - pt2.x,
+  y: pt1.y - pt2.y,
+  z: pt1.z - pt2.z,
 })
 
-const cross = (a: Point3D, b: Point3D): Point3D => ({
-  x: a.y * b.z - a.z * b.y,
-  y: a.z * b.x - a.x * b.z,
-  z: a.x * b.y - a.y * b.x,
+const cross = (vec1: Point3D, vec2: Point3D): Point3D => ({
+  x: vec1.y * vec2.z - vec1.z * vec2.y,
+  y: vec1.z * vec2.x - vec1.x * vec2.z,
+  z: vec1.x * vec2.y - vec1.y * vec2.x,
 })
 
-const norm = (a: Point3D): number => Math.sqrt(a.x * a.x + a.y * a.y + a.z * a.z)
+const norm = (point: Point3D): number =>
+  Math.sqrt(point.x * point.x + point.y * point.y + point.z * point.z)
 
-function normalize(v: Point3D): Point3D {
-  const length = norm(v)
+function normalize(point: Point3D): Point3D {
+  const length = norm(point)
   if (length < EPS) return { x: 0, y: 0, z: 0 }
-  return { x: v.x / length, y: v.y / length, z: v.z / length }
+  return { x: point.x / length, y: point.y / length, z: point.z / length }
 }
 
-function compute_plane(a: Point3D, b: Point3D, c: Point3D): Plane {
-  const ab = subtract(b, a)
-  const ac = subtract(c, a)
-  const n = normalize(cross(ab, ac))
-  const offset = -(n.x * a.x + n.y * a.y + n.z * a.z)
-  return { normal: n, offset }
+function compute_plane(p1: Point3D, p2: Point3D, p3: Point3D): Plane {
+  const edge_12 = subtract(p2, p1)
+  const edge_13 = subtract(p3, p1)
+  const normal = normalize(cross(edge_12, edge_13))
+  const offset = -(normal.x * p1.x + normal.y * p1.y + normal.z * p1.z)
+  return { normal, offset }
 }
 
-const point_plane_signed_distance = (plane: Plane, p: Point3D): number =>
-  plane.normal.x * p.x + plane.normal.y * p.y + plane.normal.z * p.z + plane.offset
+const point_plane_signed_distance = (plane: Plane, point: Point3D): number =>
+  plane.normal.x * point.x + plane.normal.y * point.y + plane.normal.z * point.z +
+  plane.offset
 
-const compute_centroid = (a: Point3D, b: Point3D, c: Point3D): Point3D => ({
-  x: (a.x + b.x + c.x) / 3,
-  y: (a.y + b.y + c.y) / 3,
-  z: (a.z + b.z + c.z) / 3,
+const compute_centroid = (p1: Point3D, p2: Point3D, p3: Point3D): Point3D => ({
+  x: (p1.x + p2.x + p3.x) / 3,
+  y: (p1.y + p2.y + p3.y) / 3,
+  z: (p1.z + p2.z + p3.z) / 3,
 })
 
-function distance_point_to_line(a: Point3D, b: Point3D, p: Point3D): number {
-  const ab = subtract(b, a)
-  const ap = subtract(p, a)
-  const cross_prod = cross(ab, ap)
-  const ab_len = norm(ab)
-  if (ab_len < EPS) return 0
-  return norm(cross_prod) / ab_len
+function distance_point_to_line(
+  line_start: Point3D,
+  line_end: Point3D,
+  point: Point3D,
+): number {
+  const line_vec = subtract(line_end, line_start)
+  const to_point = subtract(point, line_start)
+  const cross_prod = cross(line_vec, to_point)
+  const line_len = norm(line_vec)
+  if (line_len < EPS) return 0
+  return norm(cross_prod) / line_len
 }
 
 function choose_initial_tetrahedron(
@@ -851,23 +857,28 @@ interface Plane4D {
   offset: number
 }
 
-const subtract_4d = (a: Point4D, b: Point4D): Point4D => ({
-  x: a.x - b.x,
-  y: a.y - b.y,
-  z: a.z - b.z,
-  w: a.w - b.w,
+const subtract_4d = (pt1: Point4D, pt2: Point4D): Point4D => ({
+  x: pt1.x - pt2.x,
+  y: pt1.y - pt2.y,
+  z: pt1.z - pt2.z,
+  w: pt1.w - pt2.w,
 })
 
-const dot_4d = (a: Point4D, b: Point4D): number =>
-  a.x * b.x + a.y * b.y + a.z * b.z + a.w * b.w
+const dot_4d = (vec_a: Point4D, vec_b: Point4D): number =>
+  vec_a.x * vec_b.x + vec_a.y * vec_b.y + vec_a.z * vec_b.z + vec_a.w * vec_b.w
 
-const norm_4d = (v: Point4D): number =>
-  Math.sqrt(v.x * v.x + v.y * v.y + v.z * v.z + v.w * v.w)
+const norm_4d = (point: Point4D): number =>
+  Math.sqrt(point.x * point.x + point.y * point.y + point.z * point.z + point.w * point.w)
 
-function normalize_4d(v: Point4D): Point4D {
-  const length = norm_4d(v)
+function normalize_4d(point: Point4D): Point4D {
+  const length = norm_4d(point)
   if (length < EPS) return { x: 0, y: 0, z: 0, w: 0 }
-  return { x: v.x / length, y: v.y / length, z: v.z / length, w: v.w / length }
+  return {
+    x: point.x / length,
+    y: point.y / length,
+    z: point.z / length,
+    w: point.w / length,
+  }
 }
 
 // Compute normal to a 3D hyperplane in 4D space defined by 4 points
@@ -937,8 +948,8 @@ function compute_plane_4d(p1: Point4D, p2: Point4D, p3: Point4D, p4: Point4D): P
   return { normal, offset }
 }
 
-const point_plane_signed_distance_4d = (plane: Plane4D, p: Point4D): number =>
-  dot_4d(plane.normal, p) + plane.offset
+const point_plane_signed_distance_4d = (plane: Plane4D, point: Point4D): number =>
+  dot_4d(plane.normal, point) + plane.offset
 
 const compute_centroid_4d = (
   p1: Point4D,
@@ -1032,8 +1043,8 @@ function choose_initial_4_simplex(
     : Array.from({ length: sample_size }, (_, idx) =>
       Math.floor((idx * points.length) / sample_size))
 
-  let idx_min_x = 0
-  let idx_max_x = 0
+  let idx_far_a = 0
+  let idx_far_b = 0
   let max_dist_sq = -1
 
   for (const idx_a of sample_indices) {
@@ -1045,21 +1056,21 @@ function choose_initial_4_simplex(
         (pa.w - pb.w) ** 2
       if (dist_sq > max_dist_sq) {
         max_dist_sq = dist_sq
-        idx_min_x = idx_a
-        idx_max_x = idx_b
+        idx_far_a = idx_a
+        idx_far_b = idx_b
       }
     }
   }
-  if (idx_min_x === idx_max_x || max_dist_sq < EPS) return null
+  if (idx_far_a === idx_far_b || max_dist_sq < EPS) return null
 
-  // Find point farthest from line through idx_min_x and idx_max_x
+  // Find point farthest from line through idx_far_a and idx_far_b
   let idx_far_line = -1
   let best_dist_line = -1
   for (let idx = 0; idx < points.length; idx++) {
-    if (idx === idx_min_x || idx === idx_max_x) continue
+    if (idx === idx_far_a || idx === idx_far_b) continue
     const dist = distance_point_to_line_4d(
-      points[idx_min_x],
-      points[idx_max_x],
+      points[idx_far_a],
+      points[idx_far_b],
       points[idx],
     )
     if (dist > best_dist_line) {
@@ -1073,10 +1084,10 @@ function choose_initial_4_simplex(
   let idx_far_plane = -1
   let best_dist_plane = -1
   for (let idx = 0; idx < points.length; idx++) {
-    if (idx === idx_min_x || idx === idx_max_x || idx === idx_far_line) continue
+    if (idx === idx_far_a || idx === idx_far_b || idx === idx_far_line) continue
     const dist = distance_point_to_hyperplane_4d(
-      points[idx_min_x],
-      points[idx_max_x],
+      points[idx_far_a],
+      points[idx_far_b],
       points[idx_far_line],
       points[idx],
     )
@@ -1089,8 +1100,8 @@ function choose_initial_4_simplex(
 
   // Find point farthest from 3D hyperplane through first four points
   const plane0 = compute_plane_4d(
-    points[idx_min_x],
-    points[idx_max_x],
+    points[idx_far_a],
+    points[idx_far_b],
     points[idx_far_line],
     points[idx_far_plane],
   )
@@ -1098,7 +1109,7 @@ function choose_initial_4_simplex(
   let best_dist_hyperplane = -1
   for (let idx = 0; idx < points.length; idx++) {
     if (
-      idx === idx_min_x || idx === idx_max_x || idx === idx_far_line ||
+      idx === idx_far_a || idx === idx_far_b || idx === idx_far_line ||
       idx === idx_far_plane
     ) continue
     const dist = Math.abs(point_plane_signed_distance_4d(plane0, points[idx]))
@@ -1109,7 +1120,7 @@ function choose_initial_4_simplex(
   }
   if (idx_far_hyperplane === -1 || best_dist_hyperplane < EPS) return null
 
-  return [idx_min_x, idx_max_x, idx_far_line, idx_far_plane, idx_far_hyperplane]
+  return [idx_far_a, idx_far_b, idx_far_line, idx_far_plane, idx_far_hyperplane]
 }
 
 function make_face_4d(

--- a/src/lib/convex-hull/thermodynamics.ts
+++ b/src/lib/convex-hull/thermodynamics.ts
@@ -482,17 +482,19 @@ export function interpolate_hull_2d(hull: Point2D[], x: number): number | null {
 
 const EPS = 1e-9
 
-function subtract(a: Point3D, b: Point3D): Point3D {
-  return { x: a.x - b.x, y: a.y - b.y, z: a.z - b.z }
-}
+const subtract = (a: Point3D, b: Point3D): Point3D => ({
+  x: a.x - b.x,
+  y: a.y - b.y,
+  z: a.z - b.z,
+})
 
-function cross(a: Point3D, b: Point3D): Point3D {
-  return { x: a.y * b.z - a.z * b.y, y: a.z * b.x - a.x * b.z, z: a.x * b.y - a.y * b.x }
-}
+const cross = (a: Point3D, b: Point3D): Point3D => ({
+  x: a.y * b.z - a.z * b.y,
+  y: a.z * b.x - a.x * b.z,
+  z: a.x * b.y - a.y * b.x,
+})
 
-function norm(a: Point3D): number {
-  return Math.sqrt(a.x * a.x + a.y * a.y + a.z * a.z)
-}
+const norm = (a: Point3D): number => Math.sqrt(a.x * a.x + a.y * a.y + a.z * a.z)
 
 function normalize(v: Point3D): Point3D {
   const length = norm(v)
@@ -508,13 +510,14 @@ function compute_plane(a: Point3D, b: Point3D, c: Point3D): Plane {
   return { normal: n, offset }
 }
 
-function point_plane_signed_distance(plane: Plane, p: Point3D): number {
-  return plane.normal.x * p.x + plane.normal.y * p.y + plane.normal.z * p.z + plane.offset
-}
+const point_plane_signed_distance = (plane: Plane, p: Point3D): number =>
+  plane.normal.x * p.x + plane.normal.y * p.y + plane.normal.z * p.z + plane.offset
 
-function compute_centroid(a: Point3D, b: Point3D, c: Point3D): Point3D {
-  return { x: (a.x + b.x + c.x) / 3, y: (a.y + b.y + c.y) / 3, z: (a.z + b.z + c.z) / 3 }
-}
+const compute_centroid = (a: Point3D, b: Point3D, c: Point3D): Point3D => ({
+  x: (a.x + b.x + c.x) / 3,
+  y: (a.y + b.y + c.y) / 3,
+  z: (a.z + b.z + c.z) / 3,
+})
 
 function distance_point_to_line(a: Point3D, b: Point3D, p: Point3D): number {
   const ab = subtract(b, a)
@@ -849,17 +852,18 @@ interface Plane4D {
   offset: number
 }
 
-function subtract_4d(a: Point4D, b: Point4D): Point4D {
-  return { x: a.x - b.x, y: a.y - b.y, z: a.z - b.z, w: a.w - b.w }
-}
+const subtract_4d = (a: Point4D, b: Point4D): Point4D => ({
+  x: a.x - b.x,
+  y: a.y - b.y,
+  z: a.z - b.z,
+  w: a.w - b.w,
+})
 
-function dot_4d(a: Point4D, b: Point4D): number {
-  return a.x * b.x + a.y * b.y + a.z * b.z + a.w * b.w
-}
+const dot_4d = (a: Point4D, b: Point4D): number =>
+  a.x * b.x + a.y * b.y + a.z * b.z + a.w * b.w
 
-function norm_4d(v: Point4D): number {
-  return Math.sqrt(v.x * v.x + v.y * v.y + v.z * v.z + v.w * v.w)
-}
+const norm_4d = (v: Point4D): number =>
+  Math.sqrt(v.x * v.x + v.y * v.y + v.z * v.z + v.w * v.w)
 
 function normalize_4d(v: Point4D): Point4D {
   const length = norm_4d(v)
@@ -934,9 +938,8 @@ function compute_plane_4d(p1: Point4D, p2: Point4D, p3: Point4D, p4: Point4D): P
   return { normal, offset }
 }
 
-function point_plane_signed_distance_4d(plane: Plane4D, p: Point4D): number {
-  return dot_4d(plane.normal, p) + plane.offset
-}
+const point_plane_signed_distance_4d = (plane: Plane4D, p: Point4D): number =>
+  dot_4d(plane.normal, p) + plane.offset
 
 function compute_centroid_4d(
   p1: Point4D,

--- a/src/lib/convex-hull/thermodynamics.ts
+++ b/src/lib/convex-hull/thermodynamics.ts
@@ -748,10 +748,10 @@ export interface HullFaceModel {
   denom: number
 }
 
-export function build_lower_hull_model(
+export const build_lower_hull_model = (
   faces: ConvexHullTriangle[],
-): HullFaceModel[] {
-  return faces.map((tri) => {
+): HullFaceModel[] =>
+  faces.map((tri) => {
     const [p1, p2, p3] = tri.vertices
     const plane = (() => {
       const x1 = p1.x, y1 = p1.y, z1 = p1.z
@@ -789,7 +789,6 @@ export function build_lower_hull_model(
       denom,
     }
   })
-}
 
 function point_in_triangle_xy(model: HullFaceModel, x: number, y: number): boolean {
   const { x1, y1, x2, y2, x3, y3, denom } = model
@@ -941,19 +940,17 @@ function compute_plane_4d(p1: Point4D, p2: Point4D, p3: Point4D, p4: Point4D): P
 const point_plane_signed_distance_4d = (plane: Plane4D, p: Point4D): number =>
   dot_4d(plane.normal, p) + plane.offset
 
-function compute_centroid_4d(
+const compute_centroid_4d = (
   p1: Point4D,
   p2: Point4D,
   p3: Point4D,
   p4: Point4D,
-): Point4D {
-  return {
-    x: (p1.x + p2.x + p3.x + p4.x) / 4,
-    y: (p1.y + p2.y + p3.y + p4.y) / 4,
-    z: (p1.z + p2.z + p3.z + p4.z) / 4,
-    w: (p1.w + p2.w + p3.w + p4.w) / 4,
-  }
-}
+): Point4D => ({
+  x: (p1.x + p2.x + p3.x + p4.x) / 4,
+  y: (p1.y + p2.y + p3.y + p4.y) / 4,
+  z: (p1.z + p2.z + p3.z + p4.z) / 4,
+  w: (p1.w + p2.w + p3.w + p4.w) / 4,
+})
 
 function distance_point_to_hyperplane_4d(
   p1: Point4D,
@@ -1399,10 +1396,10 @@ interface TetrahedronModel {
   max_z: number
 }
 
-function build_tetrahedron_models(
+const build_tetrahedron_models = (
   hull_tetrahedra: ConvexHullTetrahedron[],
-): TetrahedronModel[] {
-  return hull_tetrahedra.map((tet) => {
+): TetrahedronModel[] =>
+  hull_tetrahedra.map((tet) => {
     const [p0, p1, p2, p3] = tet.vertices
     const vertices_3d: [Point3D, Point3D, Point3D, Point3D] = [
       { x: p0.x, y: p0.y, z: p0.z },
@@ -1424,7 +1421,6 @@ function build_tetrahedron_models(
       max_z: Math.max(...zs),
     }
   })
-}
 
 // Compute distance from point to lower hull in 4D
 export const compute_e_above_hull_4d = (

--- a/src/lib/convex-hull/types.ts
+++ b/src/lib/convex-hull/types.ts
@@ -143,9 +143,8 @@ export interface PhaseStats {
 }
 
 // Arity helpers (inlined from former arity.ts)
-export function get_arity(entry: PhaseData) {
-  return Object.values(entry.composition).filter((v) => v > 0).length
-}
+export const get_arity = (entry: PhaseData): number =>
+  Object.values(entry.composition).filter((v) => v > 0).length
 
 export const is_unary_entry = (entry: PhaseData) => get_arity(entry) === 1
 export const is_binary_entry = (entry: PhaseData) => get_arity(entry) === 2

--- a/src/lib/convex-hull/types.ts
+++ b/src/lib/convex-hull/types.ts
@@ -144,7 +144,7 @@ export interface PhaseStats {
 
 // Arity helpers (inlined from former arity.ts)
 export const get_arity = (entry: PhaseData): number =>
-  Object.values(entry.composition).filter((v) => v > 0).length
+  Object.values(entry.composition).filter((count) => count > 0).length
 
 export const is_unary_entry = (entry: PhaseData) => get_arity(entry) === 1
 export const is_binary_entry = (entry: PhaseData) => get_arity(entry) === 2

--- a/src/lib/fermi-surface/compute.ts
+++ b/src/lib/fermi-surface/compute.ts
@@ -503,9 +503,8 @@ function compute_in_plane_basis(normal: Vec3): [Vec3, Vec3] {
 }
 
 // Helper to create edge key (sorted vertex indices)
-function make_edge_key(v0_idx: number, v1_idx: number): string {
-  return `${Math.min(v0_idx, v1_idx)},${Math.max(v0_idx, v1_idx)}`
-}
+const make_edge_key = (v0_idx: number, v1_idx: number): string =>
+  `${Math.min(v0_idx, v1_idx)},${Math.max(v0_idx, v1_idx)}`
 
 // Compute intersection point on an edge
 function compute_edge_intersection(

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -97,15 +97,12 @@ export const escape_html = (unsafe_string: string): string =>
     .replaceAll(`'`, `&#39;`)
 
 // Simplified binary detection
-export function is_binary(content: string): boolean {
-  return (
-    content.includes(`\0`) ||
-    // deno-lint-ignore no-control-regex
-    (content.match(/[\u0000-\u0008\u000E-\u001F\u007F-\u00FF]/g) || []).length /
-          content.length > 0.1 ||
-    (content.match(/[\u0020-\u007E]/g) || []).length / content.length < 0.7
-  )
-}
+export const is_binary = (content: string): boolean =>
+  content.includes(`\0`) ||
+  // deno-lint-ignore no-control-regex
+  (content.match(/[\u0000-\u0008\u000E-\u001F\u007F-\u00FF]/g) || []).length /
+        content.length > 0.1 ||
+  (content.match(/[\u0020-\u007E]/g) || []).length / content.length < 0.7
 
 export async function toggle_fullscreen(wrapper?: HTMLDivElement): Promise<void> {
   if (!wrapper) return

--- a/src/lib/labels.ts
+++ b/src/lib/labels.ts
@@ -253,13 +253,12 @@ export const SUBSCRIPT_MAP = {
   '9': `₉`,
 } as const
 
-export function superscript_digits(input: string): string {
-  // use replace all signs and digits with their unicode superscript equivalent
-  return input.replace(
+// replaces all signs and digits with their unicode superscript equivalent
+export const superscript_digits = (input: string): string =>
+  input.replace(
     /[\d+-]/g,
     (match) => SUPERSCRIPT_MAP[match as keyof typeof SUPERSCRIPT_MAP] ?? match,
   )
-}
 
 // Trajectory property configuration: clean labels and units as structured data
 export const trajectory_property_config: Record<string, { label: string; unit: string }> =

--- a/src/lib/math.ts
+++ b/src/lib/math.ts
@@ -378,19 +378,24 @@ export function det_4x4(matrix: Matrix4x4): number {
 }
 
 // 3D cross product
-export function cross_3d(a: Vec3, b: Vec3): Vec3 {
-  return [a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0]]
-}
+export const cross_3d = (
+  a: Vec3,
+  b: Vec3,
+): Vec3 => [
+  a[1] * b[2] - a[2] * b[1],
+  a[2] * b[0] - a[0] * b[2],
+  a[0] * b[1] - a[1] * b[0],
+]
 
 // Scalar linear interpolation
-export function lerp(a: number, b: number, t: number): number {
-  return a + t * (b - a)
-}
+export const lerp = (a: number, b: number, t: number): number => a + t * (b - a)
 
 // Vec3 linear interpolation
-export function lerp_vec3(a: Vec3, b: Vec3, t: number): Vec3 {
-  return [a[0] + t * (b[0] - a[0]), a[1] + t * (b[1] - a[1]), a[2] + t * (b[2] - a[2])]
-}
+export const lerp_vec3 = (
+  a: Vec3,
+  b: Vec3,
+  t: number,
+): Vec3 => [a[0] + t * (b[0] - a[0]), a[1] + t * (b[1] - a[1]), a[2] + t * (b[2] - a[2])]
 
 // Normalize a Vec3 to unit length, returns zero vector if input is zero
 export function normalize_vec3(vec: Vec3, fallback?: Vec3): Vec3 {

--- a/src/lib/math.ts
+++ b/src/lib/math.ts
@@ -379,23 +379,28 @@ export function det_4x4(matrix: Matrix4x4): number {
 
 // 3D cross product
 export const cross_3d = (
-  a: Vec3,
-  b: Vec3,
+  vec1: Vec3,
+  vec2: Vec3,
 ): Vec3 => [
-  a[1] * b[2] - a[2] * b[1],
-  a[2] * b[0] - a[0] * b[2],
-  a[0] * b[1] - a[1] * b[0],
+  vec1[1] * vec2[2] - vec1[2] * vec2[1],
+  vec1[2] * vec2[0] - vec1[0] * vec2[2],
+  vec1[0] * vec2[1] - vec1[1] * vec2[0],
 ]
 
 // Scalar linear interpolation
-export const lerp = (a: number, b: number, t: number): number => a + t * (b - a)
+export const lerp = (start: number, end: number, t: number): number =>
+  start + t * (end - start)
 
 // Vec3 linear interpolation
 export const lerp_vec3 = (
-  a: Vec3,
-  b: Vec3,
+  start: Vec3,
+  end: Vec3,
   t: number,
-): Vec3 => [a[0] + t * (b[0] - a[0]), a[1] + t * (b[1] - a[1]), a[2] + t * (b[2] - a[2])]
+): Vec3 => [
+  start[0] + t * (end[0] - start[0]),
+  start[1] + t * (end[1] - start[1]),
+  start[2] + t * (end[2] - start[2]),
+]
 
 // Normalize a Vec3 to unit length, returns zero vector if input is zero
 export function normalize_vec3(vec: Vec3, fallback?: Vec3): Vec3 {

--- a/src/lib/math.ts
+++ b/src/lib/math.ts
@@ -65,9 +65,8 @@ export function calc_lattice_params(
   return { a, b, c, alpha, beta, gamma, volume }
 }
 
-export function scale<T extends NdVector>(vec: T, factor: number): T {
-  return vec.map((component) => component * factor) as T
-}
+export const scale = <T extends NdVector>(vec: T, factor: number): T =>
+  vec.map((component) => component * factor) as T
 
 export const euclidean_dist = (vec1: NdVector, vec2: NdVector): number => {
   if (vec1.length !== vec2.length) {

--- a/src/lib/plot/interactions.ts
+++ b/src/lib/plot/interactions.ts
@@ -11,10 +11,8 @@ export function get_relative_coords(evt: MouseEvent): { x: number; y: number } |
 }
 
 // Check if a value is within a range
-export function is_valid_dimension(
+export const is_valid_dimension = (
   val: number | null | undefined,
   min: number,
   max: number,
-): boolean {
-  return val !== null && val !== undefined && !isNaN(val) && val >= min && val <= max
-}
+): boolean => val !== null && val !== undefined && !isNaN(val) && val >= min && val <= max

--- a/src/lib/structure/atom-properties.ts
+++ b/src/lib/structure/atom-properties.ts
@@ -102,16 +102,15 @@ export const apply_categorical_color_scale = (
 
 // Get original site index for property color lookup.
 // Supercell atoms use orig_unit_cell_idx, image atoms use orig_site_idx, otherwise use site_idx.
-export function get_orig_site_idx(
+export const get_orig_site_idx = (
   site: Site | undefined,
   site_idx: number,
-): number {
-  return typeof site?.properties?.orig_unit_cell_idx === `number`
+): number =>
+  typeof site?.properties?.orig_unit_cell_idx === `number`
     ? site.properties.orig_unit_cell_idx
     : typeof site?.properties?.orig_site_idx === `number`
     ? site.properties.orig_site_idx
     : site_idx
-}
 
 // Expand structure with PBC images - use minimal expansion based on atom positions
 function expand_structure_for_pbc(structure: AnyStructure): AnyStructure {

--- a/src/lib/structure/atom-properties.ts
+++ b/src/lib/structure/atom-properties.ts
@@ -28,8 +28,8 @@ export interface AtomPropertyColors {
 const GRAY = `#808080`
 const DEFAULT_COLOR_SCALE = `interpolateViridis`
 
-export const get_d3_color_scales = () =>
-  Object.keys(d3_sc).filter((k) => k.startsWith(`interpolate`))
+export const get_d3_color_scales = (): string[] =>
+  Object.keys(d3_sc).filter((key) => key.startsWith(`interpolate`))
 
 const get_interp = (scale: string) => {
   const fn = d3_sc[scale as keyof typeof d3_sc]

--- a/src/lib/structure/bonding.ts
+++ b/src/lib/structure/bonding.ts
@@ -135,15 +135,14 @@ function setup_spatial_grid(sites: Site[], cutoff: number) {
 }
 
 // Get candidate neighbor indices using spatial grid or all sites.
-function get_candidates(
+const get_candidates = (
   pos: Vec3,
   sites: Site[],
   spatial: ReturnType<typeof setup_spatial_grid>,
-): number[] {
-  return spatial
+): number[] =>
+  spatial
     ? get_neighbors_from_grid(pos, spatial.grid, spatial.cell_size)
     : Array.from({ length: sites.length }, (_, idx) => idx)
-}
 
 export const BONDING_STRATEGIES = { electroneg_ratio, solid_angle } as const
 export type BondingStrategy = keyof typeof BONDING_STRATEGIES

--- a/src/lib/structure/bonding.ts
+++ b/src/lib/structure/bonding.ts
@@ -17,7 +17,7 @@ const covalent_radii: Map<string, number> = new Map(
 // Get the species with highest occupancy from a site.
 const get_majority_species = (site: Site) =>
   (site.species ?? []).reduce(
-    (max, spec) => (spec.occu > max.occu ? spec : max),
+    (max_species, species) => (species.occu > max_species.occu ? species : max_species),
     site.species?.[0] ?? { element: ``, occu: -1 },
   )
 

--- a/src/lib/structure/bonding.ts
+++ b/src/lib/structure/bonding.ts
@@ -15,12 +15,11 @@ const covalent_radii: Map<string, number> = new Map(
 )
 
 // Get the species with highest occupancy from a site.
-function get_majority_species(site: Site) {
-  return (site.species ?? []).reduce(
+const get_majority_species = (site: Site) =>
+  (site.species ?? []).reduce(
     (max, spec) => (spec.occu > max.occu ? spec : max),
     site.species?.[0] ?? { element: ``, occu: -1 },
   )
-}
 
 // Helper to extract numeric index from site properties
 function get_orig_idx(site: Site, fallback: number): number {

--- a/src/lib/structure/index.ts
+++ b/src/lib/structure/index.ts
@@ -40,11 +40,9 @@ export type Site = {
 export const LATTICE_PARAM_KEYS = [`a`, `b`, `c`, `alpha`, `beta`, `gamma`] as const
 export type LatticeParams = { [key in (typeof LATTICE_PARAM_KEYS)[number]]: number }
 
-export type PymatgenLattice = {
-  matrix: math.Matrix3x3
-  pbc: Pbc
-  volume: number
-} & LatticeParams
+export type PymatgenLattice =
+  & { matrix: math.Matrix3x3; pbc: Pbc; volume: number }
+  & LatticeParams
 
 export type PymatgenMolecule = { sites: Site[]; charge?: number; id?: string }
 export type PymatgenStructure = PymatgenMolecule & { lattice: PymatgenLattice }

--- a/src/lib/structure/parse.ts
+++ b/src/lib/structure/parse.ts
@@ -503,7 +503,7 @@ export function parse_xyz(content: string): ParsedStructure | null {
 // Returns the numeric coefficient for each variable and the translation constant
 const parse_symmetry_expression = (
   expr_input: string,
-): { coefficients: [number, number, number]; translation: number } | null => {
+): { coefficients: [number, number, number]; translation: number } => {
   const coefficients: [number, number, number] = [0, 0, 0]
   let translation = 0
 
@@ -605,24 +605,15 @@ const apply_symmetry_ops = (
     if (parts.length !== 3) continue
 
     const new_coords: Vec3 = [0, 0, 0]
-    let valid = true
 
     for (let dim = 0; dim < 3; dim++) {
-      const parsed = parse_symmetry_expression(parts[dim])
-      if (!parsed) {
-        valid = false
-        break
-      }
-
-      const { coefficients, translation } = parsed
+      const { coefficients, translation } = parse_symmetry_expression(parts[dim])
       // Apply: new_coord = coeff_x * x + coeff_y * y + coeff_z * z + translation
       new_coords[dim] = coefficients[0] * atom.coords[0] +
         coefficients[1] * atom.coords[1] +
         coefficients[2] * atom.coords[2] +
         translation
     }
-
-    if (!valid) continue
 
     // Wrap and deduplicate transformed coordinates
     const wrapped = wrap(new_coords)
@@ -1503,9 +1494,8 @@ export function is_optimade_json(content: string): boolean {
 }
 
 // Check if already-parsed JSON is OPTIMADE-like
-export function is_optimade_raw(raw: unknown): boolean {
-  return Boolean(extract_optimade_structure_from_raw(raw))
-}
+export const is_optimade_raw = (raw: unknown): boolean =>
+  Boolean(extract_optimade_structure_from_raw(raw))
 
 // Shared helper to extract an OPTIMADE structure from raw JSON-like data
 function extract_optimade_structure_from_raw(raw: unknown): OptimadeStructure | null {

--- a/src/lib/structure/parse.ts
+++ b/src/lib/structure/parse.ts
@@ -64,14 +64,9 @@ export interface PhonopyData {
   [key: string]: unknown
 }
 
-// Normalize scientific notation in coordinate strings
-// Handles eEdD and *^ notation variants
-function normalize_scientific_notation(str: string): string {
-  return str
-    .toLowerCase()
-    .replace(/d/g, `e`) // Replace D/d with e
-    .replace(/\*\^/g, `e`) // Replace *^ with e
-}
+// Normalize scientific notation in coordinate strings (handles eEdD and *^ notation variants)
+const normalize_scientific_notation = (str: string): string =>
+  str.toLowerCase().replace(/d/g, `e`).replace(/\*\^/g, `e`)
 
 // Parse a coordinate value that might be in various scientific notation formats
 function parse_coordinate(str: string): number {
@@ -504,6 +499,82 @@ export function parse_xyz(content: string): ParsedStructure | null {
   }
 }
 
+// Parse a single symmetry expression dimension (e.g., "x-y+1/3" or "-x+y")
+// Returns the numeric coefficient for each variable and the translation constant
+const parse_symmetry_expression = (
+  expr_input: string,
+): { coefficients: [number, number, number]; translation: number } | null => {
+  const coefficients: [number, number, number] = [0, 0, 0]
+  let translation = 0
+
+  // Remove all whitespace
+  const expr = expr_input.replace(/\s+/g, ``)
+  if (!expr) return { coefficients, translation }
+
+  // Tokenize: split into terms while preserving signs
+  // E.g., "x-y+1/3" → ["x", "-y", "+1/3"] or "-x+y" → ["-x", "+y"]
+  const tokens: string[] = []
+  let current_token = ``
+
+  for (let idx = 0; idx < expr.length; idx++) {
+    const char = expr[idx]
+    if ((char === `+` || char === `-`) && current_token.length > 0) {
+      tokens.push(current_token)
+      current_token = char
+    } else {
+      current_token += char
+    }
+  }
+  if (current_token) tokens.push(current_token)
+
+  for (const token of tokens) {
+    // Check if this token is a variable term (x, y, or z with optional sign)
+    const var_match = token.match(/^([+-]?)([xyz])$/)
+    if (var_match) {
+      const sign = var_match[1] === `-` ? -1 : 1
+      const var_char = var_match[2]
+      const var_idx = var_char === `x` ? 0 : var_char === `y` ? 1 : 2
+      coefficients[var_idx] += sign
+      continue
+    }
+
+    // Check if this is a numeric term (integer, decimal, or fraction)
+    let sign = 1
+    let num_str = token
+
+    // Handle leading sign
+    if (num_str.startsWith(`+`)) {
+      num_str = num_str.slice(1)
+    } else if (num_str.startsWith(`-`)) {
+      sign = -1
+      num_str = num_str.slice(1)
+    }
+
+    // Skip empty tokens (from dangling operators like "x+")
+    if (!num_str || num_str === `+` || num_str === `-`) continue
+
+    if (num_str.includes(`/`)) {
+      // Fraction
+      const parts = num_str.split(`/`)
+      if (parts.length === 2) {
+        const numerator = parseFloat(parts[0])
+        const denominator = parseFloat(parts[1])
+        if (!isNaN(numerator) && !isNaN(denominator) && denominator !== 0) {
+          translation += sign * (numerator / denominator)
+        }
+      }
+    } else {
+      // Integer or decimal
+      const val = parseFloat(num_str)
+      if (!isNaN(val)) {
+        translation += sign * val
+      }
+    }
+  }
+
+  return { coefficients, translation }
+}
+
 // Apply symmetry operations to generate equivalent positions
 const apply_symmetry_ops = (
   atom: CifAtom,
@@ -516,9 +587,11 @@ const apply_symmetry_ops = (
   const seen = new Set<string>()
   const wrap = (
     v: Vec3,
-  ): Vec3 => (wrap_frac ? v.map((c) => c - Math.floor(c)) as Vec3 : v)
+  ): Vec3 => (wrap_frac ? v.map((coord) => coord - Math.floor(coord)) as Vec3 : v)
+  // Use 6 decimal places for deduplication to handle floating point imprecision
+  // from compound symmetry operations like x-y, -x+y which can produce small errors
   const key = (v: Vec3): string =>
-    `${v[0].toFixed(12)},${v[1].toFixed(12)},${v[2].toFixed(12)}`
+    `${v[0].toFixed(6)},${v[1].toFixed(6)},${v[2].toFixed(6)}`
 
   // Always include base atom (optionally wrapped)
   const base_coords = wrap(atom.coords as Vec3)
@@ -532,61 +605,24 @@ const apply_symmetry_ops = (
     if (parts.length !== 3) continue
 
     const new_coords: Vec3 = [0, 0, 0]
+    let valid = true
 
     for (let dim = 0; dim < 3; dim++) {
-      const part = parts[dim]
-      let expr = part.replace(/\s+/g, ``)
-
-      let coord = 0
-      let translation = 0
-
-      // Support both var+number and number+var forms, with optional sign on var
-      const var_match = expr.match(/([+-]?)(x|y|z)/)
-      if (var_match) {
-        const sign_char = var_match[1]
-        const var_char = var_match[2]
-        const var_index = var_char === `x` ? 0 : var_char === `y` ? 1 : 2
-        const var_sign = sign_char === `-` ? -1 : 1
-        coord = var_sign * atom.coords[var_index]
-        // Remove the variable term (including its sign) to leave pure translation
-        expr = expr.replace(var_match[0], ``)
-
-        // Normalize the remaining expression: trim whitespace and remove trailing operators
-        expr = expr.trim()
-        if (expr.endsWith(`+`) || expr.endsWith(`-`)) expr = expr.slice(0, -1)
-
-        // Treat empty expression as "0"
-        if (expr.length === 0) expr = `0`
+      const parsed = parse_symmetry_expression(parts[dim])
+      if (!parsed) {
+        valid = false
+        break
       }
 
-      if (expr.length > 0) {
-        // Remaining is numeric translation, possibly with leading sign
-        let sign = 1
-        let number_str = expr
-        if (expr[0] === `+` || expr[0] === `-`) {
-          sign = expr[0] === `-` ? -1 : 1
-          number_str = expr.slice(1)
-        }
-        if (number_str.includes(`/`)) {
-          const [num, den] = number_str.split(`/`)
-          const numerator = parseFloat(num)
-          const denominator = parseFloat(den)
-          if (isNaN(numerator) || isNaN(denominator)) {
-            console.warn(`Malformed fraction in symmetry operation: ${num}/${den}`)
-          } else if (denominator === 0) {
-            console.warn(`Division by zero in symmetry operation: ${num}/${den}`)
-          } else translation = sign * (numerator / denominator)
-        } else {
-          const val = parseFloat(number_str)
-          // Log malformed numeric value for debugging
-          if (isNaN(val)) {
-            console.warn(`Malformed numeric value in symmetry operation: ${number_str}`)
-          } else translation = sign * val
-        }
-      }
-
-      new_coords[dim] = coord + translation
+      const { coefficients, translation } = parsed
+      // Apply: new_coord = coeff_x * x + coeff_y * y + coeff_z * z + translation
+      new_coords[dim] = coefficients[0] * atom.coords[0] +
+        coefficients[1] * atom.coords[1] +
+        coefficients[2] * atom.coords[2] +
+        translation
     }
+
+    if (!valid) continue
 
     // Wrap and deduplicate transformed coordinates
     const wrapped = wrap(new_coords)
@@ -948,11 +984,10 @@ export function parse_cif(
     const ops_to_use = already_enumerated ? [] : normalized_ops
 
     // Global deduplication of final sites (per element + coordinates + label)
+    // Use 6 decimal places to handle floating point imprecision from compound symmetry ops
     const seen_site_keys = new Set<string>()
     const site_key = (element: string, abc: Vec3, label: string): string =>
-      `${element}|${label}|${abc[0].toFixed(12)},${abc[1].toFixed(12)},${
-        abc[2].toFixed(12)
-      }`
+      `${element}|${label}|${abc[0].toFixed(6)},${abc[1].toFixed(6)},${abc[2].toFixed(6)}`
 
     for (const atom of atoms) {
       const element = validate_element_symbol(atom.element, all_sites.length)

--- a/src/lib/structure/parse.ts
+++ b/src/lib/structure/parse.ts
@@ -586,12 +586,12 @@ const apply_symmetry_ops = (
   const equivalent_atoms: CifAtom[] = []
   const seen = new Set<string>()
   const wrap = (
-    v: Vec3,
-  ): Vec3 => (wrap_frac ? v.map((coord) => coord - Math.floor(coord)) as Vec3 : v)
+    coords: Vec3,
+  ): Vec3 => (wrap_frac ? coords.map((val) => val - Math.floor(val)) as Vec3 : coords)
   // Use 6 decimal places for deduplication to handle floating point imprecision
   // from compound symmetry operations like x-y, -x+y which can produce small errors
-  const key = (v: Vec3): string =>
-    `${v[0].toFixed(6)},${v[1].toFixed(6)},${v[2].toFixed(6)}`
+  const key = (coords: Vec3): string =>
+    `${coords[0].toFixed(6)},${coords[1].toFixed(6)},${coords[2].toFixed(6)}`
 
   // Always include base atom (optionally wrapped)
   const base_coords = wrap(atom.coords as Vec3)

--- a/src/lib/structure/pbc.ts
+++ b/src/lib/structure/pbc.ts
@@ -6,12 +6,11 @@ import type { ParsedStructure } from './parse'
 export type Pbc = readonly [boolean, boolean, boolean]
 
 // Wrap fractional coordinates to [0, 1) range for periodicity.
-export function wrap_to_unit_cell(frac: Vec3): Vec3 {
-  return frac.map((coord) => {
+export const wrap_to_unit_cell = (frac: Vec3): Vec3 =>
+  frac.map((coord) => {
     const wrapped = ((coord % 1) + 1) % 1
     return wrapped >= 1 - 1e-10 ? 0 : wrapped // clamp near-1 to 0 for float precision
   }) as Vec3
-}
 
 export function find_image_atoms(
   structure: ParsedStructure,

--- a/src/lib/structure/supercell.ts
+++ b/src/lib/structure/supercell.ts
@@ -92,21 +92,18 @@ export function make_supercell(
     throw new Error(`Cannot create supercell: structure has no lattice`)
   }
 
-  const scaling_factors = parse_supercell_scaling(scaling)
-  const [nx, ny, nz] = scaling_factors
+  const supercell_scaling = parse_supercell_scaling(scaling)
+  const [nx, ny, nz] = supercell_scaling
   const det = nx * ny * nz
 
   // Short circuit for 1x1x1 (no actual supercell needed)
   if (nx === 1 && ny === 1 && nz === 1) {
-    return {
-      ...structure,
-      supercell_scaling: scaling_factors,
-    } as SupercellType
+    return { ...structure, supercell_scaling } as SupercellType
   }
 
   const orig_matrix = structure.lattice.matrix
   // Create new scaled lattice
-  const new_lattice_matrix = scale_lattice_matrix(orig_matrix, scaling_factors)
+  const new_lattice_matrix = scale_lattice_matrix(orig_matrix, supercell_scaling)
   const lattice_params = math.calc_lattice_params(new_lattice_matrix)
 
   const new_lattice = {
@@ -182,7 +179,7 @@ export function make_supercell(
     lattice: new_lattice,
     sites: new_sites,
     charge: structure.charge ? structure.charge * det : structure.charge,
-    supercell_scaling: scaling_factors,
+    supercell_scaling,
   } as SupercellType
 }
 
@@ -195,10 +192,4 @@ export function is_valid_supercell_input(input: string): boolean {
   } catch {
     return false
   }
-}
-
-// Format supercell scaling factors for display
-// Takes scaling factors and returns formatted string like "2×2×2"
-export function format_supercell_scaling(scaling: Vec3): string {
-  return scaling.join(`×`)
 }

--- a/src/lib/xrd/parse.ts
+++ b/src/lib/xrd/parse.ts
@@ -26,9 +26,8 @@ function create_pattern(
 }
 
 // Parse whitespace-separated numbers from text. Used by multiple formats.
-function parse_number_list(text: string): number[] {
-  return text.trim().split(/\s+/).map(parseFloat).filter((val) => !isNaN(val))
-}
+const parse_number_list = (text: string): number[] =>
+  text.trim().split(/\s+/).map(parseFloat).filter((val) => !isNaN(val))
 
 // Extract numeric value from header line matching "KEY=VALUE" or "KEY VALUE" pattern.
 // Returns null if not found or not a valid number.

--- a/src/lib/xrd/parse.ts
+++ b/src/lib/xrd/parse.ts
@@ -8,9 +8,8 @@ const DEFAULT_STEP_SIZE = 0.02
 
 // Generate x values from scan parameters (start angle, step size, point count).
 // Used by formats that store metadata + intensity-only data.
-function generate_x_from_scan(start: number, step: number, count: number): number[] {
-  return Array.from({ length: count }, (_, idx) => start + idx * step)
-}
+const generate_x_from_scan = (start: number, step: number, count: number): number[] =>
+  Array.from({ length: count }, (_, idx) => start + idx * step)
 
 // Create normalized XrdPattern from scan metadata and intensities.
 // Returns null if no intensity data. Used by all parsers as final step.

--- a/tests/vitest/fermi-surface/marching-cubes.test.ts
+++ b/tests/vitest/fermi-surface/marching-cubes.test.ts
@@ -4,17 +4,16 @@ import type { Matrix3x3, Vec3 } from '$lib/math'
 import { describe, expect, test } from 'vitest'
 
 // Helper: create uniform grid with constant value
-function create_uniform_grid(
+const create_uniform_grid = (
   nx: number,
   ny: number,
   nz: number,
   value: number,
-): number[][][] {
-  return Array.from(
+): number[][][] =>
+  Array.from(
     { length: nx },
     () => Array.from({ length: ny }, () => Array.from({ length: nz }, () => value)),
   )
-}
 
 // Helper: create gradient grid along specified axis
 function create_gradient_grid(
@@ -40,7 +39,7 @@ function create_gradient_grid(
 }
 
 // Helper: create spherical grid (distance² from center)
-function create_spherical_grid(size: number): number[][][] {
+const create_spherical_grid = (size: number): number[][][] => {
   const center = (size - 1) / 2
   return Array.from(
     { length: size },

--- a/tests/vitest/plot/PlotTooltip.test.ts
+++ b/tests/vitest/plot/PlotTooltip.test.ts
@@ -4,11 +4,10 @@ import { describe, expect, test } from 'vitest'
 import { doc_query } from '../setup'
 
 // Helper to create a simple children snippet for testing.
-function make_children(text: string = `Test`) {
-  return createRawSnippet(() => ({
+const make_children = (text: string = `Test`) =>
+  createRawSnippet(() => ({
     render: () => `<span>${text}</span>`,
   }))
-}
 
 describe(`PlotTooltip`, () => {
   test(`renders with basic positioning, default offset, and absolute position`, () => {

--- a/tests/vitest/structure/Structure.test.svelte.ts
+++ b/tests/vitest/structure/Structure.test.svelte.ts
@@ -28,26 +28,22 @@ Direct
 0.5 0.0 0.5
 0.0 0.5 0.5`
 
-function create_mock_data_transfer(files: File[]): DataTransfer {
-  return {
-    files,
-    getData: () => ``,
-    dropEffect: `copy` as const,
-    effectAllowed: `copy` as const,
-    items: [] as unknown as DataTransferItemList,
-    types: [] as readonly string[],
-    clearData: () => {},
-    setData: () => {},
-    setDragImage: () => {},
-  } as unknown as DataTransfer
-}
+const create_mock_data_transfer = (files: File[]): DataTransfer => ({
+  files: Object.assign(files, { item: (idx: number) => files[idx] ?? null }) as FileList,
+  getData: () => ``,
+  dropEffect: `copy` as const,
+  effectAllowed: `copy` as const,
+  items: [] as unknown as DataTransferItemList,
+  types: [] as readonly string[],
+  clearData: () => {},
+  setData: () => {},
+  setDragImage: () => {},
+})
 
-function create_drop_event(files: File[]): DragEvent {
+const create_drop_event = (files: File[]): DragEvent => {
   const drag_event = new DragEvent(`drop`)
-  Object.defineProperty(drag_event, `dataTransfer`, {
-    value: create_mock_data_transfer(files),
-    writable: false,
-  })
+  const descriptor = { value: create_mock_data_transfer(files), writable: false }
+  Object.defineProperty(drag_event, `dataTransfer`, descriptor)
   return drag_event
 }
 

--- a/tests/vitest/structure/bonding.test.ts
+++ b/tests/vitest/structure/bonding.test.ts
@@ -9,7 +9,7 @@ import process from 'node:process'
 import { describe, expect, test } from 'vitest'
 import { create_test_structure } from '../setup'
 
-function measure_performance(func: () => void): number {
+const measure_performance = (func: () => void): number => {
   const start = performance.now()
   func()
   return performance.now() - start

--- a/tests/vitest/structure/bonding.test.ts
+++ b/tests/vitest/structure/bonding.test.ts
@@ -15,33 +15,31 @@ const measure_performance = (func: () => void): number => {
   return performance.now() - start
 }
 
-function make_site(xyz: Vec3, element = `C`): Site {
-  return {
-    xyz,
-    abc: [0, 0, 0],
-    species: [{ element: element as ElementSymbol, occu: 1, oxidation_state: 0 }],
-    label: element,
-    properties: {},
-  }
-}
+const make_site = (xyz: Vec3, element = `C`): Site => ({
+  xyz,
+  abc: [0, 0, 0],
+  species: [{ element: element as ElementSymbol, occu: 1, oxidation_state: 0 }],
+  label: element,
+  properties: {},
+})
 
-function get_test_structure(sites: { xyz: Vec3; element?: string }[]): PymatgenStructure {
-  return {
-    sites: sites.map(({ xyz, element = `C` }) => make_site(xyz, element)),
-    charge: 0,
-    lattice: {
-      matrix: [[1, 0, 0], [0, 1, 0], [0, 0, 1]] satisfies Matrix3x3,
-      pbc: [true, true, true],
-      a: 1,
-      b: 1,
-      c: 1,
-      alpha: 90,
-      beta: 90,
-      gamma: 90,
-      volume: 1,
-    },
-  }
-}
+const get_test_structure = (
+  sites: { xyz: Vec3; element?: string }[],
+): PymatgenStructure => ({
+  sites: sites.map(({ xyz, element = `C` }) => make_site(xyz, element)),
+  charge: 0,
+  lattice: {
+    matrix: [[1, 0, 0], [0, 1, 0], [0, 0, 1]] satisfies Matrix3x3,
+    pbc: [true, true, true],
+    a: 1,
+    b: 1,
+    c: 1,
+    alpha: 90,
+    beta: 90,
+    gamma: 90,
+    volume: 1,
+  },
+})
 
 function make_random_structure(n_atoms: number): PymatgenStructure {
   const elements = [`C`, `H`, `N`, `O`, `S`, `Fe`, `Na`, `Cl`]

--- a/tests/vitest/structure/supercell.test.ts
+++ b/tests/vitest/structure/supercell.test.ts
@@ -3,7 +3,6 @@ import * as math from '$lib/math'
 import type { PymatgenStructure } from '$lib/structure'
 import { find_image_atoms, get_pbc_image_sites } from '$lib/structure/pbc'
 import {
-  format_supercell_scaling,
   generate_lattice_points,
   is_valid_supercell_input,
   make_supercell,
@@ -217,15 +216,6 @@ describe(`validation and formatting`, () => {
     [``, false],
   ])(`validates %s as %s`, (input, expected) => {
     expect(is_valid_supercell_input(input)).toBe(expected)
-  })
-
-  test.each([
-    [[1, 1, 1], `1×1×1`],
-    [[2, 2, 2], `2×2×2`],
-    [[3, 1, 2], `3×1×2`],
-    [[5, 4, 3], `5×4×3`],
-  ])(`formats %s as %s`, (input, expected) => {
-    expect(format_supercell_scaling(input as Vec3)).toBe(expected)
   })
 })
 


### PR DESCRIPTION
closes #226

- Parse compound crystallographic symmetry operations robustly so CIF expansion generates all expected sites.
- Reduce floating-point noise during site deduplication and improve numerical robustness in geometry and sampling.
- Add composition and arity predicates and handle fullscreen API failures.