### PR TITLE
Add `StructureMatcher.find_matches` for efficient new vs existing structure matching

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,12 @@
 default_install_hook_types: [pre-commit, commit-msg]
 
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+  - repo: builtin
     hooks:
       - id: check-case-conflict
       - id: check-symlinks
       - id: check-yaml
-      - id: destroyed-symlinks
       - id: end-of-file-fixer
-      - id: forbid-new-submodules
       - id: mixed-line-ending
       - id: trailing-whitespace
 
@@ -32,6 +29,19 @@ repos:
         entry: bash -c 'deno install --allow-scripts && deno run -A --node-modules-dir npm:@sveltejs/kit sync && deno run -A --node-modules-dir npm:svelte-check-rs@latest --fail-on-warnings --threshold error'
         language: system
         types_or: [ts, svelte]
+        pass_filenames: false
+
+      - id: cargo-fmt
+        name: Cargo format
+        entry: cargo fmt --manifest-path extensions/rust/Cargo.toml --
+        language: system
+        types: [rust]
+        pass_filenames: false
+      - id: cargo-clippy
+        name: Cargo clippy
+        entry: cargo clippy --manifest-path extensions/rust/Cargo.toml --all-targets -- -D warnings
+        language: system
+        types: [rust]
         pass_filenames: false
 
   - repo: https://github.com/codespell-project/codespell

--- a/extensions/rust/Cargo.toml
+++ b/extensions/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrox"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2024"
 authors = ["Janosh Riebesell <janosh@lbl.gov>"]
 description = "High-performance structure matching for crystallographic data"

