### PR TITLE
Add ScatterPlot3D projections and fix reactivity warnings

### DIFF
--- a/src/lib/convex-hull/ConvexHull3D.svelte
+++ b/src/lib/convex-hull/ConvexHull3D.svelte
@@ -1054,10 +1054,7 @@
     fullscreen = Boolean(document.fullscreenElement)
   }}
   onmousemove={handle_mouse_move}
-  onmouseup={() => {
-    is_dragging = false
-    drag_started = false
-  }}
+  onmouseup={() => ([is_dragging, drag_started] = [false, false])}
 />
 
 <div

--- a/src/lib/convex-hull/ConvexHull3D.svelte
+++ b/src/lib/convex-hull/ConvexHull3D.svelte
@@ -1054,7 +1054,10 @@
     fullscreen = Boolean(document.fullscreenElement)
   }}
   onmousemove={handle_mouse_move}
-  onmouseup={() => is_dragging = false}
+  onmouseup={() => {
+    is_dragging = false
+    drag_started = false
+  }}
 />
 
 <div

--- a/src/lib/convex-hull/ConvexHull3D.svelte
+++ b/src/lib/convex-hull/ConvexHull3D.svelte
@@ -1054,7 +1054,7 @@
     fullscreen = Boolean(document.fullscreenElement)
   }}
   onmousemove={handle_mouse_move}
-  onmouseup={() => [is_dragging, drag_started] = [false, false]}
+  onmouseup={() => is_dragging = false}
 />
 
 <div

