### PR TITLE
Parse and display metadata from Optimade JSON files + codebase improvements

### DIFF
--- a/src/lib/api/mp.ts
+++ b/src/lib/api/mp.ts
@@ -1,6 +1,7 @@
 import { fetch_zipped } from '$lib/io/fetch'
 
-// TODO update to get MP details pages working again
+// Materials Project S3 bucket for pre-computed data (summary, similarity, robocrys)
+// Note: This bucket may be outdated. Check https://materialsproject.org for current API endpoints
 export const mp_bucket =
   `https://materialsproject-build.s3.amazonaws.com/collections/2022-10-28`
 

--- a/src/lib/api/mp.ts
+++ b/src/lib/api/mp.ts
@@ -1,7 +1,6 @@
 import { fetch_zipped } from '$lib/io/fetch'
 
-// Materials Project S3 bucket for pre-computed data (summary, similarity, robocrys)
-// Note: This bucket may be outdated. Check https://materialsproject.org for current API endpoints
+// Materials Project S3 bucket for pre-computed data (may be outdated)
 export const mp_bucket =
   `https://materialsproject-build.s3.amazonaws.com/collections/2022-10-28`
 

--- a/src/lib/element/BohrAtom.svelte
+++ b/src/lib/element/BohrAtom.svelte
@@ -7,7 +7,7 @@
     name?: string // usually Hydrogen, Helium, etc. but can be anything
     shells: number[]
     adapt_size?: boolean
-    shell_width?: number // TODO SVG is fixed so increasing this will make large atoms overflow
+    shell_width?: number
     size?: number
     base_fill?: string
     orbital_period?: number // time for inner-most electron orbit in seconds, 0 for no motion
@@ -29,9 +29,9 @@
     symbol = ``,
     name = ``,
     shells,
-    adapt_size = false,
+    adapt_size = true,
     shell_width = 20,
-    size = adapt_size ? (shells.length + 1) * 2 * shell_width + 50 : 270,
+    size = adapt_size ? (shells.length + 1) * 2 * shell_width + 30 : 270,
     base_fill = `var(--text-color)`,
     orbital_period = 3,
     nucleus_props = {},

--- a/src/lib/element/ElementTile.svelte
+++ b/src/lib/element/ElementTile.svelte
@@ -60,6 +60,16 @@
     bg_color ?? colors.category[element.category] ?? `#cccccc`,
   )
 
+  // Compute contrast text color from background when in heatmap mode (single bg_color set)
+  let computed_text_color = $derived.by(() => {
+    if (text_color) return text_color
+    // For single-color backgrounds, compute contrast color
+    if (bg_color && !Array.isArray(value)) {
+      return pick_contrast_color({ bg_color, luminance_threshold })
+    }
+    return undefined // let contrast_color action handle it
+  })
+
   // Determine if we should show the atomic number
   const should_show_number = $derived.by(() => {
     if (show_number !== undefined) return show_number
@@ -147,7 +157,6 @@
   })
 </script>
 
-<!-- TODO need a way for contrast_color() to override text_color in heatmap mode -->
 <svelte:element
   this={href ? `a` : `div`}
   bind:this={node}
@@ -158,8 +167,8 @@
   class:last-active={selected.last_element === element}
   class:clickable={Boolean(onclick)}
   style:background-color={Array.isArray(value) && bg_colors?.length > 1 ? `transparent` : fallback_bg_color}
-  style:color={text_color}
-  {@attach text_color ? null : contrast_color()}
+  style:color={computed_text_color}
+  {@attach computed_text_color ? null : contrast_color()}
   {...(href ? { role: `link`, tabindex: 0 } : {})}
   onclick={(event: MouseEvent) => onclick?.({ element, event })}
   {...rest}

--- a/src/lib/element/ElementTile.svelte
+++ b/src/lib/element/ElementTile.svelte
@@ -60,15 +60,13 @@
     bg_color ?? colors.category[element.category] ?? `#cccccc`,
   )
 
