### PR TITLE
Wrap fractional coordinates to [0, 1) for nested `pymatgen` JSON structures

### DIFF
--- a/src/lib/coordination/CoordinationBarPlot.svelte
+++ b/src/lib/coordination/CoordinationBarPlot.svelte
@@ -13,7 +13,7 @@
   import { BarPlot } from '$lib/plot'
   import type { BondingStrategy } from '$lib/structure/bonding'
   import { parse_any_structure } from '$lib/structure/parse'
-  import { is_valid_structure } from '$lib/structure/validation'
+  import { is_crystal } from '$lib/structure/validation'
   import type { ComponentProps } from 'svelte'
   import { SvelteMap, SvelteSet } from 'svelte/reactivity'
   import { calc_coordination_nums, type CoordinationData } from './calc-coordination'
@@ -68,7 +68,7 @@
 
     const base_entries = Array.isArray(structures)
       ? (structures as StructureEntry[])
-      : (is_valid_structure(structures)
+      : (is_crystal(structures)
         ? [{ label: `Structure`, structure: structures as AnyStructure }]
         : Object.entries(
           structures as Record<
@@ -217,7 +217,7 @@
           ? new TextDecoder().decode(content)
           : content
         const parsed_structure = parse_any_structure(text_content, filename)
-        if (is_valid_structure(parsed_structure)) {
+        if (is_crystal(parsed_structure)) {
           dropped_entries = [{
             label: filename || `Dropped structure`,
             structure: parsed_structure,

--- a/src/lib/math.ts
+++ b/src/lib/math.ts
@@ -301,8 +301,8 @@ export const create_frac_to_cart = (lattice: Matrix3x3) => {
 
 // Curried Cartesian→fractional converter (caches inverse transpose)
 export const create_cart_to_frac = (lattice: Matrix3x3) => {
-  const inv_t = matrix_inverse_3x3(transpose_3x3_matrix(lattice))
-  return (cart: Vec3) => mat3x3_vec3_multiply(inv_t, cart)
+  const inv_transposed = matrix_inverse_3x3(transpose_3x3_matrix(lattice))
+  return (cart: Vec3) => mat3x3_vec3_multiply(inv_transposed, cart)
 }
 
 // Convert unit cell parameters to lattice matrix (crystallographic convention)
@@ -334,13 +334,13 @@ export function cell_to_lattice_matrix(
   )
 
   // Standard crystallographic lattice vectors
-  const c1 = c * cos_beta
-  const c2 = (c * (cos_alpha - cos_beta * cos_gamma)) / sin_gamma
-  const c3 = (c * vol_factor) / sin_gamma
+  const c_x = c * cos_beta
+  const c_y = (c * (cos_alpha - cos_beta * cos_gamma)) / sin_gamma
+  const c_z = (c * vol_factor) / sin_gamma
   return [
     [a, 0, 0],
     [b * cos_gamma, b * sin_gamma, 0],
-    [c1, c2, c3],
+    [c_x, c_y, c_z],
   ]
 }
 

--- a/src/lib/rdf/RdfPlot.svelte
+++ b/src/lib/rdf/RdfPlot.svelte
@@ -7,7 +7,7 @@
   import { ScatterPlot } from '$lib/plot'
   import type { Crystal, Pbc } from '$lib/structure'
   import { parse_any_structure } from '$lib/structure/parse'
-  import { is_valid_structure } from '$lib/structure/validation'
+  import { is_crystal } from '$lib/structure/validation'
   import type { ComponentProps, Snippet } from 'svelte'
   import { calculate_all_pair_rdfs, calculate_rdf, type RdfEntry } from './index'
 
@@ -66,7 +66,7 @@
           ? new TextDecoder().decode(content)
           : content
         const parsed_struct = parse_any_structure(text, filename)
-        if (is_valid_structure(parsed_struct)) {
+        if (is_crystal(parsed_struct)) {
           drag_dropped = [...drag_dropped, parsed_struct]
         } else error_msg = `Crystal has no lattice or sites; cannot compute RDF`
       } catch (exc) {
@@ -114,7 +114,7 @@
             label: format_structure_label(struct, `Crystal ${idx + 1}`),
           })
         )
-      } else if (is_valid_structure(structures)) {
+      } else if (is_crystal(structures)) {
         struct_list.push({
           struct: structures,
           label: format_structure_label(structures, ``),

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -8,7 +8,7 @@
   import { DEFAULTS } from '$lib/settings'
   import { colors } from '$lib/state.svelte'
   import type { Crystal } from '$lib/structure'
-  import { get_elem_amounts, get_pbc_image_sites } from '$lib/structure'
+  import { get_element_counts, get_pbc_image_sites } from '$lib/structure'
   import { is_valid_supercell_input, make_supercell } from '$lib/structure/supercell'
   import type { CellType, SymmetrySettings } from '$lib/symmetry'
   import * as symmetry from '$lib/symmetry'
@@ -879,7 +879,7 @@
     <AtomLegend
       bind:atom_color_config
       {property_colors}
-      elements={get_elem_amounts(supercell_structure ?? structure!)}
+      elements={get_element_counts(supercell_structure ?? structure!)}
       bind:hidden_elements
       bind:hidden_prop_vals
       bind:element_mapping

--- a/src/lib/structure/bonding.ts
+++ b/src/lib/structure/bonding.ts
@@ -210,30 +210,33 @@ export function electroneg_ratio(
 
   for (let idx_a = 0; idx_a < sites.length - 1; idx_a++) {
     const [x1, y1, z1] = sites[idx_a].xyz
-    const pa = props[idx_a]
+    const props_a = props[idx_a]
 
     for (const idx_b of get_candidates(sites[idx_a].xyz, sites, spatial)) {
       if (idx_b <= idx_a) continue
 
       const [x2, y2, z2] = sites[idx_b].xyz
-      const pb = props[idx_b]
+      const props_b = props[idx_b]
 
       const [dx, dy, dz] = [x2 - x1, y2 - y1, z2 - z1]
       const dist_sq = dx * dx + dy * dy + dz * dz
       const dist = Math.sqrt(dist_sq)
 
-      if (dist_sq < min_dist_sq || !pa.radius || !pb.radius) continue
+      if (dist_sq < min_dist_sq || !props_a.radius || !props_b.radius) continue
 
-      const expected = pa.radius + pb.radius
+      const expected = props_a.radius + props_b.radius
       if (dist > expected * max_distance_ratio) continue
 
-      const electroneg_diff = Math.abs(pa.electroneg - pb.electroneg)
-      const electroneg_ratio = electroneg_diff / (pa.electroneg + pb.electroneg)
+      const electroneg_diff = Math.abs(props_a.electroneg - props_b.electroneg)
+      const electroneg_ratio = electroneg_diff / (props_a.electroneg + props_b.electroneg)
 
       let bond_strength = 1.0
-      if (pa.is_metal && pb.is_metal) {
+      if (props_a.is_metal && props_b.is_metal) {
         bond_strength *= metal_metal_penalty
-      } else if ((pa.is_metal && pb.is_nonmetal) || (pa.is_nonmetal && pb.is_metal)) {
+      } else if (
+        (props_a.is_metal && props_b.is_nonmetal) ||
+        (props_a.is_nonmetal && props_b.is_metal)
+      ) {
         bond_strength *= metal_nonmetal_bonus
         if (electroneg_diff > electronegativity_threshold) bond_strength *= 1.3
       } else if (electroneg_diff < 0.5) {
@@ -244,7 +247,7 @@ export function electroneg_ratio(
       const electroneg_weight = 1.0 - 0.3 * electroneg_ratio
       let strength = bond_strength * dist_weight * electroneg_weight
 
-      if (pa.element === pb.element) strength *= same_species_penalty
+      if (props_a.element === props_b.element) strength *= same_species_penalty
 
       // If raw strength is already too low, we can skip early
       // (penalty will only reduce it further)
@@ -258,11 +261,11 @@ export function electroneg_ratio(
       // Normalized distance handles atoms of different sizes better than raw distance
       // (e.g. C-H is short but C-C is longer; we don't want C-H to penalize C-C just because H is small)
       const norm_dist = dist / expected
-      const ca = closest.get(orig_idx_a) ?? Infinity
-      if (norm_dist < ca) closest.set(orig_idx_a, norm_dist)
+      const closest_dist_a = closest.get(orig_idx_a) ?? Infinity
+      if (norm_dist < closest_dist_a) closest.set(orig_idx_a, norm_dist)
 
-      const cb = closest.get(orig_idx_b) ?? Infinity
-      if (norm_dist < cb) closest.set(orig_idx_b, norm_dist)
+      const closest_dist_b = closest.get(orig_idx_b) ?? Infinity
+      if (norm_dist < closest_dist_b) closest.set(orig_idx_b, norm_dist)
 
       potential_bonds.push({
         site_idx_1: idx_a,
@@ -288,18 +291,18 @@ export function electroneg_ratio(
       orig_idx_b,
     } = bond
 
-    const ca = closest.get(orig_idx_a) ?? Infinity
-    const cb = closest.get(orig_idx_b) ?? Infinity
+    const closest_dist_a = closest.get(orig_idx_a) ?? Infinity
+    const closest_dist_b = closest.get(orig_idx_b) ?? Infinity
     const norm_dist = dist / expected_dist
 
     let strength = base_strength
 
     // Apply penalty if this bond is much longer (relative to radii) than the closest known bond
-    if (norm_dist > ca) {
-      strength *= Math.exp(-(norm_dist / ca - 1) / 0.5)
+    if (norm_dist > closest_dist_a) {
+      strength *= Math.exp(-(norm_dist / closest_dist_a - 1) / 0.5)
     }
-    if (orig_idx_b !== orig_idx_a && norm_dist > cb) {
-      strength *= Math.exp(-(norm_dist / cb - 1) / 0.5)
+    if (orig_idx_b !== orig_idx_a && norm_dist > closest_dist_b) {
+      strength *= Math.exp(-(norm_dist / closest_dist_b - 1) / 0.5)
     }
 
     if (strength > strength_threshold) {

--- a/src/lib/structure/bonding.ts
+++ b/src/lib/structure/bonding.ts
@@ -227,22 +227,22 @@ export function electroneg_ratio(
       const expected = pa.radius + pb.radius
       if (dist > expected * max_distance_ratio) continue
 
-      const en_diff = Math.abs(pa.electroneg - pb.electroneg)
-      const en_ratio = en_diff / (pa.electroneg + pb.electroneg)
+      const electroneg_diff = Math.abs(pa.electroneg - pb.electroneg)
+      const electroneg_ratio = electroneg_diff / (pa.electroneg + pb.electroneg)
 
       let bond_strength = 1.0
       if (pa.is_metal && pb.is_metal) {
         bond_strength *= metal_metal_penalty
       } else if ((pa.is_metal && pb.is_nonmetal) || (pa.is_nonmetal && pb.is_metal)) {
         bond_strength *= metal_nonmetal_bonus
-        if (en_diff > electronegativity_threshold) bond_strength *= 1.3
-      } else if (en_diff < 0.5) {
+        if (electroneg_diff > electronegativity_threshold) bond_strength *= 1.3
+      } else if (electroneg_diff < 0.5) {
         bond_strength *= similar_electronegativity_bonus
       }
 
       const dist_weight = Math.exp(-((dist / expected - 1) ** 2) / 0.18)
-      const en_weight = 1.0 - 0.3 * en_ratio
-      let strength = bond_strength * dist_weight * en_weight
+      const electroneg_weight = 1.0 - 0.3 * electroneg_ratio
+      let strength = bond_strength * dist_weight * electroneg_weight
 
       if (pa.element === pb.element) strength *= same_species_penalty
 
@@ -347,28 +347,34 @@ export function solid_angle(
   for (let idx_a = 0; idx_a < sites.length - 1; idx_a++) {
     const [x1, y1, z1] = sites[idx_a].xyz
     const majority_a = get_majority_species(sites[idx_a])
-    const ra = majority_a.element ? covalent_radii.get(majority_a.element) : undefined
+    const radius_a = majority_a.element
+      ? covalent_radii.get(majority_a.element)
+      : undefined
 
     for (const idx_b of get_candidates(sites[idx_a].xyz, sites, spatial)) {
       if (idx_b <= idx_a) continue
 
       const [x2, y2, z2] = sites[idx_b].xyz
       const majority_b = get_majority_species(sites[idx_b])
-      const rb = majority_b.element ? covalent_radii.get(majority_b.element) : undefined
+      const radius_b = majority_b.element
+        ? covalent_radii.get(majority_b.element)
+        : undefined
 
       const [dx, dy, dz] = [x2 - x1, y2 - y1, z2 - z1]
       const dist_sq = dx * dx + dy * dy + dz * dz
       const dist = Math.sqrt(dist_sq)
 
-      if (dist_sq < min_dist_sq || dist_sq > max_dist_sq || !ra || !rb) continue
+      if (dist_sq < min_dist_sq || dist_sq > max_dist_sq || !radius_a || !radius_b) {
+        continue
+      }
 
-      const avg_r = (ra + rb) / 2.0
-      const face_area = Math.PI * avg_r * avg_r
+      const avg_radius = (radius_a + radius_b) / 2.0
+      const face_area = Math.PI * avg_radius * avg_radius
       const solid_angle = face_area / dist_sq
 
       if (solid_angle < min_solid_angle || face_area < min_face_area) continue
 
-      const dist_penalty = Math.exp(-((dist / (ra + rb) - 1) ** 2) / 0.4)
+      const dist_penalty = Math.exp(-((dist / (radius_a + radius_b) - 1) ** 2) / 0.4)
       const angle_strength = Math.min(solid_angle / (4.0 * Math.PI), 1.0)
       const strength = angle_strength * dist_penalty
 

--- a/src/lib/structure/index.ts
+++ b/src/lib/structure/index.ts
@@ -63,7 +63,7 @@ export type BondPair = {
   transform_matrix: Float32Array
 }
 
-export function get_elem_amounts(structure: AnyStructure) {
+export function get_element_counts(structure: AnyStructure) {
   const elements: CompositionType = {}
   for (const site of structure.sites) {
     for (const species of site.species) {
@@ -79,7 +79,7 @@ export function format_chemical_formula(
   sort_fn: (symbols: ElementSymbol[]) => ElementSymbol[],
 ): string {
   // concatenate elements in a structure followed by their amount
-  const elements = get_elem_amounts(structure)
+  const elements = get_element_counts(structure)
   const formula = []
   for (const el of sort_fn(Object.keys(elements) as ElementSymbol[])) {
     const amount = elements[el] ?? 0
@@ -89,7 +89,7 @@ export function format_chemical_formula(
   return formula.join(` `)
 }
 
-export function electro_neg_formula(structure: AnyStructure): string {
+export function format_formula_by_electronegativity(structure: AnyStructure): string {
   // concatenate elements in a structure followed by their amount sorted by electronegativity
   return format_chemical_formula(structure, (symbols) => (symbols.sort((el1, el2) => {
     const elec_neg1 = element_data.find((el) => el.symbol === el1)?.electronegativity ??
@@ -108,24 +108,24 @@ export const atomic_radii: CompositionType = Object.fromEntries(
 
 // unified atomic mass units (u) per cubic angstrom (Å^3)
 // to grams per cubic centimeter (g/cm^3)
-const uA3_to_gcm3 = 1.66053907
+const AMU_PER_A3_TO_G_PER_CM3 = 1.66053907
 
 export function get_density(structure: Crystal): number {
   // calculate the density of a Crystal in g/cm³
-  const elements = get_elem_amounts(structure)
+  const elements = get_element_counts(structure)
   let mass = 0
   for (const [el, amt] of Object.entries(elements)) {
     const weight = ATOMIC_WEIGHTS.get(el as ElementSymbol)
     if (weight !== undefined) mass += amt * weight
   }
-  return (uA3_to_gcm3 * mass) / structure.lattice.volume
+  return (AMU_PER_A3_TO_G_PER_CM3 * mass) / structure.lattice.volume
 }
 
-export function get_center_of_mass(struct_or_mol: AnyStructure): Vec3 {
+export function get_center_of_mass(structure: AnyStructure): Vec3 {
   let center: Vec3 = [0, 0, 0]
   let total_weight = 0
 
-  for (const site of struct_or_mol.sites) {
+  for (const site of structure.sites) {
     // Handle disordered sites by summing contributions from all species
     for (const species of site.species) {
       const atomic_weight = ATOMIC_WEIGHTS.get(species.element) ?? 1

--- a/src/lib/structure/index.ts
+++ b/src/lib/structure/index.ts
@@ -81,10 +81,10 @@ export function format_chemical_formula(
   // concatenate elements in a structure followed by their amount
   const elements = get_element_counts(structure)
   const formula = []
-  for (const el of sort_fn(Object.keys(elements) as ElementSymbol[])) {
-    const amount = elements[el] ?? 0
-    if (amount === 1) formula.push(el)
-    else formula.push(`${el}<sub>${amount}</sub>`)
+  for (const element of sort_fn(Object.keys(elements) as ElementSymbol[])) {
+    const amount = elements[element] ?? 0
+    if (amount === 1) formula.push(element)
+    else formula.push(`${element}<sub>${amount}</sub>`)
   }
   return formula.join(` `)
 }
@@ -114,9 +114,9 @@ export function get_density(structure: Crystal): number {
   // calculate the density of a Crystal in g/cm³
   const elements = get_element_counts(structure)
   let mass = 0
-  for (const [el, amt] of Object.entries(elements)) {
-    const weight = ATOMIC_WEIGHTS.get(el as ElementSymbol)
-    if (weight !== undefined) mass += amt * weight
+  for (const [element, amount] of Object.entries(elements)) {
+    const weight = ATOMIC_WEIGHTS.get(element as ElementSymbol)
+    if (weight !== undefined) mass += amount * weight
   }
   return (AMU_PER_A3_TO_G_PER_CM3 * mass) / structure.lattice.volume
 }

--- a/src/lib/structure/validation.ts
+++ b/src/lib/structure/validation.ts
@@ -1,6 +1,6 @@
 import type { Crystal } from './index'
 
-export function is_valid_structure(obj: unknown): obj is Crystal {
+export function is_crystal(obj: unknown): obj is Crystal {
   if (obj === null || typeof obj !== `object`) return false
   const input = obj as Record<string, unknown>
   const has_sites = Array.isArray(input.sites) && input.sites.length > 0

--- a/src/lib/xrd/calc-xrd.ts
+++ b/src/lib/xrd/calc-xrd.ts
@@ -230,8 +230,8 @@ export function compute_xrd_pattern(
     // asin domain can exceed 1 by FP error — clamp to avoid NaN
     const clamped_asin_arg = Math.min(1, Math.max(-1, asin_arg))
     const theta = Math.asin(clamped_asin_arg)
-    const s_val = g_norm / 2
-    const s_sq = s_val * s_val
+    const sin_theta_over_lambda = g_norm / 2
+    const sin_theta_over_lambda_sq = sin_theta_over_lambda * sin_theta_over_lambda
 
     // g.r for all fractional coords
     const g_dot_r_all = frac_coords.map((frac_coord) =>
@@ -244,11 +244,17 @@ export function compute_xrd_pattern(
       const num_terms = Math.min(a_arr.length, b_arr.length)
       const sum_terms = a_arr
         .slice(0, num_terms)
-        .reduce((sum, a_i, term_idx) => sum + a_i * Math.exp(-b_arr[term_idx] * s_sq), 0)
+        .reduce(
+          (sum, a_i, term_idx) =>
+            sum + a_i * Math.exp(-b_arr[term_idx] * sin_theta_over_lambda_sq),
+          0,
+        )
       return sum_terms + (coeff_entry.c ?? 0)
     })
 
-    const dw_corr: number[] = dw_factors.map((dw_b) => Math.exp(-dw_b * s_sq))
+    const dw_corr: number[] = dw_factors.map((dw_b) =>
+      Math.exp(-dw_b * sin_theta_over_lambda_sq)
+    )
 
     // Structure factor sum: sum(fs * occu * exp(2πi g·r) * DW)
     const { real: f_real, imag: f_imag } = f_scattering.reduce(

--- a/src/lib/xrd/calc-xrd.ts
+++ b/src/lib/xrd/calc-xrd.ts
@@ -3,7 +3,7 @@ import { element_data } from '$lib/element'
 import * as math from '$lib/math'
 import type { Crystal } from '$lib/structure/index'
 import { parse_any_structure } from '$lib/structure/parse'
-import { is_valid_structure } from '$lib/structure/validation'
+import { is_crystal } from '$lib/structure/validation'
 // copied from pymatgen/analysis/diffraction/atomic_scattering_params.json
 import { ATOMIC_SCATTERING_PARAMS } from './atomic-scattering-params'
 import type {
@@ -377,7 +377,7 @@ export async function add_xrd_pattern(
       ? content
       : new TextDecoder().decode(content as BufferSource)
     const parsed_structure = parse_any_structure(text_content, filename)
-    if (is_valid_structure(parsed_structure)) {
+    if (is_crystal(parsed_structure)) {
       const pattern = compute_xrd_pattern(parsed_structure, {
         wavelength: typeof wavelength === `number` ? wavelength : undefined,
       })

--- a/tests/vitest/structure/index.test.ts
+++ b/tests/vitest/structure/index.test.ts
@@ -12,7 +12,7 @@ const ref_data: Record<
     density: number
     center_of_mass: Vec3
     elements: string[]
-    electro_neg_formula: string
+    formula_by_electronegativity: string
   }
 > = {
   'mp-1': {
@@ -20,49 +20,50 @@ const ref_data: Record<
     density: 1.8019302505603234,
     center_of_mass: [1.564, 1.564, 1.564],
     elements: [`Cs`],
-    electro_neg_formula: `Cs<sub>2</sub>`,
+    formula_by_electronegativity: `Cs<sub>2</sub>`,
   },
   'mp-2': {
     amounts: { Pd: 4 },
     density: 11.759135742447171,
     center_of_mass: [0.979, 0.979, 0.979],
     elements: [`Pd`],
-    electro_neg_formula: `Pd<sub>4</sub>`,
+    formula_by_electronegativity: `Pd<sub>4</sub>`,
   },
   'mp-1234': {
     amounts: { Lu: 8, Al: 16 },
     density: 6.63,
     center_of_mass: [3.119, 3.119, 3.119],
     elements: [`Al`, `Lu`],
-    electro_neg_formula: `Lu<sub>8</sub> Al<sub>16</sub>`,
+    formula_by_electronegativity: `Lu<sub>8</sub> Al<sub>16</sub>`,
   },
   'mp-30855': {
     amounts: { U: 2, Pt: 6 },
     density: 19.14,
     center_of_mass: [3.535, 3.535, 3.535],
     elements: [`Pt`, `U`],
-    electro_neg_formula: `U<sub>2</sub> Pt<sub>6</sub>`,
+    formula_by_electronegativity: `U<sub>2</sub> Pt<sub>6</sub>`,
   },
   'mp-756175': {
     amounts: { Zr: 16, Bi: 16, O: 56 },
     density: 7.457890165317997,
     center_of_mass: [5.261, 5.261, 5.261],
     elements: [`Bi`, `O`, `Zr`],
-    electro_neg_formula: `Zr<sub>16</sub> Bi<sub>16</sub> O<sub>56</sub>`,
+    formula_by_electronegativity: `Zr<sub>16</sub> Bi<sub>16</sub> O<sub>56</sub>`,
   },
   'mp-1229155': {
     amounts: { Ag: 4, Hg: 4, S: 4, Br: 1, Cl: 3 },
     density: 6.107930572082895,
     center_of_mass: [2.216, 3.594, 6.502],
     elements: [`Ag`, `Br`, `Cl`, `Hg`, `S`],
-    electro_neg_formula: `Ag<sub>4</sub> Hg<sub>4</sub> S<sub>4</sub> Br Cl<sub>3</sub>`,
+    formula_by_electronegativity:
+      `Ag<sub>4</sub> Hg<sub>4</sub> S<sub>4</sub> Br Cl<sub>3</sub>`,
   },
   'mp-1229168': {
     amounts: { Al: 54, Fe: 4, Ni: 8 },
     density: 3.6567149052096903,
     center_of_mass: [1.802, 2.991, 12.542],
     elements: [`Al`, `Fe`, `Ni`],
-    electro_neg_formula: `Al<sub>54</sub> Fe<sub>4</sub> Ni<sub>8</sub>`,
+    formula_by_electronegativity: `Al<sub>54</sub> Fe<sub>4</sub> Ni<sub>8</sub>`,
   },
 }
 
@@ -75,9 +76,9 @@ describe.each(structures)(`structure-utils`, (structure) => {
   const expected = id ? ref_data[id] : undefined
 
   test.runIf(id && id in ref_data)(
-    `get_elem_amount should return the correct element amounts for a given structure`,
+    `get_element_counts should return the correct element amounts for a given structure`,
     () => {
-      const result = struct_utils.get_elem_amounts(structure)
+      const result = struct_utils.get_element_counts(structure)
       expect(JSON.stringify(result), id).toBe(JSON.stringify(expected?.amounts))
     },
   )
@@ -105,9 +106,9 @@ test.each(structures.filter((struct) => struct.id && ref_data[struct.id]))(
     ).toEqual(expected_data.center_of_mass)
 
     // Electronegativity formula
-    const electro_formula = struct_utils.electro_neg_formula(struct)
-    expect(electro_formula, `${struct.id} electro_neg_formula`).toEqual(
-      expected_data.electro_neg_formula,
+    const electro_formula = struct_utils.format_formula_by_electronegativity(struct)
+    expect(electro_formula, `${struct.id} formula_by_electronegativity`).toEqual(
+      expected_data.formula_by_electronegativity,
     )
   },
 )

--- a/tests/vitest/structure/validation.test.ts
+++ b/tests/vitest/structure/validation.test.ts
@@ -1,7 +1,7 @@
-import { is_valid_structure } from '$lib/structure/validation'
+import { is_crystal } from '$lib/structure/validation'
 import { describe, expect, test } from 'vitest'
 
-describe(`is_valid_structure`, () => {
+describe(`is_crystal`, () => {
   test.each([
     // Valid
     {
@@ -27,6 +27,6 @@ describe(`is_valid_structure`, () => {
       label: `lattice string`,
     },
   ])(`$label → $expected`, ({ input, expected }) => {
-    expect(is_valid_structure(input)).toBe(expected)
+    expect(is_crystal(input)).toBe(expected)
   })
 })


### PR DESCRIPTION
- Normalize fractional coordinates into `[0, 1)` and recompute Cartesian coordinates, including for nested and multi-frame pymatgen JSON structures.
- Add periodic-boundary metadata whenever a lattice is present.
- Restrict affected parsing, plotting, and XRD paths to crystal structures so they receive consistent inputs.