### PR TITLE
`FermiSlice` interactive legend, tooltips, tests, better styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@types/d3-shape": "^3.1.7",
     "@types/d3-time-format": "^4.0.3",
     "@types/three": "^0.182.0",
-    "@vitest/coverage-v8": "^4.0.15",
+    "@vitest/coverage-v8": "^4.0.16",
     "d3-time-format": "^4.1.0",
     "eslint": "^9.39.2",
     "eslint-plugin-svelte": "^3.13.1",
@@ -63,13 +63,13 @@
     "rehype-katex": "^7.0.1",
     "rehype-slug": "^6.0.0",
     "remark-math": "3.0.1",
-    "svelte-check": "^4.3.4",
+    "svelte-check": "^4.3.5",
     "svelte-preprocess": "^6.0.3",
-    "svelte2tsx": "^0.7.45",
+    "svelte2tsx": "^0.7.46",
     "typescript": "5.9.3",
-    "typescript-eslint": "^8.49.0",
-    "vite": "^7.2.7",
-    "vitest": "^4.0.15"
+    "typescript-eslint": "^8.50.0",
+    "vite": "^7.3.0",
+    "vitest": "^4.0.16"
   },
   "keywords": [
     "svelte",

--- a/src/lib/app.css
+++ b/src/lib/app.css
@@ -10,6 +10,7 @@
   /* Svelte MultiSelect */
   --sms-options-bg: var(--page-bg);
   --sms-active-color: light-dark(var(--accent-color), cornflowerblue);
+  --sms-li-active-bg: light-dark(rgba(100, 149, 237, 0.25), cornflowerblue);
   --border-radius: 3pt;
 }
 

