### PR TITLE
Add disordered site support, fit_anonymous, and fix lattice parsing

### DIFF
--- a/extensions/rust/Cargo.toml
+++ b/extensions/rust/Cargo.toml
@@ -34,6 +34,7 @@ serde_json = "1.0"
 
 # Algorithms
 pathfinding = "4.14" # Hungarian algorithm (kuhn_munkres)
+itertools = "0.14" # permutations for fit_anonymous
 
 # Utilities
 indexmap = { version = "2.13", features = ["serde"] }

--- a/extensions/rust/Cargo.toml
+++ b/extensions/rust/Cargo.toml
@@ -34,7 +34,7 @@ serde_json = "1.0"
 
 # Algorithms
 pathfinding = "4.14" # Hungarian algorithm (kuhn_munkres)
-itertools = "0.14" # permutations for fit_anonymous
+itertools = "0.14"   # permutations for fit_anonymous
 
 # Utilities
 indexmap = { version = "2.13", features = ["serde"] }

--- a/extensions/rust/src/cif.rs
+++ b/extensions/rust/src/cif.rs
@@ -341,10 +341,10 @@ fn clean_element_symbol(symbol: &str) -> String {
 mod tests {
     use super::*;
 
-    // Helper to count elements in a structure
+    // Helper to count elements in a structure (counts dominant species per site)
     fn count_element(structure: &Structure, elem: Element) -> usize {
         structure
-            .species
+            .species()
             .iter()
             .filter(|sp| sp.element == elem)
             .count()
@@ -465,8 +465,8 @@ Cl Cl1 0.5 0.5 0.5
 
         let structure = parse_cif_str(cif_content, Path::new("test.cif")).unwrap();
         assert_eq!(structure.num_sites(), 2);
-        assert_eq!(structure.species[0].element, Element::Na);
-        assert_eq!(structure.species[1].element, Element::Cl);
+        assert_eq!(structure.species()[0].element, Element::Na);
+        assert_eq!(structure.species()[1].element, Element::Cl);
     }
 
     #[test]
@@ -580,9 +580,9 @@ S1   S   0.500  0.500  0.500  1.000
         assert!((angles.y - 95.0).abs() < 1e-5);
 
         // Check elements
-        assert_eq!(structure.species[0].element, Element::Ru);
-        assert_eq!(structure.species[1].element, Element::P);
-        assert_eq!(structure.species[2].element, Element::S);
+        assert_eq!(structure.species()[0].element, Element::Ru);
+        assert_eq!(structure.species()[1].element, Element::P);
+        assert_eq!(structure.species()[2].element, Element::S);
     }
 
     #[test]
@@ -641,10 +641,10 @@ N4   0.750  0.750  0.750  1.000
         assert_eq!(structure.num_sites(), 4);
 
         // Elements should be extracted from labels
-        assert_eq!(structure.species[0].element, Element::Ru);
-        assert_eq!(structure.species[1].element, Element::P);
-        assert_eq!(structure.species[2].element, Element::S);
-        assert_eq!(structure.species[3].element, Element::N);
+        assert_eq!(structure.species()[0].element, Element::Ru);
+        assert_eq!(structure.species()[1].element, Element::P);
+        assert_eq!(structure.species()[2].element, Element::S);
+        assert_eq!(structure.species()[3].element, Element::N);
     }
 
     #[test]
@@ -672,8 +672,8 @@ O2-  O1  0.5 0.5 0.5
         assert_eq!(structure.num_sites(), 2);
 
         // Oxidation states should be stripped from element
-        assert_eq!(structure.species[0].element, Element::Fe);
-        assert_eq!(structure.species[1].element, Element::O);
+        assert_eq!(structure.species()[0].element, Element::Fe);
+        assert_eq!(structure.species()[1].element, Element::O);
     }
 
     #[test]

--- a/extensions/rust/src/composition.rs
+++ b/extensions/rust/src/composition.rs
@@ -118,6 +118,26 @@ impl Composition {
     pub fn iter(&self) -> impl Iterator<Item = (&Element, &f64)> {
         self.elements.iter()
     }
+
+    /// Get elements in iteration order.
+    pub fn elements(&self) -> Vec<Element> {
+        self.elements.keys().copied().collect()
+    }
+
+    /// Create new composition with elements remapped according to mapping.
+    ///
+    /// Elements not in the mapping are preserved as-is.
+    pub fn remap_elements(&self, mapping: &std::collections::HashMap<Element, Element>) -> Self {
+        let remapped: IndexMap<Element, f64> = self
+            .elements
+            .iter()
+            .map(|(&elem, &amt)| {
+                let new_elem = mapping.get(&elem).copied().unwrap_or(elem);
+                (new_elem, amt)
+            })
+            .collect();
+        Self { elements: remapped }
+    }
 }
 
 /// Compute GCD of two floating point numbers (treating as approximate integers).

