### PR TITLE
Add arcsinh scale for 2D plots

### DIFF
--- a/src/lib/plot/BarPlot.svelte
+++ b/src/lib/plot/BarPlot.svelte
@@ -26,6 +26,7 @@
     UserContentProps,
     XyObj,
   } from '$lib/plot'
+  import { get_scale_type_name } from '$lib/plot/types'
   import {
     BarPlotControls,
     find_best_plot_area,
@@ -243,7 +244,7 @@
     const calc_y_range = (
       series_list: typeof visible_series,
       y_limit: typeof y_range,
-      scale_type: string,
+      scale_type: ScaleType,
     ) => {
       let points = series_list.flatMap((srs: BarSeries<Metadata>) =>
         srs.x.map((x_val, idx) => ({ x: x_val, y: srs.y[idx] }))
@@ -286,14 +287,15 @@
         points,
         (pt) => pt.y,
         y_limit,
-        scale_type as `linear` | `log`,
+        scale_type,
         range_padding,
         false,
       )
 
       // For bar plots, ensure the value axis starts at 0 unless there are negative values
-      // Only apply zero-clamping for linear scales
-      if (scale_type === `linear`) {
+      // Only apply zero-clamping for linear and arcsinh scales (not log)
+      const type_name = get_scale_type_name(scale_type)
+      if (type_name === `linear` || type_name === `arcsinh`) {
         const has_negative = points.some((pt) => pt.y < 0)
         const has_positive = points.some((pt) => pt.y > 0)
 
@@ -1179,15 +1181,17 @@
 
       <!-- Clipped content: zero lines, bars, and lines -->
       <g clip-path="url(#{clip_path_id})">
-        <!-- Zero lines -->
-        {#if display.x_zero_line && (x_axis.scale_type ?? `linear`) === `linear` &&
+        <!-- Zero lines (shown for linear and arcsinh scales, not log) -->
+        {#if display.x_zero_line &&
+          get_scale_type_name(x_axis.scale_type) !== `log` &&
           ranges.current.x[0] <= 0 && ranges.current.x[1] >= 0}
           {@const zx = scales.x(0)}
           {#if isFinite(zx)}
             <line class="zero-line" x1={zx} x2={zx} y1={pad.t} y2={height - pad.b} />
           {/if}
         {/if}
-        {#if display.y_zero_line && (y_axis.scale_type ?? `linear`) === `linear` &&
+        {#if display.y_zero_line &&
+          get_scale_type_name(y_axis.scale_type) !== `log` &&
           ranges.current.y[0] <= 0 && ranges.current.y[1] >= 0}
           {@const zy = scales.y(0)}
           {#if isFinite(zy)}
@@ -1195,7 +1199,7 @@
           {/if}
         {/if}
         {#if display.y_zero_line && y2_series.length > 0 &&
-          (y2_axis.scale_type ?? `linear`) === `linear` &&
+          get_scale_type_name(y2_axis.scale_type) !== `log` &&
           ranges.current.y2[0] <= 0 && ranges.current.y2[1] >= 0}
           {@const zero_y2 = scales.y2(0)}
           {#if isFinite(zero_y2)}

--- a/src/lib/plot/BarPlot.svelte
+++ b/src/lib/plot/BarPlot.svelte
@@ -26,7 +26,6 @@
     UserContentProps,
     XyObj,
   } from '$lib/plot'
-  import { get_scale_type_name } from '$lib/plot/types'
   import {
     BarPlotControls,
     find_best_plot_area,
@@ -51,7 +50,11 @@
     generate_ticks,
     get_nice_data_range,
   } from '$lib/plot/scales'
-  import { DEFAULT_GRID_STYLE, DEFAULT_MARKERS } from '$lib/plot/types'
+  import {
+    DEFAULT_GRID_STYLE,
+    DEFAULT_MARKERS,
+    get_scale_type_name,
+  } from '$lib/plot/types'
   import { DEFAULTS } from '$lib/settings'
   import { extent } from 'd3-array'
   import type { Snippet } from 'svelte'

--- a/src/lib/plot/ColorBar.svelte
+++ b/src/lib/plot/ColorBar.svelte
@@ -140,7 +140,7 @@
 
     // For arcsinh, use our custom scale
     if (type_name === `arcsinh`) {
-      // Guard against invalid/non-positive threshold to prevent Infinity/NaN from asinh(x/0)
+      // Guard against very small thresholds that could cause precision issues
       const threshold = Math.max(get_arcsinh_threshold(scale_type), Number.EPSILON)
       const scale = scale_arcsinh(threshold)
         .domain([scale_min, scale_max])
@@ -179,7 +179,7 @@
 
     // Arcsinh tick generation
     if (type_name === `arcsinh`) {
-      // Guard against invalid/non-positive threshold to prevent Infinity/NaN
+      // Guard against very small thresholds that could cause precision issues
       const threshold = Math.max(get_arcsinh_threshold(scale_type), Number.EPSILON)
       return generate_arcsinh_ticks(scale_min, scale_max, threshold, n_ticks)
     }
@@ -306,7 +306,7 @@
 
     // For arcsinh, create a custom color scale
     if (type_name === `arcsinh`) {
-      // Guard against invalid/non-positive threshold to prevent Infinity/NaN from asinh(x/0)
+      // Guard against very small thresholds that could cause precision issues
       const threshold = Math.max(get_arcsinh_threshold(scale_type), Number.EPSILON)
       const t_min = Math.asinh(lo / threshold)
       const t_max = Math.asinh(hi / threshold)
@@ -364,7 +364,7 @@
       log_max = Math.log10(adjusted_max_ramp)
       log_span = log_max - log_min
     } else if (type_name === `arcsinh`) {
-      // Guard against invalid/non-positive threshold to prevent Infinity/NaN from asinh(x/0)
+      // Guard against very small thresholds that could cause precision issues
       asinh_threshold = Math.max(get_arcsinh_threshold(scale_type), Number.EPSILON)
       asinh_min = Math.asinh(min_ramp_domain / asinh_threshold)
       asinh_max = Math.asinh(max_ramp_domain / asinh_threshold)

--- a/src/lib/plot/Histogram.svelte
+++ b/src/lib/plot/Histogram.svelte
@@ -226,6 +226,13 @@
           max(hist(srs.y), (data) => data.length) || 0
         ),
       )
+
+      // If there's effectively no data, avoid log-range issues (counts can't be <= 0 on log)
+      if (max_count <= 0) {
+        const fallback = type_name === `log` ? 1 : 0
+        return [fallback, 1] as Vec2
+      }
+
       const [y0, y1] = get_nice_data_range(
         [{ x: 0, y: 0 }, { x: max_count, y: 0 }],
         ({ x }) => x,

--- a/src/lib/plot/Histogram.svelte
+++ b/src/lib/plot/Histogram.svelte
@@ -1051,7 +1051,7 @@
         <line class="zero-line" x1={pad.l} x2={width - pad.r} y1={zero_y} y2={zero_y} />
       {/if}
     {/if}
-    {#if (display.y_zero_line) && y2_series.length > 0 &&
+    {#if display.y_zero_line && y2_series.length > 0 &&
         get_scale_type_name(final_y2_axis.scale_type) !== `log` &&
         ranges.current.y2[0] <= 0 && ranges.current.y2[1] >= 0}
       {@const zero_y2 = scales.y2(0)}

--- a/src/lib/plot/Line.svelte
+++ b/src/lib/plot/Line.svelte
@@ -37,8 +37,12 @@
   let [x_min, x_max] = $derived(extent(points.map((p) => p[0])))
   let line_path = $derived(lineGenerator(points) ?? ``)
   let ymin = $derived(origin[1] ?? min(points.map((p) => p[1])))
+  // Guard against NaN/Infinity in area_path coords (can happen during scale transitions)
   let area_path = $derived(
-    line_path ? `${line_path}L${x_max},${ymin}L${x_min},${ymin}Z` : ``,
+    line_path && isFinite(x_min ?? NaN) && isFinite(x_max ?? NaN) &&
+      isFinite(ymin ?? NaN)
+      ? `${line_path}L${x_max},${ymin}L${x_min},${ymin}Z`
+      : ``,
   )
 
   const default_tween = {

--- a/src/lib/plot/PlotControls.svelte
+++ b/src/lib/plot/PlotControls.svelte
@@ -6,6 +6,8 @@
   import { timeFormat } from 'd3-time-format'
   import type { Vec2 } from '../math'
   import type { AxisKey, PlotControlsProps } from './index'
+  import type { ScaleTypeName } from './types'
+  import { get_scale_type_name } from './types'
 
   let {
     show_controls = $bindable(false),
@@ -252,6 +254,61 @@
         </label>
       </SettingsSection>
     {/if}
+
+    <!-- Scale Type controls -->
+    <SettingsSection
+      title="Scale Type"
+      current_values={{
+        x_scale: get_scale_type_name(x_axis.scale_type),
+        y_scale: get_scale_type_name(y_axis.scale_type),
+        y2_scale: get_scale_type_name(y2_axis.scale_type),
+      }}
+      on_reset={() => {
+        x_axis.scale_type = `linear`
+        y_axis.scale_type = `linear`
+        y2_axis.scale_type = `linear`
+      }}
+      style="display: flex; flex-wrap: wrap; gap: 1ex"
+    >
+      <label>X:
+        <select
+          value={get_scale_type_name(x_axis.scale_type)}
+          onchange={(e) => {
+            x_axis.scale_type = e.currentTarget.value as ScaleTypeName
+          }}
+        >
+          <option value="linear">Linear</option>
+          <option value="log">Log</option>
+          <option value="arcsinh">Arcsinh</option>
+        </select>
+      </label>
+      <label>Y:
+        <select
+          value={get_scale_type_name(y_axis.scale_type)}
+          onchange={(e) => {
+            y_axis.scale_type = e.currentTarget.value as ScaleTypeName
+          }}
+        >
+          <option value="linear">Linear</option>
+          <option value="log">Log</option>
+          <option value="arcsinh">Arcsinh</option>
+        </select>
+      </label>
+      {#if has_y2_points}
+        <label>Y2:
+          <select
+            value={get_scale_type_name(y2_axis.scale_type)}
+            onchange={(e) => {
+              y2_axis.scale_type = e.currentTarget.value as ScaleTypeName
+            }}
+          >
+            <option value="linear">Linear</option>
+            <option value="log">Log</option>
+            <option value="arcsinh">Arcsinh</option>
+          </select>
+        </label>
+      {/if}
+    </SettingsSection>
 
     <!-- Base Tick Format controls -->
     <SettingsSection

--- a/src/lib/plot/ScatterPlot.svelte
+++ b/src/lib/plot/ScatterPlot.svelte
@@ -1761,8 +1761,7 @@
       {/if}
       {#if final_display.y_zero_line &&
         get_scale_type_name(final_y_axis.scale_type) !== `log` &&
-        y_min <= 0 &&
-        y_max >= 0}
+        y_min <= 0 && y_max >= 0}
         {@const zero_y_pos = y_scale_fn(0)}
         {#if isFinite(zero_y_pos)}
           <line

--- a/src/lib/plot/scales.ts
+++ b/src/lib/plot/scales.ts
@@ -2,6 +2,7 @@ import type { D3ColorSchemeName, D3InterpolateName } from '$lib/colors'
 import type { Vec2 } from '$lib/math'
 import * as math from '$lib/math'
 import type { Point, ScaleType, TimeInterval } from '$lib/plot'
+import { get_arcsinh_threshold, get_scale_type_name } from '$lib/plot/types'
 import { extent, range } from 'd3-array'
 import type { ScaleContinuousNumeric, ScaleTime } from 'd3-scale'
 import {
@@ -16,16 +17,216 @@ import * as d3_sc from 'd3-scale-chromatic'
 // Type for ticks parameter - can be count, array of values, time interval, or object mapping values to labels
 export type TicksOption = number | number[] | TimeInterval | Record<number, string>
 
+// --- Arcsinh Scale Implementation ---
+// The arcsinh scale provides smooth transition between linear (near zero) and
+// logarithmic (for large |x|) behavior. Unlike log, it handles negative values.
+// Formula: y = asinh(x / threshold) = ln(x/c + sqrt((x/c)² + 1))
+
+// Interface for arcsinh scale (D3-compatible)
+// Accepts both number and Date for compatibility with time-based data
+export interface ArcsinhScale {
+  (value: number | Date): number
+  domain(): [number, number]
+  domain(domain: [number, number]): ArcsinhScale
+  range(): [number, number]
+  range(range: [number, number]): ArcsinhScale
+  invert(value: number): number
+  copy(): ArcsinhScale
+  ticks(count?: number): number[]
+  threshold: number
+}
+
+// Union type for all scale functions used in plots
+export type PlotScaleFn =
+  | ScaleContinuousNumeric<number, number>
+  | ScaleTime<number, number>
+  | ArcsinhScale
+
+// Create an arcsinh scale with configurable threshold
+export function scale_arcsinh(threshold = 1): ArcsinhScale {
+  let _domain: [number, number] = [0, 1]
+  let _range: [number, number] = [0, 1]
+
+  // Forward transform: data value → arcsinh-space
+  const arcsinh_transform = (x: number): number => Math.asinh(x / threshold)
+
+  // Inverse transform: arcsinh-space → data value
+  const sinh_transform = (y: number): number => Math.sinh(y) * threshold
+
+  // Map from data domain to output range
+  // Accepts Date for compatibility with D3 time scales
+  const scale = ((value: number | Date): number => {
+    const num_value = value instanceof Date ? value.getTime() : value
+    const [d_min, d_max] = _domain
+    const [r_min, r_max] = _range
+
+    // Transform domain endpoints
+    const t_min = arcsinh_transform(d_min)
+    const t_max = arcsinh_transform(d_max)
+
+    // Transform input value
+    const t_val = arcsinh_transform(num_value)
+
+    // Linear interpolation in transformed space
+    if (t_max === t_min) return (r_min + r_max) / 2
+    const t = (t_val - t_min) / (t_max - t_min)
+    return r_min + t * (r_max - r_min)
+  }) as ArcsinhScale
+
+  // Domain getter/setter
+  scale.domain = function (domain?: [number, number]): [number, number] | ArcsinhScale {
+    if (domain === undefined) return _domain
+    _domain = domain
+    return scale
+  } as ArcsinhScale[`domain`]
+
+  // Range getter/setter
+  scale.range = function (range?: [number, number]): [number, number] | ArcsinhScale {
+    if (range === undefined) return _range
+    _range = range
+    return scale
+  } as ArcsinhScale[`range`]
+
+  // Invert: screen position → data value
+  scale.invert = (value: number): number => {
+    const [d_min, d_max] = _domain
+    const [r_min, r_max] = _range
+
+    // Transform domain endpoints
+    const t_min = arcsinh_transform(d_min)
+    const t_max = arcsinh_transform(d_max)
+
+    // Inverse linear interpolation
+    if (r_max === r_min) return (d_min + d_max) / 2
+    const t = (value - r_min) / (r_max - r_min)
+    const t_val = t_min + t * (t_max - t_min)
+
+    // Inverse transform
+    return sinh_transform(t_val)
+  }
+
+  // Copy the scale
+  scale.copy = (): ArcsinhScale => {
+    const copy = scale_arcsinh(threshold)
+    copy.domain(_domain)
+    copy.range(_range)
+    return copy
+  }
+
+  // Generate nice ticks for arcsinh scale
+  scale.ticks = (count = 10): number[] => {
+    return generate_arcsinh_ticks(_domain[0], _domain[1], threshold, count)
+  }
+
+  scale.threshold = threshold
+
+  return scale
+}
+
+// Generate nice tick values for arcsinh scale
+// Strategy: symmetric around zero when possible, with powers of 10 for large values
+export function generate_arcsinh_ticks(
+  min: number,
+  max: number,
+  threshold = 1,
+  count = 10,
+): number[] {
+  // For purely positive or purely negative ranges, use log-like spacing
+  if (min >= 0) {
+    return generate_positive_arcsinh_ticks(min, max, threshold, count)
+  }
+  if (max <= 0) {
+    // Negative range: mirror the positive logic
+    return generate_positive_arcsinh_ticks(-max, -min, threshold, count)
+      .map((t) => -t)
+      .reverse()
+  }
+
+  // Mixed range: symmetric ticks around zero (includes_zero is always true here)
+  const half_count = Math.floor((count - 1) / 2)
+  const ticks: number[] = [0]
+
+  // Add positive ticks
+  const pos_ticks = generate_positive_arcsinh_ticks(0, max, threshold, half_count)
+  ticks.push(...pos_ticks.filter((t) => t > 0))
+
+  // Add negative ticks (mirror of positive)
+  const neg_ticks = generate_positive_arcsinh_ticks(0, -min, threshold, half_count)
+  ticks.push(...neg_ticks.filter((t) => t > 0).map((t) => -t))
+
+  // Sort and dedupe
+  return [...new Set(ticks)].sort((a, b) => a - b)
+}
+
+// Generate positive arcsinh ticks (helper)
+function generate_positive_arcsinh_ticks(
+  min: number,
+  max: number,
+  threshold: number,
+  count: number,
+): number[] {
+  if (count <= 0 || max <= min) return []
+
+  const ticks: number[] = []
+
+  // For values near threshold, use linear-like spacing
+  // For values >> threshold, use log-like spacing (powers of 10)
+
+  if (max <= threshold * 2) {
+    // Small range: use linear ticks
+    const step = (max - min) / count
+    for (let idx = 0; idx <= count; idx++) {
+      const val = min + step * idx
+      if (val >= min && val <= max) ticks.push(val)
+    }
+  } else {
+    // Large range: combine linear near zero with powers of 10
+
+    // Add threshold as a tick if in range
+    if (threshold >= min && threshold <= max) ticks.push(threshold)
+
+    // Add powers of 10 that are in range
+    const min_power = Math.floor(Math.log10(Math.max(min, threshold / 10)))
+    const max_power = Math.ceil(Math.log10(max))
+
+    for (let power = min_power; power <= max_power; power++) {
+      const val = Math.pow(10, power)
+      if (val >= min && val <= max) ticks.push(val)
+    }
+
+    // Add intermediate values (2x, 5x) for sparser regions
+    if (ticks.length < count) {
+      for (let power = min_power; power < max_power; power++) {
+        const base = Math.pow(10, power)
+        for (const mult of [2, 5]) {
+          const val = base * mult
+          if (val >= min && val <= max) ticks.push(val)
+        }
+      }
+    }
+  }
+
+  // Sort and dedupe
+  return [...new Set(ticks)].sort((a, b) => a - b)
+}
+
 // Create a scale function based on type, domain, and range
 export function create_scale(
   scale_type: ScaleType,
   domain: [number, number],
   range: [number, number],
-) {
+): ScaleContinuousNumeric<number, number> | ArcsinhScale {
   const [min_val, max_val] = domain
-  return scale_type === `log`
-    ? scaleLog().domain([Math.max(min_val, math.LOG_EPS), max_val]).range(range)
-    : scaleLinear().domain(domain).range(range)
+  const type_name = get_scale_type_name(scale_type)
+
+  if (type_name === `log`) {
+    return scaleLog().domain([Math.max(min_val, math.LOG_EPS), max_val]).range(range)
+  }
+  if (type_name === `arcsinh`) {
+    const threshold = get_arcsinh_threshold(scale_type)
+    return scale_arcsinh(threshold).domain(domain).range(range)
+  }
+  return scaleLinear().domain(domain).range(range)
 }
 
 // Create a time scale for time-based data
@@ -43,7 +244,7 @@ export function generate_ticks(
   domain: [number, number],
   scale_type: ScaleType,
   ticks_option: TicksOption | undefined,
-  scale_fn: ScaleContinuousNumeric<number, number> | ScaleTime<number, number>, // D3 scale function with .ticks() method
+  scale_fn: PlotScaleFn, // D3 scale function with .ticks() method
   options: {
     format?: string // For detecting time format
     default_count?: number // Default tick count
@@ -93,8 +294,19 @@ export function generate_ticks(
     return ticks.map((d: Date) => d.getTime())
   }
 
+  const type_name = get_scale_type_name(scale_type)
+
   // Log scale ticks
-  if (scale_type === `log`) return generate_log_ticks(min_val, max_val, ticks_option)
+  if (type_name === `log`) return generate_log_ticks(min_val, max_val, ticks_option)
+
+  // Arcsinh scale ticks
+  if (type_name === `arcsinh`) {
+    const threshold = get_arcsinh_threshold(scale_type)
+    const tick_count = typeof ticks_option === `number` && ticks_option > 0
+      ? ticks_option
+      : default_count
+    return generate_arcsinh_ticks(min_val, max_val, threshold, tick_count)
+  }
 
   // Linear scale with interval (negative number indicates interval)
   if (typeof ticks_option === `number` && ticks_option < 0) {
@@ -120,7 +332,10 @@ export function calculate_domain(
   const [min_val, max_val] = extent(values)
   if (min_val === undefined || max_val === undefined) return [0, 1]
 
-  return scale_type === `log`
+  const type_name = get_scale_type_name(scale_type)
+  // Only log scale needs domain clamping to positive values
+  // Arcsinh and linear can handle any values
+  return type_name === `log`
     ? [Math.max(min_val, math.LOG_EPS), max_val]
     : [min_val, max_val]
 }
@@ -138,6 +353,7 @@ export function get_nice_data_range(
   const [min_ext, max_ext] = extent(points, get_value)
   let data_min = min ?? min_ext ?? 0
   let data_max = max ?? max_ext ?? 1
+  const type_name = get_scale_type_name(scale_type)
 
   // Apply padding *only if* limits were NOT provided
   if (min === null && max === null && points.length > 0) {
@@ -148,12 +364,20 @@ export function get_nice_data_range(
         const padding_ms = span * padding_factor
         data_min = data_min - padding_ms
         data_max = data_max + padding_ms
-      } else if (scale_type === `log`) {
+      } else if (type_name === `log`) {
         const log_min = Math.log10(Math.max(data_min, math.LOG_EPS))
         const log_max = Math.log10(Math.max(data_max, math.LOG_EPS))
         const log_span = log_max - log_min
         data_min = Math.pow(10, log_min - log_span * padding_factor)
         data_max = Math.pow(10, log_max + log_span * padding_factor)
+      } else if (type_name === `arcsinh`) {
+        // Arcsinh: apply padding in arcsinh-transformed space
+        const threshold = get_arcsinh_threshold(scale_type)
+        const asinh_min = Math.asinh(data_min / threshold)
+        const asinh_max = Math.asinh(data_max / threshold)
+        const asinh_span = asinh_max - asinh_min
+        data_min = Math.sinh(asinh_min - asinh_span * padding_factor) * threshold
+        data_max = Math.sinh(asinh_max + asinh_span * padding_factor) * threshold
       } else {
         // Linear scale
         const padding_abs = span * padding_factor
@@ -166,9 +390,16 @@ export function get_nice_data_range(
         const one_day = 86_400_000 // milliseconds in a day
         data_min = data_min - one_day
         data_max = data_max + one_day
-      } else if (scale_type === `log`) {
+      } else if (type_name === `log`) {
         data_min = Math.max(math.LOG_EPS, data_min / 1.1) // 10% multiplicative padding
         data_max = data_max * 1.1
+      } else if (type_name === `arcsinh`) {
+        // Arcsinh: 10% padding in transformed space
+        const threshold = get_arcsinh_threshold(scale_type)
+        const asinh_val = Math.asinh(data_min / threshold)
+        const padding = Math.abs(asinh_val) * 0.1 || 0.1 // Use 0.1 if value is 0
+        data_min = Math.sinh(asinh_val - padding) * threshold
+        data_max = Math.sinh(asinh_val + padding) * threshold
       } else {
         const padding_abs = data_min === 0 ? 1 : Math.abs(data_min * 0.1) // 10% additive padding, or 1 if value is 0
         data_min = data_min - padding_abs
@@ -181,8 +412,13 @@ export function get_nice_data_range(
   if (is_time || data_min === data_max) return [data_min, data_max]
 
   // Use D3's nice() to create pretty boundaries
+  // For arcsinh, we don't use D3's nice() - just return padded domain
+  if (type_name === `arcsinh`) {
+    return [data_min, data_max]
+  }
+
   // Create the scale with the *padded* data domain
-  const scale = scale_type === `log`
+  const scale = type_name === `log`
     ? scaleLog().domain([
       Math.max(data_min, math.LOG_EPS),
       Math.max(data_max, data_min * 1.1),
@@ -274,12 +510,45 @@ export function create_color_scale(
     ? undefined
     : color_scale_config.type
 
-  return scale_type === `log`
-    ? scaleSequentialLog(interpolator).domain([
+  const type_name = get_scale_type_name(scale_type)
+
+  if (type_name === `log`) {
+    return scaleSequentialLog(interpolator).domain([
       Math.max(min_val, math.LOG_EPS),
       Math.max(max_val, min_val * 1.1),
     ])
-    : scaleSequential(interpolator).domain([min_val, max_val])
+  }
+  if (type_name === `arcsinh`) {
+    // For arcsinh color scale, we create a custom scale that wraps the interpolator
+    const threshold = get_arcsinh_threshold(scale_type)
+    return create_arcsinh_color_scale(interpolator, [min_val, max_val], threshold)
+  }
+  return scaleSequential(interpolator).domain([min_val, max_val])
+}
+
+// Create an arcsinh-based color scale (custom sequential scale)
+function create_arcsinh_color_scale(
+  interpolator: (t: number) => string,
+  domain: [number, number],
+  threshold: number,
+) {
+  const [d_min, d_max] = domain
+  const t_min = Math.asinh(d_min / threshold)
+  const t_max = Math.asinh(d_max / threshold)
+
+  type ArcsinhColorScale = ((value: number) => string) & {
+    domain: () => [number, number]
+  }
+
+  const scale = ((value: number): string => {
+    const t_val = Math.asinh(value / threshold)
+    // Normalize to [0, 1]
+    const normalized = t_max === t_min ? 0.5 : (t_val - t_min) / (t_max - t_min)
+    return interpolator(Math.max(0, Math.min(1, normalized)))
+  }) as ArcsinhColorScale
+
+  scale.domain = () => domain
+  return scale
 }
 
 // Create a size scale function from configuration
@@ -299,12 +568,38 @@ export function create_size_scale(
   const safe_min = min_val ?? 0
   const safe_max = max_val ?? (safe_min > 0 ? safe_min * 1.1 : 1)
 
-  const scale = config.type === `log`
-    ? scaleLog().domain([
-      Math.max(safe_min, math.LOG_EPS),
-      Math.max(safe_max, safe_min * 1.1),
-    ])
-    : scaleLinear().domain([safe_min, safe_max])
+  const type_name = get_scale_type_name(config.type)
 
-  return scale.range([min_radius, max_radius]).clamp(true)
+  if (type_name === `log`) {
+    return scaleLog()
+      .domain([Math.max(safe_min, math.LOG_EPS), Math.max(safe_max, safe_min * 1.1)])
+      .range([min_radius, max_radius])
+      .clamp(true)
+  }
+  if (type_name === `arcsinh`) {
+    // Create arcsinh-based size scale
+    const threshold = get_arcsinh_threshold(config.type)
+    const arcsinh_scale = scale_arcsinh(threshold)
+      .domain([safe_min, safe_max])
+      .range([min_radius, max_radius])
+
+    type ClampedSizeScale = ((value: number) => number) & {
+      domain: () => [number, number]
+      range: () => [number, number]
+    }
+
+    // Wrap with clamping
+    const clamped_scale = ((value: number): number => {
+      const result = arcsinh_scale(value)
+      return Math.max(min_radius, Math.min(max_radius, result))
+    }) as ClampedSizeScale
+
+    clamped_scale.domain = () => arcsinh_scale.domain()
+    clamped_scale.range = () => arcsinh_scale.range()
+    return clamped_scale
+  }
+
+  return scaleLinear().domain([safe_min, safe_max]).range([min_radius, max_radius]).clamp(
+    true,
+  )
 }

--- a/src/lib/plot/scales.ts
+++ b/src/lib/plot/scales.ts
@@ -17,6 +17,9 @@ import * as d3_sc from 'd3-scale-chromatic'
 // Type for ticks parameter - can be count, array of values, time interval, or object mapping values to labels
 export type TicksOption = number | number[] | TimeInterval | Record<number, string>
 
+// Dedupe and sort numeric array (used in tick generation)
+const dedupe_sort = (arr: number[]): number[] => [...new Set(arr)].sort((a, b) => a - b)
+
 // --- Arcsinh Scale Implementation ---
 // The arcsinh scale provides smooth transition between linear (near zero) and
 // logarithmic (for large |x|) behavior. Unlike log, it handles negative values.
@@ -154,8 +157,7 @@ export function generate_arcsinh_ticks(
   const neg_ticks = generate_positive_arcsinh_ticks(0, -min, threshold, half_count)
   ticks.push(...neg_ticks.filter((t) => t > 0).map((t) => -t))
 
-  // Sort and dedupe
-  return [...new Set(ticks)].sort((a, b) => a - b)
+  return dedupe_sort(ticks)
 }
 
 // Generate positive arcsinh ticks (helper)
@@ -206,8 +208,7 @@ function generate_positive_arcsinh_ticks(
     }
   }
 
-  // Sort and dedupe
-  return [...new Set(ticks)].sort((a, b) => a - b)
+  return dedupe_sort(ticks)
 }
 
 // Create a scale function based on type, domain, and range

--- a/src/lib/plot/types.ts
+++ b/src/lib/plot/types.ts
@@ -191,7 +191,38 @@ export interface HistogramHandlerProps<Metadata = Record<string, unknown>>
 }
 
 export type TimeInterval = `day` | `month` | `year`
-export type ScaleType = `linear` | `log`
+
+// Base scale type names
+export type ScaleTypeName = `linear` | `log` | `arcsinh`
+
+// Arcsinh scale configuration with optional threshold parameter
+// threshold controls where linear→log transition occurs (default: 1)
+// For |x| << threshold: behaves linearly
+// For |x| >> threshold: behaves logarithmically
+export interface ArcsinhScaleConfig {
+  type: `arcsinh`
+  threshold?: number // default: 1
+}
+
+// Scale type can be a simple string or arcsinh config object
+export type ScaleType = `linear` | `log` | `arcsinh` | ArcsinhScaleConfig
+
+// Helper to normalize ScaleType to base type name
+export function get_scale_type_name(scale_type: ScaleType | undefined): ScaleTypeName {
+  if (!scale_type) return `linear`
+  if (typeof scale_type === `string`) return scale_type
+  return scale_type.type
+}
+
+// Helper to get arcsinh threshold (returns undefined for non-arcsinh scales)
+export function get_arcsinh_threshold(scale_type: ScaleType | undefined): number {
+  if (!scale_type) return 1
+  if (typeof scale_type === `object` && scale_type.type === `arcsinh`) {
+    return scale_type.threshold ?? 1
+  }
+  return 1 // default threshold
+}
+
 export type QuadrantCounts = {
   top_left: number
   top_right: number

--- a/src/lib/plot/utils/label-placement.ts
+++ b/src/lib/plot/utils/label-placement.ts
@@ -1,6 +1,7 @@
 import type { AxisConfig, DataSeries, XyObj } from '$lib/plot'
 import type { PlotScaleFn } from '$lib/plot/scales'
 import type { LabelNode, LabelPlacementConfig } from '$lib/plot/types'
+import { is_time_scale } from '$lib/plot/types'
 import { forceCollide, forceLink, forceManyBody, forceSimulation } from 'd3-force'
 
 type ScaleFn = PlotScaleFn
@@ -50,7 +51,7 @@ export function compute_label_positions(
     for (const pt of series.filtered_data ?? []) {
       if (!pt.point_label?.auto_placement || !pt.point_label.text) continue
 
-      const ax = x_axis.format?.startsWith(`%`)
+      const ax = is_time_scale(x_axis.scale_type, x_axis.format)
         ? x_scale_fn(new Date(pt.x))
         : x_scale_fn(pt.x)
       const ay = (series.y_axis === `y2` ? y2_scale_fn : y_scale_fn)(pt.y)

--- a/src/lib/plot/utils/label-placement.ts
+++ b/src/lib/plot/utils/label-placement.ts
@@ -1,9 +1,9 @@
 import type { AxisConfig, DataSeries, XyObj } from '$lib/plot'
+import type { PlotScaleFn } from '$lib/plot/scales'
 import type { LabelNode, LabelPlacementConfig } from '$lib/plot/types'
 import { forceCollide, forceLink, forceManyBody, forceSimulation } from 'd3-force'
-import type { ScaleContinuousNumeric, ScaleTime } from 'd3-scale'
 
-type ScaleFn = ScaleContinuousNumeric<number, number> | ScaleTime<number, number>
+type ScaleFn = PlotScaleFn
 
 export interface AnchorNode {
   id: string

--- a/src/routes/(demos)/plot/bar-plot/+page.md
+++ b/src/routes/(demos)/plot/bar-plot/+page.md
@@ -320,6 +320,76 @@ Add rich interactivity with custom tooltips, hover effects, and click handlers:
 </div>
 ```
 
+## Arcsinh Scale: Large Range with Positive and Negative Values
+
+The **arcsinh scale** (`scale_type='arcsinh'`) handles data spanning wide ranges including negative values—ideal for formation energies, binding energies, or financial data. Unlike log scale, it smoothly transitions through zero.
+
+```svelte example
+<script>
+  import { BarPlot } from 'matterviz'
+
+  const scale_types = [`linear`, `log`, `arcsinh`]
+  let y_scale_type = $state(`arcsinh`)
+  let arcsinh_threshold = $state(1)
+
+  // Data with wide range: negative to positive, varying magnitudes
+  const energy_data = [
+    {
+      x: [1, 2, 3, 4, 5, 6, 7, 8],
+      y: [-500, -50, -5, -0.5, 0.5, 5, 50, 500],
+      label: `Energy (eV)`,
+      color: `#4c6ef5`,
+      labels: [`Mg`, `Ca`, `Li`, `Na`, `K`, `Rb`, `Cs`, `Fr`],
+    },
+  ]
+
+  let y_axis = $derived({
+    label: `Energy (${y_scale_type})`,
+    scale_type: y_scale_type === `arcsinh`
+      ? { type: `arcsinh`, threshold: arcsinh_threshold }
+      : y_scale_type,
+  })
+</script>
+
+<div
+  style="display: flex; gap: 2em; margin-bottom: 1em; flex-wrap: wrap; align-items: center"
+>
+  <fieldset>
+    <legend>Y-axis Scale</legend>
+    {#each scale_types as scale (scale)}
+      <label style="margin-right: 0.5em">
+        <input type="radio" bind:group={y_scale_type} value={scale} />
+        {scale}
+      </label>
+    {/each}
+  </fieldset>
+
+  {#if y_scale_type === `arcsinh`}
+    <label>
+      Threshold: {arcsinh_threshold}
+      <input type="range" bind:value={arcsinh_threshold} min="0.1" max="10" step="0.1" />
+    </label>
+  {/if}
+</div>
+
+<p style="font-size: 0.9em; opacity: 0.8">
+  Energy values span -500 to +500 eV. Log scale can't display negatives. Try switching
+  scales!
+</p>
+
+<BarPlot
+  series={energy_data}
+  x_axis={{ label: `Element` }}
+  {y_axis}
+  style="height: 400px"
+>
+  {#snippet tooltip({ y, labels, x })}
+    <strong>{labels?.[x - 1] ?? `Element ${x}`}</strong><br />
+    Energy: {y.toLocaleString()} eV
+  {/snippet}
+</BarPlot>
+```
+
 ## Formation Energy Diagram
 
 Bar plots handle negative values automatically and display zero lines for reference. The threshold line uses `markers: 'line'` to show only the line without marker points:

--- a/src/routes/(demos)/plot/color-bar/+page.md
+++ b/src/routes/(demos)/plot/color-bar/+page.md
@@ -426,3 +426,83 @@ Demonstrating the color bar with large numeric ranges, using both linear and log
   />
 </div>
 ```
+
+## Arcsinh Scale: Symmetric Ranges Including Negative Values
+
+The **arcsinh scale** (`scale_type='arcsinh'`) handles ranges that span both positive and negative values—something log scale cannot do. The gradient smoothly transitions through zero, with symmetric ticks like -1000, -100, -10, 0, 10, 100, 1000.
+
+```svelte example
+<script>
+  import { ColorBar } from 'matterviz'
+
+  const scale_types = [`linear`, `log`, `arcsinh`]
+  let scale_type = $state(`arcsinh`)
+  let threshold = $state(1)
+</script>
+
+<div
+  style="display: flex; gap: 2em; margin-bottom: 1em; align-items: center; flex-wrap: wrap"
+>
+  <fieldset>
+    <legend>Scale Type</legend>
+    {#each scale_types as scale (scale)}
+      <label style="margin-right: 0.5em">
+        <input type="radio" bind:group={scale_type} value={scale} />
+        {scale}
+      </label>
+    {/each}
+  </fieldset>
+
+  {#if scale_type === `arcsinh`}
+    <label>
+      Threshold: {threshold}
+      <input type="range" bind:value={threshold} min="0.1" max="100" step="0.1" />
+    </label>
+  {/if}
+</div>
+
+<div
+  style="display: grid; grid-template-columns: 1fr 1fr; gap: 3em; place-items: center; margin: 1em 0"
+>
+  <ColorBar
+    title="Symmetric Range (-1000 to 1000)"
+    range={[-1000, 1000]}
+    scale_type={scale_type === `arcsinh` ? { type: `arcsinh`, threshold } : scale_type}
+    color_scale="interpolateRdBu"
+    tick_labels={7}
+    bar_style="width: 350px"
+  />
+
+  <ColorBar
+    title="Asymmetric Range (-100 to 1000)"
+    range={[-100, 1000]}
+    scale_type={scale_type === `arcsinh` ? { type: `arcsinh`, threshold } : scale_type}
+    color_scale="interpolatePuOr"
+    tick_labels={6}
+    bar_style="width: 350px"
+  />
+
+  <ColorBar
+    title="Vertical Arcsinh (-500 to 500)"
+    range={[-500, 500]}
+    scale_type={scale_type === `arcsinh` ? { type: `arcsinh`, threshold } : scale_type}
+    orientation="vertical"
+    color_scale="interpolateBrBG"
+    bar_style="height: 200px"
+  />
+
+  <ColorBar
+    title="Near-Zero Focus (-10 to 10)"
+    range={[-10, 10]}
+    scale_type={scale_type === `arcsinh` ? { type: `arcsinh`, threshold } : scale_type}
+    color_scale="interpolatePiYG"
+    tick_labels={5}
+    bar_style="width: 350px"
+  />
+</div>
+
+<p style="font-size: 0.9em; opacity: 0.8; text-align: center">
+  Try switching to "log" to see it fail on negative ranges. Arcsinh handles all ranges
+  smoothly.
+</p>
+```

--- a/src/routes/(demos)/plot/scatter-plot/+page.md
+++ b/src/routes/(demos)/plot/scatter-plot/+page.md
@@ -890,7 +890,7 @@ The configurable `threshold` parameter controls the transition point: smaller va
   let arcsinh_threshold = $state(10)
 
   // Seeded random for reproducibility
-  function seeded_random(seed: number): () => number {
+  function seeded_random(seed) {
     let state = seed
     return (): number => {
       state = (state * 1103515245 + 12345) & 0x7fffffff

--- a/src/routes/(demos)/plot/scatter-plot/+page.md
+++ b/src/routes/(demos)/plot/scatter-plot/+page.md
@@ -1017,7 +1017,8 @@ The configurable `threshold` parameter controls the transition point: smaller va
       style="width: 200px"
     />
     <span style="font-size: 0.85em; opacity: 0.7">
-      (smaller = sharper transition at zero)
+      (smaller = sharper transition; default is 1, demo uses 10 for clearer visual
+      separation)
     </span>
   </label>
 {/if}


### PR DESCRIPTION
## Summary

Implements **arcsinh scale** support for all 2D plotting components (ScatterPlot, BarPlot, Histogram, ColorBar). The arcsinh scale provides smooth transition between linear behavior near zero and logarithmic behavior for large absolute values—perfect for data with wide dynamic ranges that includes negative, zero, and positive values.

- Harden tick generation, domain handling, color interpolation, and area rendering against NaN and Infinity values.

## Key Features

- **Configurable threshold parameter**: Controls where linear→log transition occurs (default: 1)
- **Full D3 compatibility**: Works with existing plot infrastructure
- **Handles negative values**: Unlike log scale which can't display non-positive values
- **Intelligent tick placement**: Symmetric around zero with powers of 10 for large values

## Changes

### Core Implementation (`scales.ts`, `types.ts`)
- Add `ScaleTypeName`, `ArcsinhScaleConfig` types and updated `ScaleType` union
- Add `get_scale_type_name()` and `get_arcsinh_threshold()` helper functions
- Implement `scale_arcsinh()` with domain, range, invert, copy, ticks methods
- Implement `generate_arcsinh_ticks()` for intelligent tick placement
- Update `create_scale()`, `create_color_scale()`, `create_size_scale()`
- Add `PlotScaleFn` union type for flexible scale typing

### Component Integration
- Update ScatterPlot, BarPlot, Histogram, ColorBar to support arcsinh
- Add scale type selector to PlotControls (Linear/Log/Arcsinh options)
- Zero lines now render for arcsinh scales (can handle zero)

### Demos
- ScatterPlot: 80 clustered points across ±1000 range
- BarPlot: Positive/negative value bars
- Histogram: Mixed value ranges
- ColorBar: Symmetric and asymmetric ranges
- Each demo includes interactive scale type toggles and threshold slider