### PR TITLE
Extract shared TooltipContent component and generic types

### DIFF
--- a/src/lib/brillouin/BrillouinZoneTooltip.svelte
+++ b/src/lib/brillouin/BrillouinZoneTooltip.svelte
@@ -1,89 +1,60 @@
 <script lang="ts">
   // Tooltip component for Brillouin zone hover information
   // Displays k-coordinates, BZ order, volume, and IBZ-specific info
-  import { format_num } from '$lib/labels'
-  import type { Vec3 } from '$lib/math'
-  import type { Snippet } from 'svelte'
-  import type { BZHoverData, BZTooltipConfig } from './types'
+  import { format_num, format_vec3 } from '$lib/labels'
+  import { TooltipContent } from '$lib/tooltip'
+  import type { BZHoverData, BZTooltipProp } from './types'
 
   let {
     hover_data,
     tooltip,
   }: {
     hover_data: BZHoverData
-    tooltip?: Snippet<[{ hover_data: BZHoverData }]> | BZTooltipConfig
+    tooltip?: BZTooltipProp
   } = $props()
-
-  // Determine tooltip mode: snippet replaces content, config adds prefix/suffix
-  const is_snippet = $derived(typeof tooltip === `function`)
-  const config = $derived(
-    !is_snippet && tooltip ? (tooltip as BZTooltipConfig) : null,
-  )
-  const prefix_html = $derived(
-    typeof config?.prefix === `function` ? config.prefix(hover_data) : config?.prefix,
-  )
-  const suffix_html = $derived(
-    typeof config?.suffix === `function` ? config.suffix(hover_data) : config?.suffix,
-  )
-  const tooltip_snippet = $derived(
-    is_snippet ? (tooltip as Snippet<[{ hover_data: BZHoverData }]>) : null,
-  )
-
-  // Format coordinate for display
-  const fmt = (val: number) => format_num(val, `.4~`)
-  const fmt_vec = (vec: Vec3) => `(${fmt(vec[0])}, ${fmt(vec[1])}, ${fmt(vec[2])})`
 
   // Ordinal for BZ order (only 1-3 in practice)
   const ordinal = (num: number) => `${num}${[`th`, `st`, `nd`, `rd`][num] ?? `th`}`
 </script>
 