--- a/extensions/rust/src/composition.rs
+++ b/extensions/rust/src/composition.rs
@@ -361,25 +361,6 @@ mod tests {
     #[test]
     fn test_remap_elements_combines_amounts() {
         // Multiple source elements mapping to the same target should sum their amounts
-        let comp = Composition::new([(Element::Na, 2.0), (Element::K, 1.0)]);
-        let mapping = HashMap::from([(Element::Na, Element::Li), (Element::K, Element::Li)]);
-        let remapped = comp.remap_elements(&mapping);
-
-        assert_eq!(
-            remapped.get(Element::Li),
-            3.0,
-            "Na (2.0) + K (1.0) both mapping to Li should give Li: 3.0"
-        );
-        assert_eq!(
-            remapped.num_elements(),
-            1,
-            "Should only have Li after remapping"
-        );
-    }
-
-    #[test]
-    fn test_remap_elements_multiple_to_same_target() {
-        // More comprehensive test: 3 elements mapping to 2 targets
         let comp = Composition::new([
             (Element::Na, 1.0),
             (Element::K, 2.0),
@@ -387,24 +368,24 @@ mod tests {
             (Element::Cl, 4.0),
         ]);
         let mapping = HashMap::from([
-            (Element::Na, Element::Li), // alkali metals -> Li
+            (Element::Na, Element::Li),
             (Element::K, Element::Li),
             (Element::Rb, Element::Li),
-            (Element::Cl, Element::F), // halide -> F
+            (Element::Cl, Element::F),
         ]);
         let remapped = comp.remap_elements(&mapping);
 
         assert_eq!(
             remapped.get(Element::Li),
             6.0,
-            "Na (1) + K (2) + Rb (3) -> Li should give 6.0"
+            "Na + K + Rb should sum to Li"
         );
         assert_eq!(
             remapped.get(Element::F),
             4.0,
             "Cl -> F should preserve amount"
         );
-        assert_eq!(remapped.num_elements(), 2, "Should only have Li and F");
+        assert_eq!(remapped.num_elements(), 2);
     }
 
     // =========================================================================

--- a/extensions/rust/src/composition.rs
+++ b/extensions/rust/src/composition.rs
@@ -120,6 +120,9 @@ impl Composition {
     }
 
     /// Get elements in iteration order.
+    ///
+    /// Note: This allocates a new Vec. For iteration without allocation,
+    /// use `self.iter().map(|(elem, _)| *elem)`.
     pub fn elements(&self) -> Vec<Element> {
         self.elements.keys().copied().collect()
     }

--- a/extensions/rust/src/io.rs
+++ b/extensions/rust/src/io.rs
@@ -309,7 +309,6 @@ pub fn parse_structure_json(json: &str) -> Result<Structure> {
     // Extract properties from JSON
     let properties = match parsed.properties {
         serde_json::Value::Object(map) => map.into_iter().collect(),
-        serde_json::Value::Null => std::collections::HashMap::new(),
         _ => std::collections::HashMap::new(),
     };
 

--- a/extensions/rust/src/matcher.rs
+++ b/extensions/rust/src/matcher.rs
@@ -604,6 +604,12 @@ impl StructureMatcher {
         let comp2 = struct2.composition();
         let comp2_hash = comp2.hash();
 
+        // Create element-only matcher once (used for all permutations)
+        let element_matcher = Self {
+            comparator_type: ComparatorType::Element,
+            ..self.clone()
+        };
+
         // Try all permutations of elements2
         for perm in elements2.iter().permutations(elements2.len()) {
             // Create mapping: elements1[i] -> perm[i]
@@ -619,14 +625,8 @@ impl StructureMatcher {
                 continue;
             }
 
-            // Composition matches - do full structure comparison with element-only matching.
-            // We use ComparatorType::Element to ignore oxidation states, matching
-            // pymatgen's anonymous matching behavior.
+            // Composition matches - do full structure comparison
             let remapped_struct1 = struct1.remap_species(&mapping);
-            let element_matcher = Self {
-                comparator_type: ComparatorType::Element,
-                ..self.clone()
-            };
             if element_matcher.fit(&remapped_struct1, struct2) {
                 return true;
             }

--- a/extensions/rust/src/matcher.rs
+++ b/extensions/rust/src/matcher.rs
@@ -1034,44 +1034,33 @@ mod tests {
 
     #[test]
     fn test_fit_anonymous_swapped_species() {
-        let nacl = Structure::new(
-            Lattice::cubic(5.64),
-            vec![Species::neutral(Element::Na), Species::neutral(Element::Cl)],
-            vec![Vector3::new(0.0, 0.0, 0.0), Vector3::new(0.5, 0.5, 0.5)],
-        );
+        // NaCl with swapped species order should match
+        let nacl = make_nacl();
         let clna = Structure::new(
             Lattice::cubic(5.64),
             vec![Species::neutral(Element::Cl), Species::neutral(Element::Na)],
             vec![Vector3::new(0.0, 0.0, 0.0), Vector3::new(0.5, 0.5, 0.5)],
         );
-        let matcher = StructureMatcher::new();
-        assert!(matcher.fit_anonymous(&nacl, &clna));
+        assert!(StructureMatcher::new().fit_anonymous(&nacl, &clna));
     }
 
     #[test]
     fn test_fit_anonymous_same_prototype() {
-        let nacl = Structure::new(
-            Lattice::cubic(5.64),
-            vec![Species::neutral(Element::Na), Species::neutral(Element::Cl)],
-            vec![Vector3::new(0.0, 0.0, 0.0), Vector3::new(0.5, 0.5, 0.5)],
-        );
+        // NaCl and MgO have the same rocksalt prototype
+        let nacl = make_nacl();
         let mgo = Structure::new(
             Lattice::cubic(4.21),
             vec![Species::neutral(Element::Mg), Species::neutral(Element::O)],
             vec![Vector3::new(0.0, 0.0, 0.0), Vector3::new(0.5, 0.5, 0.5)],
         );
-        let matcher = StructureMatcher::new();
-        assert!(matcher.fit_anonymous(&nacl, &mgo));
+        assert!(StructureMatcher::new().fit_anonymous(&nacl, &mgo));
     }
 
     #[test]
     fn test_fit_anonymous_different_stoichiometry() {
-        let nacl = Structure::new(
-            Lattice::cubic(5.64),
-            vec![Species::neutral(Element::Na), Species::neutral(Element::Cl)],
-            vec![Vector3::new(0.0, 0.0, 0.0), Vector3::new(0.5, 0.5, 0.5)],
-        );
-        let fe2o3 = Structure::new(
+        // AB vs A2B3 stoichiometry should not match
+        let nacl = make_nacl();
+        let a2b3 = Structure::new(
             Lattice::cubic(5.0),
             vec![
                 Species::neutral(Element::Fe),
@@ -1088,8 +1077,7 @@ mod tests {
                 Vector3::new(0.25, 0.75, 0.25),
             ],
         );
-        let matcher = StructureMatcher::new();
-        assert!(!matcher.fit_anonymous(&nacl, &fe2o3));
+        assert!(!StructureMatcher::new().fit_anonymous(&nacl, &a2b3));
     }
 
     #[test]

--- a/extensions/rust/src/species.rs
+++ b/extensions/rust/src/species.rs
@@ -417,15 +417,16 @@ mod tests {
     }
 
     #[test]
-    fn test_site_occupancy_dominant_with_equal_occupancy() {
-        // When occupancies are equal, should return one deterministically
+    fn test_site_occupancy_equal_occupancy_deterministic() {
+        // When occupancies are equal, result should be deterministic across calls
         let so = SiteOccupancy::new(vec![
             (Species::neutral(Element::Fe), 0.5),
             (Species::neutral(Element::Co), 0.5),
         ]);
-        // Should not panic, should return one of them
-        let dominant = so.dominant_species();
-        assert!(dominant.element == Element::Fe || dominant.element == Element::Co);
+        let dom1 = so.dominant_species().element;
+        let dom2 = so.dominant_species().element;
+        assert_eq!(dom1, dom2, "dominant_species should be deterministic");
+        assert!(dom1 == Element::Fe || dom1 == Element::Co);
     }
 
     #[test]
@@ -480,31 +481,6 @@ mod tests {
             (so.total_occupancy() - 0.7).abs() < 1e-10,
             "Total occupancy should be 0.7, got {}",
             so.total_occupancy()
-        );
-    }
-
-    #[test]
-    fn test_site_occupancy_dominant_deterministic() {
-        // When occupancies are equal, result should be deterministic across calls
-        let so = SiteOccupancy::new(vec![
-            (Species::neutral(Element::Fe), 0.5),
-            (Species::neutral(Element::Co), 0.5),
-        ]);
-        let dom1 = so.dominant_species().element;
-        let dom2 = so.dominant_species().element;
-        assert_eq!(dom1, dom2, "dominant_species should be deterministic");
-    }
-
-    #[test]
-    fn test_site_occupancy_full_occupancy_check() {
-        // Verify total_occupancy() works for full occupancy
-        let so = SiteOccupancy::new(vec![
-            (Species::neutral(Element::Fe), 0.5),
-            (Species::neutral(Element::Co), 0.5),
-        ]);
-        assert!(
-            (so.total_occupancy() - 1.0).abs() < 1e-10,
-            "Total occupancy should be 1.0"
         );
     }
 }

--- a/extensions/rust/src/species.rs
+++ b/extensions/rust/src/species.rs
@@ -165,6 +165,52 @@ impl From<Element> for Species {
     }
 }
 
+/// A site with potentially multiple species (partial occupancy).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SiteOccupancy {
+    /// Species with their occupancies.
+    pub species: Vec<(Species, f64)>,
+}
+
+impl SiteOccupancy {
+    /// Create a new site occupancy from species-occupancy pairs.
+    pub fn new(species: Vec<(Species, f64)>) -> Self {
+        Self { species }
+    }
+
+    /// Create an ordered site with a single species at full occupancy.
+    pub fn ordered(species: Species) -> Self {
+        Self {
+            species: vec![(species, 1.0)],
+        }
+    }
+
+    /// Check if this is an ordered site (single species).
+    pub fn is_ordered(&self) -> bool {
+        self.species.len() == 1
+    }
+
+    /// Get the dominant species (highest occupancy).
+    pub fn dominant_species(&self) -> &Species {
+        self.species
+            .iter()
+            .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
+            .map(|(sp, _)| sp)
+            .expect("SiteOccupancy must have at least one species")
+    }
+
+    /// Get the total occupancy.
+    pub fn total_occupancy(&self) -> f64 {
+        self.species.iter().map(|(_, occ)| occ).sum()
+    }
+}
+
+impl From<Species> for SiteOccupancy {
+    fn from(species: Species) -> Self {
+        Self::ordered(species)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/extensions/rust/src/species.rs
+++ b/extensions/rust/src/species.rs
@@ -177,11 +177,17 @@ impl SiteOccupancy {
     ///
     /// # Panics
     ///
-    /// Panics if `species` is empty.
+    /// Panics if `species` is empty or if any occupancy is not finite or negative.
     pub fn new(species: Vec<(Species, f64)>) -> Self {
         assert!(
             !species.is_empty(),
             "SiteOccupancy requires at least one species"
+        );
+        assert!(
+            species
+                .iter()
+                .all(|(_, occ)| occ.is_finite() && *occ >= 0.0),
+            "SiteOccupancy occupancies must be finite and non-negative"
         );
         Self { species }
     }
@@ -434,6 +440,24 @@ mod tests {
     #[should_panic(expected = "SiteOccupancy requires at least one species")]
     fn test_site_occupancy_empty_panics() {
         SiteOccupancy::new(vec![]);
+    }
+
+    #[test]
+    #[should_panic(expected = "SiteOccupancy occupancies must be finite and non-negative")]
+    fn test_site_occupancy_negative_panics() {
+        SiteOccupancy::new(vec![(Species::neutral(Element::Fe), -0.5)]);
+    }
+
+    #[test]
+    #[should_panic(expected = "SiteOccupancy occupancies must be finite and non-negative")]
+    fn test_site_occupancy_nan_panics() {
+        SiteOccupancy::new(vec![(Species::neutral(Element::Fe), f64::NAN)]);
+    }
+
+    #[test]
+    #[should_panic(expected = "SiteOccupancy occupancies must be finite and non-negative")]
+    fn test_site_occupancy_infinity_panics() {
+        SiteOccupancy::new(vec![(Species::neutral(Element::Fe), f64::INFINITY)]);
     }
 
     #[test]

--- a/extensions/rust/src/structure.rs
+++ b/extensions/rust/src/structure.rs
@@ -1,13 +1,14 @@
 //! Crystal structure representation.
 //!
 //! This module provides the `Structure` type for representing crystal structures
-//! with a lattice, species, and fractional coordinates.
+//! with a lattice, site occupancies, and fractional coordinates.
 
 use crate::composition::Composition;
 use crate::element::Element;
 use crate::error::{FerroxError, Result};
 use crate::lattice::Lattice;
-use crate::species::Species;
+use crate::species::{SiteOccupancy, Species};
+use itertools::Itertools;
 use moyo::MoyoDataset;
 use moyo::base::{AngleTolerance, Cell as MoyoCell, Lattice as MoyoLattice};
 use moyo::data::Setting;
@@ -15,13 +16,16 @@ use nalgebra::{Matrix3, Vector3};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-/// A crystal structure with lattice, species, and coordinates.
+/// A crystal structure with lattice, site occupancies, and coordinates.
+///
+/// Each site can have multiple species with partial occupancies (disordered sites).
+/// For ordered sites, there is a single species with occupancy 1.0.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Structure {
     /// The crystal lattice.
     pub lattice: Lattice,
-    /// Species at each site.
-    pub species: Vec<Species>,
+    /// Site occupancies (species + occupancy) at each site.
+    pub site_occupancies: Vec<SiteOccupancy>,
     /// Fractional coordinates for each site.
     pub frac_coords: Vec<Vector3<f64>>,
     /// Optional properties (for caching).
@@ -30,11 +34,46 @@ pub struct Structure {
 }
 
 impl Structure {
-    /// Try to create a new structure, returning an error if inputs are invalid.
-    ///
-    /// # Errors
-    ///
-    /// Returns `FerroxError::InvalidStructure` if `species.len() != frac_coords.len()`.
+    /// Try to create a new structure from site occupancies.
+    pub fn try_new_from_occupancies(
+        lattice: Lattice,
+        site_occupancies: Vec<SiteOccupancy>,
+        frac_coords: Vec<Vector3<f64>>,
+    ) -> Result<Self> {
+        Self::try_new_from_occupancies_with_properties(
+            lattice,
+            site_occupancies,
+            frac_coords,
+            HashMap::new(),
+        )
+    }
+
+    /// Create a structure with site occupancies and properties.
+    pub fn try_new_from_occupancies_with_properties(
+        lattice: Lattice,
+        site_occupancies: Vec<SiteOccupancy>,
+        frac_coords: Vec<Vector3<f64>>,
+        properties: HashMap<String, serde_json::Value>,
+    ) -> Result<Self> {
+        if site_occupancies.len() != frac_coords.len() {
+            return Err(FerroxError::InvalidStructure {
+                index: 0,
+                reason: format!(
+                    "site_occupancies and frac_coords must have same length: {} vs {}",
+                    site_occupancies.len(),
+                    frac_coords.len()
+                ),
+            });
+        }
+        Ok(Self {
+            lattice,
+            site_occupancies,
+            frac_coords,
+            properties,
+        })
+    }
+
+    /// Try to create a new structure from ordered species (convenience constructor).
     pub fn try_new(
         lattice: Lattice,
         species: Vec<Species>,
@@ -43,58 +82,64 @@ impl Structure {
         Self::try_new_with_properties(lattice, species, frac_coords, HashMap::new())
     }
 
-    /// Create a structure with properties.
-    ///
-    /// # Errors
-    ///
-    /// Returns `FerroxError::InvalidStructure` if `species.len() != frac_coords.len()`.
+    /// Create a structure from ordered species with properties (convenience constructor).
     pub fn try_new_with_properties(
         lattice: Lattice,
         species: Vec<Species>,
         frac_coords: Vec<Vector3<f64>>,
         properties: HashMap<String, serde_json::Value>,
     ) -> Result<Self> {
-        if species.len() != frac_coords.len() {
-            return Err(FerroxError::InvalidStructure {
-                index: 0,
-                reason: format!(
-                    "species and frac_coords must have same length: {} vs {}",
-                    species.len(),
-                    frac_coords.len()
-                ),
-            });
-        }
-        Ok(Self {
+        let site_occupancies = species.into_iter().map(SiteOccupancy::ordered).collect();
+        Self::try_new_from_occupancies_with_properties(
             lattice,
-            species,
+            site_occupancies,
             frac_coords,
             properties,
-        })
+        )
     }
 
-    /// Create a new structure.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `species.len() != frac_coords.len()`.
-    /// For fallible construction, use [`Structure::try_new`] instead.
+    /// Create a new structure from ordered species (convenience constructor).
     pub fn new(lattice: Lattice, species: Vec<Species>, frac_coords: Vec<Vector3<f64>>) -> Self {
         Self::try_new(lattice, species, frac_coords)
             .expect("species and frac_coords must have same length")
     }
 
-    /// Get the number of sites in the structure.
-    pub fn num_sites(&self) -> usize {
-        self.species.len()
+    /// Create a new structure from site occupancies.
+    pub fn new_from_occupancies(
+        lattice: Lattice,
+        site_occupancies: Vec<SiteOccupancy>,
+        frac_coords: Vec<Vector3<f64>>,
+    ) -> Self {
+        Self::try_new_from_occupancies(lattice, site_occupancies, frac_coords)
+            .expect("site_occupancies and frac_coords must have same length")
     }
 
-    /// Get the composition of the structure.
+    /// Get the number of sites in the structure.
+    pub fn num_sites(&self) -> usize {
+        self.site_occupancies.len()
+    }
+
+    /// Check if all sites are ordered (single species per site).
+    pub fn is_ordered(&self) -> bool {
+        self.site_occupancies.iter().all(|so| so.is_ordered())
+    }
+
+    /// Get the dominant species at each site.
+    pub fn species(&self) -> Vec<&Species> {
+        self.site_occupancies
+            .iter()
+            .map(|so| so.dominant_species())
+            .collect()
+    }
+
+    /// Get the composition of the structure (weighted by occupancy for disordered sites).
     pub fn composition(&self) -> Composition {
-        // Use BTreeMap for deterministic iteration order (sorted by element)
         let mut counts: std::collections::BTreeMap<Element, f64> =
             std::collections::BTreeMap::new();
-        for sp in &self.species {
-            *counts.entry(sp.element).or_insert(0.0) += 1.0;
+        for site_occ in &self.site_occupancies {
+            for (sp, occ) in &site_occ.species {
+                *counts.entry(sp.element).or_insert(0.0) += occ;
+            }
         }
         Composition::new(counts)
     }
@@ -104,10 +149,7 @@ impl Structure {
         self.lattice.get_cartesian_coords(&self.frac_coords)
     }
 
-    /// Convert to moyo::base::Cell for symmetry analysis.
-    ///
-    /// This creates a moyo Cell from the structure's lattice, positions,
-    /// and atomic numbers (derived from species).
+    /// Convert to moyo::base::Cell for symmetry analysis (uses dominant species).
     pub fn to_moyo_cell(&self) -> MoyoCell {
         let m = self.lattice.matrix();
         let moyo_matrix = Matrix3::new(
@@ -124,34 +166,21 @@ impl Structure {
         let moyo_lattice = MoyoLattice::new(moyo_matrix);
         let positions: Vec<Vector3<f64>> = self.frac_coords.clone();
         let numbers: Vec<i32> = self
-            .species
+            .site_occupancies
             .iter()
-            .map(|sp| sp.element.atomic_number() as i32)
+            .map(|so| so.dominant_species().element.atomic_number() as i32)
             .collect();
-
         MoyoCell::new(moyo_lattice, positions, numbers)
     }
 
-    /// Create Structure from moyo::base::Cell.
-    ///
-    /// Note: moyo Cell only has atomic numbers, not full species info.
-    /// This method creates neutral Species from atomic numbers.
-    ///
-    /// # Arguments
-    ///
-    /// * `cell` - The moyo Cell to convert
-    ///
-    /// # Returns
-    ///
-    /// A Structure with neutral species matching the atomic numbers.
+    /// Create Structure from moyo::base::Cell (creates ordered sites).
     pub fn from_moyo_cell(cell: &MoyoCell) -> Result<Self> {
         let lattice = Lattice::new(cell.lattice.basis);
-        let species: Vec<Species> = cell
+        let site_occupancies: Vec<SiteOccupancy> = cell
             .numbers
             .iter()
             .enumerate()
             .map(|(idx, &n)| {
-                // Guard against invalid atomic numbers (negative or > 255)
                 let z = u8::try_from(n).ok().filter(|&z| z > 0 && z <= 118);
                 let elem = z.and_then(Element::from_atomic_number).ok_or_else(|| {
                     FerroxError::InvalidStructure {
@@ -159,70 +188,79 @@ impl Structure {
                         reason: format!("Invalid atomic number: {n}"),
                     }
                 })?;
-                Ok(Species::neutral(elem))
+                Ok(SiteOccupancy::ordered(Species::neutral(elem)))
             })
             .collect::<Result<Vec<_>>>()?;
         let frac_coords = cell.positions.clone();
-
-        Structure::try_new(lattice, species, frac_coords)
+        Structure::try_new_from_occupancies(lattice, site_occupancies, frac_coords)
     }
 
     /// Get the primitive cell using moyo symmetry analysis.
-    ///
-    /// This finds the symmetry of the structure and returns the
-    /// primitive standardized cell.
-    ///
-    /// # Arguments
-    ///
-    /// * `symprec` - Symmetry precision (typically 1e-4 to 1e-2)
-    ///
-    /// # Returns
-    ///
-    /// Primitive cell Structure, or error if symmetry analysis fails.
     pub fn get_primitive(&self, symprec: f64) -> Result<Self> {
         let moyo_cell = self.to_moyo_cell();
-
         let dataset = MoyoDataset::new(
             &moyo_cell,
             symprec,
             AngleTolerance::Default,
             Setting::Standard,
-            false, // rotate_basis: keep original orientation
+            false,
         )
         .map_err(|e| FerroxError::MoyoError {
             index: 0,
             reason: format!("{e:?}"),
         })?;
-
-        // prim_std_cell is the primitive standardized cell
         Self::from_moyo_cell(&dataset.prim_std_cell)
     }
 
     /// Get the spacegroup number using moyo.
-    ///
-    /// # Arguments
-    ///
-    /// * `symprec` - Symmetry precision (typically 1e-4 to 1e-2)
-    ///
-    /// # Returns
-    ///
-    /// Spacegroup number (1-230), or error if analysis fails.
     pub fn get_spacegroup_number(&self, symprec: f64) -> Result<i32> {
         let moyo_cell = self.to_moyo_cell();
-
         let dataset = MoyoDataset::new(
             &moyo_cell,
             symprec,
             AngleTolerance::Default,
             Setting::Standard,
-            false, // rotate_basis: not needed for spacegroup detection
+            false,
         )
         .map_err(|e| FerroxError::MoyoError {
             index: 0,
             reason: format!("{e:?}"),
         })?;
-
         Ok(dataset.number)
+    }
+
+    /// Get unique elements in this structure.
+    pub fn unique_elements(&self) -> Vec<Element> {
+        self.site_occupancies
+            .iter()
+            .flat_map(|so| so.species.iter().map(|(sp, _)| sp.element))
+            .unique()
+            .collect()
+    }
+
+    /// Create a copy with species elements remapped.
+    pub fn remap_species(&self, mapping: &HashMap<Element, Element>) -> Self {
+        let new_site_occupancies: Vec<SiteOccupancy> = self
+            .site_occupancies
+            .iter()
+            .map(|so| {
+                let new_species: Vec<(Species, f64)> = so
+                    .species
+                    .iter()
+                    .map(|(sp, occ)| {
+                        let new_elem = mapping.get(&sp.element).copied().unwrap_or(sp.element);
+                        (Species::new(new_elem, sp.oxidation_state), *occ)
+                    })
+                    .collect();
+                SiteOccupancy::new(new_species)
+            })
+            .collect();
+        Self {
+            lattice: self.lattice.clone(),
+            site_occupancies: new_site_occupancies,
+            frac_coords: self.frac_coords.clone(),
+            properties: self.properties.clone(),
+        }
     }
 }
 
@@ -240,12 +278,7 @@ mod tests {
 
     fn make_fcc_conventional(element: Element, a: f64) -> Structure {
         let lattice = Lattice::cubic(a);
-        let species = vec![
-            Species::neutral(element),
-            Species::neutral(element),
-            Species::neutral(element),
-            Species::neutral(element),
-        ];
+        let species = vec![Species::neutral(element); 4];
         let coords = vec![
             Vector3::new(0.0, 0.0, 0.0),
             Vector3::new(0.5, 0.5, 0.0),
@@ -253,103 +286,6 @@ mod tests {
             Vector3::new(0.0, 0.5, 0.5),
         ];
         Structure::new(lattice, species, coords)
-    }
-
-    #[test]
-    fn test_new() {
-        let lattice = Lattice::cubic(4.0);
-        let species = vec![Species::neutral(Element::Na), Species::neutral(Element::Cl)];
-        let coords = vec![Vector3::new(0.0, 0.0, 0.0), Vector3::new(0.5, 0.5, 0.5)];
-
-        let structure = Structure::new(lattice, species, coords);
-        assert_eq!(structure.num_sites(), 2);
-    }
-
-    #[test]
-    fn test_try_new_success() {
-        let lattice = Lattice::cubic(4.0);
-        let species = vec![Species::neutral(Element::Na), Species::neutral(Element::Cl)];
-        let coords = vec![Vector3::new(0.0, 0.0, 0.0), Vector3::new(0.5, 0.5, 0.5)];
-
-        let result = Structure::try_new(lattice, species, coords);
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap().num_sites(), 2);
-    }
-
-    #[test]
-    fn test_try_new_length_mismatch() {
-        let lattice = Lattice::cubic(4.0);
-        let species = vec![Species::neutral(Element::Na), Species::neutral(Element::Cl)];
-        let coords = vec![Vector3::new(0.0, 0.0, 0.0)]; // Only 1 coord for 2 species
-
-        let result = Structure::try_new(lattice, species, coords);
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(err.to_string().contains("same length"));
-        assert!(err.to_string().contains("2 vs 1"));
-    }
-
-    #[test]
-    fn test_composition() {
-        let lattice = Lattice::cubic(4.0);
-        let species = vec![Species::neutral(Element::Na), Species::neutral(Element::Cl)];
-        let coords = vec![Vector3::new(0.0, 0.0, 0.0), Vector3::new(0.5, 0.5, 0.5)];
-
-        let structure = Structure::new(lattice, species, coords);
-        let comp = structure.composition();
-        assert_eq!(comp.reduced_formula(), "NaCl");
-    }
-
-    #[test]
-    fn test_to_moyo_cell() {
-        let s = make_nacl();
-        let cell = s.to_moyo_cell();
-
-        assert_eq!(cell.num_atoms(), 2);
-        assert_eq!(cell.numbers, vec![11, 17]); // Na=11, Cl=17
-    }
-
-    #[test]
-    fn test_from_moyo_cell_roundtrip() {
-        let s = make_nacl();
-        let cell = s.to_moyo_cell();
-        let s2 = Structure::from_moyo_cell(&cell).unwrap();
-
-        assert_eq!(s2.num_sites(), s.num_sites());
-        assert_eq!(s2.species[0].element, Element::Na);
-        assert_eq!(s2.species[1].element, Element::Cl);
-    }
-
-    #[test]
-    fn test_get_primitive_fcc() {
-        // FCC conventional cell (4 atoms) -> primitive (1 atom)
-        let fcc_conv = make_fcc_conventional(Element::Cu, 3.6);
-        assert_eq!(fcc_conv.num_sites(), 4);
-
-        let prim = fcc_conv.get_primitive(1e-4).unwrap();
-        assert_eq!(prim.num_sites(), 1);
-        assert_eq!(prim.species[0].element, Element::Cu);
-    }
-
-    #[test]
-    fn test_get_primitive_already_primitive() {
-        // Simple cubic is already primitive
-        let lattice = Lattice::cubic(2.87);
-        let s = Structure::new(
-            lattice,
-            vec![Species::neutral(Element::Fe)],
-            vec![Vector3::new(0.0, 0.0, 0.0)],
-        );
-
-        let prim = s.get_primitive(1e-4).unwrap();
-        assert_eq!(prim.num_sites(), s.num_sites());
-    }
-
-    #[test]
-    fn test_get_spacegroup_number() {
-        let fcc = make_fcc_conventional(Element::Cu, 3.6);
-        let sg = fcc.get_spacegroup_number(1e-4).unwrap();
-        assert_eq!(sg, 225); // Fm-3m for FCC
     }
 
     fn make_bcc(element: Element, a: f64) -> Structure {
@@ -360,66 +296,115 @@ mod tests {
     }
 
     #[test]
-    fn test_structure_basics() {
+    fn test_new() {
+        let structure = Structure::new(
+            Lattice::cubic(4.0),
+            vec![Species::neutral(Element::Na), Species::neutral(Element::Cl)],
+            vec![Vector3::new(0.0, 0.0, 0.0), Vector3::new(0.5, 0.5, 0.5)],
+        );
+        assert_eq!(structure.num_sites(), 2);
+    }
+
+    #[test]
+    fn test_try_new_success() {
+        let result = Structure::try_new(
+            Lattice::cubic(4.0),
+            vec![Species::neutral(Element::Na), Species::neutral(Element::Cl)],
+            vec![Vector3::new(0.0, 0.0, 0.0), Vector3::new(0.5, 0.5, 0.5)],
+        );
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().num_sites(), 2);
+    }
+
+    #[test]
+    fn test_try_new_length_mismatch() {
+        let result = Structure::try_new(
+            Lattice::cubic(4.0),
+            vec![Species::neutral(Element::Na), Species::neutral(Element::Cl)],
+            vec![Vector3::new(0.0, 0.0, 0.0)],
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_composition() {
+        let structure = Structure::new(
+            Lattice::cubic(4.0),
+            vec![Species::neutral(Element::Na), Species::neutral(Element::Cl)],
+            vec![Vector3::new(0.0, 0.0, 0.0), Vector3::new(0.5, 0.5, 0.5)],
+        );
+        assert_eq!(structure.composition().reduced_formula(), "NaCl");
+    }
+
+    #[test]
+    fn test_to_moyo_cell() {
         let s = make_nacl();
+        let cell = s.to_moyo_cell();
+        assert_eq!(cell.num_atoms(), 2);
+        assert_eq!(cell.numbers, vec![11, 17]);
+    }
 
-        // num_sites, volume, clone
-        assert_eq!(s.num_sites(), 2);
-        assert!((s.lattice.volume() - 5.64_f64.powi(3)).abs() < 1e-6);
+    #[test]
+    fn test_from_moyo_cell_roundtrip() {
+        let s = make_nacl();
+        let s2 = Structure::from_moyo_cell(&s.to_moyo_cell()).unwrap();
+        assert_eq!(s2.num_sites(), s.num_sites());
+        assert_eq!(s2.species()[0].element, Element::Na);
+        assert_eq!(s2.species()[1].element, Element::Cl);
+    }
 
-        let s2 = s.clone();
-        assert_eq!(s.num_sites(), s2.num_sites());
+    #[test]
+    fn test_get_primitive_fcc() {
+        let fcc_conv = make_fcc_conventional(Element::Cu, 3.6);
+        assert_eq!(fcc_conv.num_sites(), 4);
+        let prim = fcc_conv.get_primitive(1e-4).unwrap();
+        assert_eq!(prim.num_sites(), 1);
+        assert_eq!(prim.species()[0].element, Element::Cu);
+    }
 
-        // composition
-        let comp = s.composition();
-        assert_eq!(comp.num_elements(), 2);
-        assert_eq!(comp.reduced_formula(), "NaCl");
+    #[test]
+    fn test_get_spacegroup_number() {
+        let fcc = make_fcc_conventional(Element::Cu, 3.6);
+        assert_eq!(fcc.get_spacegroup_number(1e-4).unwrap(), 225);
     }
 
     #[test]
     fn test_spacegroups() {
-        // FCC Cu: 225 (Fm-3m)
-        let fcc = make_fcc_conventional(Element::Cu, 3.6);
-        assert_eq!(fcc.get_spacegroup_number(1e-4).unwrap(), 225);
-
-        // BCC Fe: 229 (Im-3m)
-        let bcc = make_bcc(Element::Fe, 2.87);
-        assert_eq!(bcc.get_spacegroup_number(1e-4).unwrap(), 229);
-
-        // CsCl-type NaCl: 221 (Pm-3m)
-        let nacl = make_nacl();
-        assert_eq!(nacl.get_spacegroup_number(1e-4).unwrap(), 221);
+        assert_eq!(
+            make_fcc_conventional(Element::Cu, 3.6)
+                .get_spacegroup_number(1e-4)
+                .unwrap(),
+            225
+        );
+        assert_eq!(
+            make_bcc(Element::Fe, 2.87)
+                .get_spacegroup_number(1e-4)
+                .unwrap(),
+            229
+        );
+        assert_eq!(make_nacl().get_spacegroup_number(1e-4).unwrap(), 221);
     }
 
     #[test]
     fn test_get_primitive() {
-        // FCC conventional (4 atoms) -> primitive (1 atom)
         let fcc = make_fcc_conventional(Element::Cu, 3.6);
-        assert_eq!(fcc.num_sites(), 4);
-        let prim = fcc.get_primitive(1e-4).unwrap();
-        assert_eq!(prim.num_sites(), 1);
-
-        // BCC conventional (2 atoms) -> primitive (1 atom)
+        assert_eq!(fcc.get_primitive(1e-4).unwrap().num_sites(), 1);
         let bcc = make_bcc(Element::Fe, 2.87);
-        let prim = bcc.get_primitive(1e-4).unwrap();
-        assert_eq!(prim.num_sites(), 1);
+        assert_eq!(bcc.get_primitive(1e-4).unwrap().num_sites(), 1);
     }
 
     #[test]
     fn test_moyo_roundtrip() {
         let fcc = make_fcc_conventional(Element::Cu, 3.6);
-        let cell = fcc.to_moyo_cell();
-        let restored = Structure::from_moyo_cell(&cell).unwrap();
-
+        let restored = Structure::from_moyo_cell(&fcc.to_moyo_cell()).unwrap();
         assert_eq!(restored.num_sites(), fcc.num_sites());
-        for (orig, new) in fcc.species.iter().zip(restored.species.iter()) {
+        for (orig, new) in fcc.species().iter().zip(restored.species().iter()) {
             assert_eq!(orig.element, new.element);
         }
     }
 
     #[test]
     fn test_oxidation_states() {
-        // Test structures with various oxidation state configurations
         let nacl = Structure::new(
             Lattice::cubic(5.64),
             vec![
@@ -428,109 +413,113 @@ mod tests {
             ],
             vec![Vector3::new(0.0, 0.0, 0.0), Vector3::new(0.5, 0.5, 0.5)],
         );
-        assert_eq!(nacl.species[0].oxidation_state, Some(1));
-        assert_eq!(nacl.species[1].oxidation_state, Some(-1));
-
-        // Mixed neutral and charged
-        let mixed = Structure::new(
-            Lattice::cubic(4.0),
-            vec![
-                Species::neutral(Element::Fe),
-                Species::new(Element::Fe, Some(2)),
-                Species::new(Element::Fe, Some(3)),
-            ],
-            vec![
-                Vector3::new(0.0, 0.0, 0.0),
-                Vector3::new(0.5, 0.0, 0.0),
-                Vector3::new(0.0, 0.5, 0.0),
-            ],
-        );
-        assert_eq!(mixed.species[0].oxidation_state, None);
-        assert_eq!(mixed.species[1].oxidation_state, Some(2));
-        assert_eq!(mixed.species[2].oxidation_state, Some(3));
-
-        // Oxidation states are preserved in composition (element only)
-        assert_eq!(mixed.composition().reduced_formula(), "Fe");
+        assert_eq!(nacl.species()[0].oxidation_state, Some(1));
+        assert_eq!(nacl.species()[1].oxidation_state, Some(-1));
     }
 
     #[test]
     fn test_cart_coords() {
         let s = Structure::new(
             Lattice::cubic(4.0),
-            vec![Species::neutral(Element::Cu), Species::neutral(Element::Cu)],
+            vec![Species::neutral(Element::Cu); 2],
             vec![Vector3::new(0.0, 0.0, 0.0), Vector3::new(0.5, 0.5, 0.5)],
         );
-
         let cart = s.cart_coords();
         assert_eq!(cart.len(), 2);
-
-        // Origin stays at origin
-        assert!((cart[0][0]).abs() < 1e-10);
-        assert!((cart[0][1]).abs() < 1e-10);
-        assert!((cart[0][2]).abs() < 1e-10);
-
-        // (0.5, 0.5, 0.5) in fractional -> (2.0, 2.0, 2.0) in Cartesian for 4.0 cubic
         assert!((cart[1][0] - 2.0).abs() < 1e-10);
-        assert!((cart[1][1] - 2.0).abs() < 1e-10);
-        assert!((cart[1][2] - 2.0).abs() < 1e-10);
-    }
-
-    #[test]
-    fn test_cart_coords_hexagonal() {
-        // Test with non-cubic lattice
-        let hex = Lattice::hexagonal(3.0, 5.0);
-        let s = Structure::new(
-            hex,
-            vec![Species::neutral(Element::Zn)],
-            vec![Vector3::new(0.0, 0.0, 0.5)],
-        );
-
-        let cart = s.cart_coords();
-        assert_eq!(cart.len(), 1);
-
-        // z = 0.5 in fractional -> z = 2.5 in Cartesian for c=5.0
-        assert!((cart[0][2] - 2.5).abs() < 1e-10);
     }
 
     #[test]
     fn test_empty_structure() {
-        // Empty structures are valid (useful for lattice-only operations)
         let s = Structure::new(Lattice::cubic(4.0), vec![], vec![]);
         assert_eq!(s.num_sites(), 0);
-        assert!(s.cart_coords().is_empty());
         assert!(s.composition().is_empty());
-
-        // Lattice properties still work
-        assert!((s.lattice.volume() - 64.0).abs() < 1e-10);
-        let lengths = s.lattice.lengths();
-        assert!((lengths[0] - 4.0).abs() < 1e-10);
-        assert!((lengths[1] - 4.0).abs() < 1e-10);
-        assert!((lengths[2] - 4.0).abs() < 1e-10);
     }
 
     #[test]
-    fn test_large_structure() {
-        // Test with more sites
-        let lattice = Lattice::cubic(10.0);
-        let mut species = Vec::new();
-        let mut coords = Vec::new();
+    fn test_disordered_structure() {
+        let site_occ = vec![
+            SiteOccupancy::new(vec![
+                (Species::neutral(Element::Fe), 0.5),
+                (Species::neutral(Element::Co), 0.5),
+            ]),
+            SiteOccupancy::ordered(Species::neutral(Element::O)),
+        ];
+        let s = Structure::new_from_occupancies(
+            Lattice::cubic(4.0),
+            site_occ,
+            vec![Vector3::new(0.0, 0.0, 0.0), Vector3::new(0.5, 0.5, 0.5)],
+        );
+        assert_eq!(s.num_sites(), 2);
+        assert!(!s.is_ordered());
+        assert!(!s.site_occupancies[0].is_ordered());
+        assert!(s.site_occupancies[1].is_ordered());
+    }
 
-        // Create 8 sites in a 2x2x2 grid
-        for idx in 0..2 {
-            for jdx in 0..2 {
-                for kdx in 0..2 {
-                    species.push(Species::neutral(Element::Fe));
-                    coords.push(Vector3::new(
-                        idx as f64 * 0.5,
-                        jdx as f64 * 0.5,
-                        kdx as f64 * 0.5,
-                    ));
-                }
-            }
-        }
+    #[test]
+    fn test_disordered_composition() {
+        let site_occ = vec![
+            SiteOccupancy::new(vec![
+                (Species::neutral(Element::Fe), 0.5),
+                (Species::neutral(Element::Co), 0.5),
+            ]),
+            SiteOccupancy::new(vec![
+                (Species::neutral(Element::Fe), 0.5),
+                (Species::neutral(Element::Co), 0.5),
+            ]),
+        ];
+        let s = Structure::new_from_occupancies(
+            Lattice::cubic(4.0),
+            site_occ,
+            vec![Vector3::new(0.0, 0.0, 0.0), Vector3::new(0.5, 0.5, 0.5)],
+        );
+        let comp = s.composition();
+        assert!((comp.get(Element::Fe) - 1.0).abs() < 1e-10);
+        assert!((comp.get(Element::Co) - 1.0).abs() < 1e-10);
+        assert_eq!(comp.reduced_formula(), "FeCo");
+    }
 
-        let s = Structure::new(lattice, species, coords);
-        assert_eq!(s.num_sites(), 8);
-        assert_eq!(s.composition().reduced_formula(), "Fe");
+    #[test]
+    fn test_ordered_structure_is_ordered() {
+        assert!(make_nacl().is_ordered());
+    }
+
+    #[test]
+    fn test_species_accessor() {
+        let site_occ = vec![
+            SiteOccupancy::new(vec![
+                (Species::neutral(Element::Fe), 0.7),
+                (Species::neutral(Element::Co), 0.3),
+            ]),
+            SiteOccupancy::ordered(Species::neutral(Element::O)),
+        ];
+        let s = Structure::new_from_occupancies(
+            Lattice::cubic(4.0),
+            site_occ,
+            vec![Vector3::new(0.0, 0.0, 0.0), Vector3::new(0.5, 0.5, 0.5)],
+        );
+        assert_eq!(s.species()[0].element, Element::Fe);
+        assert_eq!(s.species()[1].element, Element::O);
+    }
+
+    #[test]
+    fn test_unique_elements_disordered() {
+        let site_occ = vec![
+            SiteOccupancy::new(vec![
+                (Species::neutral(Element::Fe), 0.5),
+                (Species::neutral(Element::Co), 0.5),
+            ]),
+            SiteOccupancy::ordered(Species::neutral(Element::O)),
+        ];
+        let s = Structure::new_from_occupancies(
+            Lattice::cubic(4.0),
+            site_occ,
+            vec![Vector3::new(0.0, 0.0, 0.0), Vector3::new(0.5, 0.5, 0.5)],
+        );
+        let elements = s.unique_elements();
+        assert_eq!(elements.len(), 3);
+        assert!(elements.contains(&Element::Fe));
+        assert!(elements.contains(&Element::Co));
+        assert!(elements.contains(&Element::O));
     }
 }

--- a/extensions/rust/tests/compatibility_tests.rs
+++ b/extensions/rust/tests/compatibility_tests.rs
@@ -408,98 +408,27 @@ fn test_spacegroup_bcc() {
 }
 
 // =============================================================================
-// fit_anonymous Tests
+// fit_anonymous Integration Tests (complements unit tests in matcher.rs)
 // =============================================================================
 
 #[test]
-fn test_fit_anonymous_nacl_vs_clna() {
-    // NaCl with swapped species (ClNa) should match
-    let nacl = make_rocksalt(Element::Na, Element::Cl, 5.64);
-    let clna = Structure::new(
-        Lattice::cubic(5.64),
-        vec![Species::neutral(Element::Cl), Species::neutral(Element::Na)],
-        vec![Vector3::new(0.0, 0.0, 0.0), Vector3::new(0.5, 0.5, 0.5)],
-    );
-    let matcher = StructureMatcher::new();
-    assert!(
-        matcher.fit_anonymous(&nacl, &clna),
-        "NaCl vs ClNa should match anonymously"
-    );
-}
-
-#[test]
-fn test_fit_anonymous_nacl_vs_mgo() {
-    // NaCl and MgO have the same rocksalt prototype
-    let nacl = make_rocksalt(Element::Na, Element::Cl, 5.64);
-    let mgo = make_rocksalt(Element::Mg, Element::O, 4.21);
-    let matcher = StructureMatcher::new();
-    assert!(
-        matcher.fit_anonymous(&nacl, &mgo),
-        "NaCl and MgO should match as same rocksalt prototype"
-    );
-}
-
-#[test]
-fn test_fit_anonymous_different_stoichiometry() {
-    // NaCl (AB) vs different stoichiometry (A2B3) should NOT match
-    let nacl = make_rocksalt(Element::Na, Element::Cl, 5.64);
-    // Create a simple structure with 2:3 stoichiometry
-    let a2b3 = Structure::new(
-        Lattice::cubic(5.0),
-        vec![
-            Species::neutral(Element::Fe),
-            Species::neutral(Element::Fe),
-            Species::neutral(Element::O),
-            Species::neutral(Element::O),
-            Species::neutral(Element::O),
-        ],
-        vec![
-            Vector3::new(0.0, 0.0, 0.0),
-            Vector3::new(0.5, 0.5, 0.5),
-            Vector3::new(0.25, 0.25, 0.25),
-            Vector3::new(0.75, 0.75, 0.75),
-            Vector3::new(0.25, 0.75, 0.25),
-        ],
-    );
-    let matcher = StructureMatcher::new();
-    assert!(
-        !matcher.fit_anonymous(&nacl, &a2b3),
-        "Different stoichiometry (AB vs A2B3) should not match"
-    );
-}
-
-#[test]
-fn test_fit_anonymous_single_element_structures() {
-    // Same structure with different single elements should match
-    let fe = make_cubic(Element::Fe, 4.0);
-    let cu = make_cubic(Element::Cu, 4.0);
-    let matcher = StructureMatcher::new();
-    assert!(
-        matcher.fit_anonymous(&fe, &cu),
-        "Single-element structures with same arrangement should match"
-    );
-}
-
-#[test]
 fn test_fit_anonymous_bcc_vs_bcc() {
-    // Two BCC structures with different elements should match
+    // Two BCC structures with different elements and lattice parameters
     let fe_bcc = make_bcc(Element::Fe, 2.87);
     let w_bcc = make_bcc(Element::W, 3.16);
-    let matcher = StructureMatcher::new();
     assert!(
-        matcher.fit_anonymous(&fe_bcc, &w_bcc),
+        StructureMatcher::new().fit_anonymous(&fe_bcc, &w_bcc),
         "BCC Fe and BCC W should match anonymously"
     );
 }
 
 #[test]
 fn test_fit_anonymous_fcc_vs_fcc() {
-    // Two FCC structures with different elements should match
+    // Two FCC structures with different elements and lattice parameters
     let cu_fcc = make_fcc(Element::Cu, 3.6);
     let al_fcc = make_fcc(Element::Al, 4.05);
-    let matcher = StructureMatcher::new();
     assert!(
-        matcher.fit_anonymous(&cu_fcc, &al_fcc),
+        StructureMatcher::new().fit_anonymous(&cu_fcc, &al_fcc),
         "FCC Cu and FCC Al should match anonymously"
     );
 }
@@ -507,37 +436,13 @@ fn test_fit_anonymous_fcc_vs_fcc() {
 #[test]
 fn test_fit_anonymous_bcc_vs_fcc_no_match() {
     // BCC vs FCC should NOT match (different structures)
-    let fe_bcc = make_bcc(Element::Fe, 2.87);
-    let cu_fcc = make_fcc(Element::Cu, 3.6);
     // Note: with primitive_cell=true (default), both reduce to 1 atom
     // so they would match. Use primitive_cell=false for this test.
-    let matcher_no_prim = StructureMatcher::new().with_primitive_cell(false);
+    let fe_bcc = make_bcc(Element::Fe, 2.87);
+    let cu_fcc = make_fcc(Element::Cu, 3.6);
+    let matcher = StructureMatcher::new().with_primitive_cell(false);
     assert!(
-        !matcher_no_prim.fit_anonymous(&fe_bcc, &cu_fcc),
+        !matcher.fit_anonymous(&fe_bcc, &cu_fcc),
         "BCC vs FCC should not match (without primitive reduction)"
-    );
-}
-
-#[test]
-fn test_fit_anonymous_different_num_elements() {
-    // Structure with 2 elements vs structure with 1 element should NOT match
-    let nacl = make_rocksalt(Element::Na, Element::Cl, 5.64);
-    let fe = make_cubic(Element::Fe, 4.0);
-    let matcher = StructureMatcher::new();
-    assert!(
-        !matcher.fit_anonymous(&nacl, &fe),
-        "Different number of unique elements should not match"
-    );
-}
-
-#[test]
-fn test_fit_anonymous_empty_structures() {
-    // Empty structures should not match
-    let empty1 = Structure::new(Lattice::cubic(4.0), vec![], vec![]);
-    let empty2 = Structure::new(Lattice::cubic(5.0), vec![], vec![]);
-    let matcher = StructureMatcher::new();
-    assert!(
-        !matcher.fit_anonymous(&empty1, &empty2),
-        "Empty structures should not match"
     );
 }

--- a/extensions/rust/tests/compatibility_tests.rs
+++ b/extensions/rust/tests/compatibility_tests.rs
@@ -124,7 +124,7 @@ fn test_scaled_volume_matches() {
     let s1 = make_cubic(Element::Fe, 4.0);
     let s2 = Structure::new(
         Lattice::cubic(4.2), // 5% larger
-        s1.species.clone(),
+        s1.species().into_iter().cloned().collect(),
         s1.frac_coords.clone(),
     );
     let matcher = StructureMatcher::new().with_scale(true);
@@ -405,4 +405,139 @@ fn test_spacegroup_bcc() {
     let bcc = make_bcc(Element::Fe, 2.87);
     let sg = bcc.get_spacegroup_number(1e-4).unwrap();
     assert_eq!(sg, 229, "BCC should be spacegroup 229 (Im-3m)");
+}
+
+// =============================================================================
+// fit_anonymous Tests
+// =============================================================================
+
+#[test]
+fn test_fit_anonymous_nacl_vs_clna() {
+    // NaCl with swapped species (ClNa) should match
+    let nacl = make_rocksalt(Element::Na, Element::Cl, 5.64);
+    let clna = Structure::new(
+        Lattice::cubic(5.64),
+        vec![Species::neutral(Element::Cl), Species::neutral(Element::Na)],
+        vec![Vector3::new(0.0, 0.0, 0.0), Vector3::new(0.5, 0.5, 0.5)],
+    );
+    let matcher = StructureMatcher::new();
+    assert!(
+        matcher.fit_anonymous(&nacl, &clna),
+        "NaCl vs ClNa should match anonymously"
+    );
+}
+
+#[test]
+fn test_fit_anonymous_nacl_vs_mgo() {
+    // NaCl and MgO have the same rocksalt prototype
+    let nacl = make_rocksalt(Element::Na, Element::Cl, 5.64);
+    let mgo = make_rocksalt(Element::Mg, Element::O, 4.21);
+    let matcher = StructureMatcher::new();
+    assert!(
+        matcher.fit_anonymous(&nacl, &mgo),
+        "NaCl and MgO should match as same rocksalt prototype"
+    );
+}
+
+#[test]
+fn test_fit_anonymous_different_stoichiometry() {
+    // NaCl (AB) vs different stoichiometry (A2B3) should NOT match
+    let nacl = make_rocksalt(Element::Na, Element::Cl, 5.64);
+    // Create a simple structure with 2:3 stoichiometry
+    let a2b3 = Structure::new(
+        Lattice::cubic(5.0),
+        vec![
+            Species::neutral(Element::Fe),
+            Species::neutral(Element::Fe),
+            Species::neutral(Element::O),
+            Species::neutral(Element::O),
+            Species::neutral(Element::O),
+        ],
+        vec![
+            Vector3::new(0.0, 0.0, 0.0),
+            Vector3::new(0.5, 0.5, 0.5),
+            Vector3::new(0.25, 0.25, 0.25),
+            Vector3::new(0.75, 0.75, 0.75),
+            Vector3::new(0.25, 0.75, 0.25),
+        ],
+    );
+    let matcher = StructureMatcher::new();
+    assert!(
+        !matcher.fit_anonymous(&nacl, &a2b3),
+        "Different stoichiometry (AB vs A2B3) should not match"
+    );
+}
+
+#[test]
+fn test_fit_anonymous_single_element_structures() {
+    // Same structure with different single elements should match
+    let fe = make_cubic(Element::Fe, 4.0);
+    let cu = make_cubic(Element::Cu, 4.0);
+    let matcher = StructureMatcher::new();
+    assert!(
+        matcher.fit_anonymous(&fe, &cu),
+        "Single-element structures with same arrangement should match"
+    );
+}
+
+#[test]
+fn test_fit_anonymous_bcc_vs_bcc() {
+    // Two BCC structures with different elements should match
+    let fe_bcc = make_bcc(Element::Fe, 2.87);
+    let w_bcc = make_bcc(Element::W, 3.16);
+    let matcher = StructureMatcher::new();
+    assert!(
+        matcher.fit_anonymous(&fe_bcc, &w_bcc),
+        "BCC Fe and BCC W should match anonymously"
+    );
+}
+
+#[test]
+fn test_fit_anonymous_fcc_vs_fcc() {
+    // Two FCC structures with different elements should match
+    let cu_fcc = make_fcc(Element::Cu, 3.6);
+    let al_fcc = make_fcc(Element::Al, 4.05);
+    let matcher = StructureMatcher::new();
+    assert!(
+        matcher.fit_anonymous(&cu_fcc, &al_fcc),
+        "FCC Cu and FCC Al should match anonymously"
+    );
+}
+
+#[test]
+fn test_fit_anonymous_bcc_vs_fcc_no_match() {
+    // BCC vs FCC should NOT match (different structures)
+    let fe_bcc = make_bcc(Element::Fe, 2.87);
+    let cu_fcc = make_fcc(Element::Cu, 3.6);
+    // Note: with primitive_cell=true (default), both reduce to 1 atom
+    // so they would match. Use primitive_cell=false for this test.
+    let matcher_no_prim = StructureMatcher::new().with_primitive_cell(false);
+    assert!(
+        !matcher_no_prim.fit_anonymous(&fe_bcc, &cu_fcc),
+        "BCC vs FCC should not match (without primitive reduction)"
+    );
+}
+
+#[test]
+fn test_fit_anonymous_different_num_elements() {
+    // Structure with 2 elements vs structure with 1 element should NOT match
+    let nacl = make_rocksalt(Element::Na, Element::Cl, 5.64);
+    let fe = make_cubic(Element::Fe, 4.0);
+    let matcher = StructureMatcher::new();
+    assert!(
+        !matcher.fit_anonymous(&nacl, &fe),
+        "Different number of unique elements should not match"
+    );
+}
+
+#[test]
+fn test_fit_anonymous_empty_structures() {
+    // Empty structures should not match
+    let empty1 = Structure::new(Lattice::cubic(4.0), vec![], vec![]);
+    let empty2 = Structure::new(Lattice::cubic(5.0), vec![], vec![]);
+    let matcher = StructureMatcher::new();
+    assert!(
+        !matcher.fit_anonymous(&empty1, &empty2),
+        "Empty structures should not match"
+    );
 }


### PR DESCRIPTION
## Summary

- Add `SiteOccupancy` struct to support partial occupancies on crystallographic sites (disordered structures)
- Refactor `Structure` to use `site_occupancies` field instead of `species`, with backward-compatible `species()` method
- Implement `fit_anonymous()` for matching structures regardless of element identity (e.g., NaCl matches MgO as same rocksalt prototype)
- Fix `Matrix3` construction in POSCAR and extXYZ parsers - `Matrix3::new()` takes column-major order but lattice vectors are naturally row-major, now uses `from_row_slice()`

- Add composition remapping and occupancy-aware element remapping.

## Changes

### Disordered Site Support
- New `SiteOccupancy` struct in `species.rs` with species-occupancy pairs
- `Structure.site_occupancies` replaces `Structure.species` field
- `Structure.species()` returns dominant species per site for backward compatibility
- `Structure.is_ordered()` checks if all sites have single species
- `Structure.composition()` now weights by occupancy for disordered sites
- JSON parsing/serialization preserves all species and occupancies per site

### Anonymous Structure Matching
- `StructureMatcher.fit_anonymous()` matches structures under element permutations
- Uses composition hash for fast pruning before expensive structure comparison
- Python binding added for `fit_anonymous`
- Comprehensive tests for various cases (same prototype, different stoichiometry, etc.)

### Bug Fixes
- POSCAR parser: `Matrix3::new()` → `Matrix3::from_row_slice()` for correct lattice matrix
- extXYZ parser: Same fix for lattice matrix construction