### PR TITLE
Add irreducible Brillouin zone visualization

### DIFF
--- a/extensions/dash/matterviz_dash_components/typed.py
+++ b/extensions/dash/matterviz_dash_components/typed.py
@@ -406,10 +406,14 @@ class BrillouinZone(MatterViz):
         hovered: bool | None = None,
         hovered_k_point: Any | None = None,
         hovered_qpoint_index: int | None = None,
+        ibz_color: str | None = None,
+        ibz_data: Any | None = None,
+        ibz_opacity: float | None = None,
         info_pane_open: bool | None = None,
         k_path_points: list | None = None,
         loading: bool | None = None,
         png_dpi: float | None = None,
+        show_ibz: bool | None = None,
         show_vectors: bool | None = None,
         spinner_props: dict | None = None,
         structure: Any | None = None,
@@ -459,6 +463,12 @@ class BrillouinZone(MatterViz):
             mv_props['hovered_k_point'] = hovered_k_point
         if hovered_qpoint_index is not None:
             mv_props['hovered_qpoint_index'] = hovered_qpoint_index
+        if ibz_color is not None:
+            mv_props['ibz_color'] = ibz_color
+        if ibz_data is not None:
+            mv_props['ibz_data'] = ibz_data
+        if ibz_opacity is not None:
+            mv_props['ibz_opacity'] = ibz_opacity
         if info_pane_open is not None:
             mv_props['info_pane_open'] = info_pane_open
         if k_path_points is not None:
@@ -467,6 +477,8 @@ class BrillouinZone(MatterViz):
             mv_props['loading'] = loading
         if png_dpi is not None:
             mv_props['png_dpi'] = png_dpi
+        if show_ibz is not None:
+            mv_props['show_ibz'] = show_ibz
         if show_vectors is not None:
             mv_props['show_vectors'] = show_vectors
         if spinner_props is not None:

--- a/extensions/dash/matterviz_dash_components/typed.py
+++ b/extensions/dash/matterviz_dash_components/typed.py
@@ -385,7 +385,7 @@ class BrillouinZone(MatterViz):
 
     Component key: ``brillouin/BrillouinZone``
 