-{#if tooltip_snippet}
-  {@render tooltip_snippet({ hover_data })}
-{:else}
-  <!-- Note: prefix/suffix use {@html} - ensure content is trusted -->
-  {#if prefix_html}
-    <div class="bz-tooltip-prefix">{@html prefix_html}</div>
-  {/if}
-
+<TooltipContent data={hover_data} snippet_arg={{ hover_data }} {tooltip}>
   <div class="bz-tooltip-content">
     <div class="bz-tooltip-title">
-      <strong>{
-        hover_data.is_ibz ? `Irreducible BZ` : `Brillouin Zone`
-      }</strong>{#if hover_data.bz_order > 1}<span class="bz-tooltip-badge">{
-          ordinal(hover_data.bz_order)
-        }</span>{/if}
+      <strong>{hover_data.is_ibz ? `Irreducible BZ` : `Brillouin Zone`}</strong>
+      {#if hover_data.bz_order > 1}
+        <span class="bz-tooltip-badge">{ordinal(hover_data.bz_order)}</span>
+      {/if}
     </div>
     <div class="bz-tooltip-row">
       <span class="bz-tooltip-label">k (Å⁻¹):</span>
-      <span class="bz-tooltip-value">{fmt_vec(hover_data.position_cartesian)}</span>
+      <span class="bz-tooltip-value">{format_vec3(hover_data.position_cartesian)}</span>
     </div>
     {#if hover_data.position_fractional}
       <div class="bz-tooltip-row">
         <span class="bz-tooltip-label">k (frac):</span>
-        <span class="bz-tooltip-value">{fmt_vec(hover_data.position_fractional)}</span>
+        <span class="bz-tooltip-value">{
+          format_vec3(hover_data.position_fractional)
+        }</span>
       </div>
     {/if}
     <div class="bz-tooltip-row">
       <span class="bz-tooltip-label">BZ Volume:</span>
-      <span class="bz-tooltip-value">{fmt(hover_data.bz_volume)} Å⁻³</span>
+      <span class="bz-tooltip-value">{format_num(hover_data.bz_volume, `.4~`)} Å⁻³</span>
     </div>
     {#if hover_data.is_ibz && hover_data.ibz_volume != null}
       <div class="bz-tooltip-row">
         <span class="bz-tooltip-label">IBZ Volume:</span>
-        <span class="bz-tooltip-value">{fmt(hover_data.ibz_volume)} Å⁻³</span>
+        <span class="bz-tooltip-value">{format_num(hover_data.ibz_volume, `.4~`)}
+          Å⁻³</span>
       </div>
       {#if hover_data.symmetry_multiplicity != null}
         <div class="bz-tooltip-symmetry">
-          Symmetry: 1/{hover_data.symmetry_multiplicity} of BZ
+          Symmetry: 1/{Math.round(hover_data.symmetry_multiplicity)} of BZ
         </div>
       {/if}
     {/if}
   </div>
-
-  {#if suffix_html}
-    <div class="bz-tooltip-suffix">{@html suffix_html}</div>
-  {/if}
-{/if}
+</TooltipContent>
 
 <style>
   .bz-tooltip-content {

--- a/src/lib/brillouin/types.ts
+++ b/src/lib/brillouin/types.ts
@@ -1,6 +1,6 @@
 import type { Matrix3x3, Vec3 } from '$lib/math'
 import type { Crystal } from '$lib/structure'
-import type { Snippet } from 'svelte'
+import type { TooltipConfig, TooltipProp } from '$lib/tooltip'
 
 // Hover data for BZ tooltip
 export type BZHoverData = {
@@ -15,13 +15,10 @@ export type BZHoverData = {
 }
 
 // Tooltip configuration for prefix/suffix customization
-export type BZTooltipConfig = {
-  prefix?: string | ((data: BZHoverData) => string)
-  suffix?: string | ((data: BZHoverData) => string)
-}
+export type BZTooltipConfig = TooltipConfig<BZHoverData>
 
 // Tooltip prop can be a snippet for full customization or config for prefix/suffix
-export type BZTooltipProp = Snippet<[{ hover_data: BZHoverData }]> | BZTooltipConfig
+export type BZTooltipProp = TooltipProp<BZHoverData, [{ hover_data: BZHoverData }]>
 
 // Data structure for the irreducible Brillouin zone wedge
 export type IrreducibleBZData = {

--- a/src/lib/convex-hull/index.ts
+++ b/src/lib/convex-hull/index.ts
@@ -35,17 +35,12 @@ export interface TooltipSnippetProps<AnyDimEntry = PhaseData> {
   highlight_style?: HighlightStyle
 }
 
-// Tooltip configuration object for prefix/suffix content
-// Values can be static strings or functions that receive the entry for dynamic content
-export interface TooltipConfig<AnyDimEntry = PhaseData> {
-  prefix?: string | ((entry: AnyDimEntry) => string)
-  suffix?: string | ((entry: AnyDimEntry) => string)
-}
-
-// Union type for tooltip prop - can be a snippet or config object
-export type TooltipProp<AnyDimEntry = PhaseData> =
+// ConvexHull-specific tooltip types
+import type { TooltipConfig } from '$lib/tooltip'
+export type ConvexHullTooltipConfig<AnyDimEntry = PhaseData> = TooltipConfig<AnyDimEntry>
+export type ConvexHullTooltipProp<AnyDimEntry = PhaseData> =
   | Snippet<[TooltipSnippetProps<AnyDimEntry>]>
-  | TooltipConfig<AnyDimEntry>
+  | ConvexHullTooltipConfig<AnyDimEntry>
 
 // Base props shared across all convex hull components (2D, 3D, 4D)
 export interface BaseConvexHullProps<AnyDimEntry = PhaseData>
@@ -95,7 +90,7 @@ export interface BaseConvexHullProps<AnyDimEntry = PhaseData>
   selected_entry?: AnyDimEntry | null
   children?: Snippet<[BaseConvexHullChildrenProps<AnyDimEntry>]>
   // Custom tooltip - can be a snippet (replaces default) or config object (adds prefix/suffix)
-  tooltip?: TooltipProp<AnyDimEntry>
+  tooltip?: ConvexHullTooltipProp<AnyDimEntry>
 }
 
 // Additional props specific to 3D and 4D convex hulls

--- a/src/lib/fermi-surface/types.ts
+++ b/src/lib/fermi-surface/types.ts
@@ -1,5 +1,6 @@
 // Type definitions for Fermi surface visualization
 import type { Matrix3x3, Vec3 } from '$lib/math'
+import type { TooltipConfig, TooltipProp } from '$lib/tooltip'
 
 // Spin channel type
 export type SpinChannel = `up` | `down` | null
@@ -144,10 +145,11 @@ export interface FermiHoverData {
 }
 
 // Tooltip config for prefix/suffix content
-export interface FermiTooltipConfig {
-  prefix?: string | ((data: FermiHoverData) => string)
-  suffix?: string | ((data: FermiHoverData) => string)
-}
+export type FermiTooltipConfig = TooltipConfig<FermiHoverData>
+export type FermiTooltipProp = TooltipProp<
+  FermiHoverData,
+  [{ hover_data: FermiHoverData }]
+>
 
 // Type guard: checks if parsed result is FermiSurfaceData (has pre-computed isosurfaces)
 export const is_fermi_surface_data = (

--- a/src/lib/labels.ts
+++ b/src/lib/labels.ts
@@ -138,6 +138,15 @@ export const format_num = (num: number, fmt?: string | number) => {
   return format(fmt)(num)
 }
 
+// Format a 3D vector as "(x, y, z)" with configurable precision
+export const format_vec3 = (
+  vec: readonly [number, number, number],
+  fmt_spec = `.4~`,
+): string =>
+  `(${format_num(vec[0], fmt_spec)}, ${format_num(vec[1], fmt_spec)}, ${
+    format_num(vec[2], fmt_spec)
+  })`
+
 const BYTE_UNITS = [`B`, `KiB`, `MiB`, `GiB`, `TiB`, `PiB`] as const
 
 // Format file sizes using IEC binary units (1024 factor).

--- a/src/lib/phase-diagram/PhaseDiagramTooltip.svelte
+++ b/src/lib/phase-diagram/PhaseDiagramTooltip.svelte
@@ -2,10 +2,10 @@
   import { ATOMIC_WEIGHTS } from '$lib/composition/parse'
   import type { ElementSymbol } from '$lib/element'
   import { format_num } from '$lib/labels'
-  import type { Snippet } from 'svelte'
+  import { TooltipContent } from '$lib/tooltip'
   import type {
     PhaseBoundary,
-    PhaseDiagramTooltipConfig,
+    PhaseDiagramTooltipProp,
     PhaseHoverInfo,
   } from './types'
   import {
@@ -29,20 +29,8 @@
     component_a?: string
     component_b?: string
     boundaries?: PhaseBoundary[]
-    tooltip?: Snippet<[PhaseHoverInfo]> | PhaseDiagramTooltipConfig
+    tooltip?: PhaseDiagramTooltipProp
   } = $props()
-
-  // Custom tooltip: snippet replaces default, config object adds prefix/suffix
-  const config = $derived(
-    typeof tooltip !== `function` && tooltip
-      ? (tooltip as PhaseDiagramTooltipConfig)
-      : null,
-  )
-  // Resolve prefix/suffix - call if function, otherwise use directly
-  const resolve = (val: string | ((info: PhaseHoverInfo) => string) | undefined) =>
-    typeof val === `function` ? val(hover_info) : val
-  const prefix_html = $derived(resolve(config?.prefix))
-  const suffix_html = $derived(resolve(config?.suffix))
 
   // Convert atomic fraction to weight fraction: wt_B = (x_B * M_B) / (x_A * M_A + x_B * M_B)
   const wt_fraction_b = $derived.by(() => {
@@ -117,14 +105,8 @@
   })
 </script>
 
-{#if typeof tooltip === `function`}
-  {@render tooltip(hover_info)}
-{:else}
+<TooltipContent data={hover_info} snippet_arg={hover_info} {tooltip}>
   <div class="phase-diagram-tooltip">
-    {#if prefix_html}
-      <div class="tooltip-prefix">{@html prefix_html}</div>
-    {/if}
-
     <header>
       <strong>{hover_info.region.name}</strong>
       {#if special_point_info}<span class="special-point-badge">{
@@ -192,12 +174,8 @@
         {Math.round(Math.abs(delta_t))} {temperature_unit} {label} {type}
       </div>
     {/if}
-
-    {#if suffix_html}
-      <div class="tooltip-suffix">{@html suffix_html}</div>
-    {/if}
   </div>
-{/if}
+</TooltipContent>
 
 <style>
   .phase-diagram-tooltip {
@@ -254,7 +232,6 @@
     margin: 0;
     font-weight: 500;
     font-variant-numeric: tabular-nums;
-
     small {
       opacity: 0.6;
       font-weight: normal;
@@ -265,7 +242,6 @@
     margin-top: 6px;
     padding-top: 6px;
     border-top: 1px solid var(--border);
-
     & > span {
       font-size: 10px;
       opacity: 0.7;
@@ -279,7 +255,6 @@
     display: flex;
     margin-top: 3px;
     background: light-dark(rgba(0, 0, 0, 0.1), rgba(255, 255, 255, 0.15));
-
     & > div:first-child {
       height: 100%;
       background: rgba(144, 238, 144, 0.8);
@@ -304,7 +279,6 @@
     margin-top: 3px;
     font-size: 10px;
     font-variant-numeric: tabular-nums;
-
     small {
       opacity: 0.6;
       margin-left: 2px;
@@ -317,15 +291,5 @@
     font-size: 10px;
     opacity: 0.85;
     font-style: italic;
-  }
-  .tooltip-prefix {
-    margin-bottom: 6px;
-    padding-bottom: 6px;
-    border-bottom: 1px solid var(--border);
-  }
-  .tooltip-suffix {
-    margin-top: 6px;
-    padding-top: 6px;
-    border-top: 1px solid var(--border);
   }
 </style>

--- a/src/lib/phase-diagram/types.ts
+++ b/src/lib/phase-diagram/types.ts
@@ -1,4 +1,5 @@
 import type { Sides } from '$lib/plot'
+import type { TooltipConfig, TooltipProp } from '$lib/tooltip'
 import type { Vec2 } from '../math.ts'
 
 export type TempUnit = `K` | `°C` | `°F`
@@ -126,11 +127,7 @@ export interface PhaseHoverInfo {
   special_point?: SpecialPoint // Populated when hovering near a special point
 }
 
-// Tooltip configuration object for prefix/suffix content
-// Values can be static strings or functions that receive hover info for dynamic content
-// Note: prefix/suffix are rendered via {@html}, so ensure values are developer-defined,
-// not user input, to avoid XSS vulnerabilities.
-export interface PhaseDiagramTooltipConfig {
-  prefix?: string | ((info: PhaseHoverInfo) => string)
-  suffix?: string | ((info: PhaseHoverInfo) => string)
-}
+// Tooltip configuration for prefix/suffix content
+// Note: prefix/suffix are rendered via {@html} - ensure values are trusted
+export type PhaseDiagramTooltipConfig = TooltipConfig<PhaseHoverInfo>
+export type PhaseDiagramTooltipProp = TooltipProp<PhaseHoverInfo, [PhaseHoverInfo]>

--- a/src/lib/tooltip/TooltipContent.svelte
+++ b/src/lib/tooltip/TooltipContent.svelte
@@ -46,11 +46,12 @@
   .tooltip-prefix {
     margin-bottom: 6px;
     padding-bottom: 6px;
-    border-bottom: 1px solid var(--tooltip-border, rgba(128, 128, 128, 0.3));
+    border-bottom: 1px solid
+      var(--tooltip-border, var(--border, rgba(128, 128, 128, 0.3)));
   }
   .tooltip-suffix {
     margin-top: 6px;
     padding-top: 6px;
-    border-top: 1px solid var(--tooltip-border, rgba(128, 128, 128, 0.3));
+    border-top: 1px solid var(--tooltip-border, var(--border, rgba(128, 128, 128, 0.3)));
   }
 </style>

--- a/src/lib/tooltip/TooltipContent.svelte
+++ b/src/lib/tooltip/TooltipContent.svelte
@@ -1,0 +1,56 @@
+<script lang="ts" generics="T, SnippetArg = T">
+  // Wrapper component that handles the common tooltip pattern:
+  // - If tooltip is a snippet function, render it exclusively (replaces default content)
+  // - If tooltip is a config object, render prefix/suffix around the default content
+  // - Otherwise, render just the default content
+  import type { Snippet } from 'svelte'
+  import type { TooltipConfig } from './types'
+
+  let {
+    data,
+    snippet_arg,
+    tooltip,
+    children,
+  }: {
+    data: T // Data passed to config prefix/suffix functions
+    snippet_arg: SnippetArg // Single arg passed to custom snippet (can differ from data)
+    tooltip?: Snippet<[SnippetArg]> | TooltipConfig<T>
+    children: Snippet
+  } = $props()
+
+  const is_snippet = $derived(typeof tooltip === `function`)
+  const config = $derived(
+    !is_snippet && tooltip ? (tooltip as TooltipConfig<T>) : null,
+  )
+  const prefix = $derived(
+    typeof config?.prefix === `function` ? config.prefix(data) : config?.prefix,
+  )
+  const suffix = $derived(
+    typeof config?.suffix === `function` ? config.suffix(data) : config?.suffix,
+  )
+</script>
+
+{#if is_snippet}
+  {@render (tooltip as Snippet<[SnippetArg]>)(snippet_arg)}
+{:else}
+  {#if prefix}
+    <div class="tooltip-prefix">{@html prefix}</div>
+  {/if}
+  {@render children()}
+  {#if suffix}
+    <div class="tooltip-suffix">{@html suffix}</div>
+  {/if}
+{/if}
+
+<style>
+  .tooltip-prefix {
+    margin-bottom: 6px;
+    padding-bottom: 6px;
+    border-bottom: 1px solid var(--tooltip-border, rgba(128, 128, 128, 0.3));
+  }
+  .tooltip-suffix {
+    margin-top: 6px;
+    padding-top: 6px;
+    border-top: 1px solid var(--tooltip-border, rgba(128, 128, 128, 0.3));
+  }
+</style>

--- a/src/lib/tooltip/index.ts
+++ b/src/lib/tooltip/index.ts
@@ -1,0 +1,2 @@
+export { default as TooltipContent } from './TooltipContent.svelte'
+export type { TooltipConfig, TooltipProp } from './types'

--- a/src/lib/tooltip/types.ts
+++ b/src/lib/tooltip/types.ts
@@ -1,0 +1,13 @@
+// Generic tooltip configuration types for prefix/suffix customization
+// Prefix/suffix are rendered via {@html} - ensure values are developer-defined, not user input
+import type { Snippet } from 'svelte'
+
+export type TooltipConfig<T> = {
+  prefix?: string | ((data: T) => string)
+  suffix?: string | ((data: T) => string)
+}
+
+// Union type: snippet replaces content entirely, config adds prefix/suffix
+export type TooltipProp<T, SnippetArgs extends unknown[] = [{ hover_data: T }]> =
+  | Snippet<SnippetArgs>
+  | TooltipConfig<T>

--- a/tests/vitest/convex-hull/ConvexHullTooltip.test.ts
+++ b/tests/vitest/convex-hull/ConvexHullTooltip.test.ts
@@ -1,7 +1,7 @@
 // Tests for ConvexHullTooltip component
 import ConvexHullTooltip from '$lib/convex-hull/ConvexHullTooltip.svelte'
 import type { PolymorphStats } from '$lib/convex-hull/helpers'
-import type { TooltipProp } from '$lib/convex-hull/index'
+import type { ConvexHullTooltipProp } from '$lib/convex-hull/index'
 import type { PhaseData } from '$lib/convex-hull/types'
 import { mount } from 'svelte'
 import { describe, expect, test } from 'vitest'
@@ -20,7 +20,7 @@ type TooltipProps = {
   polymorph_stats_map?: Map<string, PolymorphStats>
   highlight_style?: { color?: string }
   show_fractional?: boolean
-  tooltip?: TooltipProp<PhaseData>
+  tooltip?: ConvexHullTooltipProp<PhaseData>
 }
 
 const mount_tooltip = (props: Partial<TooltipProps> = {}) =>


### PR DESCRIPTION
- Add `$lib/tooltip` module with `TooltipContent.svelte` wrapper, `TooltipConfig<T>`, and `TooltipProp<T>` generic types
- Refactor `BrillouinZoneTooltip`, `FermiSurfaceTooltip`, `PhaseDiagramTooltip`, and `ConvexHullTooltip` to use the shared wrapper
- Add `format_vec3()` utility to `$lib/labels` for consistent 3D vector formatting
- Net reduction of 47 lines while improving consistency across tooltip components