### PR TITLE
Add sync_y_zoom for Bands/DOS plots, Formula copy, and plot padding fix

### DIFF
--- a/src/lib/brillouin/BrillouinZoneScene.svelte
+++ b/src/lib/brillouin/BrillouinZoneScene.svelte
@@ -264,7 +264,7 @@
       {#each k_path_points.slice(0, -1) as
         from_point,
         idx
-        (`${from_point}${k_path_points[idx + 1]}`)
+        (`${from_point}-${k_path_points[idx + 1]}#${idx}`)
       }
         {@const to_point = k_path_points[idx + 1]}
         {@const is_hovered = hovered_qpoint_index !== null &&

--- a/src/lib/plot/BarPlot.svelte
+++ b/src/lib/plot/BarPlot.svelte
@@ -76,6 +76,7 @@
   import {
     calc_auto_padding,
     constrain_tooltip_position,
+    filter_padding,
     LABEL_GAP_DEFAULT,
     measure_text_width,
   } from './layout'
@@ -397,8 +398,9 @@
 
   // Layout: dynamic padding based on tick label widths
   const default_padding = { t: 20, b: 60, l: 60, r: 20 }
-  let pad = $derived({ ...default_padding, ...padding })
-  // Update padding when format or ticks change, but prevent infinite loop
+  let pad = $derived(filter_padding(padding, default_padding))
+
+  // Update padding when format or ticks change
   $effect(() => {
     const new_pad = width && height && ticks.y.length
       ? calc_auto_padding({
@@ -407,7 +409,7 @@
         y_axis: { ...y_axis, tick_values: ticks.y },
         y2_axis: { ...y2_axis, tick_values: ticks.y2 },
       })
-      : { ...default_padding, ...padding }
+      : filter_padding(padding, default_padding)
     // Expand right padding if y2 ticks are shown (only for vertical orientation)
     if (
       width && height && y2_series.length && ticks.y2.length &&

--- a/src/lib/plot/Histogram.svelte
+++ b/src/lib/plot/Histogram.svelte
@@ -37,6 +37,7 @@
   import {
     calc_auto_padding,
     constrain_tooltip_position,
+    filter_padding,
     LABEL_GAP_DEFAULT,
     measure_text_width,
   } from '$lib/plot/layout'
@@ -357,7 +358,7 @@
 
   // Layout: dynamic padding based on tick label widths
   const default_padding = { t: 20, b: 60, l: 60, r: 20 }
-  let pad = $derived({ ...default_padding, ...padding })
+  let pad = $derived(filter_padding(padding, default_padding))
 
   // Update padding based on tick label widths (untrack breaks circular dependency)
   $effect(() => {
@@ -371,7 +372,7 @@
         y_axis: { ...final_y_axis, tick_values: current_ticks_y },
         y2_axis: { ...final_y2_axis, tick_values: current_ticks_y2 },
       })
-      : { ...default_padding, ...padding }
+      : filter_padding(padding, default_padding)
 
     // Add y2 axis label space (calc_auto_padding only accounts for tick labels)
     if (

--- a/src/lib/plot/ScatterPlot.svelte
+++ b/src/lib/plot/ScatterPlot.svelte
@@ -98,7 +98,11 @@
     pixels_to_data_delta,
   } from './interactions'
   import type { Rect } from './layout'
-  import { calc_auto_padding, constrain_tooltip_position } from './layout'
+  import {
+    calc_auto_padding,
+    constrain_tooltip_position,
+    filter_padding,
+  } from './layout'
   import type { IndexedRefLine } from './reference-line'
   import { group_ref_lines_by_z, index_ref_lines } from './reference-line'
   import {
@@ -368,8 +372,9 @@
 
   // Layout: dynamic padding based on tick label widths
   const default_padding = { t: 5, b: 50, l: 50, r: 20 }
-  let pad = $derived({ ...default_padding, ...padding })
-  // Update padding when format or ticks change, but prevent infinite loop
+  let pad = $derived(filter_padding(padding, default_padding))
+
+  // Update padding when format or ticks change
   $effect(() => {
     const new_pad = width && height && (y_tick_values.length || y2_tick_values.length)
       ? calc_auto_padding({
@@ -378,9 +383,8 @@
         y_axis: { ...final_y_axis, tick_values: y_tick_values },
         y2_axis: { ...final_y2_axis, tick_values: y2_tick_values },
       })
-      : { ...default_padding, ...padding }
+      : filter_padding(padding, default_padding)
 
-    // Only update if padding actually changed (prevents infinite loop)
     if (JSON.stringify(pad) !== JSON.stringify(new_pad)) pad = new_pad
   })
 

--- a/src/lib/plot/layout.ts
+++ b/src/lib/plot/layout.ts
@@ -6,13 +6,14 @@ import type { AxisConfig, Sides } from '$lib/plot'
 export const LABEL_GAP_DEFAULT = 30
 
 // Filter undefined values from padding to prevent overriding defaults when spreading
+// Guards against undefined/null padding inputs (common for optional props)
 export const filter_padding = <T extends Partial<Sides>>(
-  padding: T,
+  padding: T | undefined | null,
   defaults: Required<Sides>,
 ): Required<Sides> => ({
   ...defaults,
   ...Object.fromEntries(
-    Object.entries(padding).filter(([, v]) => v !== undefined),
+    Object.entries(padding ?? {}).filter(([, v]) => v !== undefined),
   ),
 } as Required<Sides>)
 

--- a/src/lib/plot/layout.ts
+++ b/src/lib/plot/layout.ts
@@ -5,6 +5,17 @@ import type { AxisConfig, Sides } from '$lib/plot'
 // Default gap between tick labels and axis labels
 export const LABEL_GAP_DEFAULT = 30
 
+// Filter undefined values from padding to prevent overriding defaults when spreading
+export const filter_padding = <T extends Partial<Sides>>(
+  padding: T,
+  defaults: Required<Sides>,
+): Required<Sides> => ({
+  ...defaults,
+  ...Object.fromEntries(
+    Object.entries(padding).filter(([, v]) => v !== undefined),
+  ),
+} as Required<Sides>)
+
 // Measure text width using canvas (singleton pattern for performance)
 let measurement_canvas: HTMLCanvasElement | null = null
 

--- a/src/lib/spectral/Bands.svelte
+++ b/src/lib/spectral/Bands.svelte
@@ -474,13 +474,10 @@
   // Sync zoom changes from ScatterPlot back to parent via bindable y_axis
   $effect(() => {
     const range = internal_y_axis.range
-    // Only sync if range changed (to avoid infinite loops)
     if (
-      range && Array.isArray(range) &&
+      helpers.is_valid_range(range) &&
       (y_axis.range?.[0] !== range[0] || y_axis.range?.[1] !== range[1])
-    ) {
-      y_axis = { ...y_axis, range }
-    }
+    ) y_axis = { ...y_axis, range }
   })
 
   let display = $state({ x_grid: false, y_grid: true, y_zero_line: true })

--- a/src/lib/spectral/Bands.svelte
+++ b/src/lib/spectral/Bands.svelte
@@ -472,12 +472,20 @@
   })
 
   // Sync zoom changes from ScatterPlot back to parent via bindable y_axis
+  // Also clears parent range when internal range becomes invalid (auto-range reset)
   $effect(() => {
     const range = internal_y_axis.range
-    if (
-      helpers.is_valid_range(range) &&
-      (y_axis.range?.[0] !== range[0] || y_axis.range?.[1] !== range[1])
-    ) y_axis = { ...y_axis, range }
+    if (helpers.is_valid_range(range)) {
+      if (y_axis.range?.[0] !== range[0] || y_axis.range?.[1] !== range[1]) {
+        y_axis = { ...y_axis, range }
+      }
+      return
+    }
+    // Range became invalid - clear parent's range to propagate reset
+    if (`range` in y_axis) {
+      const { range: _omit, ...rest } = y_axis
+      y_axis = rest
+    }
   })
 
   let display = $state({ x_grid: false, y_grid: true, y_zero_line: true })

--- a/src/lib/spectral/BandsAndDos.svelte
+++ b/src/lib/spectral/BandsAndDos.svelte
@@ -1,9 +1,17 @@
 <script lang="ts">
+  import type { Vec2 } from '$lib/math'
+  import type { AxisConfig } from '$lib/plot/types'
+  import { untrack } from 'svelte'
   import type { ComponentProps, Snippet } from 'svelte'
   import type { HTMLAttributes } from 'svelte/elements'
   import Bands from './Bands.svelte'
   import Dos from './Dos.svelte'
-  import { compute_frequency_range, extract_efermi } from './helpers'
+  import {
+    compute_frequency_range,
+    extract_efermi,
+    is_valid_range,
+    ranges_equal,
+  } from './helpers'
   import type { BaseBandStructure, DosInput, HoveredData } from './types'
 
   let {
@@ -12,6 +20,7 @@
     bands_props = {},
     dos_props = {},
     shared_y_axis = true,
+    sync_y_zoom = true,
     children,
     ...rest
   }: HTMLAttributes<HTMLDivElement> & {
@@ -20,29 +29,65 @@
     bands_props?: Partial<ComponentProps<typeof Bands>>
     dos_props?: Partial<ComponentProps<typeof Dos>>
     shared_y_axis?: boolean
+    sync_y_zoom?: boolean // Sync frequency/energy axis zoom between plots (default: true)
     class?: string
     children?: Snippet<[HoveredData]>
   } = $props()
 
-  // Compute shared frequency/energy range from both bands and DOS data
   let shared_frequency_range = $derived(
     shared_y_axis ? compute_frequency_range(band_structs, doses) : undefined,
   )
-
-  // Extract Fermi level from electronic band structure or DOS data
   let fermi_level = $derived(extract_efermi(band_structs) ?? extract_efermi(doses))
 
-  // Shared y-axis configuration
-  let bands_y_axis = $derived(
-    shared_y_axis ? { range: shared_frequency_range, ...bands_props.y_axis } : {},
-  )
-  let dos_y_axis = $derived(
-    shared_y_axis
-      ? { label: ``, range: shared_frequency_range, ...dos_props.y_axis }
-      : { label: `` },
-  )
+  // Synced zoom state (null = use auto-computed range)
+  let synced_zoom_range = $state<Vec2 | null>(null)
+  let bands_y_axis = $state<AxisConfig>({})
+  let dos_y_axis = $state<AxisConfig>({ label: `` })
 
-  // Track hovered frequency from DOS to show reference line in Bands
+  // Update y-axis configs when props or shared range changes
+  $effect(() => {
+    const base_range = synced_zoom_range ?? shared_frequency_range
+    bands_y_axis = shared_y_axis
+      ? { range: base_range, ...bands_props.y_axis }
+      : { ...bands_props.y_axis }
+  })
+
+  $effect(() => {
+    const base_range = synced_zoom_range ?? shared_frequency_range
+    dos_y_axis = shared_y_axis
+      ? { label: ``, range: base_range, ...dos_props.y_axis }
+      : { label: ``, ...dos_props.y_axis }
+  })
+
+  // Detect zoom changes and sync between components
+  $effect(() => {
+    if (!sync_y_zoom || !shared_frequency_range) return
+
+    const bands_range = bands_y_axis.range
+    const dos_range = dos_y_axis.range
+    const current_synced = untrack(() => synced_zoom_range)
+
+    const bands_at_shared = is_valid_range(bands_range) &&
+      ranges_equal(bands_range, shared_frequency_range)
+    const dos_at_shared = is_valid_range(dos_range) &&
+      ranges_equal(dos_range, shared_frequency_range)
+    const bands_is_new = is_valid_range(bands_range) &&
+      !ranges_equal(bands_range, shared_frequency_range) &&
+      !ranges_equal(bands_range, current_synced)
+    const dos_is_new = is_valid_range(dos_range) &&
+      !ranges_equal(dos_range, shared_frequency_range) &&
+      !ranges_equal(dos_range, current_synced)
+
+    // Reset if either returns to shared range
+    if (current_synced !== null && (bands_at_shared || dos_at_shared)) {
+      synced_zoom_range = null
+    } else if (bands_is_new && !dos_is_new) {
+      synced_zoom_range = bands_range as Vec2
+    } else if (dos_is_new && !bands_is_new) {
+      synced_zoom_range = dos_range as Vec2
+    }
+  })
+
   let hovered_frequency = $state<number | null>(null)
 </script>
 
@@ -56,7 +101,7 @@
     {band_structs}
     {fermi_level}
     {...bands_props}
-    y_axis={bands_y_axis}
+    bind:y_axis={bands_y_axis}
     reference_frequency={hovered_frequency}
     padding={{ r: 15, ...bands_props.padding }}
   />
@@ -66,7 +111,7 @@
     {fermi_level}
     orientation="horizontal"
     {...dos_props}
-    y_axis={dos_y_axis}
+    bind:y_axis={dos_y_axis}
     bind:hovered_frequency
     reference_frequency={hovered_frequency}
     padding={{ l: 15, ...dos_props.padding }}

--- a/src/lib/spectral/BandsAndDos.svelte
+++ b/src/lib/spectral/BandsAndDos.svelte
@@ -60,28 +60,37 @@
   // Propagate synced range to bands y-axis (untrack current to avoid overwriting child zoom)
   $effect(() => {
     const base_range = synced_zoom_range ?? shared_frequency_range
-    const current_range = untrack(() => bands_y_axis.range)
-    // Skip if current range is valid but differs from base (child zoom in progress)
-    if (
-      is_valid_range(current_range) &&
-      !ranges_equal(current_range, base_range)
-    ) return
+    const current_range = untrack(() => bands_y_axis.range) as Vec2 | undefined
+    // Skip if current range already matches base, or is valid but differs (child zoom in progress)
+    if (ranges_equal(current_range, base_range)) return
+    if (is_valid_range(current_range) && !ranges_equal(current_range, base_range)) {
+      return
+    }
+    // Only include range if it's valid (don't override child's auto-range with undefined)
     bands_y_axis = shared_y_axis
-      ? { ...(bands_props.y_axis ?? {}), range: base_range }
+      ? {
+        ...(bands_props.y_axis ?? {}),
+        ...(is_valid_range(base_range) && { range: base_range }),
+      }
       : { ...(bands_props.y_axis ?? {}) }
   })
 
   // Propagate synced range to DOS y-axis (untrack current to avoid overwriting child zoom)
   $effect(() => {
     const base_range = synced_zoom_range ?? shared_frequency_range
-    const current_range = untrack(() => dos_y_axis.range)
-    // Skip if current range is valid but differs from base (child zoom in progress)
-    if (
-      is_valid_range(current_range) &&
-      !ranges_equal(current_range, base_range)
-    ) return
+    const current_range = untrack(() => dos_y_axis.range) as Vec2 | undefined
+    // Skip if current range already matches base, or is valid but differs (child zoom in progress)
+    if (ranges_equal(current_range, base_range)) return
+    if (is_valid_range(current_range) && !ranges_equal(current_range, base_range)) {
+      return
+    }
+    // Only include range if it's valid (don't override child's auto-range with undefined)
     dos_y_axis = shared_y_axis
-      ? { label: ``, ...(dos_props.y_axis ?? {}), range: base_range }
+      ? {
+        label: ``,
+        ...(dos_props.y_axis ?? {}),
+        ...(is_valid_range(base_range) && { range: base_range }),
+      }
       : { label: ``, ...(dos_props.y_axis ?? {}) }
   })
 

--- a/src/lib/spectral/BandsAndDos.svelte
+++ b/src/lib/spectral/BandsAndDos.svelte
@@ -48,15 +48,15 @@
   $effect(() => {
     const base_range = synced_zoom_range ?? shared_frequency_range
     bands_y_axis = shared_y_axis
-      ? { range: base_range, ...bands_props.y_axis }
-      : { ...bands_props.y_axis }
+      ? { range: base_range, ...(bands_props.y_axis ?? {}) }
+      : { ...(bands_props.y_axis ?? {}) }
   })
 
   $effect(() => {
     const base_range = synced_zoom_range ?? shared_frequency_range
     dos_y_axis = shared_y_axis
-      ? { label: ``, range: base_range, ...dos_props.y_axis }
-      : { label: ``, ...dos_props.y_axis }
+      ? { label: ``, range: base_range, ...(dos_props.y_axis ?? {}) }
+      : { label: ``, ...(dos_props.y_axis ?? {}) }
   })
 
   // Detect zoom changes and sync between components

--- a/src/lib/spectral/BrillouinBandsDos.svelte
+++ b/src/lib/spectral/BrillouinBandsDos.svelte
@@ -122,26 +122,37 @@
   // Propagate synced range to bands y-axis (untrack current to avoid overwriting child zoom)
   $effect(() => {
     const base_range = synced_zoom_range ?? shared_frequency_range
-    const current_range = untrack(() => bands_y_axis.range)
-    // Skip if current range is valid but differs from base (child zoom in progress)
+    const current_range = untrack(() => bands_y_axis.range) as Vec2 | undefined
+    // Skip if current range already matches base, or is valid but differs (child zoom in progress)
+    if (helpers.ranges_equal(current_range, base_range)) return
     if (
       helpers.is_valid_range(current_range) &&
       !helpers.ranges_equal(current_range, base_range)
     ) return
-    bands_y_axis = { ...(bands_props.y_axis ?? {}), range: base_range }
+    // Only include range if it's valid (don't override child's auto-range with undefined)
+    bands_y_axis = {
+      ...(bands_props.y_axis ?? {}),
+      ...(helpers.is_valid_range(base_range) && { range: base_range }),
+    }
   })
 
   // Propagate synced range to DOS y-axis (untrack current to avoid overwriting child zoom)
   $effect(() => {
     const base_range = synced_zoom_range ?? shared_frequency_range
-    const current_range = untrack(() => dos_y_axis.range)
-    // Skip if current range is valid but differs from base (child zoom in progress)
+    const current_range = untrack(() => dos_y_axis.range) as Vec2 | undefined
+    // Skip if current range already matches base, or is valid but differs (child zoom in progress)
+    if (helpers.ranges_equal(current_range, base_range)) return
     if (
       helpers.is_valid_range(current_range) &&
       !helpers.ranges_equal(current_range, base_range)
     ) return
+    // Only include range if it's valid (don't override child's auto-range with undefined)
     dos_y_axis = is_desktop
-      ? { label: ``, ...(dos_props.y_axis ?? {}), range: base_range }
+      ? {
+        label: ``,
+        ...(dos_props.y_axis ?? {}),
+        ...(helpers.is_valid_range(base_range) && { range: base_range }),
+      }
       : { ...(dos_props.y_axis ?? {}) }
   })
 

--- a/src/lib/spectral/BrillouinBandsDos.svelte
+++ b/src/lib/spectral/BrillouinBandsDos.svelte
@@ -109,14 +109,14 @@
   // Update y-axis configs when props or shared range changes
   $effect(() => {
     const base_range = synced_zoom_range ?? shared_frequency_range
-    bands_y_axis = { range: base_range, ...bands_props.y_axis }
+    bands_y_axis = { range: base_range, ...(bands_props.y_axis ?? {}) }
   })
 
   $effect(() => {
     const base_range = synced_zoom_range ?? shared_frequency_range
     dos_y_axis = is_desktop
-      ? { label: ``, range: base_range, ...dos_props.y_axis }
-      : { ...dos_props.y_axis }
+      ? { label: ``, range: base_range, ...(dos_props.y_axis ?? {}) }
+      : { ...(dos_props.y_axis ?? {}) }
   })
 
   // Detect zoom changes and sync between components

--- a/src/lib/spectral/BrillouinBandsDos.svelte
+++ b/src/lib/spectral/BrillouinBandsDos.svelte
@@ -106,20 +106,7 @@
   let bands_y_axis = $state<AxisConfig>({})
   let dos_y_axis = $state<AxisConfig>({})
 
-  // Update y-axis configs when props or shared range changes
-  $effect(() => {
-    const base_range = synced_zoom_range ?? shared_frequency_range
-    bands_y_axis = { ...(bands_props.y_axis ?? {}), range: base_range }
-  })
-
-  $effect(() => {
-    const base_range = synced_zoom_range ?? shared_frequency_range
-    dos_y_axis = is_desktop
-      ? { label: ``, ...(dos_props.y_axis ?? {}), range: base_range }
-      : { ...(dos_props.y_axis ?? {}) }
-  })
-
-  // Detect zoom changes and sync between components (DOS sync only on desktop)
+  // Detect zoom changes and sync between components (runs first to capture child updates)
   $effect(() => {
     if (!sync_y_zoom || !shared_frequency_range) return
     const result = helpers.detect_zoom_change(
@@ -130,6 +117,32 @@
       is_desktop, // DOS sync only enabled on desktop
     )
     if (result !== undefined) synced_zoom_range = result
+  })
+
+  // Propagate synced range to bands y-axis (untrack current to avoid overwriting child zoom)
+  $effect(() => {
+    const base_range = synced_zoom_range ?? shared_frequency_range
+    const current_range = untrack(() => bands_y_axis.range)
+    // Skip if current range is valid but differs from base (child zoom in progress)
+    if (
+      helpers.is_valid_range(current_range) &&
+      !helpers.ranges_equal(current_range, base_range)
+    ) return
+    bands_y_axis = { ...(bands_props.y_axis ?? {}), range: base_range }
+  })
+
+  // Propagate synced range to DOS y-axis (untrack current to avoid overwriting child zoom)
+  $effect(() => {
+    const base_range = synced_zoom_range ?? shared_frequency_range
+    const current_range = untrack(() => dos_y_axis.range)
+    // Skip if current range is valid but differs from base (child zoom in progress)
+    if (
+      helpers.is_valid_range(current_range) &&
+      !helpers.ranges_equal(current_range, base_range)
+    ) return
+    dos_y_axis = is_desktop
+      ? { label: ``, ...(dos_props.y_axis ?? {}), range: base_range }
+      : { ...(dos_props.y_axis ?? {}) }
   })
 
   let hovered_frequency = $state<number | null>(null)

--- a/src/lib/spectral/Dos.svelte
+++ b/src/lib/spectral/Dos.svelte
@@ -42,7 +42,7 @@
     orientation = `vertical`,
     show_legend = true,
     x_axis = {},
-    y_axis = {},
+    y_axis = $bindable({}),
     hovered_frequency = $bindable(null),
     reference_frequency = null,
     fermi_level = undefined,
@@ -347,12 +347,26 @@
     ...(is_horizontal && { ticks: 4 }),
     ...x_axis,
   })