-  // Compute contrast text color from background when in heatmap mode (single bg_color set)
-  let computed_text_color = $derived.by(() => {
-    if (text_color) return text_color
-    // For single-color backgrounds, compute contrast color
-    if (bg_color && !Array.isArray(value)) {
-      return pick_contrast_color({ bg_color, luminance_threshold })
-    }
-    return undefined // let contrast_color action handle it
-  })
+  // Compute contrast text color from background when in heatmap mode (single bg_color)
+  let computed_text_color = $derived(
+    text_color ??
+      (bg_color && !Array.isArray(value)
+        ? pick_contrast_color({ bg_color, luminance_threshold })
+        : undefined),
+  )
 
   // Determine if we should show the atomic number
   const should_show_number = $derived.by(() => {

--- a/src/lib/periodic-table/PeriodicTable.svelte
+++ b/src/lib/periodic-table/PeriodicTable.svelte
@@ -150,32 +150,22 @@
     event.preventDefault() // prevent scrolling the page
     event.stopPropagation()
 
-    // change the active element in the periodic table with arrow keys
-    // handles main table (rows 1-7) plus lanthanides (row 9) and actinides (row 10)
-    const { column, row } = active_element
-    let target_row = row
-    let target_col = column
-
-    if (event.key === `ArrowUp`) {
-      // From lanthanides/actinides, go back to main table
-      if (row === 9 && column >= 3) target_row = 6
-      else if (row === 10 && column >= 3) target_row = 7
-      else target_row = row - 1
-    } else if (event.key === `ArrowDown`) {
-      // From row 6/7 column 3+, go to lanthanides/actinides
-      if (row === 6 && column >= 3 && column <= 17) target_row = 9
-      else if (row === 7 && column >= 3 && column <= 17) target_row = 10
-      else target_row = row + 1
-    } else if (event.key === `ArrowLeft`) {
-      target_col = column - 1
-    } else if (event.key === `ArrowRight`) {
-      target_col = column + 1
+    // Arrow key navigation including lanthanides (row 9) and actinides (row 10)
+    const { column: col, row } = active_element
+    const in_f_block = col >= 3 && col <= 17
+    const row_map: Record<string, number> = {
+      ArrowUp: row === 9 ? 6 : row === 10 ? 7 : row - 1,
+      ArrowDown: row === 6 && in_f_block ? 9 : row === 7 && in_f_block ? 10 : row + 1,
     }
-
+    const target_row = row_map[event.key] ?? row
+    const target_col = event.key === `ArrowLeft`
+      ? col - 1
+      : event.key === `ArrowRight`
+      ? col + 1
+      : col
     active_element =
-      element_data.find((elem) =>
-        elem.column === target_col && elem.row === target_row
-      ) ?? active_element
+      element_data.find((el) => el.column === target_col && el.row === target_row) ??
+        active_element
   }
 
   function handle_tooltip_enter(element: ChemicalElement, event: MouseEvent) {

--- a/src/lib/periodic-table/PeriodicTable.svelte
+++ b/src/lib/periodic-table/PeriodicTable.svelte
@@ -151,16 +151,31 @@
     event.stopPropagation()
 
     // change the active element in the periodic table with arrow keys
-    // TODO doesn't allow navigating to lanthanides and actinides yet
+    // handles main table (rows 1-7) plus lanthanides (row 9) and actinides (row 10)
     const { column, row } = active_element
-    active_element = element_data.find((elem) => {
-      return {
-        ArrowUp: elem.column == column && elem.row == row - 1,
-        ArrowDown: elem.column == column && elem.row == row + 1,
-        ArrowLeft: elem.column == column - 1 && elem.row == row,
-        ArrowRight: elem.column == column + 1 && elem.row == row,
-      }[event.key]
-    }) ?? active_element
+    let target_row = row
+    let target_col = column
+
+    if (event.key === `ArrowUp`) {
+      // From lanthanides/actinides, go back to main table
+      if (row === 9 && column >= 3) target_row = 6
+      else if (row === 10 && column >= 3) target_row = 7
+      else target_row = row - 1
+    } else if (event.key === `ArrowDown`) {
+      // From row 6/7 column 3+, go to lanthanides/actinides
+      if (row === 6 && column >= 3 && column <= 17) target_row = 9
+      else if (row === 7 && column >= 3 && column <= 17) target_row = 10
+      else target_row = row + 1
+    } else if (event.key === `ArrowLeft`) {
+      target_col = column - 1
+    } else if (event.key === `ArrowRight`) {
+      target_col = column + 1
+    }
+
+    active_element =
+      element_data.find((elem) =>
+        elem.column === target_col && elem.row === target_row
+      ) ?? active_element
   }
 
   function handle_tooltip_enter(element: ChemicalElement, event: MouseEvent) {

--- a/src/lib/structure/Lattice.svelte
+++ b/src/lib/structure/Lattice.svelte
@@ -80,10 +80,10 @@
     if (length === 0) { // Zero-length: no rotation; render a degenerate cylinder
       return { position: center.toArray(), rotation: [0, 0, 0], length }
     }
-    // Calculate rotation to align cylinder with the line
+    // Calculate rotation to align cylinder with the line (zero-length guarded above)
     const quaternion = new Quaternion().setFromUnitVectors(
-      new Vector3(0, 1, 0), // cylinder default orientation
-      direction.normalize(), // TODO guard against zero-length direction vector
+      new Vector3(0, 1, 0),
+      direction.normalize(),
     )
     const euler = new Euler().setFromQuaternion(quaternion)
 

--- a/src/lib/structure/StructureInfoPane.svelte
+++ b/src/lib/structure/StructureInfoPane.svelte
@@ -71,16 +71,17 @@
     ]
 
     if (`properties` in structure) {
-      for (
-        const [key, value] of Object.entries(structure.properties ?? {})
-      ) {
-        if (value != null) {
-          structure_items.push({
-            label: key.replace(/_/g, ` `).replace(/\b\w/g, (l) => l.toUpperCase()),
-            value: String(value),
-            key: `structure-prop-${key}`,
-          })
-        }
+      for (const [key, value] of Object.entries(structure.properties ?? {})) {
+        // Only display scalar values (skip arrays and objects)
+        if (value == null || typeof value === `object`) continue
+        structure_items.push({
+          label: key.replace(/_/g, ` `).replace(
+            /\b\w/g,
+            (char) => char.toUpperCase(),
+          ),
+          value: String(value),
+          key: `structure-prop-${key}`,
+        })
       }
     }
     sections.push({ title: `Structure`, items: structure_items })

--- a/src/lib/structure/index.ts
+++ b/src/lib/structure/index.ts
@@ -43,7 +43,12 @@ export type LatticeType =
   & { matrix: math.Matrix3x3; pbc: Pbc; volume: number }
   & LatticeParams
 
-export type Molecule = { sites: Site[]; charge?: number; id?: string }
+export type Molecule = {
+  sites: Site[]
+  charge?: number
+  id?: string
+  properties?: Record<string, unknown>
+}
 export type Crystal = Molecule & { lattice: LatticeType }
 export type AnyStructure = Crystal | Molecule
 

--- a/src/lib/structure/parse.ts
+++ b/src/lib/structure/parse.ts
@@ -1560,13 +1560,13 @@ export function optimade_to_crystal(
         abc = [0, 0, 0]
       }
 
-      // Extract site properties from species data
-      const spec_data = species_map.get(element_symbol)
+      // Extract mass/concentration from species data
+      const spec = species_map.get(element_symbol)
       const site_props: Record<string, unknown> = {}
-      if (spec_data?.mass?.[0]) site_props.mass = spec_data.mass[0]
-      const conc = spec_data?.concentration?.[0]
-      if (conc !== undefined && conc !== 1) site_props.concentration = conc
-
+      if (spec?.mass?.[0]) site_props.mass = spec.mass[0]
+      if (spec?.concentration?.[0] !== undefined && spec.concentration[0] !== 1) {
+        site_props.concentration = spec.concentration[0]
+      }
       return {
         species: [{ element, occu: 1, oxidation_state: 0 }],
         abc,

--- a/src/lib/structure/parse.ts
+++ b/src/lib/structure/parse.ts
@@ -1521,44 +1521,51 @@ function is_optimade_structure_object(value: unknown): value is OptimadeStructur
 export function optimade_to_crystal(
   optimade_structure: OptimadeStructure,
 ): Crystal | null {
-  const attrs = optimade_structure.attributes
+  const {
+    lattice_vectors,
+    cartesian_site_positions,
+    species_at_sites,
+    species,
+    ...properties
+  } = optimade_structure.attributes
 
-  if (
-    !attrs.lattice_vectors || !attrs.cartesian_site_positions || !attrs.species_at_sites
-  ) {
+  if (!lattice_vectors || !cartesian_site_positions || !species_at_sites) {
     console.error(`Missing required OPTIMADE structure data`)
     return null
   }
 
   try {
-    // Convert lattice vectors to matrix format
     const lattice_matrix: math.Matrix3x3 = [
-      attrs.lattice_vectors[0] as Vec3,
-      attrs.lattice_vectors[1] as Vec3,
-      attrs.lattice_vectors[2] as Vec3,
+      lattice_vectors[0] as Vec3,
+      lattice_vectors[1] as Vec3,
+      lattice_vectors[2] as Vec3,
     ]
-
-    // Use math utilities to calculate lattice parameters
     const lattice_params = math.calc_lattice_params(lattice_matrix)
 
-    // Create sites with proper fractional coordinate conversion
-    const sites = attrs.cartesian_site_positions.map((pos, idx) => {
-      const element_symbol = attrs.species_at_sites?.[idx]
-      if (!element_symbol) {
-        throw new Error(`Missing species for site ${idx}`)
-      }
+    // Build species lookup for site properties (mass, concentration, etc.)
+    const species_map = new Map(species?.map((spec) => [spec.name, spec]))
+
+    const sites = cartesian_site_positions.map((pos, idx) => {
+      const element_symbol = species_at_sites[idx]
+      if (!element_symbol) throw new Error(`Missing species for site ${idx}`)
       const element = validate_element_symbol(element_symbol, idx)
 
-      // Convert to fractional coordinates using matrix inversion
       const xyz: Vec3 = [pos[0], pos[1], pos[2]]
       let abc: Vec3
       try {
         const lattice_transposed = math.transpose_3x3_matrix(lattice_matrix)
         const inv_matrix = math.matrix_inverse_3x3(lattice_transposed)
         abc = math.mat3x3_vec3_multiply(inv_matrix, xyz)
-      } catch (err) {
-        console.warn(`Failed to convert to fractional coordinates for site ${idx}:`, err)
-        abc = [0, 0, 0] // Fallback to origin
+      } catch {
+        abc = [0, 0, 0]
+      }
+
+      // Extract site properties from species data
+      const spec_data = species_map.get(element_symbol)
+      const site_props: Record<string, unknown> = {}
+      if (spec_data?.mass?.[0]) site_props.mass = spec_data.mass[0]
+      if (spec_data?.concentration?.[0] !== 1) {
+        site_props.concentration = spec_data?.concentration?.[0]
       }
 
       return {
@@ -1566,18 +1573,15 @@ export function optimade_to_crystal(
         abc,
         xyz,
         label: `${element}${idx + 1}`,
-        properties: {},
+        properties: site_props,
       }
     })
 
     return {
       sites,
-      lattice: {
-        matrix: lattice_matrix,
-        ...lattice_params,
-        pbc: [true, true, true],
-      },
+      lattice: { matrix: lattice_matrix, ...lattice_params, pbc: [true, true, true] },
       id: optimade_structure.id,
+      properties,
     }
   } catch (err) {
     console.error(`Error converting OPTIMADE to Crystal format:`, err)

--- a/src/lib/structure/parse.ts
+++ b/src/lib/structure/parse.ts
@@ -1564,9 +1564,8 @@ export function optimade_to_crystal(
       const spec_data = species_map.get(element_symbol)
       const site_props: Record<string, unknown> = {}
       if (spec_data?.mass?.[0]) site_props.mass = spec_data.mass[0]
-      if (spec_data?.concentration?.[0] !== 1) {
-        site_props.concentration = spec_data?.concentration?.[0]
-      }
+      const conc = spec_data?.concentration?.[0]
+      if (conc !== undefined && conc !== 1) site_props.concentration = conc
 
       return {
         species: [{ element, occu: 1, oxidation_state: 0 }],

--- a/src/lib/structure/parse.ts
+++ b/src/lib/structure/parse.ts
@@ -1563,7 +1563,7 @@ export function optimade_to_crystal(
       // Extract mass/concentration from species data
       const spec = species_map.get(element_symbol)
       const site_props: Record<string, unknown> = {}
-      if (spec?.mass?.[0]) site_props.mass = spec.mass[0]
+      if (spec?.mass?.[0] !== undefined) site_props.mass = spec.mass[0]
       if (spec?.concentration?.[0] !== undefined && spec.concentration[0] !== 1) {
         site_props.concentration = spec.concentration[0]
       }


### PR DESCRIPTION
Closes #131

- Preserve structure metadata and per-site properties when importing OPTIMADE JSON.
- Extend periodic-table keyboard navigation to lanthanides and actinides and improve heatmap-tile text contrast.
- Show only non-null scalar values in the structure properties panel.
- Account for mixed-occupancy sites in RDF calculations and make atom sizing more consistent.