-    Events: on_error, on_file_drop, on_file_load, on_fullscreen_change
+    Events: on_error, on_file_drop, on_file_load, on_fullscreen_change, on_hover
     """
 
     def __init__(
@@ -420,6 +420,7 @@ class BrillouinZone(MatterViz):
         structure_string: str | None = None,
         surface_color: str | None = None,
         surface_opacity: float | None = None,
+        tooltip_config: Any | None = None,
         vector_scale: float | None = None,
         width: float | None = None,
         mv_props: dict | None = None,
@@ -491,6 +492,8 @@ class BrillouinZone(MatterViz):
             mv_props['surface_color'] = surface_color
         if surface_opacity is not None:
             mv_props['surface_opacity'] = surface_opacity
+        if tooltip_config is not None:
+            mv_props['tooltip_config'] = tooltip_config
         if vector_scale is not None:
             mv_props['vector_scale'] = vector_scale
         if width is not None:

--- a/src/lib/brillouin/BrillouinZoneControls.svelte
+++ b/src/lib/brillouin/BrillouinZoneControls.svelte
@@ -12,6 +12,10 @@
     edge_width = $bindable(0.05),
     show_vectors = $bindable(true),
     camera_projection = $bindable(`perspective`),
+    // Irreducible BZ options
+    show_ibz = $bindable(false),
+    ibz_color = $bindable(`#ff8844`),
+    ibz_opacity = $bindable(0.5),
   }: {
     controls_open?: boolean
     bz_order?: number
@@ -21,6 +25,10 @@
     edge_width?: number
     show_vectors?: boolean
     camera_projection?: CameraProjection
+    // Irreducible BZ options
+    show_ibz?: boolean
+    ibz_color?: string
+    ibz_opacity?: number
   } = $props()
 </script>
 
@@ -106,5 +114,31 @@
         <option value="orthographic">Orthographic</option>
       </select>
     </label>
+  </SettingsSection>
+
+  <SettingsSection
+    title="Irreducible BZ"
+    current_values={{ show_ibz, ibz_color, ibz_opacity }}
+    on_reset={() => {
+      show_ibz = false
+      ibz_color = `#ff8844`
+      ibz_opacity = 0.5
+    }}
+  >
+    <label>
+      <span>Show IBZ:</span>
+      <input type="checkbox" bind:checked={show_ibz} />
+    </label>
+    {#if show_ibz}
+      <label>
+        <span>Color:</span>
+        <input type="color" bind:value={ibz_color} />
+      </label>
+      <label>
+        <span>Opacity:</span>
+        <input type="range" min="0" max="1" step="0.01" bind:value={ibz_opacity} />
+        <span class="value">{ibz_opacity.toFixed(2)}</span>
+      </label>
+    {/if}
   </SettingsSection>
 </DraggablePane>

--- a/src/lib/brillouin/BrillouinZoneScene.svelte
+++ b/src/lib/brillouin/BrillouinZoneScene.svelte
@@ -207,13 +207,14 @@
       : null,
   )
 
+  // Separate effects to avoid disposing one geometry when only the other changes
   $effect(() => {
-    const prev_bz = bz_geometry
-    const prev_ibz = ibz_geometry
-    return () => {
-      prev_bz?.dispose()
-      prev_ibz?.dispose()
-    }
+    const prev = bz_geometry
+    return () => prev?.dispose()
+  })
+  $effect(() => {
+    const prev = ibz_geometry
+    return () => prev?.dispose()
   })
 </script>
 
@@ -255,7 +256,7 @@
     {/if}
 
     <!-- BZ edges -->
-    {#each bz_data.edges as edge_segment, idx (`bz-edge-${idx}`)}
+    {#each bz_data.edges as edge_segment (JSON.stringify(edge_segment))}
       {@const [from, to] = edge_segment}
       <Cylinder {from} {to} thickness={edge_width} color={edge_color} />
     {/each}
@@ -275,7 +276,7 @@
 
     <!-- IBZ edges -->
     {#if show_ibz && ibz_data}
-      {#each ibz_data.edges as edge_segment, idx (`ibz-edge-${idx}`)}
+      {#each ibz_data.edges as edge_segment (JSON.stringify(edge_segment))}
         {@const [from, to] = edge_segment}
         <Cylinder {from} {to} thickness={edge_width * 1.5} color={ibz_color} />
       {/each}

--- a/src/lib/brillouin/BrillouinZoneScene.svelte
+++ b/src/lib/brillouin/BrillouinZoneScene.svelte
@@ -250,6 +250,9 @@
 
   // Track IBZ hover state - IBZ takes priority over BZ
   let ibz_hovered = false
+  $effect(() => {
+    if (!show_ibz) ibz_hovered = false
+  }) // reset when mesh removed
 
   // Create hover data from pointer event
   function create_hover_data(

--- a/src/lib/brillouin/BrillouinZoneTooltip.svelte
+++ b/src/lib/brillouin/BrillouinZoneTooltip.svelte
@@ -74,7 +74,7 @@
       </div>
       {#if hover_data.symmetry_multiplicity != null}
         <div class="bz-tooltip-symmetry">
-          Symmetry: 1/{Math.round(hover_data.symmetry_multiplicity)} of BZ
+          Symmetry: 1/{hover_data.symmetry_multiplicity} of BZ
         </div>
       {/if}
     {/if}

--- a/src/lib/brillouin/BrillouinZoneTooltip.svelte
+++ b/src/lib/brillouin/BrillouinZoneTooltip.svelte
@@ -1,0 +1,121 @@
+<script lang="ts">
+  // Tooltip component for Brillouin zone hover information
+  // Displays k-coordinates, BZ order, volume, and IBZ-specific info
+  import { format_num } from '$lib/labels'
+  import type { Vec3 } from '$lib/math'
+  import type { Snippet } from 'svelte'
+  import type { BZHoverData, BZTooltipConfig } from './types'
+
+  let {
+    hover_data,
+    tooltip,
+  }: {
+    hover_data: BZHoverData
+    tooltip?: Snippet<[{ hover_data: BZHoverData }]> | BZTooltipConfig
+  } = $props()
+
+  // Determine tooltip mode: snippet replaces content, config adds prefix/suffix
+  const is_snippet = $derived(typeof tooltip === `function`)
+  const config = $derived(
+    !is_snippet && tooltip ? (tooltip as BZTooltipConfig) : null,
+  )
+  const prefix_html = $derived(
+    typeof config?.prefix === `function` ? config.prefix(hover_data) : config?.prefix,
+  )
+  const suffix_html = $derived(
+    typeof config?.suffix === `function` ? config.suffix(hover_data) : config?.suffix,
+  )
+  const tooltip_snippet = $derived(
+    is_snippet ? (tooltip as Snippet<[{ hover_data: BZHoverData }]>) : null,
+  )
+
+  // Format coordinate for display
+  const fmt = (val: number) => format_num(val, `.4~`)
+  const fmt_vec = (vec: Vec3) => `(${fmt(vec[0])}, ${fmt(vec[1])}, ${fmt(vec[2])})`
+
+  // Ordinal for BZ order (only 1-3 in practice)
+  const ordinal = (num: number) => `${num}${[`th`, `st`, `nd`, `rd`][num] ?? `th`}`
+</script>
+
+{#if tooltip_snippet}
+  {@render tooltip_snippet({ hover_data })}
+{:else}
+  <!-- Note: prefix/suffix use {@html} - ensure content is trusted -->
+  {#if prefix_html}
+    <div class="bz-tooltip-prefix">{@html prefix_html}</div>
+  {/if}
+
+  <div class="bz-tooltip-content">
+    <div class="bz-tooltip-title">
+      <strong>{
+        hover_data.is_ibz ? `Irreducible BZ` : `Brillouin Zone`
+      }</strong>{#if hover_data.bz_order > 1}<span class="bz-tooltip-badge">{
+          ordinal(hover_data.bz_order)
+        }</span>{/if}
+    </div>
+    <div class="bz-tooltip-row">
+      <span class="bz-tooltip-label">k (Å⁻¹):</span>
+      <span class="bz-tooltip-value">{fmt_vec(hover_data.position_cartesian)}</span>
+    </div>
+    {#if hover_data.position_fractional}
+      <div class="bz-tooltip-row">
+        <span class="bz-tooltip-label">k (frac):</span>
+        <span class="bz-tooltip-value">{fmt_vec(hover_data.position_fractional)}</span>
+      </div>
+    {/if}
+    <div class="bz-tooltip-row">
+      <span class="bz-tooltip-label">BZ Volume:</span>
+      <span class="bz-tooltip-value">{fmt(hover_data.bz_volume)} Å⁻³</span>
+    </div>
+    {#if hover_data.is_ibz && hover_data.ibz_volume != null}
+      <div class="bz-tooltip-row">
+        <span class="bz-tooltip-label">IBZ Volume:</span>
+        <span class="bz-tooltip-value">{fmt(hover_data.ibz_volume)} Å⁻³</span>
+      </div>
+      {#if hover_data.symmetry_multiplicity != null}
+        <div class="bz-tooltip-symmetry">
+          Symmetry: 1/{Math.round(hover_data.symmetry_multiplicity)} of BZ
+        </div>
+      {/if}
+    {/if}
+  </div>
+
+  {#if suffix_html}
+    <div class="bz-tooltip-suffix">{@html suffix_html}</div>
+  {/if}
+{/if}
+
+<style>
+  .bz-tooltip-content {
+    max-width: var(--bz-tooltip-max-width, 250px);
+    text-align: left;
+  }
+  .bz-tooltip-title {
+    margin-bottom: 4px;
+  }
+  .bz-tooltip-badge {
+    font-size: 0.85em;
+    padding: 1px 4px;
+    border-radius: 3px;
+    font-weight: 500;
+    background: #666;
+    color: white;
+    margin-left: 6px;
+  }
+  .bz-tooltip-row {
+    display: flex;
+    gap: 4px;
+  }
+  .bz-tooltip-label {
+    opacity: 0.8;
+    min-width: 75px;
+  }
+  .bz-tooltip-value {
+    font-family: monospace;
+  }
+  .bz-tooltip-symmetry {
+    margin-top: 2px;
+    opacity: 0.8;
+    font-style: italic;
+  }
+</style>

--- a/src/lib/brillouin/compute.ts
+++ b/src/lib/brillouin/compute.ts
@@ -386,7 +386,8 @@ function clip_polyhedron_by_plane(
     const d1 = signed_dists[i1]
     const d2 = signed_dists[i2]
 
-    if ((d1 > TOL && d2 < -TOL) || (d1 < -TOL && d2 > TOL)) {
+    // Detect sign change (edge crosses plane) - use product to catch edges near tolerance
+    if (d1 * d2 < 0) {
       const t = d1 / (d1 - d2)
       const [v1, v2] = [vertices[i1], vertices[i2]]
       result.push([

--- a/src/lib/brillouin/compute.ts
+++ b/src/lib/brillouin/compute.ts
@@ -2,13 +2,43 @@
 
 import type { Matrix3x3, Vec2, Vec3 } from '$lib/math'
 import * as math from '$lib/math'
+import type { MoyoDataset } from '@spglib/moyo-wasm'
 import { Vector3 } from 'three'
 import { ConvexGeometry } from 'three/examples/jsm/geometries/ConvexGeometry.js'
-import type { BrillouinZoneData, ConvexHullData } from './types'
+import type { BrillouinZoneData, ConvexHullData, IrreducibleBZData } from './types'
+
+const TOL = 1e-8
 
 const normalize = (vec: Vec3): Vec3 => {
   const mag = Math.hypot(...vec)
   return mag < 1e-10 ? [0, 0, 0] : [vec[0] / mag, vec[1] / mag, vec[2] / mag]
+}
+
+// Check if rotation matrix is identity
+function is_identity_rotation(rot: Matrix3x3): boolean {
+  return rot.every((row, idx) =>
+    row.every((val, jdx) => Math.abs(val - (idx === jdx ? 1 : 0)) < TOL)
+  )
+}
+
+// Extract unique point group rotation matrices from space group operations.
+// In reciprocal space, real-space rotation R becomes R^T (transpose).
+export function extract_point_group_from_operations(
+  operations: MoyoDataset[`operations`],
+): Matrix3x3[] {
+  const seen = new Set<string>()
+  const unique_rotations: Matrix3x3[] = []
+
+  for (const { rotation } of operations) {
+    const key = rotation.map((val) => val.toFixed(6)).join(`,`)
+    if (seen.has(key)) continue
+    seen.add(key)
+
+    const rot = math.vec9_to_mat3x3(Array.from(rotation)) as Matrix3x3
+    unique_rotations.push(math.transpose_3x3_matrix(rot))
+  }
+
+  return unique_rotations
 }
 
 // Compute reciprocal lattice: k = inv(real).T * 2π
@@ -37,8 +67,6 @@ function generate_k_space_grid(k_lattice: Matrix3x3, order: number): Vec3[] {
   }
   return points
 }
-
-const TOL = 1e-8
 
 // O(1) duplicate vertex detection using spatial hashing
 class VertexDeduplicator {
@@ -157,6 +185,22 @@ export function generate_bz_vertices(
   return vertices
 }
 
+// Compute polyhedron volume via divergence theorem (sum of signed tetrahedral volumes)
+function compute_hull_volume(vertices: Vec3[], faces: number[][]): number {
+  if (faces.length === 0) return 0
+  return Math.abs(
+    faces.reduce((sum, face) => {
+      if (face.length < 3) return sum
+      const [v0, v1, v2] = face.slice(0, 3).map((idx) => vertices[idx])
+      const area_normal = math.scale(
+        math.cross_3d(math.subtract(v1, v0), math.subtract(v2, v0)),
+        0.5,
+      ) as Vec3
+      return sum + (math.dot(v0, area_normal) as number) / 3
+    }, 0),
+  )
+}
+
 // Build convex hull from vertices and extract topology
 export function compute_convex_hull(
   vertices: Vec3[],
@@ -248,25 +292,168 @@ export function compute_brillouin_zone(
 
   const hull = compute_convex_hull(vertices, edge_sharp_angle_deg)
 
-  // Compute volume via divergence theorem (sum of signed tetrahedral volumes)
-  const volume = Math.abs(
-    hull.faces.reduce((sum, face) => {
-      if (face.length < 3) return sum
-      const [v0, v1, v2] = face.slice(0, 3).map((idx) => hull.vertices[idx])
-      const area_normal = math.scale(
-        math.cross_3d(math.subtract(v1, v0), math.subtract(v2, v0)),
-        0.5,
-      ) as Vec3
-      return sum + (math.dot(v0, area_normal) as number) / 3
-    }, 0),
-  )
-
   return {
     order,
     vertices: hull.vertices,
     faces: hull.faces,
     edges: hull.edges.map(([i1, i2]) => [hull.vertices[i1], hull.vertices[i2]]),
     k_lattice,
-    volume,
+    volume: compute_hull_volume(hull.vertices, hull.faces),
+  }
+}
+
+// Clipping plane defined by normal and distance from origin (n·x = d)
+type ClippingPlane = { normal: Vec3; dist: number }
+
+// Compute clipping planes from point group operations.
+// For each non-identity rotation, we define a plane that selects one representative
+// from each equivalence class. The plane normal is chosen to create a consistent
+// fundamental domain.
+export function compute_ibz_clipping_planes(
+  point_group_ops: Matrix3x3[],
+): ClippingPlane[] {
+  const planes: ClippingPlane[] = []
+  const seen_normals = new Set<string>()
+
+  for (const rot of point_group_ops) {
+    // Skip identity matrix
+    if (is_identity_rotation(rot)) continue
+
+    // Test points chosen to avoid rotation axes for common symmetries
+    // Includes basis vectors, face diagonals, and body diagonal
+    const test_points: Vec3[] = [
+      [1, 0, 0],
+      [0, 1, 0],
+      [0, 0, 1], // basis vectors
+      [1, 1, 0],
+      [1, 0, 1],
+      [0, 1, 1], // face diagonals
+      [1, 1, 1],
+      [1, 2, 3], // body diagonal + generic point
+    ]
+
+    for (const test_pt of test_points) {
+      const rotated = math.mat3x3_vec3_multiply(rot, test_pt)
+      const diff: Vec3 = math.subtract(rotated, test_pt)
+      if (Math.hypot(...diff) < TOL) continue // point on rotation axis
+
+      const plane_normal = normalize(diff)
+      const key = plane_normal.map((val) => Math.round(val * 1000)).join(`,`)
+      const neg_key = plane_normal.map((val) => Math.round(-val * 1000)).join(`,`)
+
+      if (!seen_normals.has(key) && !seen_normals.has(neg_key)) {
+        seen_normals.add(key)
+        planes.push({ normal: plane_normal, dist: 0 })
+      }
+      break
+    }
+  }
+
+  return planes
+}
+
+// Flip a clipping plane to the opposite half-space
+const flip_plane = (p: ClippingPlane): ClippingPlane => ({
+  normal: math.scale(p.normal, -1) as Vec3,
+  dist: -p.dist,
+})
+
+// Clip polyhedron vertices by a half-space, adding intersection points where edges cross
+function clip_polyhedron_by_plane(
+  vertices: Vec3[],
+  faces: number[][],
+  plane: ClippingPlane,
+): Vec3[] {
+  const { normal, dist } = plane
+  const signed_dists = vertices.map((v) => (math.dot(v, normal) as number) - dist)
+
+  // Keep vertices inside the half-space
+  const result = vertices.filter((_, idx) => signed_dists[idx] <= TOL)
+
+  // Build edge set from faces
+  const edge_set = new Set<string>()
+  for (const face of faces) {
+    for (let idx = 0; idx < face.length; idx++) {
+      const i1 = face[idx]
+      const i2 = face[(idx + 1) % face.length]
+      edge_set.add(i1 < i2 ? `${i1},${i2}` : `${i2},${i1}`)
+    }
+  }
+
+  // Add intersection points where edges cross the plane
+  for (const key of edge_set) {
+    const [i1, i2] = key.split(`,`).map(Number)
+    const d1 = signed_dists[i1]
+    const d2 = signed_dists[i2]
+
+    if ((d1 > TOL && d2 < -TOL) || (d1 < -TOL && d2 > TOL)) {
+      const t = d1 / (d1 - d2)
+      const [v1, v2] = [vertices[i1], vertices[i2]]
+      result.push([
+        v1[0] + t * (v2[0] - v1[0]),
+        v1[1] + t * (v2[1] - v1[1]),
+        v1[2] + t * (v2[2] - v1[2]),
+      ])
+    }
+  }
+
+  return result
+}
+
+// Try to build hull from vertices, returns null on failure
+function try_build_hull(
+  vertices: Vec3[],
+  edge_sharp_angle_deg: number,
+): ConvexHullData | null {
+  if (vertices.length < 4) return null
+  try {
+    return compute_convex_hull(vertices, edge_sharp_angle_deg)
+  } catch {
+    return null
+  }
+}
+
+// Compute the irreducible Brillouin zone by clipping the full BZ with symmetry planes
+export function compute_irreducible_bz(
+  bz_data: BrillouinZoneData,
+  point_group_ops: Matrix3x3[],
+  edge_sharp_angle_deg = 5,
+): IrreducibleBZData | null {
+  const clipping_planes = compute_ibz_clipping_planes(point_group_ops)
+
+  if (clipping_planes.length === 0) {
+    // No symmetry (P1), IBZ = full BZ
+    return {
+      vertices: [...bz_data.vertices],
+      faces: [...bz_data.faces],
+      edges: [...bz_data.edges],
+      volume: bz_data.volume,
+    }
+  }
+
+  let current_vertices = [...bz_data.vertices]
+  let current_faces = [...bz_data.faces]
+
+  for (const plane of clipping_planes) {
+    // Try clipping with plane, then flipped plane if needed
+    for (const try_plane of [plane, flip_plane(plane)]) {
+      const clipped = clip_polyhedron_by_plane(current_vertices, current_faces, try_plane)
+      const hull = try_build_hull(clipped, edge_sharp_angle_deg)
+      if (hull) {
+        current_vertices = hull.vertices
+        current_faces = hull.faces
+        break
+      }
+    }
+  }
+
+  const hull = try_build_hull(current_vertices, edge_sharp_angle_deg)
+  if (!hull) return null
+
+  return {
+    vertices: hull.vertices,
+    faces: hull.faces,
+    edges: hull.edges.map(([i1, i2]) => [hull.vertices[i1], hull.vertices[i2]]),
+    volume: compute_hull_volume(hull.vertices, hull.faces),
   }
 }

--- a/src/lib/brillouin/index.ts
+++ b/src/lib/brillouin/index.ts
@@ -3,5 +3,6 @@ export { default as BrillouinZoneControls } from './BrillouinZoneControls.svelte
 export { default as BrillouinZoneExportPane } from './BrillouinZoneExportPane.svelte'
 export { default as BrillouinZoneInfoPane } from './BrillouinZoneInfoPane.svelte'
 export { default as BrillouinZoneScene } from './BrillouinZoneScene.svelte'
+export { default as BrillouinZoneTooltip } from './BrillouinZoneTooltip.svelte'
 export * from './compute'
 export * from './types'

--- a/src/lib/brillouin/types.ts
+++ b/src/lib/brillouin/types.ts
@@ -1,6 +1,14 @@
 import type { Matrix3x3, Vec3 } from '$lib/math'
 import type { Crystal } from '$lib/structure'
 
+// Data structure for the irreducible Brillouin zone wedge
+export type IrreducibleBZData = {
+  vertices: Vec3[] // Vertices of the irreducible wedge
+  faces: number[][] // Face indices for IBZ mesh
+  edges: Vec3[][] // Edge segments for IBZ boundary rendering
+  volume: number // IBZ volume in Å⁻³
+}
+
 export type BrillouinZoneData = {
   order: number // 1st, 2nd, 3rd BZ
   vertices: Vec3[]

--- a/src/lib/brillouin/types.ts
+++ b/src/lib/brillouin/types.ts
@@ -1,5 +1,27 @@
 import type { Matrix3x3, Vec3 } from '$lib/math'
 import type { Crystal } from '$lib/structure'
+import type { Snippet } from 'svelte'
+
+// Hover data for BZ tooltip
+export type BZHoverData = {
+  position_cartesian: Vec3 // k-point in Cartesian coords (Å⁻¹)
+  position_fractional: Vec3 | null // k-point in fractional coords
+  screen_position: { x: number; y: number } // for tooltip positioning
+  is_ibz: boolean // true if hovering the IBZ mesh
+  bz_order: number
+  bz_volume: number
+  ibz_volume: number | null // only when IBZ is shown
+  symmetry_multiplicity: number | null // BZ volume / IBZ volume (e.g., 48 for cubic)
+}
+
+// Tooltip configuration for prefix/suffix customization
+export type BZTooltipConfig = {
+  prefix?: string | ((data: BZHoverData) => string)
+  suffix?: string | ((data: BZHoverData) => string)
+}
+
+// Tooltip prop can be a snippet for full customization or config for prefix/suffix
+export type BZTooltipProp = Snippet<[{ hover_data: BZHoverData }]> | BZTooltipConfig
 
 // Data structure for the irreducible Brillouin zone wedge
 export type IrreducibleBZData = {

--- a/src/lib/convex-hull/ConvexHull2D.svelte
+++ b/src/lib/convex-hull/ConvexHull2D.svelte
@@ -738,7 +738,7 @@
       selected_entry,
     })}
     <h3 style="position: absolute; left: 1em; top: 1ex; margin: 0">
-      {phase_stats?.chemical_system}
+      {merged_controls.title || phase_stats?.chemical_system}
     </h3>
 
     <ClickFeedback

--- a/src/lib/convex-hull/ConvexHull3D.svelte
+++ b/src/lib/convex-hull/ConvexHull3D.svelte
@@ -1058,7 +1058,7 @@
       selected_entry,
     })}
   <h3 style="position: absolute; left: 1em; top: 1ex; margin: 0">
-    {phase_stats?.chemical_system}
+    {merged_controls.title || phase_stats?.chemical_system}
   </h3>
   <canvas
     bind:this={canvas}

--- a/src/lib/convex-hull/ConvexHull4D.svelte
+++ b/src/lib/convex-hull/ConvexHull4D.svelte
@@ -999,7 +999,7 @@
       selected_entry,
     })}
   <h3 style="position: absolute; left: 1em; top: 1ex; margin: 0">
-    {phase_stats?.chemical_system}
+    {merged_controls.title || phase_stats?.chemical_system}
   </h3>
 
   <canvas

--- a/src/lib/plot/Histogram.svelte
+++ b/src/lib/plot/Histogram.svelte
@@ -17,11 +17,11 @@
     PlotLegend,
     ReferenceLine,
   } from '$lib/plot'
+  import type { AxisChangeState } from '$lib/plot/axis-utils'
   import {
     AXIS_LABEL_CONTAINER,
     create_axis_change_handler,
   } from '$lib/plot/axis-utils'
-  import type { AxisChangeState } from '$lib/plot/axis-utils'
   import { extract_series_color, prepare_legend_data } from '$lib/plot/data-transform'
   import { AXIS_DEFAULTS } from '$lib/plot/defaults'
   import {

--- a/src/lib/table/HeatmapTable.svelte
+++ b/src/lib/table/HeatmapTable.svelte
@@ -129,7 +129,7 @@
   )
 
   // Normalize export_data config
-  type ExportFormat = 'csv' | 'json'
+  type ExportFormat = `csv` | `json`
   const default_formats: ExportFormat[] = [`csv`, `json`]
   let export_config = $derived(
     export_data

--- a/src/routes/(demos)/reciprocal/brillouin-zone/+page.svelte
+++ b/src/routes/(demos)/reciprocal/brillouin-zone/+page.svelte
@@ -2,11 +2,20 @@
   import { BrillouinZone } from '$lib'
   import { structure_map } from '$site/structures'
 
-  const examples = [
+  type BZExample = {
+    id: string
+    label: string
+    description: string
+    show_ibz?: boolean
+    order?: number
+  }
+
+  const examples: BZExample[] = [
     {
       id: `Po-simple-cubic`,
       label: `Simple Cubic (SC)`,
-      description: `Po - cubic BZ`,
+      description: `Po - cubic BZ with IBZ wedge (1/48th)`,
+      show_ibz: true,
     },
     {
       id: `Fe-BCC`,
@@ -16,7 +25,8 @@
     {
       id: `Cu-FCC`,
       label: `Face-Centered Cubic (FCC)`,
-      description: `Cu - rhombic dodecahedron BZ`,
+      description: `Cu - rhombic dodecahedron with IBZ`,
+      show_ibz: true,
     },
     {
       id: `mp-1207297-Ac2Br2O1-tetragonal`,
@@ -26,7 +36,8 @@
     {
       id: `mp-862690-Ac4-hexagonal`,
       label: `Hexagonal`,
-      description: `Ac - hexagonal prism BZ`,
+      description: `Ac - hexagonal prism with IBZ`,
+      show_ibz: true,
     },
     {
       id: `mp-1183085-Ac4Mg2-orthorhombic`,
@@ -94,12 +105,12 @@
 </label>
 
 <div class="full-bleed grid">
-  {#each examples as { id, label, description } (id)}
+  {#each examples as { id, label, description, show_ibz } (id)}
     {@const structure = structure_map.get(id)}
     <div>
       <h3>{label}</h3>
       <p>{description}</p>
-      <BrillouinZone {structure} {surface_opacity} />
+      <BrillouinZone {structure} {surface_opacity} {show_ibz} />
     </div>
   {/each}
 </div>

--- a/src/routes/test/brillouin-zone/+page.svelte
+++ b/src/routes/test/brillouin-zone/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { BrillouinZone, type Crystal } from '$lib'
+  import type { IrreducibleBZData } from '$lib/brillouin/types'
   import mp1_struct from '$site/structures/mp-1.json'
 
   let controls_open = $state(false)
@@ -15,6 +16,11 @@
   let show_controls = $state<`always` | `hover` | `never`>(`hover`)
   let png_dpi = $state(150)
   let fullscreen = $state(false)
+  // IBZ state
+  let show_ibz = $state(false)
+  let ibz_color = $state(`#ff8844`)
+  let ibz_opacity = $state(0.5)
+  let ibz_data = $state<IrreducibleBZData | null>(null)
 
   let structure = $state<Crystal | undefined>(
     mp1_struct as unknown as Crystal,
@@ -51,6 +57,10 @@
     if (params.has(`show_controls`)) {
       const param = params.get(`show_controls`) as `always` | `hover` | `never` | null
       if (param && [`always`, `hover`, `never`].includes(param)) show_controls = param
+    }
+
+    if (params.has(`show_ibz`)) {
+      show_ibz = params.get(`show_ibz`) === `true`
     }
 
     ;(globalThis as Record<string, unknown>).event_calls = event_calls
@@ -94,6 +104,25 @@
       data-testid="fullscreen-checkbox"
       type="checkbox"
       bind:checked={fullscreen}
+    /></label><br />
+  <label>Show IBZ: <input
+      id="show-ibz"
+      data-testid="show-ibz-checkbox"
+      type="checkbox"
+      bind:checked={show_ibz}
+    /></label><br />
+  <label>IBZ Color: <input
+      id="ibz-color"
+      type="color"
+      bind:value={ibz_color}
+    /></label><br />
+  <label>IBZ Opacity: <input
+      id="ibz-opacity"
+      type="range"
+      min="0"
+      max="1"
+      step="0.1"
+      bind:value={ibz_opacity}
     /></label>
 </section>
 
@@ -105,6 +134,11 @@
   <p data-testid="show-controls">{show_controls}</p>
   <p data-testid="camera-projection">{camera_projection}</p>
   <p data-testid="fullscreen-status">{fullscreen}</p>
+  <p data-testid="show-ibz">{show_ibz}</p>
+  <p data-testid="ibz-color">{ibz_color}</p>
+  <p data-testid="ibz-opacity">{ibz_opacity}</p>
+  <p data-testid="ibz-data-status">{ibz_data ? `loaded` : `null`}</p>
+  <p data-testid="ibz-vertices-count">{ibz_data?.vertices?.length ?? 0}</p>
   <p data-testid="events">{event_calls.map((ec) => ec.event).join(`, `)}</p>
 </section>
 
@@ -124,6 +158,10 @@
   bind:camera_projection
   bind:png_dpi
   bind:fullscreen
+  bind:show_ibz
+  bind:ibz_color
+  bind:ibz_opacity
+  bind:ibz_data
   {show_controls}
   on_file_load={log_event(`on_file_load`)}
   on_error={log_event(`on_error`)}

--- a/tests/playwright/brillouin-zone.test.ts
+++ b/tests/playwright/brillouin-zone.test.ts
@@ -2,6 +2,9 @@ import { expect, type Page, test } from '@playwright/test'
 import { IS_CI, wait_for_3d_canvas } from './helpers'
 
 const BZ_SELECTOR = `#test-brillouin-zone`
+// IBZ computation requires moyo-wasm symmetry analysis which can be slow,
+// especially in CI with software rendering. 10s accommodates most structures.
+const IBZ_LOAD_TIMEOUT = 10000
 
 test.describe(`BrillouinZone Component Tests`, () => {
   test.beforeEach(async ({ page }: { page: Page }) => {
@@ -176,7 +179,7 @@ test.describe(`BrillouinZone Event Handler Tests`, () => {
     })
     await page.waitForSelector(`${BZ_SELECTOR} canvas`, { timeout: 20000 })
     await expect(page.locator(`[data-testid="events"]`)).toContainText(`on_file_load`, {
-      timeout: 10000,
+      timeout: IBZ_LOAD_TIMEOUT,
     })
   })
 
@@ -226,7 +229,7 @@ test.describe(`BrillouinZone IBZ (Irreducible Brillouin Zone) Tests`, () => {
     await checkbox.check()
 
     // Wait for IBZ data to load (async operation via moyo-wasm)
-    await expect(data_status).toHaveText(`loaded`, { timeout: 10000 })
+    await expect(data_status).toHaveText(`loaded`, { timeout: IBZ_LOAD_TIMEOUT })
 
     // Should have vertices
     await expect(async () => {
@@ -265,7 +268,7 @@ test.describe(`BrillouinZone IBZ (Irreducible Brillouin Zone) Tests`, () => {
     // Enable IBZ and wait for it to load
     await show_ibz.check()
     await expect(page.locator(`[data-testid="ibz-data-status"]`)).toHaveText(`loaded`, {
-      timeout: 10000,
+      timeout: IBZ_LOAD_TIMEOUT,
     })
 
     // Screenshot with IBZ - should be different (retry handles render timing)
@@ -287,7 +290,7 @@ test.describe(`BrillouinZone IBZ (Irreducible Brillouin Zone) Tests`, () => {
 
     // IBZ data should load automatically
     await expect(page.locator(`[data-testid="ibz-data-status"]`)).toHaveText(`loaded`, {
-      timeout: 10000,
+      timeout: IBZ_LOAD_TIMEOUT,
     })
   })
 
@@ -297,7 +300,7 @@ test.describe(`BrillouinZone IBZ (Irreducible Brillouin Zone) Tests`, () => {
 
     // Enable IBZ and wait for data
     await checkbox.check()
-    await expect(data_status).toHaveText(`loaded`, { timeout: 10000 })
+    await expect(data_status).toHaveText(`loaded`, { timeout: IBZ_LOAD_TIMEOUT })
 
     // Disable IBZ
     await checkbox.uncheck()

--- a/tests/playwright/brillouin-zone.test.ts
+++ b/tests/playwright/brillouin-zone.test.ts
@@ -190,3 +190,117 @@ test.describe(`BrillouinZone Event Handler Tests`, () => {
     })
   })
 })
+
+test.describe(`BrillouinZone IBZ (Irreducible Brillouin Zone) Tests`, () => {
+  test.beforeEach(async ({ page }: { page: Page }) => {
+    test.skip(IS_CI, `BrillouinZone IBZ tests timeout in CI`)
+    await page.goto(`/test/brillouin-zone`, { waitUntil: `networkidle` })
+    await wait_for_3d_canvas(page, BZ_SELECTOR)
+  })
+
+  test(`IBZ toggle control works`, async ({ page }) => {
+    const checkbox = page.locator(`#show-ibz`)
+    const status = page.locator(`[data-testid="show-ibz"]`)
+
+    await expect(checkbox).not.toBeChecked()
+    await expect(status).toHaveText(`false`)
+
+    await checkbox.check()
+    await expect(status).toHaveText(`true`)
+    await expect(checkbox).toBeChecked()
+
+    await checkbox.uncheck()
+    await expect(status).toHaveText(`false`)
+  })
+
+  test(`IBZ data loads when enabled`, async ({ page }) => {
+    const checkbox = page.locator(`#show-ibz`)
+    const data_status = page.locator(`[data-testid="ibz-data-status"]`)
+    const vertices_count = page.locator(`[data-testid="ibz-vertices-count"]`)
+
+    // Initially null
+    await expect(data_status).toHaveText(`null`)
+    await expect(vertices_count).toHaveText(`0`)
+
+    // Enable IBZ
+    await checkbox.check()
+
+    // Wait for IBZ data to load (async operation via moyo-wasm)
+    await expect(data_status).toHaveText(`loaded`, { timeout: 10000 })
+
+    // Should have vertices
+    await expect(async () => {
+      const count = await vertices_count.textContent()
+      expect(parseInt(count || `0`)).toBeGreaterThan(0)
+    }).toPass({ timeout: 5000 })
+  })
+
+  test(`IBZ color control updates`, async ({ page }) => {
+    const color_input = page.locator(`#ibz-color`)
+    const color_status = page.locator(`[data-testid="ibz-color"]`)
+
+    await expect(color_status).toHaveText(`#ff8844`)
+
+    await color_input.fill(`#00ff00`)
+    await expect(color_status).toHaveText(`#00ff00`)
+  })
+
+  test(`IBZ opacity control updates`, async ({ page }) => {
+    const opacity_input = page.locator(`#ibz-opacity`)
+    const opacity_status = page.locator(`[data-testid="ibz-opacity"]`)
+
+    await expect(opacity_status).toHaveText(`0.5`)
+
+    await opacity_input.fill(`0.8`)
+    await expect(opacity_status).toHaveText(`0.8`)
+  })
+
+  test(`IBZ renders differently from full BZ`, async ({ page }) => {
+    const canvas = page.locator(`${BZ_SELECTOR} canvas`)
+    const show_ibz = page.locator(`#show-ibz`)
+
+    // Screenshot without IBZ
+    const without_ibz = await canvas.screenshot()
+
+    // Enable IBZ and wait for it to load
+    await show_ibz.check()
+    await expect(page.locator(`[data-testid="ibz-data-status"]`)).toHaveText(`loaded`, {
+      timeout: 10000,
+    })
+
+    // Screenshot with IBZ - should be different (retry handles render timing)
+    await expect(async () => {
+      const with_ibz = await canvas.screenshot()
+      expect(with_ibz.equals(without_ibz)).toBe(false)
+    }).toPass({ timeout: 5000 })
+  })
+
+  test(`IBZ can be enabled via URL parameter`, async ({ page }) => {
+    await page.goto(`/test/brillouin-zone?show_ibz=true`, { waitUntil: `networkidle` })
+    await wait_for_3d_canvas(page, BZ_SELECTOR)
+
+    const checkbox = page.locator(`#show-ibz`)
+    const status = page.locator(`[data-testid="show-ibz"]`)
+
+    await expect(checkbox).toBeChecked()
+    await expect(status).toHaveText(`true`)
+
+    // IBZ data should load automatically
+    await expect(page.locator(`[data-testid="ibz-data-status"]`)).toHaveText(`loaded`, {
+      timeout: 10000,
+    })
+  })
+
+  test(`IBZ data cleared when disabled`, async ({ page }) => {
+    const checkbox = page.locator(`#show-ibz`)
+    const data_status = page.locator(`[data-testid="ibz-data-status"]`)
+
+    // Enable IBZ and wait for data
+    await checkbox.check()
+    await expect(data_status).toHaveText(`loaded`, { timeout: 10000 })
+
+    // Disable IBZ
+    await checkbox.uncheck()
+    await expect(data_status).toHaveText(`null`)
+  })
+})

--- a/tests/vitest/brillouin-compute.test.ts
+++ b/tests/vitest/brillouin-compute.test.ts
@@ -424,7 +424,11 @@ describe(`compute_irreducible_bz`, () => {
     expect(ibz).not.toBeNull()
     if (!ibz) return
     expect(ibz.volume).toBeGreaterThan(0)
-    expect(ibz.volume).toBeLessThan(hex_bz.volume * 0.6)
+    // C3 symmetry should give ~1/3 of BZ volume (geometric clipping is approximate)
+    const expected_ratio = 1 / 3
+    const actual_ratio = ibz.volume / hex_bz.volume
+    expect(actual_ratio).toBeGreaterThan(expected_ratio * 0.7) // at least 70% of expected
+    expect(actual_ratio).toBeLessThan(expected_ratio * 1.3) // at most 130% of expected
   })
 })
 
@@ -444,5 +448,24 @@ describe(`fractional_to_cartesian_rotation`, () => {
     expect(R[0][0]).toBeCloseTo(-0.4226497308103744, 6)
     expect(R[0][1]).toBeCloseTo(-0.6547005383792517, 6)
     expect(R[1][0]).toBeCloseTo(1.1547005383792515, 6)
+  })
+
+  test.each([
+    {
+      name: `singular W`,
+      W: [[0, 0, 0], [0, 1, 0], [0, 0, 1]] as Matrix3x3,
+      k: k_lattice,
+    },
+    {
+      name: `singular k_lattice`,
+      W: IDENTITY_MAT,
+      k: [[0, 0, 0], [0, 0, 0], [0, 0, 0]] as Matrix3x3,
+    },
+  ])(`returns identity matrix for $name`, ({ W, k }) => {
+    expect(fractional_to_cartesian_rotation(W, k)).toEqual([[1, 0, 0], [0, 1, 0], [
+      0,
+      0,
+      1,
+    ]])
   })
 })

--- a/tests/vitest/brillouin-compute.test.ts
+++ b/tests/vitest/brillouin-compute.test.ts
@@ -1,78 +1,62 @@
 import {
   compute_brillouin_zone,
   compute_convex_hull,
+  compute_ibz_clipping_planes,
+  compute_irreducible_bz,
+  extract_point_group_from_operations,
   generate_bz_vertices,
   reciprocal_lattice,
 } from '$lib/brillouin/compute'
-import type { Matrix3x3, Vec3 } from '$lib/math'
+import type { Matrix3x3, Vec3, Vec9 } from '$lib/math'
+import type { MoyoDataset } from '@spglib/moyo-wasm'
 import { describe, expect, test } from 'vitest'
 import reference_data from './bz_reference_data.json' with { type: 'json' }
 
-// Helper to check if vertex exists in list
-const has_vertex = (vertices: Vec3[], target: Vec3, tol = 1e-8) =>
-  vertices.some(
-    (vert) =>
-      Math.abs(vert[0] - target[0]) < tol &&
-      Math.abs(vert[1] - target[1]) < tol &&
-      Math.abs(vert[2] - target[2]) < tol,
-  )
+// Common test constants
+const CUBIC_5: Matrix3x3 = [[5, 0, 0], [0, 5, 0], [0, 0, 5]]
+const IDENTITY_MAT: Matrix3x3 = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+const INVERSION_MAT: Matrix3x3 = [[-1, 0, 0], [0, -1, 0], [0, 0, -1]]
 
-// Helper to create edge key for deduplication
+// Helpers
+const has_vertex = (vertices: Vec3[], target: Vec3, tol = 1e-8) =>
+  vertices.some((v) => v.every((c, idx) => Math.abs(c - target[idx]) < tol))
+
 const edge_key = (v1: Vec3, v2: Vec3) =>
-  [v1, v2].map((vert) => vert.map((coord) => coord.toFixed(8)).join(`,`)).sort().join(`|`)
+  [v1, v2].map((v) => v.map((c) => c.toFixed(8)).join(`,`)).sort().join(`|`)
 
 describe(`reciprocal_lattice`, () => {
   test(`correct for all crystal systems`, () => {
     for (const [_type, data] of Object.entries(reference_data)) {
       const computed = reciprocal_lattice(data.real_lattice as Matrix3x3)
       const expected = data.reciprocal_lattice as Matrix3x3
-      for (let idx_i = 0; idx_i < 3; idx_i++) {
-        for (let idx_j = 0; idx_j < 3; idx_j++) {
-          expect(computed[idx_i][idx_j]).toBeCloseTo(expected[idx_i][idx_j], 10)
-        }
-      }
+      computed.forEach((row, idx_i) =>
+        row.forEach((val, idx_j) => expect(val).toBeCloseTo(expected[idx_i][idx_j], 10))
+      )
     }
   })
 
-  test(`double reciprocal preserves structure (orthogonal remains orthogonal)`, () => {
-    const real: Matrix3x3 = [[5, 0, 0], [0, 5, 0], [0, 0, 5]]
-    const double_recip = reciprocal_lattice(reciprocal_lattice(real))
-
-    // Off-diagonal should remain zero
-    for (const [idx_i, idx_j] of [[0, 1], [0, 2], [1, 0], [1, 2], [2, 0], [2, 1]]) {
-      expect(double_recip[idx_i][idx_j]).toBeCloseTo(0, 10)
+  test(`double reciprocal preserves cubic structure`, () => {
+    const double_recip = reciprocal_lattice(reciprocal_lattice(CUBIC_5))
+    // Off-diagonal elements should be zero
+    for (let row = 0; row < 3; row++) {
+      for (let col = 0; col < 3; col++) {
+        if (row !== col) expect(double_recip[row][col]).toBeCloseTo(0, 10)
+      }
     }
-    // Diagonal should be equal and positive
+    // Diagonal elements equal and positive
     expect(double_recip[0][0]).toBeCloseTo(double_recip[1][1], 10)
-    expect(double_recip[1][1]).toBeCloseTo(double_recip[2][2], 10)
     expect(double_recip[0][0]).toBeGreaterThan(0)
   })
 
-  test(`simple cubic: b_i = 2π/a`, () => {
-    const lattice_constant = 5.0
-    const real: Matrix3x3 = [[lattice_constant, 0, 0], [0, lattice_constant, 0], [
-      0,
-      0,
-      lattice_constant,
-    ]]
-    const recip = reciprocal_lattice(real)
-    const expected = (2 * Math.PI) / lattice_constant
-
-    expect(recip[0][0]).toBeCloseTo(expected, 10)
-    expect(recip[1][1]).toBeCloseTo(expected, 10)
-    expect(recip[2][2]).toBeCloseTo(expected, 10)
-    expect(recip[0][1]).toBeCloseTo(0, 10)
-    expect(recip[0][2]).toBeCloseTo(0, 10)
-  })
-
-  test(`non-orthogonal: a_i · b_j = 2π δ_ij`, () => {
-    const real: Matrix3x3 = [[0, 2.5, 2.5], [2.5, 0, 2.5], [2.5, 2.5, 0]] // FCC
-    const recip = reciprocal_lattice(real)
-
+  test(`non-orthogonal FCC: a_i · b_j = 2π δ_ij`, () => {
+    const fcc: Matrix3x3 = [[0, 2.5, 2.5], [2.5, 0, 2.5], [2.5, 2.5, 0]]
+    const recip = reciprocal_lattice(fcc)
     for (let idx_i = 0; idx_i < 3; idx_i++) {
       for (let idx_j = 0; idx_j < 3; idx_j++) {
-        const dot = real[idx_i][0] * recip[idx_j][0] + real[idx_i][1] * recip[idx_j][1] +
-          real[idx_i][2] * recip[idx_j][2]
+        const dot = fcc[idx_i].reduce(
+          (sum, val, idx_k) => sum + val * recip[idx_j][idx_k],
+          0,
+        )
         expect(dot).toBeCloseTo(idx_i === idx_j ? 2 * Math.PI : 0, 8)
       }
     }
@@ -184,23 +168,13 @@ describe(`BZ edge filtering`, () => {
 })
 
 describe(`generate_bz_vertices`, () => {
-  const k_lattice = reciprocal_lattice([[5, 0, 0], [0, 5, 0], [0, 0, 5]])
+  const k_lattice = reciprocal_lattice(CUBIC_5)
 
   test(`cubic BZ: 8 vertices at corners`, () => {
     const vertices = generate_bz_vertices(k_lattice, 1)
     expect(vertices.length).toBe(8)
     const k_max = Math.PI / 5
-    for (const vert of vertices) {
-      expect(Math.abs(vert[0])).toBeCloseTo(k_max, 5)
-      expect(Math.abs(vert[1])).toBeCloseTo(k_max, 5)
-      expect(Math.abs(vert[2])).toBeCloseTo(k_max, 5)
-    }
-  })
-
-  test(`higher order generates more vertices`, () => {
-    const v1 = generate_bz_vertices(k_lattice, 1)
-    const v2 = generate_bz_vertices(k_lattice, 2)
-    expect(v2.length).toBeGreaterThan(v1.length)
+    vertices.forEach((v) => v.forEach((c) => expect(Math.abs(c)).toBeCloseTo(k_max, 5)))
   })
 
   test(`max_planes_by_order parameter`, () => {
@@ -268,47 +242,39 @@ describe(`compute_convex_hull`, () => {
 })
 
 describe(`BZ volume`, () => {
-  test.each([
-    [5.0, (2 * Math.PI) ** 3 / (5.0 ** 3)],
-    [3.0, (2 * Math.PI) ** 3 / (3.0 ** 3)],
-  ])(`cubic a=%d → volume ≈ (2π)³/a³`, (lattice_param, expected_vol) => {
-    const real: Matrix3x3 = [[lattice_param, 0, 0], [0, lattice_param, 0], [
-      0,
-      0,
-      lattice_param,
-    ]]
+  test.each([5.0, 3.0])(`cubic a=%d → volume ≈ (2π)³/a³`, (a) => {
+    const real: Matrix3x3 = [[a, 0, 0], [0, a, 0], [0, 0, a]]
     const bz = compute_brillouin_zone(reciprocal_lattice(real), 1)
-    expect(bz.volume).toBeCloseTo(expected_vol, 4)
+    expect(bz.volume).toBeCloseTo((2 * Math.PI) ** 3 / a ** 3, 4)
   })
 
   test(`volume = |b1 · (b2 × b3)|`, () => {
-    const real: Matrix3x3 = [[4, 0, 0], [0, 5, 0], [0, 0, 6]]
-    const k_lattice = reciprocal_lattice(real)
+    const k_lattice = reciprocal_lattice([[4, 0, 0], [0, 5, 0], [0, 0, 6]])
     const bz = compute_brillouin_zone(k_lattice, 1)
-
     const [b1, b2, b3] = k_lattice
-    const cross = [
+    const cross: Vec3 = [
       b2[1] * b3[2] - b2[2] * b3[1],
       b2[2] * b3[0] - b2[0] * b3[2],
       b2[0] * b3[1] - b2[1] * b3[0],
     ]
-    const expected_vol = Math.abs(b1[0] * cross[0] + b1[1] * cross[1] + b1[2] * cross[2])
-    expect(bz.volume).toBeCloseTo(expected_vol, 6)
+    expect(bz.volume).toBeCloseTo(
+      Math.abs(b1.reduce((s, v, idx) => s + v * cross[idx], 0)),
+      6,
+    )
   })
 })
 
 describe(`BZ order`, () => {
+  const k_lattice = reciprocal_lattice(CUBIC_5)
+
   test(`higher order → more vertices`, () => {
-    const k_lattice = reciprocal_lattice(reference_data.cubic.real_lattice as Matrix3x3)
     const bz1 = compute_brillouin_zone(k_lattice, 1)
     const bz2 = compute_brillouin_zone(k_lattice, 2)
-    expect(bz2.vertices.length).toBeGreaterThanOrEqual(bz1.vertices.length)
+    expect(bz2.vertices.length).toBeGreaterThan(bz1.vertices.length)
   })
 
   test(`order capped at 3`, () => {
-    const k_lattice = reciprocal_lattice([[5, 0, 0], [0, 5, 0], [0, 0, 5]])
-    const bz = compute_brillouin_zone(k_lattice, 3)
-    expect(bz.order).toBe(3)
+    expect(compute_brillouin_zone(k_lattice, 3).order).toBe(3)
   })
 })
 
@@ -319,8 +285,128 @@ describe(`error handling`, () => {
   })
 
   test(`handles custom max_planes_by_order`, () => {
-    const k_lattice = reciprocal_lattice([[5, 0, 0], [0, 5, 0], [0, 0, 5]])
-    const bz = compute_brillouin_zone(k_lattice, 1, 5, { 1: 50, 2: 100, 3: 200 })
+    const bz = compute_brillouin_zone(reciprocal_lattice(CUBIC_5), 1, 5, {
+      1: 50,
+      2: 100,
+      3: 200,
+    })
     expect(bz.vertices.length).toBeGreaterThan(0)
+  })
+})
+
+// Rotation matrices as Vec9 (row-major)
+const IDENTITY_ROT: Vec9 = [1, 0, 0, 0, 1, 0, 0, 0, 1]
+const ROT_Z_90: Vec9 = [0, -1, 0, 1, 0, 0, 0, 0, 1]
+const ROT_Z_180: Vec9 = [-1, 0, 0, 0, -1, 0, 0, 0, 1]
+const ROT_Z_270: Vec9 = [0, 1, 0, -1, 0, 0, 0, 0, 1]
+const MIRROR_Z: Vec9 = [1, 0, 0, 0, 1, 0, 0, 0, -1]
+const INVERSION_ROT: Vec9 = [-1, 0, 0, 0, -1, 0, 0, 0, -1]
+
+// Create mock operation for testing (Vec9 substitutes for Float64Array in tests)
+const make_op = (
+  rot: Vec9,
+  trans: Vec3 = [0, 0, 0],
+): MoyoDataset[`operations`][number] =>
+  ({ rotation: rot, translation: trans }) as unknown as MoyoDataset[`operations`][number]
+
+describe(`extract_point_group_from_operations`, () => {
+  test(`extracts identity and transposes for reciprocal space`, () => {
+    const pg = extract_point_group_from_operations([make_op(IDENTITY_ROT)])
+    expect(pg).toHaveLength(1)
+    expect(pg[0]).toEqual(IDENTITY_MAT)
+  })
+
+  test(`deduplicates same rotation with different translations`, () => {
+    const ops = [
+      make_op(IDENTITY_ROT),
+      make_op(IDENTITY_ROT, [0.5, 0, 0]),
+      make_op(IDENTITY_ROT, [0, 0.5, 0]),
+    ]
+    expect(extract_point_group_from_operations(ops)).toHaveLength(1)
+  })
+
+  test.each([
+    [`C4 group`, [IDENTITY_ROT, ROT_Z_90, ROT_Z_180, ROT_Z_270], 4],
+    [`with inversion/mirror`, [IDENTITY_ROT, INVERSION_ROT, MIRROR_Z], 3],
+    [`empty input`, [], 0],
+  ])(`%s → %d unique rotations`, (_, rots, expected) => {
+    expect(extract_point_group_from_operations(rots.map((r) => make_op(r)))).toHaveLength(
+      expected,
+    )
+  })
+
+  test(`transposes non-symmetric rotation`, () => {
+    // ROT_Z_90 [[0,-1,0],[1,0,0],[0,0,1]] → transpose [[0,1,0],[-1,0,0],[0,0,1]]
+    const [pg] = extract_point_group_from_operations([make_op(ROT_Z_90)])
+    expect(pg[0][1]).toBe(1) // from [1][0]
+    expect(pg[1][0]).toBe(-1) // from [0][1]
+  })
+})
+
+describe(`compute_ibz_clipping_planes`, () => {
+  const ROT_90: Matrix3x3 = [[0, 1, 0], [-1, 0, 0], [0, 0, 1]]
+  const ROT_180: Matrix3x3 = [[-1, 0, 0], [0, -1, 0], [0, 0, 1]]
+  const ROT_270: Matrix3x3 = [[0, -1, 0], [1, 0, 0], [0, 0, 1]]
+
+  test(`identity-only → no planes`, () => {
+    expect(compute_ibz_clipping_planes([IDENTITY_MAT])).toHaveLength(0)
+  })
+
+  test(`non-trivial symmetry → planes through origin`, () => {
+    const planes = compute_ibz_clipping_planes([IDENTITY_MAT, ROT_90])
+    expect(planes.length).toBeGreaterThan(0)
+    planes.forEach((p) => expect(p.dist).toBe(0))
+  })
+
+  test(`C4 group deduplicates planes`, () => {
+    const planes = compute_ibz_clipping_planes([IDENTITY_MAT, ROT_90, ROT_180, ROT_270])
+    expect(planes.length).toBeLessThanOrEqual(3)
+  })
+})
+
+describe(`compute_irreducible_bz`, () => {
+  const bz = compute_brillouin_zone(reciprocal_lattice(CUBIC_5), 1)
+  const MIRROR_Z_MAT: Matrix3x3 = [[1, 0, 0], [0, 1, 0], [0, 0, -1]]
+
+  test(`P1 (identity only) → full BZ`, () => {
+    const ibz = compute_irreducible_bz(bz, [IDENTITY_MAT])
+    expect(ibz).not.toBeNull()
+    if (ibz) {
+      expect(ibz.vertices).toHaveLength(bz.vertices.length)
+      expect(ibz.volume).toBeCloseTo(bz.volume, 6)
+    }
+  })
+
+  test(`inversion symmetry → smaller volume`, () => {
+    const ibz = compute_irreducible_bz(bz, [IDENTITY_MAT, INVERSION_MAT])
+    if (ibz) {
+      expect(ibz.volume).toBeLessThanOrEqual(bz.volume + 1e-6)
+      expect(ibz.vertices.length).toBeGreaterThanOrEqual(4)
+    }
+  })
+
+  test(`mirror symmetry → valid geometry`, () => {
+    const ibz = compute_irreducible_bz(bz, [IDENTITY_MAT, MIRROR_Z_MAT])
+    if (ibz) {
+      expect(ibz.vertices.length).toBeGreaterThanOrEqual(4)
+      expect(ibz.faces.length).toBeGreaterThanOrEqual(4)
+      expect(ibz.edges.length).toBeGreaterThan(0)
+      expect(ibz.volume).toBeGreaterThan(0)
+      ibz.faces.flat().forEach((idx) => {
+        expect(idx).toBeGreaterThanOrEqual(0)
+        expect(idx).toBeLessThan(ibz.vertices.length)
+      })
+    }
+  })
+
+  test(`handles all crystal systems with inversion`, () => {
+    for (const data of Object.values(reference_data)) {
+      const crystal_bz = compute_brillouin_zone(data.reciprocal_lattice as Matrix3x3, 1)
+      const ibz = compute_irreducible_bz(crystal_bz, [IDENTITY_MAT, INVERSION_MAT])
+      if (ibz) {
+        expect(ibz.volume).toBeGreaterThan(0)
+        expect(ibz.vertices.length).toBeGreaterThanOrEqual(4)
+      }
+    }
   })
 })

--- a/tests/vitest/brillouin-compute.test.ts
+++ b/tests/vitest/brillouin-compute.test.ts
@@ -335,11 +335,11 @@ describe(`extract_point_group_from_operations`, () => {
     )
   })
 
-  test(`transposes non-symmetric rotation`, () => {
-    // ROT_Z_90 [[0,-1,0],[1,0,0],[0,0,1]] → transpose [[0,1,0],[-1,0,0],[0,0,1]]
+  test(`preserves fractional rotation (no transpose)`, () => {
+    // ROT_Z_90 [[0,-1,0],[1,0,0],[0,0,1]] - returned as-is for later conversion
     const [pg] = extract_point_group_from_operations([make_op(ROT_Z_90)])
-    expect(pg[0][1]).toBe(1) // from [1][0]
-    expect(pg[1][0]).toBe(-1) // from [0][1]
+    expect(pg[0][1]).toBe(-1) // original value at [0][1]
+    expect(pg[1][0]).toBe(1) // original value at [1][0]
   })
 })
 


### PR DESCRIPTION
## Summary

Adds visualization of the irreducible Brillouin zone (IBZ) - the smallest unique part of the BZ that generates the full zone via symmetry operations.

- Computes IBZ by extracting point group operations from `moyo-wasm` symmetry analysis and clipping the full BZ with symmetry planes
- Adds UI controls: toggle, color picker, opacity slider
- IBZ rendered with distinct styling (thicker edges, different color)
- No new user input required - symmetry is computed automatically from structure

- Add configurable IBZ tooltips and hover data with k-point and symmetry information.

## Changes

- **compute.ts**: Core IBZ algorithm via iterative half-space clipping with convex hull rebuilding
- **types.ts**: Add `IrreducibleBZData` type
- **BrillouinZone/Controls/Scene**: IBZ props, controls, and 3D rendering
- **Tests**: Unit tests for all new functions + Playwright integration tests