-  let final_y_axis = $derived({
+  // Internal y_axis that ScatterPlot binds to - syncs zoom changes back to parent
+  let internal_y_axis = $derived({
     label: y_label,
     format: `.2f`,
     range: y_range,
     ...y_axis,
   })
+
+  // Sync zoom changes from ScatterPlot back to parent via bindable y_axis
+  $effect(() => {
+    const range = internal_y_axis.range
+    // Only sync if range changed (to avoid infinite loops)
+    if (
+      range && Array.isArray(range) &&
+      (y_axis.range?.[0] !== range[0] || y_axis.range?.[1] !== range[1])
+    ) {
+      y_axis = { ...y_axis, range }
+    }
+  })
+
   let display = $state({
     x_grid: true,
     y_grid: true,
@@ -416,7 +430,7 @@
   <ScatterPlot
     series={series_data}
     x_axis={final_x_axis}
-    y_axis={final_y_axis}
+    bind:y_axis={internal_y_axis}
     bind:display
     legend={show_legend ? {} : null}
     hover_config={{ threshold_px: 50 }}
@@ -437,7 +451,7 @@
       is_phonon,
       units,
       final_x_axis.label ?? ``,
-      final_y_axis.label ?? ``,
+      internal_y_axis.label ?? ``,
       Object.keys(doses_dict).length,
     )}
       {#if tooltip_data.title}<strong>{tooltip_data.title}</strong><br />{/if}

--- a/src/lib/spectral/Dos.svelte
+++ b/src/lib/spectral/Dos.svelte
@@ -16,6 +16,7 @@
     format_sigma,
     FREQUENCY_UNITS,
     IMAGINARY_MODE_NOISE_THRESHOLD,
+    is_valid_range,
     negative_fraction,
     NORMALIZATION_MODES,
     normalize_densities,
@@ -360,7 +361,7 @@
     const range = internal_y_axis.range
     // Only sync if range changed (to avoid infinite loops)
     if (
-      range && Array.isArray(range) &&
+      is_valid_range(range) &&
       (y_axis.range?.[0] !== range[0] || y_axis.range?.[1] !== range[1])
     ) {
       y_axis = { ...y_axis, range }

--- a/src/lib/spectral/Dos.svelte
+++ b/src/lib/spectral/Dos.svelte
@@ -357,14 +357,19 @@
   })
 
   // Sync zoom changes from ScatterPlot back to parent via bindable y_axis
+  // Also clears parent range when internal range becomes invalid (auto-range reset)
   $effect(() => {
     const range = internal_y_axis.range
-    // Only sync if range changed (to avoid infinite loops)
-    if (
-      is_valid_range(range) &&
-      (y_axis.range?.[0] !== range[0] || y_axis.range?.[1] !== range[1])
-    ) {
-      y_axis = { ...y_axis, range }
+    if (is_valid_range(range)) {
+      if (y_axis.range?.[0] !== range[0] || y_axis.range?.[1] !== range[1]) {
+        y_axis = { ...y_axis, range }
+      }
+      return
+    }
+    // Range became invalid - clear parent's range to propagate reset
+    if (`range` in y_axis) {
+      const { range: _omit, ...rest } = y_axis
+      y_axis = rest
     }
   })
 

--- a/src/lib/spectral/helpers.ts
+++ b/src/lib/spectral/helpers.ts
@@ -19,15 +19,20 @@ export const is_valid_range = (range: unknown): range is Vec2 =>
 
 // Check if two ranges are approximately equal (within tolerance)
 // Returns false if either range is invalid (null, undefined, or fails is_valid_range)
+// Negative tol is clamped to 0; tol=0 checks exact equality
 export const ranges_equal = (
   a: Vec2 | undefined | null,
   b: Vec2 | undefined | null,
   tol = 0.001,
-): boolean =>
-  is_valid_range(a) &&
-  is_valid_range(b) &&
-  Math.abs(a[0] - b[0]) < tol &&
-  Math.abs(a[1] - b[1]) < tol
+): boolean => {
+  const safe_tol = Math.max(0, tol)
+  return (
+    is_valid_range(a) &&
+    is_valid_range(b) &&
+    Math.abs(a[0] - b[0]) <= safe_tol &&
+    Math.abs(a[1] - b[1]) <= safe_tol
+  )
+}
 
 // Detect which plot triggered a zoom change and return the new synced range.
 // Returns null to reset to shared range, undefined for no change, or Vec2 for new zoom.

--- a/src/lib/spectral/helpers.ts
+++ b/src/lib/spectral/helpers.ts
@@ -1,8 +1,33 @@
 // Helper utilities for band structure and DOS data processing
 import { SUBSCRIPT_MAP } from '$lib/labels'
-import { centered_frac, euclidean_dist, type Matrix3x3, type Vec3 } from '$lib/math'
+import {
+  centered_frac,
+  euclidean_dist,
+  type Matrix3x3,
+  type Vec2,
+  type Vec3,
+} from '$lib/math'
 import type * as types from './types'
 import type { RibbonConfig } from './types'
+
+// Check if range is a valid [min, max] tuple (strict 2-element array of finite numbers)
+export const is_valid_range = (range: unknown): range is Vec2 =>
+  Array.isArray(range) &&
+  range.length === 2 &&
+  Number.isFinite(range[0]) &&
+  Number.isFinite(range[1])
+
+// Check if two ranges are approximately equal (within tolerance)
+// Returns false if either range is invalid (null, undefined, or fails is_valid_range)
+export const ranges_equal = (
+  a: Vec2 | undefined | null,
+  b: Vec2 | undefined | null,
+  tol = 0.001,
+): boolean =>
+  is_valid_range(a) &&
+  is_valid_range(b) &&
+  Math.abs(a[0] - b[0]) < tol &&
+  Math.abs(a[1] - b[1]) < tol
 
 // Physical constants for unit conversions (SI units)
 const PLANCK = 6.62607015e-34 // J⋅s

--- a/tests/playwright/trajectory.test.ts
+++ b/tests/playwright/trajectory.test.ts
@@ -38,7 +38,14 @@ test.describe(`Trajectory Component`, () => {
   let trajectory_viewer: Locator
   let controls: Locator
 
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    // Skip beforeEach for tests that are known to be flaky on CI
+    // This prevents the 30s timeout in beforeEach for skipped tests
+    const ci_flaky_tests = [`info pane displays trajectory information correctly`]
+    if (IS_CI && ci_flaky_tests.includes(testInfo.title)) {
+      test.skip()
+      return
+    }
     trajectory_viewer = page.locator(`#loaded-trajectory`)
     controls = trajectory_viewer.locator(`.trajectory-controls`)
     await page.goto(`/test/trajectory`, { waitUntil: `domcontentloaded` })
@@ -108,7 +115,6 @@ test.describe(`Trajectory Component`, () => {
   })
 
   test(`info pane displays trajectory information correctly`, async () => {
-    test.skip(IS_CI, `Info pane toggle flaky in CI due to timing`)
     // Wait for trajectory to be loaded first
     await expect(trajectory_viewer.locator(`.trajectory-controls`)).toBeVisible()
 

--- a/tests/vitest/plot/layout.test.ts
+++ b/tests/vitest/plot/layout.test.ts
@@ -1,7 +1,34 @@
-import { compute_element_placement, constrain_tooltip_position } from '$lib/plot/layout'
+import {
+  compute_element_placement,
+  constrain_tooltip_position,
+  filter_padding,
+} from '$lib/plot/layout'
 import { describe, expect, it, test } from 'vitest'
 
 describe(`layout utility functions`, () => {
+  describe(`filter_padding`, () => {
+    const defaults = { t: 20, b: 60, l: 60, r: 20 }
+
+    it.each([
+      // Null/undefined/empty -> defaults
+      [undefined, defaults],
+      [null, defaults],
+      [{}, defaults],
+      // Partial override
+      [{ t: 10, l: 30 }, { t: 10, b: 60, l: 30, r: 20 }],
+      // Full override
+      [{ t: 5, b: 10, l: 15, r: 25 }, { t: 5, b: 10, l: 15, r: 25 }],
+      // Filters undefined values (preserves defaults)
+      [{ t: 10, b: undefined, r: 5 }, { t: 10, b: 60, l: 60, r: 5 }],
+      // Zero values are preserved (not filtered)
+      [{ t: 0, b: 0 }, { t: 0, b: 0, l: 60, r: 20 }],
+      // Negative values are preserved
+      [{ t: -5 }, { t: -5, b: 60, l: 60, r: 20 }],
+    ])(`filter_padding(%j) -> %j`, (padding, expected) => {
+      expect(filter_padding(padding, defaults)).toEqual(expected)
+    })
+  })
+
   describe(`constrain_tooltip_position`, () => {
     // New behavior: tooltip positioned bottom-right of cursor (+offset for both x,y)
     // Flips to opposite side when it would overflow viewport


### PR DESCRIPTION
## Summary

- Add `sync_y_zoom` prop to `BandsAndDos` and `BrillouinBandsDos` components (defaults to `true`) that synchronizes the frequency/energy axis zoom between Bands and DOS plots when user drag-zooms
- Add `oncopy` handler to `Formula` component that copies formula as clean plain text (e.g., "Fe(+3)2 O(-2)3") instead of raw HTML
- Fix SVG translate errors in plot components by filtering undefined padding values before spreading

## Changes

- **sync_y_zoom feature**
  - Make `y_axis` prop bindable in `Bands.svelte` and `Dos.svelte`
  - Add zoom sync logic using `untrack()` to prevent race conditions
  - Add `is_valid_range` and `ranges_equal` helpers to `spectral/helpers.ts`

- **Formula copy**
  - Add `plain_text_formula` derived that formats formula for clipboard
  - Use parentheses for oxidation states to avoid ambiguity (e.g., "Fe(+3)2" not "Fe+32")
  - Only intercept copy when selection is fully within formula element

- **Plot padding fix**
  - Add `filter_padding` utility to `layout.ts`
  - Use in `ScatterPlot`, `BarPlot`, and `Histogram` to prevent `undefined` values from overriding defaults

- **BrillouinZoneScene k-path key**
  - Include both endpoints plus index in key (`${from}-${to}#${idx}`)
  - Prevents duplicate key errors while maintaining semantic identity