--- a/src/lib/fermi-surface/FermiSurface.svelte
+++ b/src/lib/fermi-surface/FermiSurface.svelte
@@ -536,9 +536,16 @@
   }
   /* Clip threlte HTML overlays (b₁/b₂/b₃ labels) when they fall outside canvas bounds.
   Targets threlte-generated container (parent of canvas), not main wrapper
-  so control pane can still be dragged outside component bounds. */
-  .fermi-surface :global(> div:has(> canvas)) {
+  so control pane can still be dragged outside component bounds.
+  Fallback for browsers without :has() - targets any direct child div */
+  .fermi-surface :global(> div) {
     overflow: hidden;
+  }
+  /* Modern browsers: reset overflow for non-canvas containers */
+  @supports selector(:has(> canvas)) {
+    .fermi-surface :global(> div:not(:has(> canvas))) {
+      overflow: visible;
+    }
   }
   .fermi-surface.active {
     z-index: var(--fermi-active-z-index, 2);

--- a/src/lib/overlays/DraggablePane.svelte
+++ b/src/lib/overlays/DraggablePane.svelte
@@ -386,15 +386,9 @@
     gap: 0.5em;
     align-items: center;
   }
-  /* Fallback class for browsers without :has() support */
-  .draggable-pane :global(label.range-label) {
+  /* Labels containing range inputs should fill available width */
+  .draggable-pane :global(label:has(input[type='range'])) {
     flex: 1;
-  }
-  /* Modern browsers: use :has() selector */
-  @supports selector(:has(input)) {
-    .draggable-pane :global(label:has(input[type='range'])) {
-      flex: 1;
-    }
   }
   .draggable-pane .control-buttons {
     display: flex;

--- a/src/lib/overlays/DraggablePane.svelte
+++ b/src/lib/overlays/DraggablePane.svelte
@@ -386,8 +386,15 @@
     gap: 0.5em;
     align-items: center;
   }
-  .draggable-pane :global(label:has(input[type='range'])) {
+  /* Fallback class for browsers without :has() support */
+  .draggable-pane :global(label.range-label) {
     flex: 1;
+  }
+  /* Modern browsers: use :has() selector */
+  @supports selector(:has(input)) {
+    .draggable-pane :global(label:has(input[type='range'])) {
+      flex: 1;
+    }
   }
   .draggable-pane .control-buttons {
     display: flex;

--- a/src/lib/plot/ScatterPlot3D.svelte
+++ b/src/lib/plot/ScatterPlot3D.svelte
@@ -437,11 +437,20 @@
     padding-top: var(--plot-fullscreen-padding-top, 2em);
     box-sizing: border-box;
   }
-  /* Threlte Canvas container needs flex: 1 to fill available space in flex layout */
-  div.scatter-3d > :global(div:has(> canvas)) {
+  /* Threlte Canvas container needs flex: 1 to fill available space in flex layout
+     Fallback for browsers without :has() - targets any direct child div */
+  div.scatter-3d > :global(div) {
     flex: 1;
     display: flex;
     flex-direction: column;
+  }
+  /* Modern browsers: more specific selector using :has() */
+  @supports selector(:has(> canvas)) {
+    div.scatter-3d > :global(div:not(:has(> canvas))) {
+      flex: initial;
+      display: initial;
+      flex-direction: initial;
+    }
   }
   div.scatter-3d :global(canvas) {
     width: 100% !important;

--- a/src/lib/plot/ScatterPlot3D.svelte
+++ b/src/lib/plot/ScatterPlot3D.svelte
@@ -356,7 +356,8 @@
         }}
         pane_props={{
           ...controls.pane_props,
-          style: `--pane-z-index: 100000001; ${controls.pane_props?.style ?? ``}`,
+          // z-index must exceed fullscreen z-index (100000001) to remain clickable in fullscreen mode
+          style: `--pane-z-index: 100000002; ${controls.pane_props?.style ?? ``}`,
         }}
         bind:x_axis
         bind:y_axis

--- a/src/lib/plot/ScatterPlot3D.svelte
+++ b/src/lib/plot/ScatterPlot3D.svelte
@@ -254,8 +254,14 @@
       className: `scatter3d-gizmo`,
     }
     if (gizmo === true) return base
-    // Merge user-provided gizmo config with adjusted offset
-    return { ...base, ...gizmo, offset: { ...base_offset, ...gizmo.offset } }
+    // Merge user-provided gizmo config, preserving scatter3d-gizmo class
+    const merged_class = `scatter3d-gizmo ${gizmo.className ?? ``}`.trim()
+    return {
+      ...base,
+      ...gizmo,
+      offset: { ...base_offset, ...gizmo.offset },
+      className: merged_class,
+    }
   })
 
   function toggle_series_visibility(idx: number) {

--- a/src/lib/plot/ScatterPlot3D.svelte
+++ b/src/lib/plot/ScatterPlot3D.svelte
@@ -71,7 +71,7 @@
     fov = 50,
     min_zoom = 0.1,
     max_zoom = 100,
-    rotate_speed = 2,
+    rotate_speed = 1,
     zoom_speed = 2,
     pan_speed = 2,
     // Lighting
@@ -247,11 +247,15 @@
   let computed_gizmo = $derived.by(() => {
     if (gizmo === false) return false
     const base_offset = { left: 5, bottom: has_color_bar ? 70 : 5 }
-    if (gizmo === true) {
-      return { background: { enabled: false }, offset: base_offset }
+    // className enables CSS targeting for z-index and pointer-events
+    const base = {
+      background: { enabled: false },
+      offset: base_offset,
+      className: `scatter3d-gizmo`,
     }
+    if (gizmo === true) return base
     // Merge user-provided gizmo config with adjusted offset
-    return { ...gizmo, offset: { ...base_offset, ...gizmo.offset } }
+    return { ...base, ...gizmo, offset: { ...base_offset, ...gizmo.offset } }
   })
 
   function toggle_series_visibility(idx: number) {
@@ -340,11 +344,14 @@
       <ScatterPlot3DControls
         toggle_props={{
           ...controls.toggle_props,
-          style: `--ctrl-btn-right: var(--fullscreen-btn-offset, 36px); top: 4px; ${
+          style: `--ctrl-btn-right: var(--fullscreen-btn-offset, 32px); ${
             controls.toggle_props?.style ?? ``
           }`,
         }}
-        pane_props={controls.pane_props}
+        pane_props={{
+          ...controls.pane_props,
+          style: `--pane-z-index: 100000001; ${controls.pane_props?.style ?? ``}`,
+        }}
         bind:x_axis
         bind:y_axis
         bind:z_axis
@@ -423,11 +430,23 @@
     padding-top: var(--plot-fullscreen-padding-top, 2em);
     box-sizing: border-box;
   }
+  /* Threlte Canvas container needs flex: 1 to fill available space in flex layout */
+  div.scatter-3d > :global(div:has(> canvas)) {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+  }
   div.scatter-3d :global(canvas) {
     width: 100% !important;
     height: 100% !important;
     flex: 1;
     outline: none;
+  }
+  /* Ensure gizmo is clickable above other overlay elements (ColorBar, Legend, etc.)
+     Use !important to override inline z-index: 1000 set by three-viewport-gizmo */
+  div.scatter-3d :global(.scatter3d-gizmo) {
+    z-index: 10000 !important;
+    pointer-events: auto !important;
   }
   .header-controls {
     position: absolute;

--- a/src/lib/plot/ScatterPlot3DControls.svelte
+++ b/src/lib/plot/ScatterPlot3DControls.svelte
@@ -120,12 +120,168 @@
     }}
     style="display: flex; flex-wrap: wrap; gap: 1ex"
   >
-    <label><input type="checkbox" bind:checked={display.show_axes} /> Axes</label>
-    <label><input type="checkbox" bind:checked={display.show_grid} /> Grid</label>
-    <label><input type="checkbox" bind:checked={display.show_axis_labels} />
-      Labels</label>
-    <label><input type="checkbox" bind:checked={display.show_bounding_box} />
-      Bounds</label>
+    <label>
+      <input
+        type="checkbox"
+        checked={display.show_axes}
+        onchange={() => (display = { ...display, show_axes: !display.show_axes })}
+      /> Axes
+    </label>
+    <label>
+      <input
+        type="checkbox"
+        checked={display.show_grid}
+        onchange={() => (display = { ...display, show_grid: !display.show_grid })}
+      /> Grid
+    </label>
+    <label>
+      <input
+        type="checkbox"
+        checked={display.show_axis_labels}
+        onchange={() => (display = {
+          ...display,
+          show_axis_labels: !display.show_axis_labels,
+        })}
+      /> Labels
+    </label>
+    <label>
+      <input
+        type="checkbox"
+        checked={display.show_bounding_box}
+        onchange={() => (display = {
+          ...display,
+          show_bounding_box: !display.show_bounding_box,
+        })}
+      /> Bounds
+    </label>
+  </SettingsSection>
+
+  <!-- Projections -->
+  <SettingsSection
+    title="Projections"
+    current_values={{
+      xy: display.projections?.xy,
+      xz: display.projections?.xz,
+      yz: display.projections?.yz,
+      opacity: display.projection_opacity,
+      scale: display.projection_scale,
+    }}
+    on_reset={() => {
+      display = {
+        ...display,
+        projections: { xy: false, xz: false, yz: false },
+        projection_opacity: 0.3,
+        projection_scale: 0.5,
+      }
+    }}
+  >
+    <div style="display: flex; flex-wrap: wrap; gap: 1ex">
+      <label>
+        <input
+          type="checkbox"
+          checked={display.projections?.xy}
+          onchange={() => (display = {
+            ...display,
+            projections: {
+              ...display.projections,
+              xy: !display.projections?.xy,
+            },
+          })}
+        /> XY
+      </label>
+      <label>
+        <input
+          type="checkbox"
+          checked={display.projections?.xz}
+          onchange={() => (display = {
+            ...display,
+            projections: {
+              ...display.projections,
+              xz: !display.projections?.xz,
+            },
+          })}
+        /> XZ
+      </label>
+      <label>
+        <input
+          type="checkbox"
+          checked={display.projections?.yz}
+          onchange={() => (display = {
+            ...display,
+            projections: {
+              ...display.projections,
+              yz: !display.projections?.yz,
+            },
+          })}
+        /> YZ
+      </label>
+    </div>
+    <div class="pane-row">
+      <label for="{uid}-proj-opacity">Opacity:</label>
+      <input
+        id="{uid}-proj-opacity"
+        type="range"
+        min="0"
+        max="1"
+        step="0.05"
+        value={display.projection_opacity ?? 0.3}
+        oninput={(
+          event,
+        ) => (display = {
+          ...display,
+          projection_opacity: parseFloat(
+            (event.target as HTMLInputElement).value,
+          ),
+        })}
+      />
+      <input
+        type="number"
+        min="0"
+        max="1"
+        step="0.05"
+        value={display.projection_opacity ?? 0.3}
+        oninput={(
+          event,
+        ) => (display = {
+          ...display,
+          projection_opacity: parseFloat(
+            (event.target as HTMLInputElement).value,
+          ),
+        })}
+        style="width: 3.5em"
+      />
+    </div>
+    <div class="pane-row">
+      <label for="{uid}-proj-scale">Size:</label>
+      <input
+        id="{uid}-proj-scale"
+        type="range"
+        min="0.1"
+        max="1"
+        step="0.05"
+        value={display.projection_scale ?? 0.5}
+        oninput={(
+          event,
+        ) => (display = {
+          ...display,
+          projection_scale: parseFloat((event.target as HTMLInputElement).value),
+        })}
+      />
+      <input
+        type="number"
+        min="0.1"
+        max="1"
+        step="0.05"
+        value={display.projection_scale ?? 0.5}
+        oninput={(
+          event,
+        ) => (display = {
+          ...display,
+          projection_scale: parseFloat((event.target as HTMLInputElement).value),
+        })}
+        style="width: 3.5em"
+      />
+    </div>
   </SettingsSection>
 
   <!-- X Axis Range -->
@@ -136,7 +292,18 @@
   >
     <div class="pane-row">
       <label for="{uid}-x-label">Label:</label>
-      <input id="{uid}-x-label" type="text" bind:value={x_axis.label} placeholder="X" />
+      <input
+        id="{uid}-x-label"
+        type="text"
+        value={x_axis.label}
+        oninput={(
+          event,
+        ) => (x_axis = {
+          ...x_axis,
+          label: (event.target as HTMLInputElement).value,
+        })}
+        placeholder="X"
+      />
     </div>
     <div class="pane-row">
       <label for="{uid}-x-range-min">Range:</label>
@@ -180,7 +347,18 @@
   >
     <div class="pane-row">
       <label for="{uid}-y-label">Label:</label>
-      <input id="{uid}-y-label" type="text" bind:value={y_axis.label} placeholder="Y" />
+      <input
+        id="{uid}-y-label"
+        type="text"
+        value={y_axis.label}
+        oninput={(
+          event,
+        ) => (y_axis = {
+          ...y_axis,
+          label: (event.target as HTMLInputElement).value,
+        })}
+        placeholder="Y"
+      />
     </div>
     <div class="pane-row">
       <label for="{uid}-y-range-min">Range:</label>
@@ -224,7 +402,18 @@
   >
     <div class="pane-row">
       <label for="{uid}-z-label">Label:</label>
-      <input id="{uid}-z-label" type="text" bind:value={z_axis.label} placeholder="Z" />
+      <input
+        id="{uid}-z-label"
+        type="text"
+        value={z_axis.label}
+        oninput={(
+          event,
+        ) => (z_axis = {
+          ...z_axis,
+          label: (event.target as HTMLInputElement).value,
+        })}
+        placeholder="Z"
+      />
     </div>
     <div class="pane-row">
       <label for="{uid}-z-range-min">Range:</label>

--- a/src/lib/plot/ScatterPlot3DControls.svelte
+++ b/src/lib/plot/ScatterPlot3DControls.svelte
@@ -62,12 +62,11 @@
   let auto_y_range = $derived(calc_auto_range(all_y_values))
   let auto_z_range = $derived(calc_auto_range(all_z_values))
 
-  // Helpers to update properties - avoids verbose inline handlers
+  // Helpers to update display properties - avoids verbose inline handlers
   const update_display = (key: keyof DisplayConfig3D) => (event: Event) => {
-    display = {
-      ...display,
-      [key]: parseFloat((event.target as HTMLInputElement).value),
-    }
+    const parsed = parseFloat((event.target as HTMLInputElement).value)
+    // Guard against NaN when input is cleared - preserve existing value
+    if (!Number.isNaN(parsed)) display = { ...display, [key]: parsed }
   }
   const toggle_display = (key: keyof DisplayConfig3D) => () => {
     display = { ...display, [key]: !display[key] }
@@ -78,13 +77,13 @@
       projections: { ...display.projections, [plane]: !display.projections?.[plane] },
     }
   }
-  const update_axis_label = (
-    axis: { label?: string },
-    setter: (val: typeof axis) => void,
-  ) =>
-  (event: Event) => {
-    setter({ ...axis, label: (event.target as HTMLInputElement).value })
-  }
+
+  // Helper for axis label updates
+  const update_axis_label =
+    <T extends { label?: string }>(axis: T, setter: (val: T) => void) =>
+    (event: Event) => {
+      setter({ ...axis, label: (event.target as HTMLInputElement).value })
+    }
 </script>
 
 <DraggablePane

--- a/src/lib/plot/ScatterPlot3DControls.svelte
+++ b/src/lib/plot/ScatterPlot3DControls.svelte
@@ -62,9 +62,12 @@
   let auto_y_range = $derived(calc_auto_range(all_y_values))
   let auto_z_range = $derived(calc_auto_range(all_z_values))
 
+  // Helper to extract input value from event - DRYs up event handler casts
+  const get_input_value = (event: Event) => (event.target as HTMLInputElement).value
+
   // Helpers to update display properties - avoids verbose inline handlers
   const update_display = (key: keyof DisplayConfig3D) => (event: Event) => {
-    const parsed = parseFloat((event.target as HTMLInputElement).value)
+    const parsed = parseFloat(get_input_value(event))
     // Guard against NaN when input is cleared - preserve existing value
     if (!Number.isNaN(parsed)) display = { ...display, [key]: parsed }
   }
@@ -82,7 +85,7 @@
   const update_axis_label =
     <T extends { label?: string }>(axis: T, setter: (val: T) => void) =>
     (event: Event) => {
-      setter({ ...axis, label: (event.target as HTMLInputElement).value })
+      setter({ ...axis, label: get_input_value(event) })
     }
 </script>
 

--- a/src/lib/plot/ScatterPlot3DScene.svelte
+++ b/src/lib/plot/ScatterPlot3DScene.svelte
@@ -485,24 +485,14 @@
     if (data) on_point_click?.(data)
   }
 
-  // Gizmo props - className enables CSS targeting for z-index and pointer-events
-  let gizmo_props = $derived.by(() => {
-    if (gizmo === false) return null
-    const base = {
-      background: { enabled: false },
-      offset: { left: 5, bottom: 5 },
-      className: `scatter3d-gizmo`,
-    }
-    if (gizmo === true) return base
-    // Merge user-provided gizmo config with base, preserving scatter3d-gizmo class
-    const merged_class = `scatter3d-gizmo ${gizmo.className ?? ``}`.trim()
-    return {
-      ...base,
-      ...gizmo,
-      offset: { ...base.offset, ...gizmo.offset },
-      className: merged_class,
-    }
-  })
+  // Gizmo props - parent (ScatterPlot3D) handles className and ColorBar offset adjustments
+  let gizmo_props = $derived(
+    gizmo === false
+      ? null
+      : gizmo === true
+      ? { background: { enabled: false }, offset: { left: 5, bottom: 5 } }
+      : gizmo,
+  )
 
   // Orbit controls - snappy with minimal inertia
   let orbit_controls_props = $derived({
@@ -811,7 +801,7 @@
   </extras.InstancedMesh>
 {/each}
 
-<!-- XY Plane Projections (floor/ceiling) - fix Z to pos.z, keep X and Y -->
+<!-- XY Plane Projections (floor/ceiling) - fix user Z (Three.js Y) to backside -->
 {#if display.projections?.xy}
   {#each radius_groups as group (group.radius)}
     <extras.InstancedMesh range={group.points.length} frustumCulled={false}>
@@ -819,7 +809,7 @@
       <T.MeshBasicMaterial transparent opacity={proj_opacity} depthWrite={false} />
       {#each group.points as point, idx (`xy-${point.series_idx}-${point.point_idx}`)}
         <extras.Instance
-          position={[point.x, point.y, pos.z]}
+          position={[point.x, pos.y, point.z]}
           scale={group.radius * proj_scale}
           color={group.colors[idx]}
         />
@@ -828,7 +818,7 @@
   {/each}
 {/if}
 
-<!-- XZ Plane Projections (back wall) - fix Y to pos.y, keep X and Z -->
+<!-- XZ Plane Projections (back wall) - fix user Y (Three.js Z) to backside -->
 {#if display.projections?.xz}
   {#each radius_groups as group (group.radius)}
     <extras.InstancedMesh range={group.points.length} frustumCulled={false}>
@@ -836,7 +826,7 @@
       <T.MeshBasicMaterial transparent opacity={proj_opacity} depthWrite={false} />
       {#each group.points as point, idx (`xz-${point.series_idx}-${point.point_idx}`)}
         <extras.Instance
-          position={[point.x, pos.y, point.z]}
+          position={[point.x, point.y, pos.z]}
           scale={group.radius * proj_scale}
           color={group.colors[idx]}
         />

--- a/src/lib/plot/ScatterPlot3DScene.svelte
+++ b/src/lib/plot/ScatterPlot3DScene.svelte
@@ -494,8 +494,14 @@
       className: `scatter3d-gizmo`,
     }
     if (gizmo === true) return base
-    // Merge user-provided gizmo config with base (ensures className is always included)
-    return { ...base, ...gizmo, offset: { ...base.offset, ...gizmo.offset } }
+    // Merge user-provided gizmo config with base, preserving scatter3d-gizmo class
+    const merged_class = `scatter3d-gizmo ${gizmo.className ?? ``}`.trim()
+    return {
+      ...base,
+      ...gizmo,
+      offset: { ...base.offset, ...gizmo.offset },
+      className: merged_class,
+    }
   })
 
   // Orbit controls - snappy with minimal inertia
@@ -805,7 +811,7 @@
   </extras.InstancedMesh>
 {/each}
 
-<!-- XY Plane Projections (floor/ceiling) -->
+<!-- XY Plane Projections (floor/ceiling) - fix Z to pos.z, keep X and Y -->
 {#if display.projections?.xy}
   {#each radius_groups as group (group.radius)}
     <extras.InstancedMesh range={group.points.length} frustumCulled={false}>
@@ -813,7 +819,7 @@
       <T.MeshBasicMaterial transparent opacity={proj_opacity} depthWrite={false} />
       {#each group.points as point, idx (`xy-${point.series_idx}-${point.point_idx}`)}
         <extras.Instance
-          position={[point.x, pos.y, point.z]}
+          position={[point.x, point.y, pos.z]}
           scale={group.radius * proj_scale}
           color={group.colors[idx]}
         />
@@ -822,7 +828,7 @@
   {/each}
 {/if}
 
-<!-- XZ Plane Projections (back wall) -->
+<!-- XZ Plane Projections (back wall) - fix Y to pos.y, keep X and Z -->
 {#if display.projections?.xz}
   {#each radius_groups as group (group.radius)}
     <extras.InstancedMesh range={group.points.length} frustumCulled={false}>
@@ -830,7 +836,7 @@
       <T.MeshBasicMaterial transparent opacity={proj_opacity} depthWrite={false} />
       {#each group.points as point, idx (`xz-${point.series_idx}-${point.point_idx}`)}
         <extras.Instance
-          position={[point.x, point.y, pos.z]}
+          position={[point.x, pos.y, point.z]}
           scale={group.radius * proj_scale}
           color={group.colors[idx]}
         />

--- a/src/lib/plot/types.ts
+++ b/src/lib/plot/types.ts
@@ -708,10 +708,11 @@ export interface DisplayConfig3D extends DisplayConfig {
   show_bounding_box?: boolean
   show_grid?: boolean
   // Projection settings - render point shadows on background planes
+  // Coordinate mapping: user X→Three.js X, user Y→Three.js Z, user Z→Three.js Y
   projections?: {
-    xy?: boolean // Project onto XY plane (floor/ceiling, Three.js Y backside)
-    xz?: boolean // Project onto XZ plane (back wall, Three.js Z backside)
-    yz?: boolean // Project onto YZ plane (side wall, Three.js X backside)
+    xy?: boolean // Project onto XY plane (floor/ceiling) - fixes user Z
+    xz?: boolean // Project onto XZ plane (back wall) - fixes user Y
+    yz?: boolean // Project onto YZ plane (side wall) - fixes user X
   }
   projection_opacity?: number // 0-1, default 0.3
   projection_scale?: number // Relative to point size, default 0.5

--- a/src/lib/plot/types.ts
+++ b/src/lib/plot/types.ts
@@ -707,6 +707,14 @@ export interface DisplayConfig3D extends DisplayConfig {
   show_axis_labels?: boolean
   show_bounding_box?: boolean
   show_grid?: boolean
+  // Projection settings - render point shadows on background planes
+  projections?: {
+    xy?: boolean // Project onto XY plane (floor/ceiling, Three.js Y backside)
+    xz?: boolean // Project onto XZ plane (back wall, Three.js Z backside)
+    yz?: boolean // Project onto YZ plane (side wall, Three.js X backside)
+  }
+  projection_opacity?: number // 0-1, default 0.3
+  projection_scale?: number // Relative to point size, default 0.5
 }
 
 // 3D scatter handler props

--- a/src/lib/spectral/Bands.svelte
+++ b/src/lib/spectral/Bands.svelte
@@ -576,6 +576,7 @@
     {@const bands_x_end = x_scale_fn(Object.values(x_positions ?? {}).flat().at(-1) ?? 1)}
     {#if Number.isFinite(fermi_y) && Number.isFinite(bands_x_end)}
       <line
+        class="fermi-level-line"
         x1={pad.l}
         x2={bands_x_end}
         y1={fermi_y}
@@ -586,6 +587,7 @@
         opacity="var(--bands-fermi-line-opacity, 0.8)"
       />
       <text
+        class="fermi-level-label"
         x={bands_x_end + 4}
         y={fermi_y}
         dy="0.35em"

--- a/src/lib/spectral/BandsAndDos.svelte
+++ b/src/lib/spectral/BandsAndDos.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import type { Vec2 } from '$lib/math'
   import type { AxisConfig } from '$lib/plot/types'
-  import { untrack } from 'svelte'
   import type { ComponentProps, Snippet } from 'svelte'
+  import { untrack } from 'svelte'
   import type { HTMLAttributes } from 'svelte/elements'
   import Bands from './Bands.svelte'
   import Dos from './Dos.svelte'
@@ -95,6 +95,9 @@
   })
 
   let hovered_frequency = $state<number | null>(null)
+
+  // Ensure both plots use identical top/bottom padding for aligned y_scale_fn
+  const shared_tb_padding = { t: 20, b: 50 }
 </script>
 
 <div
@@ -104,22 +107,22 @@
 >
   {@render children?.({ hovered_frequency })}
   <Bands
+    {...bands_props}
     {band_structs}
     {fermi_level}
-    {...bands_props}
     bind:y_axis={bands_y_axis}
     reference_frequency={hovered_frequency}
-    padding={{ r: 15, ...bands_props.padding }}
+    padding={{ r: 15, ...bands_props.padding, ...shared_tb_padding }}
   />
 
   <Dos
+    {...dos_props}
     {doses}
     {fermi_level}
     orientation="horizontal"
-    {...dos_props}
     bind:y_axis={dos_y_axis}
     bind:hovered_frequency
     reference_frequency={hovered_frequency}
-    padding={{ l: 15, ...dos_props.padding }}
+    padding={{ l: 15, ...dos_props.padding, ...shared_tb_padding }}
   />
 </div>

--- a/src/lib/spectral/Dos.svelte
+++ b/src/lib/spectral/Dos.svelte
@@ -575,6 +575,7 @@
       ? [pad.l, width - pad.r, fermi_pos, fermi_pos]
       : [fermi_pos, fermi_pos, pad.t, height - pad.b]}
         <line
+          class="fermi-level-line"
           {x1}
           {x2}
           {y1}
@@ -587,6 +588,7 @@
         <!-- Fermi level label -->
         {#if is_horizontal}
           <text
+            class="fermi-level-label"
             x={width - pad.r + 4}
             y={fermi_pos}
             dy="0.35em"
@@ -598,6 +600,7 @@
           </text>
         {:else}
           <text
+            class="fermi-level-label"
             x={fermi_pos}
             y={pad.t - 4}
             text-anchor="middle"

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -864,6 +864,8 @@
   {onkeydown}
   {...rest}
   class="trajectory {actual_layout} {rest.class ?? ``}"
+  class:show-both-views={[`structure+scatter`, `structure+histogram`].includes(display_mode) &&
+  actual_show_plot && show_structure}
 >
   {#if loading}
     {@const text = parsing_progress
@@ -1457,8 +1459,15 @@
   }
   /* Responsive design */
   @media (orientation: portrait) {
-    .trajectory:has(.content-area.show-both:not(.hide-plot):not(.hide-structure)) {
+    /* Fallback class for browsers without :has() support */
+    .trajectory.show-both-views {
       min-height: calc(var(--min-height) * 2);
+    }
+    /* Modern browsers: use :has() for same effect */
+    @supports selector(:has(.content-area)) {
+      .trajectory:has(.content-area.show-both:not(.hide-plot):not(.hide-structure)) {
+        min-height: calc(var(--min-height) * 2);
+      }
     }
     .trajectory .content-area.show-both:not(.hide-plot):not(.hide-structure) {
       grid-template-columns: 1fr !important;

--- a/src/routes/test/scatter-plot-3d/+page.svelte
+++ b/src/routes/test/scatter-plot-3d/+page.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  import { ScatterPlot3D } from '$lib'
+  import type { DataSeries3D } from '$lib/plot/types'
+
+  // Generate test data with color values to trigger ColorBar rendering
+  // This replicates the original issue where ColorBar could block gizmo clicks
+  const n_points = 50
+  const helix: DataSeries3D = {
+    x: Array.from({ length: n_points }, (_, idx) => Math.cos(idx * 0.2)),
+    y: Array.from({ length: n_points }, (_, idx) => idx * 0.1),
+    z: Array.from({ length: n_points }, (_, idx) => Math.sin(idx * 0.2)),
+    color_values: Array.from({ length: n_points }, (_, idx) => idx / n_points),
+    label: `Test Helix`,
+  }
+
+  // Expose camera position for testing
+  let camera_position = $state<[number, number, number]>([8, 8, 8])
+  let wrapper: HTMLDivElement | undefined = $state()
+</script>
+
+<h1>ScatterPlot3D Test Page</h1>
+
+<div id="test-scatter-3d" style="height: 500px; width: 100%">
+  <ScatterPlot3D
+    series={[helix]}
+    x_axis={{ label: `X` }}
+    y_axis={{ label: `Y` }}
+    z_axis={{ label: `Z` }}
+    gizmo={true}
+    bind:camera_position
+    bind:wrapper
+  />
+</div>
+
+<!-- Expose camera position for test assertions -->
+<div data-testid="camera-position" style="margin-top: 1em">
+  Camera: x={camera_position[0].toFixed(2)}, y={camera_position[1].toFixed(2)}, z={
+    camera_position[2].toFixed(2)
+  }
+</div>

--- a/tests/playwright/convex-hull/convex-hull-3d.test.ts
+++ b/tests/playwright/convex-hull/convex-hull-3d.test.ts
@@ -131,7 +131,8 @@ test.describe(`ConvexHull3D (Ternary)`, () => {
 
     const canvas = diagram.locator(`canvas`)
     const box = await canvas.boundingBox()
-    if (!box) return
+    expect(box, `Canvas bounding box not found - rendering may have failed`).toBeTruthy()
+    if (!box) throw new Error(`Canvas bounding box not found`)
 
     // Find an entry by scanning - selection indicates we hit one
     let entry_pos: { x: number; y: number } | null = null
@@ -149,7 +150,9 @@ test.describe(`ConvexHull3D (Ternary)`, () => {
         }
       }
     }
-    if (!entry_pos) return // No selectable entry found
+    expect(entry_pos, `No selectable entry found - data may not be rendering`)
+      .toBeTruthy()
+    if (!entry_pos) throw new Error(`No selectable entry found`)
 
     // Clear selection by clicking corner
     await page.mouse.click(box.x + 5, box.y + 5)

--- a/tests/playwright/convex-hull/convex-hull-3d.test.ts
+++ b/tests/playwright/convex-hull/convex-hull-3d.test.ts
@@ -123,6 +123,48 @@ test.describe(`ConvexHull3D (Ternary)`, () => {
     await expect(diagram.locator(`canvas`)).toBeVisible()
   })
 
+  test(`drag release does not trigger click callback`, async ({ page }) => {
+    // Regression: dragging to rotate should not trigger on_point_click
+    const diagram = page.locator(`.ternary-grid .convex-hull-3d`).first()
+    await expect(diagram).toBeVisible()
+    await expect(diagram).toHaveAttribute(`data-has-selection`, `false`)
+
+    const canvas = diagram.locator(`canvas`)
+    const box = await canvas.boundingBox()
+    if (!box) return
+
+    // Find an entry by scanning - selection indicates we hit one
+    let entry_pos: { x: number; y: number } | null = null
+    outer: for (let x_frac = 0.3; x_frac <= 0.7; x_frac += 0.04) {
+      for (let y_frac = 0.3; y_frac <= 0.7; y_frac += 0.04) {
+        const [test_x, test_y] = [box.x + box.width * x_frac, box.y + box.height * y_frac]
+        // deno-lint-ignore no-await-in-loop -- sequential scanning required
+        await page.mouse.click(test_x, test_y)
+        // deno-lint-ignore no-await-in-loop -- sequential scanning required
+        await page.waitForTimeout(30)
+        // deno-lint-ignore no-await-in-loop -- sequential scanning required
+        if ((await diagram.getAttribute(`data-has-selection`)) === `true`) {
+          entry_pos = { x: test_x, y: test_y }
+          break outer
+        }
+      }
+    }
+    if (!entry_pos) return // No selectable entry found
+
+    // Clear selection by clicking corner
+    await page.mouse.click(box.x + 5, box.y + 5)
+    await page.waitForTimeout(50)
+    await expect(diagram).toHaveAttribute(`data-has-selection`, `false`)
+
+    // Drag operation should not trigger selection
+    await page.mouse.move(entry_pos.x, entry_pos.y)
+    await page.mouse.down()
+    await page.mouse.move(entry_pos.x + 30, entry_pos.y + 30, { steps: 3 })
+    await page.mouse.up()
+    await page.waitForTimeout(50)
+    await expect(diagram).toHaveAttribute(`data-has-selection`, `false`)
+  })
+
   test(`tooltip shows fractional compositions with unicode glyphs`, async ({ page }) => {
     const diagram = page.locator(`.ternary-grid .convex-hull-3d`).first()
     await expect(diagram).toBeVisible()

--- a/tests/playwright/plot/scatter-plot-3d.test.ts
+++ b/tests/playwright/plot/scatter-plot-3d.test.ts
@@ -148,6 +148,10 @@ function get_projection_checkbox(
   )
 }
 
+// Helper to get slider row by label text
+const get_slider_row = (pane: import('@playwright/test').Locator, label: string) =>
+  pane.locator(`.pane-row`).filter({ hasText: label })
+
 test.describe(`ScatterPlot3D Projections`, () => {
   test.beforeEach(async ({ page }) => {
     test.skip(IS_CI, `ScatterPlot3D tests timeout in CI due to WebGL software rendering`)
@@ -184,10 +188,6 @@ test.describe(`ScatterPlot3D Projections`, () => {
       await expect(checkbox).toBeChecked()
     }
   })
-
-  // Helper to get slider row by label text for better selector specificity
-  const get_slider_row = (pane: import('@playwright/test').Locator, label: string) =>
-    pane.locator(`.pane-row`).filter({ hasText: label })
 
   // Parameterized slider default and range tests
   for (

--- a/tests/playwright/plot/scatter-plot-3d.test.ts
+++ b/tests/playwright/plot/scatter-plot-3d.test.ts
@@ -1,0 +1,132 @@
+// deno-lint-ignore-file no-window
+import { expect, test } from '@playwright/test'
+import {
+  expect_canvas_changed,
+  get_canvas_timeout,
+  wait_for_3d_canvas,
+  wait_for_canvas_rendered,
+} from '../helpers'
+
+const TEST_URL = `/test/scatter-plot-3d`
+const CONTAINER_SELECTOR = `#test-scatter-3d`
+
+test.describe(`ScatterPlot3D`, () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(TEST_URL, { waitUntil: `networkidle` })
+  })
+
+  test(`renders 3D canvas with content`, async ({ page }) => {
+    const canvas = await wait_for_3d_canvas(page, CONTAINER_SELECTOR)
+    await wait_for_canvas_rendered(canvas)
+    await expect(canvas).toBeVisible()
+  })
+
+  test(`gizmo is visible with correct size`, async ({ page }) => {
+    await wait_for_3d_canvas(page, CONTAINER_SELECTOR)
+    const gizmo = page.locator(`${CONTAINER_SELECTOR} .scatter3d-gizmo`)
+    await expect(gizmo).toBeVisible({ timeout: get_canvas_timeout() })
+
+    const box = await gizmo.boundingBox()
+    if (!box) throw new Error(`Gizmo bounding box not found`)
+    expect(box.width).toBeGreaterThan(50)
+    expect(box.height).toBeGreaterThan(50)
+  })
+
+  test(`gizmo click triggers camera rotation`, async ({ page }) => {
+    const canvas = await wait_for_3d_canvas(page, CONTAINER_SELECTOR)
+    await wait_for_canvas_rendered(canvas)
+
+    const gizmo = page.locator(`${CONTAINER_SELECTOR} .scatter3d-gizmo`)
+    const box = await gizmo.boundingBox()
+    if (!box) throw new Error(`Gizmo bounding box not found`)
+
+    const initial = await canvas.screenshot()
+    await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2)
+    await page.waitForTimeout(500)
+    await expect_canvas_changed(canvas, initial, get_canvas_timeout())
+  })
+
+  // Verify CSS properties that enable gizmo clickability
+  for (
+    const { selector, prop, expected, compare } of [
+      { selector: `.scatter3d-gizmo`, prop: `zIndex`, expected: 1000, compare: `gte` },
+      {
+        selector: `.scatter3d-gizmo`,
+        prop: `pointerEvents`,
+        expected: `auto`,
+        compare: `eq`,
+      },
+      { selector: `.axis-label`, prop: `pointerEvents`, expected: `none`, compare: `eq` },
+      { selector: `.tick-label`, prop: `pointerEvents`, expected: `none`, compare: `eq` },
+    ] as const
+  ) {
+    test(`${selector} has ${prop} ${compare} ${expected}`, async ({ page }) => {
+      await wait_for_3d_canvas(page, CONTAINER_SELECTOR)
+      const el = page.locator(`${CONTAINER_SELECTOR} ${selector}`).first()
+      await expect(el).toBeVisible({ timeout: get_canvas_timeout() })
+
+      const value = await el.evaluate(
+        (node, p) => window.getComputedStyle(node)[p as keyof CSSStyleDeclaration],
+        prop,
+      )
+      if (compare === `gte`) {
+        expect(parseInt(value as string, 10)).toBeGreaterThanOrEqual(expected as number)
+      } else {
+        expect(value).toBe(expected)
+      }
+    })
+  }
+
+  test(`drag to rotate changes view`, async ({ page }) => {
+    const canvas = await wait_for_3d_canvas(page, CONTAINER_SELECTOR)
+    await wait_for_canvas_rendered(canvas)
+    const initial = await canvas.screenshot()
+
+    const box = await canvas.boundingBox()
+    if (!box) throw new Error(`Canvas bounding box not found`)
+    const cx = box.x + box.width / 2
+    const cy = box.y + box.height / 2
+
+    await page.mouse.move(cx, cy)
+    await page.mouse.down()
+    await page.mouse.move(cx + 100, cy + 50, { steps: 10 })
+    await page.mouse.up()
+    await page.waitForTimeout(300)
+
+    await expect_canvas_changed(canvas, initial, get_canvas_timeout())
+  })
+
+  test(`scroll wheel zoom changes view`, async ({ page }) => {
+    const canvas = await wait_for_3d_canvas(page, CONTAINER_SELECTOR)
+    await wait_for_canvas_rendered(canvas)
+    const initial = await canvas.screenshot()
+
+    const box = await canvas.boundingBox()
+    if (!box) throw new Error(`Canvas bounding box not found`)
+
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+    await page.mouse.wheel(0, -200)
+    await page.waitForTimeout(300)
+
+    await expect_canvas_changed(canvas, initial, get_canvas_timeout())
+  })
+
+  test(`controls pane toggle visible on hover`, async ({ page }) => {
+    await wait_for_3d_canvas(page, CONTAINER_SELECTOR)
+    const container = page.locator(CONTAINER_SELECTOR)
+    await container.hover()
+    await expect(container.locator(`button.pane-toggle`)).toBeVisible({ timeout: 5000 })
+  })
+
+  test(`controls pane opens on toggle click`, async ({ page }) => {
+    await wait_for_3d_canvas(page, CONTAINER_SELECTOR)
+    const container = page.locator(CONTAINER_SELECTOR)
+    await container.hover()
+
+    const toggle = container.locator(`button.pane-toggle`)
+    await expect(toggle).toBeVisible({ timeout: 5000 })
+    await toggle.click()
+
+    await expect(container.locator(`.draggable-pane`)).toBeVisible({ timeout: 5000 })
+  })
+})

--- a/tests/playwright/plot/scatter-plot-3d.test.ts
+++ b/tests/playwright/plot/scatter-plot-3d.test.ts
@@ -126,33 +126,29 @@ test.describe(`ScatterPlot3D`, () => {
   })
 })
 