--- a/extensions/rust/src/io.rs
+++ b/extensions/rust/src/io.rs
@@ -224,7 +224,7 @@ pub fn parse_structure_json(json: &str) -> Result<Structure> {
 ///
 /// JSON string in pymatgen format.
 pub fn structure_to_pymatgen_json(structure: &Structure) -> String {
-    use serde_json::{Map, Value, json};
+    use serde_json::{Value, json};
 
     // Build lattice
     let mat = structure.lattice.matrix();
@@ -243,11 +243,12 @@ pub fn structure_to_pymatgen_json(structure: &Structure) -> String {
         .iter()
         .zip(structure.frac_coords.iter())
         .map(|(sp, coord)| {
-            let mut species_entry: Map<String, Value> = Map::new();
-            species_entry.insert("element".to_string(), json!(sp.element.symbol()));
-            species_entry.insert("occu".to_string(), json!(1.0));
+            let mut species_entry = json!({
+                "element": sp.element.symbol(),
+                "occu": 1.0
+            });
             if let Some(oxi) = sp.oxidation_state {
-                species_entry.insert("oxidation_state".to_string(), json!(oxi));
+                species_entry["oxidation_state"] = json!(oxi);
             }
 
             json!({
@@ -258,12 +259,17 @@ pub fn structure_to_pymatgen_json(structure: &Structure) -> String {
         })
         .collect();
 
+    // Build structure properties
+    let properties: serde_json::Map<String, Value> =
+        structure.properties.clone().into_iter().collect();
+
     // Build full structure
     let result = json!({
         "@module": "pymatgen.core.structure",
         "@class": "Structure",
         "lattice": lattice,
-        "sites": sites
+        "sites": sites,
+        "properties": properties
     });
 
     result.to_string()
@@ -330,56 +336,10 @@ pub fn parse_structures_glob(pattern: &str) -> Result<Vec<(String, Structure)>> 
 
 /// Serialize a structure to pymatgen JSON format.
 ///
-/// This produces JSON compatible with pymatgen's `Structure.from_dict()`.
-///
-/// # Arguments
-///
-/// * `structure` - The structure to serialize
-///
-/// # Returns
-///
-/// JSON string in pymatgen format.
+/// Alias for [`structure_to_pymatgen_json`] for backwards compatibility.
+#[inline]
 pub fn structure_to_json(structure: &Structure) -> String {
-    let mat = structure.lattice.matrix();
-
-    let sites: Vec<serde_json::Value> = structure
-        .species
-        .iter()
-        .zip(structure.frac_coords.iter())
-        .map(|(sp, fc)| {
-            let mut species_entry = serde_json::json!({
-                "element": sp.element.symbol()
-            });
-            if let Some(oxi) = sp.oxidation_state {
-                species_entry["oxidation_state"] = serde_json::json!(oxi);
-            }
-
-            serde_json::json!({
-                "species": [species_entry],
-                "abc": [fc[0], fc[1], fc[2]]
-            })
-        })
-        .collect();
-
-    let pbc = structure.lattice.pbc;
-    let properties: serde_json::Map<String, serde_json::Value> =
-        structure.properties.clone().into_iter().collect();
-
-    serde_json::json!({
-        "@module": "pymatgen.core.structure",
-        "@class": "Structure",
-        "lattice": {
-            "matrix": [
-                [mat[(0,0)], mat[(0,1)], mat[(0,2)]],
-                [mat[(1,0)], mat[(1,1)], mat[(1,2)]],
-                [mat[(2,0)], mat[(2,1)], mat[(2,2)]]
-            ],
-            "pbc": [pbc[0], pbc[1], pbc[2]]
-        },
-        "sites": sites,
-        "properties": properties
-    })
-    .to_string()
+    structure_to_pymatgen_json(structure)
 }
 
 #[cfg(test)]

--- a/extensions/rust/src/python.rs
+++ b/extensions/rust/src/python.rs
@@ -169,7 +169,11 @@ impl PyStructureMatcher {
     ///     >>> groups = matcher.group(json_strs)
     ///     >>> for canonical, members in groups.items():
     ///     ...     print(f"Group {canonical}: {members}")
-    fn group(&self, py: Python<'_>, structures: Vec<String>) -> PyResult<HashMap<usize, Vec<usize>>> {
+    fn group(
+        &self,
+        py: Python<'_>,
+        structures: Vec<String>,
+    ) -> PyResult<HashMap<usize, Vec<usize>>> {
         // Release GIL during heavy computation
         py.allow_threads(|| {
             self.inner

--- a/extensions/rust/tests/test_pymatgen_compat.py
+++ b/extensions/rust/tests/test_pymatgen_compat.py
@@ -1000,7 +1000,11 @@ def run_regression_tests() -> dict[str, bool]:
         ltol=0.2, stol=0.3, angle_tol=5.0, primitive_cell=False, scale=False
     )
     rust_matcher_noscale = RustMatcher(
-        latt_len_tol=0.2, site_pos_tol=0.3, angle_tol=5.0, primitive_cell=False, scale=False
+        latt_len_tol=0.2,
+        site_pos_tol=0.3,
+        angle_tol=5.0,
+        primitive_cell=False,
+        scale=False,
     )
 
     def run_ltol_test(
@@ -1066,7 +1070,11 @@ def run_regression_tests() -> dict[str, bool]:
         ltol=0.2, stol=0.3, angle_tol=5.0, primitive_cell=False, scale=True
     )
     rust_matcher_scale = RustMatcher(
-        latt_len_tol=0.2, site_pos_tol=0.3, angle_tol=5.0, primitive_cell=False, scale=True
+        latt_len_tol=0.2,
+        site_pos_tol=0.3,
+        angle_tol=5.0,
+        primitive_cell=False,
+        scale=True,
     )
 
     # Different angles should not match even after scaling

--- a/extensions/rust/tests/test_pymatgen_compat.py
+++ b/extensions/rust/tests/test_pymatgen_compat.py
@@ -799,6 +799,10 @@ def main() -> None:
     run_category_g_rms_consistency()
     run_cross_file_comparisons(all_structures)
 
+    # Test new APIs (find_matches, reduce_structure)
+    test_find_matches()
+    test_reduce_structure()
+
     elapsed = time.time() - start_time
 
     # Print results
@@ -1111,6 +1115,88 @@ def run_regression_tests() -> dict[str, bool]:
     print(f"  Total: {sum(results.values())}/{len(results)}")
 
     return results
+
+
+def test_find_matches() -> None:
+    """Test find_matches API for matching new structures against existing."""
+    print("\n=== Testing find_matches API ===")
+
+    matcher = RustMatcher(
+        latt_len_tol=0.2, site_pos_tol=0.3, angle_tol=5.0, primitive_cell=True
+    )
+
+    # Create existing structures (already deduplicated)
+    nacl = Structure(Lattice.cubic(5.64), ["Na", "Cl"], [[0, 0, 0], [0.5, 0.5, 0.5]])
+    fe_bcc = Structure(Lattice.cubic(2.87), ["Fe", "Fe"], [[0, 0, 0], [0.5, 0.5, 0.5]])
+    cu_fcc = Structure(Lattice.cubic(3.6), ["Cu"], [[0, 0, 0]])
+
+    existing = [nacl, fe_bcc, cu_fcc]
+    existing_json = [json.dumps(s.as_dict()) for s in existing]
+
+    # Create new structures: some match, some unique
+    nacl_shifted = Structure(
+        Lattice.cubic(5.64), ["Na", "Cl"], [[0.1, 0.1, 0.1], [0.6, 0.6, 0.6]]
+    )
+    si = Structure(Lattice.cubic(5.43), ["Si"], [[0, 0, 0]])  # unique
+
+    new = [nacl_shifted, fe_bcc, si]
+    new_json = [json.dumps(s.as_dict()) for s in new]
+
+    matches = matcher.find_matches(new_json, existing_json)
+    expected = [0, 1, None]  # nacl->0, fe->1, si->None
+
+    assert matches == expected, f"find_matches failed: {matches} != {expected}"
+    print("  find_matches: PASSED")
+
+    # Test empty inputs
+    assert matcher.find_matches([], existing_json) == []
+    assert matcher.find_matches(new_json, []) == [None, None, None]
+    print("  find_matches empty inputs: PASSED")
+
+
+def test_reduce_structure() -> None:
+    """Test reduce_structure and skip_structure_reduction APIs."""
+    print("\n=== Testing reduce_structure API ===")
+
+    matcher = RustMatcher(
+        latt_len_tol=0.2, site_pos_tol=0.3, angle_tol=5.0, primitive_cell=True
+    )
+
+    # Create structure with properties
+    nacl = Structure(Lattice.cubic(5.64), ["Na", "Cl"], [[0, 0, 0], [0.5, 0.5, 0.5]])
+    nacl.properties = {"energy": -5.5, "source": "DFT"}
+
+    json_str = json.dumps(nacl.as_dict())
+    reduced = matcher.reduce_structure(json_str)
+    reduced_dict = json.loads(reduced)
+
+    # Check structure is valid pymatgen format
+    assert "@module" in reduced_dict
+    assert "@class" in reduced_dict
+    assert "lattice" in reduced_dict
+    assert "sites" in reduced_dict
+    print("  reduce_structure format: PASSED")
+
+    # Check properties preserved
+    assert reduced_dict.get("properties") == {"energy": -5.5, "source": "DFT"}
+    print("  reduce_structure properties: PASSED")
+
+    # Test fit with skip_structure_reduction
+    reduced2 = matcher.reduce_structure(json_str)
+    assert matcher.fit(reduced, reduced2, skip_structure_reduction=True)
+    print("  fit with skip_structure_reduction: PASSED")
+
+    # Consistency: normal fit should match skip fit
+    nacl_shifted = Structure(
+        Lattice.cubic(5.64), ["Na", "Cl"], [[0.1, 0.1, 0.1], [0.6, 0.6, 0.6]]
+    )
+    json_shifted = json.dumps(nacl_shifted.as_dict())
+    reduced_shifted = matcher.reduce_structure(json_shifted)
+
+    normal_result = matcher.fit(json_str, json_shifted)
+    skip_result = matcher.fit(reduced, reduced_shifted, skip_structure_reduction=True)
+    assert normal_result == skip_result, "fit consistency failed"
+    print("  fit consistency: PASSED")
 
 
 if __name__ == "__main__":

--- a/tests/playwright/phase-diagram/isobaric-binary.test.ts
+++ b/tests/playwright/phase-diagram/isobaric-binary.test.ts
@@ -13,7 +13,7 @@ function get_diagram_elements(page: Page): { diagram: Locator; svg: Locator } {
 
 test.describe(`IsobaricBinaryPhaseDiagram`, () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(`/phase-diagram`, { waitUntil: `networkidle` })
+    await page.goto(`/phase-diagram`, { waitUntil: `domcontentloaded` })
     const { svg } = get_diagram_elements(page)
     await expect(svg.locator(`.phase-regions path`).first()).toBeVisible({
       timeout: LOAD_TIMEOUT,

--- a/tests/playwright/plot/bar-plot.test.ts
+++ b/tests/playwright/plot/bar-plot.test.ts
@@ -3,7 +3,7 @@ import { get_tick_range, IS_CI } from '../helpers'
 
 test.describe(`BarPlot Component Tests`, () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(`/test/bar-plot`, { waitUntil: `networkidle` })
+    await page.goto(`/test/bar-plot`, { waitUntil: `domcontentloaded` })
   })
 
   test(`renders basic bar plot with axes and bars`, async ({ page }) => {

--- a/tests/playwright/plot/scatter-plot.test.ts
+++ b/tests/playwright/plot/scatter-plot.test.ts
@@ -284,7 +284,7 @@ const extract_legend_properties = async <T>(
 // Scatter plot tests
 test.describe(`ScatterPlot Component Tests`, () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(`/test/scatter-plot`, { waitUntil: `networkidle` })
+    await page.goto(`/test/scatter-plot`, { waitUntil: `domcontentloaded` })
   })
 
   // Basic rendering tests


### PR DESCRIPTION
## Summary

Adds `find_matches()` to ferrox, optimized for the common deduplication scenario where:
- A small batch of new structures (~100) needs to be checked
- Against a large set of existing structures (~28,000) that are already deduplicated

- Add `reduce_structure` and `fit_preprocessed` APIs plus JSON matching endpoints.
- Allow callers with preprocessed inputs to skip automatic structure reduction.

## Key Optimizations

| Operation | `group()` on all | `find_matches()` |
|-----------|------------------|------------------|
| Existing vs existing | O(28,000²) comparisons | **Skipped** (already deduplicated) |
| New vs existing | O(100 × 28,000) | O(100 × candidates_per_composition) |

- **Skips existing vs existing** - they're already deduplicated
- **Composition hashing** - only compares structures with same composition
- **Early termination** - stops on first match for each new structure
- **Parallelized** - each new structure checked independently with Rayon

## Usage

```python
from ferrox import StructureMatcher

matcher = StructureMatcher(...)
matches = matcher.find_matches(new_json_strs, existing_json_strs)
# Returns: [Optional[int], ...] where matches[i] is:
#   - Some(j) if new[i] matches existing[j]
#   - None if new[i] is unique
```