--- a/src/lib/feedback/StatusMessage.svelte
+++ b/src/lib/feedback/StatusMessage.svelte
@@ -40,10 +40,10 @@
       padding: 0.5em 1em;
     }
     &.warning {
-      --status-message-border: 1px solid #fb8c00;
-      background: #fff3e0;
-      color: #e65100;
-      padding: 0.5em;
+      border: var(--warning-border, 1px solid #fb8c00);
+      background: color-mix(in srgb, var(--warning-color, #fb8c00) 10%, transparent);
+      color: var(--warning-color, #fb8c00);
+      padding: 0.5em 1em;
     }
   }
   button {

--- a/src/lib/feedback/StatusMessage.svelte
+++ b/src/lib/feedback/StatusMessage.svelte
@@ -27,17 +27,16 @@
 <style>
   .status-message {
     border-radius: var(--border-radius, 3pt);
-    border: var(--status-message-border);
     &.info {
-      --status-message-border: 2px dashed #ccc;
+      border: 2px dashed var(--text-color-muted, #ccc);
       background: transparent;
-      color: #666;
+      color: var(--text-color-muted, #666);
       padding: 2em;
     }
     &.error {
-      --status-message-border: 1px solid #ef5350;
-      background: #ffebee;
-      color: #c62828;
+      border: var(--error-border, 1px solid #ef4444);
+      background: color-mix(in srgb, var(--error-color, #ef4444) 10%, transparent);
+      color: var(--error-color, #ef4444);
       padding: 0.5em 1em;
     }
     &.warning {
@@ -50,12 +49,12 @@
   button {
     margin-left: 1em;
     padding: 0.2em 0.5em;
-    background: #ddd;
-    border: 1px solid #bbb;
+    background: var(--btn-bg, #ddd);
+    border: 1px solid var(--border-color, #bbb);
     border-radius: var(--border-radius, 3pt);
     cursor: pointer;
     &:hover {
-      background: #ccc;
+      background: var(--btn-bg-hover, #ccc);
     }
   }
 </style>

--- a/src/lib/fermi-surface/FermiSlice.svelte
+++ b/src/lib/fermi-surface/FermiSlice.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
   import type { Vec3 } from '$lib/math'
+  import type { DataSeries } from '$lib/plot'
+  import { ScatterPlot } from '$lib/plot'
   import type { Snippet } from 'svelte'
   import type { HTMLAttributes } from 'svelte/elements'
+  import { SvelteSet } from 'svelte/reactivity'
   import { compute_fermi_slice } from './compute'
   import { BAND_COLORS } from './constants'
   import type { FermiSliceData, FermiSurfaceData } from './types'
@@ -12,7 +15,9 @@
     distance = 0,
     line_width = 2,
     show_axes = true,
-    axis_color = `#888`,
+    axis_labels,
+    band_colors = BAND_COLORS,
+    show_legend = true,
     on_error,
     children,
     ...rest
@@ -22,98 +27,213 @@
     distance?: number
     line_width?: number
     show_axes?: boolean
-    axis_color?: string
+    axis_labels?: [string, string]
+    band_colors?: readonly string[]
+    show_legend?: boolean
     on_error?: (error: Error) => void
     children?: Snippet<
-      [{ fermi_data?: FermiSurfaceData; slice_data?: FermiSliceData | null }]
+      [{
+        fermi_data?: FermiSurfaceData
+        slice_data?: FermiSliceData | null
+        export_svg: () => string
+      }]
     >
-  } & HTMLAttributes<SVGSVGElement> = $props()
+  } & HTMLAttributes<HTMLDivElement> = $props()
 
-  const SIZE = 400 // viewBox size
+  // Using subscript characters where available in Unicode (no subscript z exists)
+  const K_LABELS = [`kₓ`, `kᵧ`, `kz`] as const
 
-  let slice_data = $derived.by((): FermiSliceData | null => {
-    if (!fermi_data) return null
+  let wrapper = $state<HTMLDivElement | undefined>(undefined)
+  let hidden_bands = new SvelteSet<number>()
+
+  // Compute axis labels from Miller indices
+  let labels = $derived.by(() => {
+    if (axis_labels) return axis_labels
+    const zeros = miller_indices.flatMap((val, idx) => (val === 0 ? [idx] : []))
+    if (zeros.length === 2) {
+      return [K_LABELS[zeros[0]], K_LABELS[zeros[1]]] as [string, string]
+    }
+    if (zeros.length === 1) return [`k⊥`, K_LABELS[zeros[0]]] as [string, string]
+    return [`k₁`, `k₂`] as [string, string]
+  })
+
+  // Compute slice with error handling
+  let slice_data = $state<FermiSliceData | null>(null)
+  $effect(() => {
+    if (!fermi_data) {
+      slice_data = null
+      return
+    }
     try {
-      return compute_fermi_slice(fermi_data, { miller_indices, distance })
+      slice_data = compute_fermi_slice(fermi_data, { miller_indices, distance })
     } catch (err) {
+      slice_data = null
       on_error?.(err instanceof Error ? err : new Error(String(err)))
-      return null
     }
   })
 
+  // Get unique band indices for legend
+  let unique_bands = $derived(
+    [...new Set(slice_data?.isolines.map((iso) => iso.band_index) ?? [])].sort(
+      (band_a, band_b) => band_a - band_b,
+    ),
+  )
+
+  // Transform isolines to ScatterPlot series format
+  let series: DataSeries[] = $derived(
+    slice_data?.isolines.map((iso, idx) => ({
+      id: `iso-${iso.band_index}-${idx}`,
+      x: iso.points_2d.map((pt) => pt[0]),
+      y: iso.points_2d.map((pt) => pt[1]),
+      markers: `line` as const,
+      visible: !hidden_bands.has(iso.band_index),
+      label: `Band ${iso.band_index + 1}`,
+      legend_group: `Bands`,
+      line_style: {
+        stroke: band_colors[iso.band_index % band_colors.length],
+        stroke_width: line_width,
+      },
+    })) ?? [],
+  )
+
+  // Compute data bounds for axis lines
   let bounds = $derived.by(() => {
-    if (!slice_data?.isolines.length) return { min: [-1, -1], max: [1, 1] }
-    let [x_min, x_max, y_min, y_max] = [Infinity, -Infinity, Infinity, -Infinity]
-    for (const { points_2d } of slice_data.isolines) {
-      for (const [x, y] of points_2d) {
-        if (x < x_min) x_min = x
-        if (x > x_max) x_max = x
-        if (y < y_min) y_min = y
-        if (y > y_max) y_max = y
+    const pts = slice_data?.isolines.flatMap((iso) => iso.points_2d) ?? []
+    if (!pts.length) return { min: [-1, -1], max: [1, 1] }
+    const xs = pts.map((pt) => pt[0]), ys = pts.map((pt) => pt[1])
+    const [xmin, xmax, ymin, ymax] = [
+      Math.min(...xs),
+      Math.max(...xs),
+      Math.min(...ys),
+      Math.max(...ys),
+    ]
+    const pad = 0.1, rx = xmax - xmin || 1, ry = ymax - ymin || 1
+    return {
+      min: [xmin - rx * pad, ymin - ry * pad],
+      max: [xmax + rx * pad, ymax + ry * pad],
+    }
+  })
+
+  function toggle_band(series_idx: number) {
+    // series_idx here is the index in the series array, need to map to band_index
+    const iso = slice_data?.isolines[series_idx]
+    if (!iso) return
+    const band_idx = iso.band_index
+    if (hidden_bands.has(band_idx)) hidden_bands.delete(band_idx)
+    else hidden_bands.add(band_idx)
+  }
+
+  function isolate_band(series_idx: number) {
+    const iso = slice_data?.isolines[series_idx]
+    if (!iso) return
+    const band_idx = iso.band_index
+    const is_solo = unique_bands.every((band) =>
+      band === band_idx || hidden_bands.has(band)
+    )
+    hidden_bands.clear()
+    if (!is_solo) {
+      for (const band of unique_bands) {
+        if (band !== band_idx) hidden_bands.add(band)
       }
     }
-    const pad = 0.1, rx = x_max - x_min || 1, ry = y_max - y_min || 1
-    return {
-      min: [x_min - rx * pad, y_min - ry * pad],
-      max: [x_max + rx * pad, y_max + ry * pad],
-    }
-  })
-
-  function to_svg([x, y]: [number, number]): [number, number] {
-    const rx = bounds.max[0] - bounds.min[0] || 1,
-      ry = bounds.max[1] - bounds.min[1] || 1
-    return [
-      ((x - bounds.min[0]) / rx) * SIZE,
-      SIZE - ((y - bounds.min[1]) / ry) * SIZE,
-    ]
   }
 
-  function path_d(pts: [number, number][]): string {
-    if (pts.length < 2) return ``
-    const [[x0, y0], ...rest] = pts.map(to_svg)
-    return `M${x0} ${y0}` + rest.map(([x, y]) => `L${x} ${y}`).join(``)
-  }
-
-  let origin = $derived(to_svg([0, 0]))
-  let x_axis = $derived([to_svg([bounds.min[0], 0]), to_svg([bounds.max[0], 0])])
-  let y_axis = $derived([to_svg([0, bounds.min[1]]), to_svg([0, bounds.max[1]])])
+  const export_svg = () => wrapper?.querySelector(`svg`)?.outerHTML ?? ``
 </script>
 
-<svg viewBox="0 0 {SIZE} {SIZE}" preserveAspectRatio="xMidYMid meet" {...rest}>
-  {#if show_axes}
-    <line
-      x1={x_axis[0][0]}
-      y1={x_axis[0][1]}
-      x2={x_axis[1][0]}
-      y2={x_axis[1][1]}
-      stroke={axis_color}
-      stroke-dasharray="4,4"
-    />
-    <line
-      x1={y_axis[0][0]}
-      y1={y_axis[0][1]}
-      x2={y_axis[1][0]}
-      y2={y_axis[1][1]}
-      stroke={axis_color}
-      stroke-dasharray="4,4"
-    />
-    <circle cx={origin[0]} cy={origin[1]} r="3" fill={axis_color} />
-  {/if}
-  {#if slice_data}
-    {#each slice_data.isolines as iso, idx (`iso-${idx}`)}
-      {@const d = path_d(iso.points_2d)}
-      {#if d}<path
-          {d}
-          stroke={BAND_COLORS[iso.band_index % BAND_COLORS.length]}
-          stroke-width={line_width}
-          fill="none"
-          stroke-linecap="round"
-        />{/if}
-    {/each}
-  {:else}
-    <text x={SIZE / 2} y={SIZE / 2} text-anchor="middle" fill="#888">
-      No slice data
-    </text>
-  {/if}
-</svg>
-{@render children?.({ fermi_data, slice_data })}
+<ScatterPlot
+  bind:wrapper
+  {series}
+  x_axis={{
+    label: show_axes ? labels[0] : undefined,
+    ticks: [],
+    range: [bounds.min[0], bounds.max[0]],
+  }}
+  y_axis={{
+    label: show_axes ? labels[1] : undefined,
+    ticks: [],
+    range: [bounds.min[1], bounds.max[1]],
+  }}
+  display={{
+    x_grid: false,
+    y_grid: false,
+    x_zero_line: show_axes,
+    y_zero_line: show_axes,
+  }}
+  styles={{ show_points: false, show_lines: true }}
+  controls={{ show: false }}
+  fullscreen_toggle={false}
+  legend={show_legend && unique_bands.length > 0
+  ? {
+    on_toggle: toggle_band,
+    on_double_click: isolate_band,
+    draggable: false,
+  }
+  : null}
+  padding={{ t: 20, b: 30, l: 40, r: 20 }}
+  class="fermi-slice {rest.class ?? ``}"
+  style={rest.style}
+>
+  {#snippet user_content({ x_scale_fn, y_scale_fn, pad, width, height })}
+    {#if show_axes && width && height}
+      <!-- Custom dashed axis lines through origin -->
+      {@const origin_x = x_scale_fn(0)}
+      {@const origin_y = y_scale_fn(0)}
+      {@const x_start = x_scale_fn(bounds.min[0])}
+      {@const x_end = x_scale_fn(bounds.max[0])}
+      {@const y_start = y_scale_fn(bounds.min[1])}
+      {@const y_end = y_scale_fn(bounds.max[1])}
+      <!-- X-axis line (horizontal through y=0) -->
+      <line
+        x1={x_start}
+        y1={origin_y}
+        x2={x_end}
+        y2={origin_y}
+        class="fermi-axis"
+      />
+      <!-- Y-axis line (vertical through x=0) -->
+      <line
+        x1={origin_x}
+        y1={y_start}
+        x2={origin_x}
+        y2={y_end}
+        class="fermi-axis"
+      />
+      <!-- Axis endpoint labels -->
+      <text
+        x={x_end - 3}
+        y={origin_y - 6}
+        text-anchor="end"
+        class="fermi-label"
+      >
+        {labels[0]}
+      </text>
+      <text
+        x={origin_x + 6}
+        y={Math.max(y_end + 12, pad.t + 12)}
+        class="fermi-label"
+      >
+        {labels[1]}
+      </text>
+    {/if}
+  {/snippet}
+</ScatterPlot>
+{@render children?.({ fermi_data, slice_data, export_svg })}
+
+<style>
+  :global(.fermi-slice) {
+    --scatter-min-height: 200px;
+  }
+  :global(.fermi-slice .zero-line) {
+    display: none; /* Hide default zero lines, we render custom dashed ones */
+  }
+  :global(.fermi-axis) {
+    stroke: var(--fermi-surface-axis-color, #888);
+    stroke-dasharray: 4, 4;
+    stroke-width: 1;
+  }
+  :global(.fermi-label) {
+    fill: var(--fermi-surface-axis-color, #888);
+    font: 10px system-ui, sans-serif;
+  }
+</style>

--- a/tests/vitest/fermi-surface/FermiSlice.test.ts
+++ b/tests/vitest/fermi-surface/FermiSlice.test.ts
@@ -1,0 +1,300 @@
+// @vitest-environment happy-dom
+// Tests for FermiSlice.svelte component
+import FermiSlice from '$lib/fermi-surface/FermiSlice.svelte'
+import type { FermiSurfaceData } from '$lib/fermi-surface/types'
+import type { Matrix3x3, Vec3 } from '$lib/math'
+import { mount, tick } from 'svelte'
+import { describe, expect, test, vi } from 'vitest'
+import { doc_query } from '../setup'
+
+// Create mock Fermi surface data with configurable bands
+function create_mock_fermi_data(band_indices: number[] = [0, 1]): FermiSurfaceData {
+  const identity_lattice: Matrix3x3 = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+  const vertices: Vec3[] = [
+    [-0.5, -0.5, 0],
+    [0.5, -0.5, 0],
+    [0.5, 0.5, 0],
+    [-0.5, 0.5, 0],
+    [-0.5, -0.5, 0.1],
+    [0.5, -0.5, 0.1],
+    [0.5, 0.5, 0.1],
+    [-0.5, 0.5, 0.1],
+  ]
+  const faces: number[][] = [
+    [0, 1, 2],
+    [0, 2, 3],
+    [4, 6, 5],
+    [4, 7, 6],
+    [0, 4, 5],
+    [0, 5, 1],
+    [2, 6, 7],
+    [2, 7, 3],
+    [0, 3, 7],
+    [0, 7, 4],
+    [1, 5, 6],
+    [1, 6, 2],
+  ]
+  return {
+    isosurfaces: band_indices.map((band_index) => ({
+      vertices,
+      faces,
+      normals: vertices.map(() => [0, 0, 1] as Vec3),
+      band_index,
+      spin: null,
+    })),
+    k_lattice: identity_lattice,
+    fermi_energy: 0,
+    reciprocal_cell: `wigner_seitz`,
+    metadata: {
+      n_bands: band_indices.length,
+      n_surfaces: band_indices.length,
+      total_area: 1,
+    },
+  }
+}
+
+describe(`FermiSlice`, () => {
+  describe(`basic rendering`, () => {
+    test(`renders container and SVG with correct class`, () => {
+      mount(FermiSlice, { target: document.body, props: {} })
+      expect(doc_query(`.fermi-slice-container`)).toBeTruthy()
+      expect(doc_query(`.fermi-slice`)).toBeTruthy()
+    })
+
+    test.each([
+      { label: `no fermi_data`, props: {}, expected: `No Fermi data` },
+      {
+        label: `no intersecting isolines`,
+        props: { fermi_data: create_mock_fermi_data([0]), distance: 10 },
+        expected: /No (isolines|slice data)/,
+      },
+    ])(`shows empty message when $label`, async ({ props, expected }) => {
+      mount(FermiSlice, { target: document.body, props })
+      await tick()
+      const empty_text = doc_query(`.empty`)
+      if (expected instanceof RegExp) {
+        expect(empty_text?.textContent?.trim()).toMatch(expected)
+      } else {
+        expect(empty_text?.textContent?.trim()).toBe(expected)
+      }
+    })
+
+    test(`renders paths with custom line_width`, async () => {
+      const fermi_data = create_mock_fermi_data([0])
+      mount(FermiSlice, {
+        target: document.body,
+        props: { fermi_data, miller_indices: [0, 0, 1], distance: 0.05, line_width: 5 },
+      })
+      await tick()
+      const paths = document.querySelectorAll(`path`)
+      expect(paths.length).toBeGreaterThan(0)
+      expect(paths[0]?.getAttribute(`stroke-width`)).toBe(`5`)
+    })
+  })
+
+  describe(`axes and labels`, () => {
+    test.each([
+      { show_axes: true, axis_count: 2, label_count: 2 },
+      { show_axes: false, axis_count: 0, label_count: 0 },
+    ])(
+      `show_axes=$show_axes renders $axis_count axes`,
+      ({ show_axes, axis_count, label_count }) => {
+        mount(FermiSlice, { target: document.body, props: { show_axes } })
+        expect(document.querySelectorAll(`.axis`).length).toBe(axis_count)
+        expect(document.querySelectorAll(`.label`).length).toBe(label_count)
+      },
+    )
+
+    test.each([
+      { miller: [1, 0, 0] as Vec3, expected: [`kᵧ`, `kz`] },
+      { miller: [0, 1, 0] as Vec3, expected: [`kₓ`, `kz`] },
+      { miller: [0, 0, 1] as Vec3, expected: [`kₓ`, `kᵧ`] },
+      { miller: [1, 1, 0] as Vec3, expected: [`k⊥`, `kz`] },
+      { miller: [1, 0, 1] as Vec3, expected: [`k⊥`, `kᵧ`] },
+      { miller: [0, 1, 1] as Vec3, expected: [`k⊥`, `kₓ`] },
+      { miller: [1, 1, 1] as Vec3, expected: [`k₁`, `k₂`] },
+      {
+        miller: null,
+        labels: [`Custom X`, `Custom Y`] as [string, string],
+        expected: [`Custom X`, `Custom Y`],
+      },
+    ])(`axis labels for miller=$miller`, ({ miller, labels, expected }) => {
+      mount(FermiSlice, {
+        target: document.body,
+        props: {
+          miller_indices: miller ?? undefined,
+          axis_labels: labels,
+          show_axes: true,
+        },
+      })
+      const rendered = Array.from(document.querySelectorAll(`.label`)).map((el) =>
+        el.textContent?.trim()
+      )
+      expect(rendered).toEqual(expected)
+    })
+  })
+
+  describe(`legend and band visibility`, () => {
+    test.each([
+      { show_legend: true, expected_items: 2 },
+      { show_legend: false, expected_items: 0 },
+    ])(`show_legend=$show_legend`, async ({ show_legend, expected_items }) => {
+      const fermi_data = create_mock_fermi_data([0, 1])
+      mount(FermiSlice, {
+        target: document.body,
+        props: { fermi_data, distance: 0.05, show_legend },
+      })
+      await tick()
+      const items = document.querySelectorAll(`.legend-item`)
+      expect(items.length).toBe(expected_items)
+      if (show_legend) expect(doc_query(`.legend`)).toBeTruthy()
+      else expect(document.querySelector(`.legend`)).toBeNull()
+    })
+
+    test(`legend items show 1-indexed band numbers`, async () => {
+      const fermi_data = create_mock_fermi_data([0, 2, 5])
+      mount(FermiSlice, { target: document.body, props: { fermi_data, distance: 0.05 } })
+      await tick()
+      const labels = Array.from(document.querySelectorAll(`.legend-label`)).map((el) =>
+        el.textContent?.trim()
+      )
+      expect(labels).toEqual([`Band 1`, `Band 3`, `Band 6`])
+    })
+
+    test(`clicking legend item toggles band visibility (hide and show)`, async () => {
+      const fermi_data = create_mock_fermi_data([0, 1])
+      mount(FermiSlice, { target: document.body, props: { fermi_data, distance: 0.05 } })
+      await tick()
+
+      const initial_paths = document.querySelectorAll(`path`).length
+      expect(initial_paths).toBeGreaterThan(0)
+
+      const legend_items = document.querySelectorAll<HTMLElement>(`.legend-item`)
+      legend_items[0].click()
+      await tick()
+      expect(document.querySelectorAll(`path`).length).toBeLessThan(initial_paths)
+      expect(legend_items[0].classList.contains(`hidden`)).toBe(true)
+
+      legend_items[0].click()
+      await tick()
+      expect(document.querySelectorAll(`path`).length).toBe(initial_paths)
+      expect(legend_items[0].classList.contains(`hidden`)).toBe(false)
+    })
+
+    test(`double-clicking legend item isolates that band`, async () => {
+      const fermi_data = create_mock_fermi_data([0, 1, 2])
+      mount(FermiSlice, { target: document.body, props: { fermi_data, distance: 0.05 } })
+      await tick()
+
+      const legend_items = document.querySelectorAll<HTMLElement>(`.legend-item`)
+      expect(legend_items.length).toBe(3)
+
+      legend_items[1].dispatchEvent(new MouseEvent(`dblclick`, { bubbles: true }))
+      await tick()
+      expect([...legend_items].map((el) => el.classList.contains(`hidden`))).toEqual([
+        true,
+        false,
+        true,
+      ])
+
+      legend_items[1].dispatchEvent(new MouseEvent(`dblclick`, { bubbles: true }))
+      await tick()
+      expect([...legend_items].every((el) => !el.classList.contains(`hidden`))).toBe(true)
+    })
+  })
+
+  describe(`tooltips`, () => {
+    test.each([
+      { show_tooltips: true, expect_tooltip: true },
+      { show_tooltips: false, expect_tooltip: false },
+    ])(`show_tooltips=$show_tooltips`, async ({ show_tooltips, expect_tooltip }) => {
+      const fermi_data = create_mock_fermi_data([0])
+      mount(FermiSlice, {
+        target: document.body,
+        props: { fermi_data, distance: 0.05, show_tooltips },
+      })
+      await tick()
+      const titles = document.querySelectorAll(`title`)
+      if (expect_tooltip) {
+        expect(titles.length).toBeGreaterThan(0)
+        expect(titles[0].textContent).toContain(`Band 1`)
+      } else {
+        expect(titles.length).toBe(0)
+      }
+    })
+  })
+
+  describe(`SVG attributes`, () => {
+    test.each([
+      { preserve_aspect_ratio: false, expected: `none` },
+      { preserve_aspect_ratio: true, expected: `xMidYMid meet` },
+    ])(
+      `preserveAspectRatio=$preserve_aspect_ratio → "$expected"`,
+      ({ preserve_aspect_ratio, expected }) => {
+        mount(FermiSlice, { target: document.body, props: { preserve_aspect_ratio } })
+        expect(doc_query(`.fermi-slice`)?.getAttribute(`preserveAspectRatio`)).toBe(
+          expected,
+        )
+      },
+    )
+
+    test.each([
+      { has_data: true, contains: [`Fermi slice`, `isolines`, `bands`] },
+      { has_data: false, exact: `Empty Fermi slice` },
+    ])(`aria-label when has_data=$has_data`, async ({ has_data, contains, exact }) => {
+      const props = has_data
+        ? { fermi_data: create_mock_fermi_data([0, 1]), distance: 0.05 }
+        : {}
+      mount(FermiSlice, { target: document.body, props })
+      await tick()
+      const label = doc_query(`.fermi-slice`)?.getAttribute(`aria-label`)
+      if (exact) expect(label).toBe(exact)
+      else contains?.forEach((text) => expect(label).toContain(text))
+    })
+  })
+
+  describe(`legend positioning`, () => {
+    test.each(
+      [
+        { position: `top-left`, checks: [`left:`, `top:`] },
+        { position: `top-right`, checks: [`right:`, `top:`] },
+        { position: `bottom-left`, checks: [`left:`, `bottom:`] },
+        { position: `bottom-right`, checks: [`right:`, `bottom:`] },
+      ] as const,
+    )(`positions legend at $position`, async ({ position, checks }) => {
+      const fermi_data = create_mock_fermi_data([0])
+      mount(FermiSlice, {
+        target: document.body,
+        props: { fermi_data, distance: 0.05, legend_position: position },
+      })
+      await tick()
+      const style = doc_query(`.legend`)?.getAttribute(`style`) ?? ``
+      checks.forEach((check) => expect(style).toContain(check))
+    })
+  })
+
+  describe(`error handling and custom colors`, () => {
+    test(`calls on_error when compute_fermi_slice throws`, async () => {
+      const mock_error = vi.fn()
+      const fermi_data = create_mock_fermi_data([0])
+      fermi_data.k_lattice = [[0, 0, 0], [0, 0, 0], [0, 0, 0]] // Degenerate to trigger error
+      mount(FermiSlice, {
+        target: document.body,
+        props: { fermi_data, miller_indices: [1, 0, 0], on_error: mock_error },
+      })
+      await tick()
+      expect(mock_error).toHaveBeenCalled()
+      expect(mock_error.mock.calls[0][0]).toBeInstanceOf(Error)
+    })
+
+    test(`applies custom band_colors`, async () => {
+      const fermi_data = create_mock_fermi_data([0])
+      mount(FermiSlice, {
+        target: document.body,
+        props: { fermi_data, distance: 0.05, band_colors: [`#ff0000`, `#00ff00`] },
+      })
+      await tick()
+      expect(doc_query(`path`)?.getAttribute(`stroke`)).toBe(`#ff0000`)
+    })
+  })
+})

--- a/tests/vitest/fermi-surface/FermiSlice.test.ts
+++ b/tests/vitest/fermi-surface/FermiSlice.test.ts
@@ -1,15 +1,14 @@
 // @vitest-environment happy-dom
-// Tests for FermiSlice.svelte component
+// Tests for FermiSlice.svelte component (ScatterPlot-based implementation)
 import FermiSlice from '$lib/fermi-surface/FermiSlice.svelte'
-import type { FermiSurfaceData } from '$lib/fermi-surface/types'
+import type { FermiSliceData, FermiSurfaceData } from '$lib/fermi-surface/types'
 import type { Matrix3x3, Vec3 } from '$lib/math'
-import { mount, tick } from 'svelte'
+import { createRawSnippet, mount, tick } from 'svelte'
 import { describe, expect, test, vi } from 'vitest'
 import { doc_query } from '../setup'
 
 // Create mock Fermi surface data with configurable bands
 function create_mock_fermi_data(band_indices: number[] = [0, 1]): FermiSurfaceData {
-  const identity_lattice: Matrix3x3 = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
   const vertices: Vec3[] = [
     [-0.5, -0.5, 0],
     [0.5, -0.5, 0],
@@ -20,7 +19,7 @@ function create_mock_fermi_data(band_indices: number[] = [0, 1]): FermiSurfaceDa
     [0.5, 0.5, 0.1],
     [-0.5, 0.5, 0.1],
   ]
-  const faces: number[][] = [
+  const faces = [
     [0, 1, 2],
     [0, 2, 3],
     [4, 6, 5],
@@ -42,7 +41,7 @@ function create_mock_fermi_data(band_indices: number[] = [0, 1]): FermiSurfaceDa
       band_index,
       spin: null,
     })),
-    k_lattice: identity_lattice,
+    k_lattice: [[1, 0, 0], [0, 1, 0], [0, 0, 1]] as Matrix3x3,
     fermi_energy: 0,
     reciprocal_cell: `wigner_seitz`,
     metadata: {
@@ -54,247 +53,115 @@ function create_mock_fermi_data(band_indices: number[] = [0, 1]): FermiSurfaceDa
 }
 
 describe(`FermiSlice`, () => {
-  describe(`basic rendering`, () => {
-    test(`renders container and SVG with correct class`, () => {
-      mount(FermiSlice, { target: document.body, props: {} })
-      expect(doc_query(`.fermi-slice-container`)).toBeTruthy()
-      expect(doc_query(`.fermi-slice`)).toBeTruthy()
-    })
-
-    test.each([
-      { label: `no fermi_data`, props: {}, expected: `No Fermi data` },
-      {
-        label: `no intersecting isolines`,
-        props: { fermi_data: create_mock_fermi_data([0]), distance: 10 },
-        expected: /No (isolines|slice data)/,
+  // Consolidated mounting tests for all prop combinations
+  test.each([
+    { desc: `empty props`, props: {} },
+    { desc: `single band`, props: { fermi_data: create_mock_fermi_data([0]) } },
+    { desc: `multiple bands`, props: { fermi_data: create_mock_fermi_data([0, 1, 2]) } },
+    {
+      desc: `miller x-normal`,
+      props: {
+        fermi_data: create_mock_fermi_data([0]),
+        miller_indices: [1, 0, 0] as Vec3,
       },
-    ])(`shows empty message when $label`, async ({ props, expected }) => {
-      mount(FermiSlice, { target: document.body, props })
-      await tick()
-      const empty_text = doc_query(`.empty`)
-      if (expected instanceof RegExp) {
-        expect(empty_text?.textContent?.trim()).toMatch(expected)
-      } else {
-        expect(empty_text?.textContent?.trim()).toBe(expected)
-      }
-    })
-
-    test(`renders paths with custom line_width`, async () => {
-      const fermi_data = create_mock_fermi_data([0])
-      mount(FermiSlice, {
-        target: document.body,
-        props: { fermi_data, miller_indices: [0, 0, 1], distance: 0.05, line_width: 5 },
-      })
-      await tick()
-      const paths = document.querySelectorAll(`path`)
-      expect(paths.length).toBeGreaterThan(0)
-      expect(paths[0]?.getAttribute(`stroke-width`)).toBe(`5`)
-    })
-  })
-
-  describe(`axes and labels`, () => {
-    test.each([
-      { show_axes: true, axis_count: 2, label_count: 2 },
-      { show_axes: false, axis_count: 0, label_count: 0 },
-    ])(
-      `show_axes=$show_axes renders $axis_count axes`,
-      ({ show_axes, axis_count, label_count }) => {
-        mount(FermiSlice, { target: document.body, props: { show_axes } })
-        expect(document.querySelectorAll(`.axis`).length).toBe(axis_count)
-        expect(document.querySelectorAll(`.label`).length).toBe(label_count)
+    },
+    {
+      desc: `miller y-normal`,
+      props: {
+        fermi_data: create_mock_fermi_data([0]),
+        miller_indices: [0, 1, 0] as Vec3,
       },
-    )
-
-    test.each([
-      { miller: [1, 0, 0] as Vec3, expected: [`kᵧ`, `kz`] },
-      { miller: [0, 1, 0] as Vec3, expected: [`kₓ`, `kz`] },
-      { miller: [0, 0, 1] as Vec3, expected: [`kₓ`, `kᵧ`] },
-      { miller: [1, 1, 0] as Vec3, expected: [`k⊥`, `kz`] },
-      { miller: [1, 0, 1] as Vec3, expected: [`k⊥`, `kᵧ`] },
-      { miller: [0, 1, 1] as Vec3, expected: [`k⊥`, `kₓ`] },
-      { miller: [1, 1, 1] as Vec3, expected: [`k₁`, `k₂`] },
-      {
-        miller: null,
-        labels: [`Custom X`, `Custom Y`] as [string, string],
-        expected: [`Custom X`, `Custom Y`],
+    },
+    {
+      desc: `miller z-normal`,
+      props: {
+        fermi_data: create_mock_fermi_data([0]),
+        miller_indices: [0, 0, 1] as Vec3,
       },
-    ])(`axis labels for miller=$miller`, ({ miller, labels, expected }) => {
-      mount(FermiSlice, {
-        target: document.body,
-        props: {
-          miller_indices: miller ?? undefined,
-          axis_labels: labels,
-          show_axes: true,
-        },
-      })
-      const rendered = Array.from(document.querySelectorAll(`.label`)).map((el) =>
-        el.textContent?.trim()
-      )
-      expect(rendered).toEqual(expected)
-    })
-  })
-
-  describe(`legend and band visibility`, () => {
-    test.each([
-      { show_legend: true, expected_items: 2 },
-      { show_legend: false, expected_items: 0 },
-    ])(`show_legend=$show_legend`, async ({ show_legend, expected_items }) => {
-      const fermi_data = create_mock_fermi_data([0, 1])
-      mount(FermiSlice, {
-        target: document.body,
-        props: { fermi_data, distance: 0.05, show_legend },
-      })
-      await tick()
-      const items = document.querySelectorAll(`.legend-item`)
-      expect(items.length).toBe(expected_items)
-      if (show_legend) expect(doc_query(`.legend`)).toBeTruthy()
-      else expect(document.querySelector(`.legend`)).toBeNull()
-    })
-
-    test(`legend items show 1-indexed band numbers`, async () => {
-      const fermi_data = create_mock_fermi_data([0, 2, 5])
-      mount(FermiSlice, { target: document.body, props: { fermi_data, distance: 0.05 } })
-      await tick()
-      const labels = Array.from(document.querySelectorAll(`.legend-label`)).map((el) =>
-        el.textContent?.trim()
-      )
-      expect(labels).toEqual([`Band 1`, `Band 3`, `Band 6`])
-    })
-
-    test(`clicking legend item toggles band visibility (hide and show)`, async () => {
-      const fermi_data = create_mock_fermi_data([0, 1])
-      mount(FermiSlice, { target: document.body, props: { fermi_data, distance: 0.05 } })
-      await tick()
-
-      const initial_paths = document.querySelectorAll(`path`).length
-      expect(initial_paths).toBeGreaterThan(0)
-
-      const legend_items = document.querySelectorAll<HTMLElement>(`.legend-item`)
-      legend_items[0].click()
-      await tick()
-      expect(document.querySelectorAll(`path`).length).toBeLessThan(initial_paths)
-      expect(legend_items[0].classList.contains(`hidden`)).toBe(true)
-
-      legend_items[0].click()
-      await tick()
-      expect(document.querySelectorAll(`path`).length).toBe(initial_paths)
-      expect(legend_items[0].classList.contains(`hidden`)).toBe(false)
-    })
-
-    test(`double-clicking legend item isolates that band`, async () => {
-      const fermi_data = create_mock_fermi_data([0, 1, 2])
-      mount(FermiSlice, { target: document.body, props: { fermi_data, distance: 0.05 } })
-      await tick()
-
-      const legend_items = document.querySelectorAll<HTMLElement>(`.legend-item`)
-      expect(legend_items.length).toBe(3)
-
-      legend_items[1].dispatchEvent(new MouseEvent(`dblclick`, { bubbles: true }))
-      await tick()
-      expect([...legend_items].map((el) => el.classList.contains(`hidden`))).toEqual([
-        true,
-        false,
-        true,
-      ])
-
-      legend_items[1].dispatchEvent(new MouseEvent(`dblclick`, { bubbles: true }))
-      await tick()
-      expect([...legend_items].every((el) => !el.classList.contains(`hidden`))).toBe(true)
-    })
-  })
-
-  describe(`tooltips`, () => {
-    test.each([
-      { show_tooltips: true, expect_tooltip: true },
-      { show_tooltips: false, expect_tooltip: false },
-    ])(`show_tooltips=$show_tooltips`, async ({ show_tooltips, expect_tooltip }) => {
-      const fermi_data = create_mock_fermi_data([0])
-      mount(FermiSlice, {
-        target: document.body,
-        props: { fermi_data, distance: 0.05, show_tooltips },
-      })
-      await tick()
-      const titles = document.querySelectorAll(`title`)
-      if (expect_tooltip) {
-        expect(titles.length).toBeGreaterThan(0)
-        expect(titles[0].textContent).toContain(`Band 1`)
-      } else {
-        expect(titles.length).toBe(0)
-      }
-    })
-  })
-
-  describe(`SVG attributes`, () => {
-    test.each([
-      { preserve_aspect_ratio: false, expected: `none` },
-      { preserve_aspect_ratio: true, expected: `xMidYMid meet` },
-    ])(
-      `preserveAspectRatio=$preserve_aspect_ratio → "$expected"`,
-      ({ preserve_aspect_ratio, expected }) => {
-        mount(FermiSlice, { target: document.body, props: { preserve_aspect_ratio } })
-        expect(doc_query(`.fermi-slice`)?.getAttribute(`preserveAspectRatio`)).toBe(
-          expected,
-        )
+    },
+    {
+      desc: `miller diagonal`,
+      props: {
+        fermi_data: create_mock_fermi_data([0]),
+        miller_indices: [1, 1, 1] as Vec3,
       },
-    )
-
-    test.each([
-      { has_data: true, contains: [`Fermi slice`, `isolines`, `bands`] },
-      { has_data: false, exact: `Empty Fermi slice` },
-    ])(`aria-label when has_data=$has_data`, async ({ has_data, contains, exact }) => {
-      const props = has_data
-        ? { fermi_data: create_mock_fermi_data([0, 1]), distance: 0.05 }
-        : {}
-      mount(FermiSlice, { target: document.body, props })
-      await tick()
-      const label = doc_query(`.fermi-slice`)?.getAttribute(`aria-label`)
-      if (exact) expect(label).toBe(exact)
-      else contains?.forEach((text) => expect(label).toContain(text))
-    })
+    },
+    {
+      desc: `positive distance`,
+      props: { fermi_data: create_mock_fermi_data([0]), distance: 0.05 },
+    },
+    {
+      desc: `negative distance`,
+      props: { fermi_data: create_mock_fermi_data([0]), distance: -0.05 },
+    },
+    {
+      desc: `large distance`,
+      props: { fermi_data: create_mock_fermi_data([0]), distance: 100 },
+    },
+    { desc: `show_axes=false`, props: { show_axes: false } },
+    { desc: `show_legend=false`, props: { show_legend: false } },
+    { desc: `custom line_width`, props: { line_width: 5 } },
+    { desc: `custom band_colors`, props: { band_colors: [`#ff0000`, `#00ff00`] } },
+    {
+      desc: `custom axis_labels`,
+      props: { axis_labels: [`X`, `Y`] as [string, string] },
+    },
+  ])(`mounts without error: $desc`, ({ props }) => {
+    expect(() => mount(FermiSlice, { target: document.body, props })).not.toThrow()
+    expect(doc_query(`.fermi-slice`)).toBeTruthy()
   })
 
-  describe(`legend positioning`, () => {
-    test.each(
-      [
-        { position: `top-left`, checks: [`left:`, `top:`] },
-        { position: `top-right`, checks: [`right:`, `top:`] },
-        { position: `bottom-left`, checks: [`left:`, `bottom:`] },
-        { position: `bottom-right`, checks: [`right:`, `bottom:`] },
-      ] as const,
-    )(`positions legend at $position`, async ({ position, checks }) => {
-      const fermi_data = create_mock_fermi_data([0])
-      mount(FermiSlice, {
-        target: document.body,
-        props: { fermi_data, distance: 0.05, legend_position: position },
-      })
-      await tick()
-      const style = doc_query(`.legend`)?.getAttribute(`style`) ?? ``
-      checks.forEach((check) => expect(style).toContain(check))
+  test(`on_error callback when compute_fermi_slice throws`, async () => {
+    const mock_error = vi.fn()
+    const fermi_data = create_mock_fermi_data([0])
+    fermi_data.k_lattice = [[0, 0, 0], [0, 0, 0], [0, 0, 0]] // degenerate
+    mount(FermiSlice, {
+      target: document.body,
+      props: { fermi_data, miller_indices: [1, 0, 0], on_error: mock_error },
     })
+    await tick()
+    expect(mock_error).toHaveBeenCalled()
+    expect(mock_error.mock.calls[0][0]).toBeInstanceOf(Error)
   })
 
-  describe(`error handling and custom colors`, () => {
-    test(`calls on_error when compute_fermi_slice throws`, async () => {
-      const mock_error = vi.fn()
-      const fermi_data = create_mock_fermi_data([0])
-      fermi_data.k_lattice = [[0, 0, 0], [0, 0, 0], [0, 0, 0]] // Degenerate to trigger error
-      mount(FermiSlice, {
-        target: document.body,
-        props: { fermi_data, miller_indices: [1, 0, 0], on_error: mock_error },
-      })
-      await tick()
-      expect(mock_error).toHaveBeenCalled()
-      expect(mock_error.mock.calls[0][0]).toBeInstanceOf(Error)
+  test(`passes class and style to wrapper`, () => {
+    mount(FermiSlice, {
+      target: document.body,
+      props: { class: `custom-class`, style: `background: red;` },
+    })
+    const wrapper = doc_query(`.fermi-slice`)
+    expect(wrapper.classList.contains(`custom-class`)).toBe(true)
+    expect(wrapper.getAttribute(`style`)).toContain(`background: red`)
+  })
+
+  test(`children snippet receives export_svg and slice_data`, async () => {
+    let snippet_called = false
+    let export_svg_fn: (() => string) | undefined
+    let received_slice_data: FermiSliceData | null = `not-set` as unknown as
+      | FermiSliceData
+      | null
+
+    const children_snippet = createRawSnippet<
+      [{ slice_data: FermiSliceData | null; export_svg: () => string }]
+    >((data) => {
+      snippet_called = true
+      export_svg_fn = data().export_svg
+      received_slice_data = data().slice_data
+      return { render: () => `<div class="children-rendered"></div>` }
     })
 
-    test(`applies custom band_colors`, async () => {
-      const fermi_data = create_mock_fermi_data([0])
-      mount(FermiSlice, {
-        target: document.body,
-        props: { fermi_data, distance: 0.05, band_colors: [`#ff0000`, `#00ff00`] },
-      })
-      await tick()
-      expect(doc_query(`path`)?.getAttribute(`stroke`)).toBe(`#ff0000`)
+    mount(FermiSlice, {
+      target: document.body,
+      // Cast needed: HTMLAttributes<HTMLDivElement> includes children?: Snippet<[]>
+      // which conflicts with the component's typed children prop
+      props: { children: children_snippet } as Record<string, unknown>,
     })
+    await tick()
+
+    expect(snippet_called).toBe(true)
+    expect(typeof export_svg_fn).toBe(`function`)
+    if (export_svg_fn) expect(typeof export_svg_fn()).toBe(`string`)
+    expect(document.querySelector(`.children-rendered`)).toBeTruthy()
+    expect(received_slice_data).toBeNull() // null when no fermi_data
   })
 })


### PR DESCRIPTION
- Render `FermiSlice` through the scatter-plot component with an interactive legend for toggling or isolating bands.
- Support custom band colors, axis labels, and SVG slice export.
- Standardize status-message and active multi-select styling on CSS variables for consistent theming.