-// Helper to open controls pane
-async function open_controls_pane(page: import('@playwright/test').Page) {
-  const container = page.locator(CONTAINER_SELECTOR)
-  await container.hover()
-  const toggle = container.locator(`button.pane-toggle`)
-  await expect(toggle).toBeVisible({ timeout: 5000 })
-  await toggle.click()
-  const pane = container.locator(`.draggable-pane`)
-  await expect(pane).toBeVisible({ timeout: 5000 })
-  return pane
-}
-
-// Helper to get projection checkbox
-function get_projection_checkbox(
-  pane: import('@playwright/test').Locator,
-  plane: string,
-) {
-  return pane.locator(`label`).filter({ hasText: plane }).locator(
-    `input[type="checkbox"]`,
-  )
-}
-
-// Helper to get slider row by label text
-const get_slider_row = (pane: import('@playwright/test').Locator, label: string) =>
-  pane.locator(`.pane-row`).filter({ hasText: label })
-
 test.describe(`ScatterPlot3D Projections`, () => {
+  // Helper to open controls pane
+  async function open_controls_pane(page: import('@playwright/test').Page) {
+    const container = page.locator(CONTAINER_SELECTOR)
+    await container.hover()
+    const toggle = container.locator(`button.pane-toggle`)
+    await expect(toggle).toBeVisible({ timeout: 5000 })
+    await toggle.click()
+    const pane = container.locator(`.draggable-pane`)
+    await expect(pane).toBeVisible({ timeout: 5000 })
+    return pane
+  }
+
+  // Helper to get projection checkbox
+  const get_projection_checkbox = (
+    pane: import('@playwright/test').Locator,
+    plane: string,
+  ) => pane.locator(`label`).filter({ hasText: plane }).locator(`input[type="checkbox"]`)
+
+  // Helper to get slider row by label text
+  const get_slider_row = (pane: import('@playwright/test').Locator, label: string) =>
+    pane.locator(`.pane-row`).filter({ hasText: label })
+
   test.beforeEach(async ({ page }) => {
     test.skip(IS_CI, `ScatterPlot3D tests timeout in CI due to WebGL software rendering`)
     await page.goto(TEST_URL, { waitUntil: `networkidle` })

--- a/tests/playwright/plot/scatter-plot-3d.test.ts
+++ b/tests/playwright/plot/scatter-plot-3d.test.ts
@@ -218,24 +218,30 @@ test.describe(`ScatterPlot3D Projections`, () => {
     }
   })
 
-  test(`opacity slider has correct default value`, async ({ page }) => {
+  test(`opacity slider has correct default value and range`, async ({ page }) => {
     await wait_for_3d_canvas(page, CONTAINER_SELECTOR)
     const pane = await open_controls_pane(page)
 
     const opacity_slider = pane.locator(`input[type="range"]`).first()
     await expect(opacity_slider).toHaveValue(`0.3`)
+    await expect(opacity_slider).toHaveAttribute(`min`, `0`)
+    await expect(opacity_slider).toHaveAttribute(`max`, `1`)
+    await expect(opacity_slider).toHaveAttribute(`step`, `0.05`)
 
     const opacity_number = pane.locator(`input[type="number"]`).first()
     await expect(opacity_number).toHaveValue(`0.3`)
   })
 
-  test(`size slider has correct default value`, async ({ page }) => {
+  test(`size slider has correct default value and range`, async ({ page }) => {
     await wait_for_3d_canvas(page, CONTAINER_SELECTOR)
     const pane = await open_controls_pane(page)
 
     // Size slider is the second range input in Projections section
     const size_slider = pane.locator(`input[type="range"]`).nth(1)
     await expect(size_slider).toHaveValue(`0.5`)
+    await expect(size_slider).toHaveAttribute(`min`, `0.1`)
+    await expect(size_slider).toHaveAttribute(`max`, `1`)
+    await expect(size_slider).toHaveAttribute(`step`, `0.05`)
 
     const size_number = pane.locator(`input[type="number"]`).nth(1)
     await expect(size_number).toHaveValue(`0.5`)

--- a/tests/playwright/plot/scatter-plot-3d.test.ts
+++ b/tests/playwright/plot/scatter-plot-3d.test.ts
@@ -270,8 +270,8 @@ test.describe(`ScatterPlot3D Projections`, () => {
     await opacity_row.locator(`input[type="range"]`).fill(`0.8`)
     await size_row.locator(`input[type="range"]`).fill(`0.9`)
 
-    // Click first reset button (Projections section is first with sliders)
-    await pane.locator(`button[title="Reset"]`).first().click()
+    // Click reset button in Projections section specifically
+    await pane.locator(`button[title="Reset projections to defaults"]`).click()
 
     // Verify reset to defaults
     for (const plane of [`XY`, `XZ`, `YZ`]) {

--- a/tests/playwright/plot/scatter-plot-3d.test.ts
+++ b/tests/playwright/plot/scatter-plot-3d.test.ts
@@ -130,3 +130,276 @@ test.describe(`ScatterPlot3D`, () => {
     await expect(container.locator(`.draggable-pane`)).toBeVisible({ timeout: 5000 })
   })
 })
+
+// Helper to open controls pane
+async function open_controls_pane(page: import('@playwright/test').Page) {
+  const container = page.locator(CONTAINER_SELECTOR)
+  await container.hover()
+  const toggle = container.locator(`button.pane-toggle`)
+  await expect(toggle).toBeVisible({ timeout: 5000 })
+  await toggle.click()
+  const pane = container.locator(`.draggable-pane`)
+  await expect(pane).toBeVisible({ timeout: 5000 })
+  return pane
+}
+
+test.describe(`ScatterPlot3D Projections`, () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(TEST_URL, { waitUntil: `networkidle` })
+  })
+
+  test(`projections section exists in controls pane`, async ({ page }) => {
+    await wait_for_3d_canvas(page, CONTAINER_SELECTOR)
+    const pane = await open_controls_pane(page)
+
+    // Find Projections section by title
+    const projections_section = pane.locator(`text=Projections`).first()
+    await expect(projections_section).toBeVisible()
+  })
+
+  test(`projection checkboxes are unchecked by default`, async ({ page }) => {
+    await wait_for_3d_canvas(page, CONTAINER_SELECTOR)
+    const pane = await open_controls_pane(page)
+
+    // Find projection checkboxes by their labels
+    for (const plane of [`XY`, `XZ`, `YZ`]) {
+      const checkbox = pane.locator(`label`).filter({ hasText: plane }).locator(
+        `input[type="checkbox"]`,
+      )
+      // deno-lint-ignore no-await-in-loop -- sequential verification required
+      await expect(checkbox).not.toBeChecked()
+    }
+  })
+
+  // Test each projection plane toggle
+  for (const plane of [`XY`, `XZ`, `YZ`] as const) {
+    test(`toggling ${plane} projection changes canvas`, async ({ page }) => {
+      const canvas = await wait_for_3d_canvas(page, CONTAINER_SELECTOR)
+      await wait_for_canvas_rendered(canvas)
+      const pane = await open_controls_pane(page)
+
+      const initial = await canvas.screenshot()
+
+      // Find and click the projection checkbox
+      const checkbox = pane.locator(`label`).filter({ hasText: plane }).locator(
+        `input[type="checkbox"]`,
+      )
+      await checkbox.click()
+      await expect(checkbox).toBeChecked()
+      await page.waitForTimeout(200)
+
+      await expect_canvas_changed(canvas, initial, get_canvas_timeout())
+    })
+  }
+
+  test(`multiple projections can be enabled simultaneously`, async ({ page }) => {
+    const canvas = await wait_for_3d_canvas(page, CONTAINER_SELECTOR)
+    await wait_for_canvas_rendered(canvas)
+    const pane = await open_controls_pane(page)
+
+    // Enable all three projections
+    for (const plane of [`XY`, `XZ`, `YZ`]) {
+      const checkbox = pane.locator(`label`).filter({ hasText: plane }).locator(
+        `input[type="checkbox"]`,
+      )
+      // deno-lint-ignore no-await-in-loop -- sequential clicks required
+      await checkbox.click()
+      // deno-lint-ignore no-await-in-loop -- sequential verification required
+      await expect(checkbox).toBeChecked()
+    }
+
+    // Verify all are checked
+    for (const plane of [`XY`, `XZ`, `YZ`]) {
+      const checkbox = pane.locator(`label`).filter({ hasText: plane }).locator(
+        `input[type="checkbox"]`,
+      )
+      // deno-lint-ignore no-await-in-loop -- sequential verification required
+      await expect(checkbox).toBeChecked()
+    }
+  })
+
+  test(`opacity slider has correct default value`, async ({ page }) => {
+    await wait_for_3d_canvas(page, CONTAINER_SELECTOR)
+    const pane = await open_controls_pane(page)
+
+    const opacity_slider = pane.locator(`input[type="range"]`).first()
+    await expect(opacity_slider).toHaveValue(`0.3`)
+
+    const opacity_number = pane.locator(`input[type="number"]`).first()
+    await expect(opacity_number).toHaveValue(`0.3`)
+  })
+
+  test(`size slider has correct default value`, async ({ page }) => {
+    await wait_for_3d_canvas(page, CONTAINER_SELECTOR)
+    const pane = await open_controls_pane(page)
+
+    // Size slider is the second range input in Projections section
+    const size_slider = pane.locator(`input[type="range"]`).nth(1)
+    await expect(size_slider).toHaveValue(`0.5`)
+
+    const size_number = pane.locator(`input[type="number"]`).nth(1)
+    await expect(size_number).toHaveValue(`0.5`)
+  })
+
+  test(`opacity slider changes projection appearance`, async ({ page }) => {
+    const canvas = await wait_for_3d_canvas(page, CONTAINER_SELECTOR)
+    await wait_for_canvas_rendered(canvas)
+    const pane = await open_controls_pane(page)
+
+    // Enable XY projection first
+    const xy_checkbox = pane.locator(`label`).filter({ hasText: `XY` }).locator(
+      `input[type="checkbox"]`,
+    )
+    await xy_checkbox.click()
+    await page.waitForTimeout(200)
+
+    const before_opacity_change = await canvas.screenshot()
+
+    // Change opacity to max
+    const opacity_slider = pane.locator(`input[type="range"]`).first()
+    await opacity_slider.fill(`1`)
+    await page.waitForTimeout(200)
+
+    await expect_canvas_changed(canvas, before_opacity_change, get_canvas_timeout())
+  })
+
+  test(`size slider changes projection appearance`, async ({ page }) => {
+    const canvas = await wait_for_3d_canvas(page, CONTAINER_SELECTOR)
+    await wait_for_canvas_rendered(canvas)
+    const pane = await open_controls_pane(page)
+
+    // Enable XY projection first
+    const xy_checkbox = pane.locator(`label`).filter({ hasText: `XY` }).locator(
+      `input[type="checkbox"]`,
+    )
+    await xy_checkbox.click()
+    await page.waitForTimeout(200)
+
+    const before_size_change = await canvas.screenshot()
+
+    // Change size to max
+    const size_slider = pane.locator(`input[type="range"]`).nth(1)
+    await size_slider.fill(`1`)
+    await page.waitForTimeout(200)
+
+    await expect_canvas_changed(canvas, before_size_change, get_canvas_timeout())
+  })
+
+  test(`opacity number input syncs with slider`, async ({ page }) => {
+    await wait_for_3d_canvas(page, CONTAINER_SELECTOR)
+    const pane = await open_controls_pane(page)
+
+    const opacity_number = pane.locator(`input[type="number"]`).first()
+    await opacity_number.fill(`0.7`)
+    await opacity_number.press(`Enter`)
+
+    const opacity_slider = pane.locator(`input[type="range"]`).first()
+    await expect(opacity_slider).toHaveValue(`0.7`)
+  })
+
+  test(`size number input syncs with slider`, async ({ page }) => {
+    await wait_for_3d_canvas(page, CONTAINER_SELECTOR)
+    const pane = await open_controls_pane(page)
+
+    const size_number = pane.locator(`input[type="number"]`).nth(1)
+    await size_number.fill(`0.8`)
+    await size_number.press(`Enter`)
+
+    const size_slider = pane.locator(`input[type="range"]`).nth(1)
+    await expect(size_slider).toHaveValue(`0.8`)
+  })
+
+  test(`reset button resets projections to defaults`, async ({ page }) => {
+    await wait_for_3d_canvas(page, CONTAINER_SELECTOR)
+    const pane = await open_controls_pane(page)
+
+    // Enable all projections and change sliders
+    for (const plane of [`XY`, `XZ`, `YZ`]) {
+      const checkbox = pane.locator(`label`).filter({ hasText: plane }).locator(
+        `input[type="checkbox"]`,
+      )
+      // deno-lint-ignore no-await-in-loop -- sequential clicks required
+      await checkbox.click()
+    }
+    const opacity_slider = pane.locator(`input[type="range"]`).first()
+    await opacity_slider.fill(`0.8`)
+    const size_slider = pane.locator(`input[type="range"]`).nth(1)
+    await size_slider.fill(`0.9`)
+
+    // Find and click reset button in Projections section
+    // Reset buttons are in SettingsSection headers
+    const projections_header = pane.locator(`text=Projections`).first()
+    const reset_btn = projections_header.locator(`..`).locator(`button[title="Reset"]`)
+    await reset_btn.click()
+
+    // Verify all checkboxes are unchecked
+    for (const plane of [`XY`, `XZ`, `YZ`]) {
+      const checkbox = pane.locator(`label`).filter({ hasText: plane }).locator(
+        `input[type="checkbox"]`,
+      )
+      // deno-lint-ignore no-await-in-loop -- sequential verification required
+      await expect(checkbox).not.toBeChecked()
+    }
+
+    // Verify sliders are at defaults
+    await expect(opacity_slider).toHaveValue(`0.3`)
+    await expect(size_slider).toHaveValue(`0.5`)
+  })
+
+  test(`disabling projection removes it from canvas`, async ({ page }) => {
+    const canvas = await wait_for_3d_canvas(page, CONTAINER_SELECTOR)
+    await wait_for_canvas_rendered(canvas)
+    const pane = await open_controls_pane(page)
+
+    // Enable XY projection
+    const xy_checkbox = pane.locator(`label`).filter({ hasText: `XY` }).locator(
+      `input[type="checkbox"]`,
+    )
+    await xy_checkbox.click()
+    await page.waitForTimeout(200)
+    const with_projection = await canvas.screenshot()
+
+    // Disable XY projection
+    await xy_checkbox.click()
+    await expect(xy_checkbox).not.toBeChecked()
+    await page.waitForTimeout(200)
+
+    await expect_canvas_changed(canvas, with_projection, get_canvas_timeout())
+  })
+
+  test(`projections update when camera rotates`, async ({ page }) => {
+    const canvas = await wait_for_3d_canvas(page, CONTAINER_SELECTOR)
+    await wait_for_canvas_rendered(canvas)
+    const pane = await open_controls_pane(page)
+
+    // Enable all projections
+    for (const plane of [`XY`, `XZ`, `YZ`]) {
+      const checkbox = pane.locator(`label`).filter({ hasText: plane }).locator(
+        `input[type="checkbox"]`,
+      )
+      // deno-lint-ignore no-await-in-loop -- sequential clicks required
+      await checkbox.click()
+    }
+    await page.waitForTimeout(200)
+    const initial = await canvas.screenshot()
+
+    // Close pane to rotate canvas
+    await page.keyboard.press(`Escape`)
+    await page.waitForTimeout(100)
+
+    // Rotate camera by dragging
+    const box = await canvas.boundingBox()
+    if (!box) throw new Error(`Canvas bounding box not found`)
+    const cx = box.x + box.width / 2
+    const cy = box.y + box.height / 2
+
+    await page.mouse.move(cx, cy)
+    await page.mouse.down()
+    await page.mouse.move(cx + 150, cy + 100, { steps: 10 })
+    await page.mouse.up()
+    await page.waitForTimeout(300)
+
+    // Projections should have moved with camera (canvas should be different)
+    await expect_canvas_changed(canvas, initial, get_canvas_timeout())
+  })
+})

--- a/tests/playwright/spectral/bands-and-dos.test.ts
+++ b/tests/playwright/spectral/bands-and-dos.test.ts
@@ -174,4 +174,43 @@ test.describe(`BandsAndDos Component Tests`, () => {
     const plots = container.locator(`.scatter`)
     expect(await plots.count()).toBe(2)
   })
+
+  // Fermi level alignment tests - verifies BandsAndDos fermi_level prop takes precedence
+  // over any fermi_level in bands_props/dos_props, ensuring Bands and DOS are aligned
+  const fermi_alignment_cases = [
+    { anchor: `#electronic-bands`, testid: `bands-and-dos-electronic`, tolerance: 15 },
+    {
+      anchor: `#electronic-spin-polarized`,
+      testid: `bands-and-dos-spin-polarized`,
+      tolerance: 30,
+    },
+  ] as const
+
+  for (const { anchor, testid, tolerance } of fermi_alignment_cases) {
+    test(`Fermi level lines aligned in ${testid}`, async ({ page }) => {
+      await page.locator(anchor).scrollIntoViewIfNeeded()
+      const container = page.locator(`[data-testid="${testid}"]`)
+      await expect(container).toBeVisible()
+      await page.waitForTimeout(500)
+
+      const plots = container.locator(`.scatter`)
+      const bands_fermi = plots.first().locator(`.fermi-level-line`)
+      const dos_fermi = plots.nth(1).locator(`.fermi-level-line`)
+
+      await expect(bands_fermi).toHaveCount(1, { timeout: 10000 })
+      await expect(dos_fermi).toHaveCount(1, { timeout: 10000 })
+
+      // Fermi lines should be at approximately the same y position
+      await expect(async () => {
+        const [bands_y1, dos_y1] = await Promise.all([
+          bands_fermi.getAttribute(`y1`),
+          dos_fermi.getAttribute(`y1`),
+        ])
+        if (!bands_y1 || !dos_y1) throw new Error(`Fermi level y-coordinates not found`)
+        expect(Math.abs(parseFloat(bands_y1) - parseFloat(dos_y1))).toBeLessThanOrEqual(
+          tolerance,
+        )
+      }).toPass({ timeout: 5000 })
+    })
+  }
 })

--- a/tests/playwright/spectral/bands-and-dos.test.ts
+++ b/tests/playwright/spectral/bands-and-dos.test.ts
@@ -191,9 +191,10 @@ test.describe(`BandsAndDos Component Tests`, () => {
       await page.locator(anchor).scrollIntoViewIfNeeded()
       const container = page.locator(`[data-testid="${testid}"]`)
       await expect(container).toBeVisible()
-      await page.waitForTimeout(500)
-
+      // Wait for plots to render rather than fixed delay
       const plots = container.locator(`.scatter`)
+      await expect(plots).toHaveCount(2)
+
       const bands_fermi = plots.first().locator(`.fermi-level-line`)
       const dos_fermi = plots.nth(1).locator(`.fermi-level-line`)
 


### PR DESCRIPTION
## Summary

- Add ability to render "shadow" projections of scatter points onto background grid planes (XY, XZ, YZ)
- Fix Svelte `binding_property_non_reactive` warnings in ScatterPlot3DControls
- Fix gizmo and controls z-index issues ensuring proper layering
- Fix ConvexHull3D drag release triggering click callback
- Align Fermi level lines in BandsAndDos with shared padding

## Changes

### ScatterPlot3D Projections Feature
- New `DisplayConfig3D.projections` config with `xy`, `xz`, `yz` boolean toggles
- `projection_opacity` (0-1, default 0.3) and `projection_scale` (0.1-1, default 0.5) settings
- Projections section in controls panel with checkboxes and sliders
- Projections follow dynamic backside planes (same behavior as grids)

### Reactivity Fixes
- Replace `bind:checked`/`bind:value` on nested object properties with `checked`/`value` + `onchange`/`oninput` handlers
- Use object reassignment pattern (`display = { ...display, prop: value }`) for proper `$bindable` reactivity

### Z-Index Fixes
- Always merge `className: 'scatter3d-gizmo'` for custom gizmo configs
- Set control pane z-index to 100000001 to render above threlte HTML labels

### Other Fixes
- ConvexHull3D: Remove `drag_started` reset in `onmouseup` to prevent drag triggering click
- BandsAndDos: Add `shared_tb_padding` to align Fermi level lines between Bands and DOS
- Bands/Dos: Add `fermi-level-line` and `fermi-level-label` classes for test selectors