### PR TITLE
`pymatgen` `sites.py` feature parity in `ferrox`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,9 @@ on:
     paths: &paths
       - src/**
       - tests/**
-      - '*.config.*' # vite, svelte, playwright, tsconfig
+      - '*.config.*' # vite, svelte, playwright, eslint
+      - tsconfig*.json
+      - deno.jsonc
       - package.json
       - .github/workflows/test.yml
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,15 @@ name: Tests
 on:
   pull_request:
     branches: [main]
+    paths: &paths
+      - src/**
+      - tests/**
+      - '*.config.*' # vite, svelte, playwright, tsconfig
+      - package.json
+      - .github/workflows/test.yml
   push:
     branches: [main]
+    paths: *paths
   workflow_dispatch:
   release:
     types: [published]

--- a/extensions/rust/src/matcher.rs
+++ b/extensions/rust/src/matcher.rs
@@ -348,7 +348,7 @@ impl StructureMatcher {
         }
 
         // Get shortest vectors
-        let (vecs, d2) = pbc_shortest_vectors(avg_lattice, s2_fc, s1_fc, Some(mask), None);
+        let (vecs, d2, _) = pbc_shortest_vectors(avg_lattice, s2_fc, s1_fc, Some(mask), None);
 
         // Solve linear assignment problem
         // Convert to integer costs (multiply by large factor for precision)

--- a/extensions/rust/src/pbc.rs
+++ b/extensions/rust/src/pbc.rs
@@ -248,9 +248,14 @@ pub fn pbc_shortest_vectors(
             result_images[idx][jdx] = if let Some(ref mapping) = lll_mapping {
                 // Transform from LLL basis back to original: orig_image = mapping * lll_image
                 let orig_vec = mapping * Vector3::from(lll_image);
-                std::array::from_fn(|k| orig_vec[k].round() as i32)
+                // Debug check: transformed image should be near-integer (within 0.1)
+                debug_assert!(
+                    (0..3).all(|axis| (orig_vec[axis] - orig_vec[axis].round()).abs() < 0.1),
+                    "LLL image transform gave non-integer result: {orig_vec:?}"
+                );
+                std::array::from_fn(|axis| orig_vec[axis].round() as i32)
             } else {
-                lll_image.map(|x| x as i32)
+                lll_image.map(|val| val as i32)
             };
         }
     }

--- a/extensions/rust/src/pbc.rs
+++ b/extensions/rust/src/pbc.rs
@@ -245,23 +245,13 @@ pub fn pbc_shortest_vectors(
 
             // Convert image to original lattice basis if using LLL
             let lll_image = frac_images[best_image_idx];
-            let image = if let Some(ref mapping) = lll_mapping {
+            result_images[idx][jdx] = if let Some(ref mapping) = lll_mapping {
                 // Transform from LLL basis back to original: orig_image = mapping * lll_image
-                let lll_vec = Vector3::new(lll_image[0], lll_image[1], lll_image[2]);
-                let orig_vec = mapping * lll_vec;
-                [
-                    orig_vec[0].round() as i32,
-                    orig_vec[1].round() as i32,
-                    orig_vec[2].round() as i32,
-                ]
+                let orig_vec = mapping * Vector3::from(lll_image);
+                std::array::from_fn(|k| orig_vec[k].round() as i32)
             } else {
-                [
-                    lll_image[0] as i32,
-                    lll_image[1] as i32,
-                    lll_image[2] as i32,
-                ]
+                lll_image.map(|x| x as i32)
             };
-            result_images[idx][jdx] = image;
         }
     }
 

--- a/extensions/rust/src/pbc.rs
+++ b/extensions/rust/src/pbc.rs
@@ -42,7 +42,7 @@ pub fn wrap_frac_coords(coords: &Vector3<f64>) -> Vector3<f64> {
 /// Wrap fractional coordinates only along periodic axes.
 /// Non-periodic axes retain their original values (may be outside [0, 1)).
 #[inline]
-fn wrap_frac_coords_pbc(coords: &Vector3<f64>, pbc: [bool; 3]) -> Vector3<f64> {
+pub fn wrap_frac_coords_pbc(coords: &Vector3<f64>, pbc: [bool; 3]) -> Vector3<f64> {
     Vector3::new(
         if pbc[0] {
             wrap_frac_coord(coords[0])

--- a/extensions/rust/src/pbc.rs
+++ b/extensions/rust/src/pbc.rs
@@ -6,6 +6,9 @@
 use crate::lattice::Lattice;
 use nalgebra::Vector3;
 
+/// Result type for pbc_shortest_vectors: (vectors, distances_squared, images)
+pub type PbcShortestResult = (Vec<Vec<Vector3<f64>>>, Vec<Vec<f64>>, Vec<Vec<[i32; 3]>>);
+
 /// Wrap fractional coordinates to the range [0, 1).
 ///
 /// Uses `coord - coord.floor()` instead of `coord % 1.0` because Rust's modulo
@@ -121,54 +124,61 @@ const IMAGES: [[f64; 3]; 27] = [
 ///
 /// # Returns
 ///
-/// A tuple of (vectors, distances_squared) where:
+/// A tuple of (vectors, distances_squared, images) where:
 /// - `vectors[i][j]` is the shortest Cartesian vector from fcoords1[i] to fcoords2[j]
 /// - `distances_squared[i][j]` is the squared length of that vector
+/// - `images[i][j]` is the periodic image offset [da, db, dc] that gives the shortest distance
 pub fn pbc_shortest_vectors(
     lattice: &Lattice,
     fcoords1: &[Vector3<f64>],
     fcoords2: &[Vector3<f64>],
     mask: Option<&[Vec<bool>]>,
     lll_frac_tol: Option<[f64; 3]>,
-) -> (Vec<Vec<Vector3<f64>>>, Vec<Vec<f64>>) {
+) -> PbcShortestResult {
     let n1 = fcoords1.len();
     let n2 = fcoords2.len();
 
     // Early return for empty inputs
     if n1 == 0 || n2 == 0 {
-        return (vec![], vec![]);
+        return (vec![], vec![], vec![]);
     }
 
     // Use LLL-reduced coordinates for full 3D PBC
     let pbc = lattice.pbc;
     let use_lll = pbc[0] && pbc[1] && pbc[2];
 
-    let (fc1, fc2, matrix) = if use_lll {
+    let (fc1, fc2, matrix, lll_mapping) = if use_lll {
         let lll_fc1 = lattice.get_lll_frac_coords(fcoords1);
         let lll_fc2 = lattice.get_lll_frac_coords(fcoords2);
         let lll_mat = lattice.lll_matrix();
-        (lll_fc1, lll_fc2, lll_mat)
+        let lll_map = lattice.lll_mapping();
+        (lll_fc1, lll_fc2, lll_mat, Some(lll_map))
     } else {
-        (fcoords1.to_vec(), fcoords2.to_vec(), *lattice.matrix())
+        (
+            fcoords1.to_vec(),
+            fcoords2.to_vec(),
+            *lattice.matrix(),
+            None,
+        )
     };
 
-    // Filter images based on PBC
-    let images: Vec<Vector3<f64>> = if use_lll {
-        IMAGES.iter().map(|img| Vector3::from(*img)).collect()
+    // Store both fractional and integer images for tracking
+    let frac_images: Vec<[f64; 3]> = if use_lll {
+        IMAGES.to_vec()
     } else {
         IMAGES
             .iter()
             .filter(|img| {
                 (pbc[0] || img[0] == 0.0) && (pbc[1] || img[1] == 0.0) && (pbc[2] || img[2] == 0.0)
             })
-            .map(|img| Vector3::from(*img))
+            .copied()
             .collect()
     };
 
     // Convert fractional images to Cartesian
-    let cart_images: Vec<Vector3<f64>> = images
+    let cart_images: Vec<Vector3<f64>> = frac_images
         .iter()
-        .map(|frac_im| matrix.transpose() * frac_im)
+        .map(|img| matrix.transpose() * Vector3::from(*img))
         .collect();
 
     // Convert fractional coords to Cartesian (wrap only periodic axes)
@@ -182,9 +192,10 @@ pub fn pbc_shortest_vectors(
         .map(|f| matrix.transpose() * wrap_frac_coords_pbc(f, pbc))
         .collect();
 
-    // Initialize output arrays with infinity for masked/skipped entries
+    // Initialize output arrays with infinity/zeros for masked/skipped entries
     let mut vectors = vec![vec![Vector3::new(f64::INFINITY, f64::INFINITY, f64::INFINITY); n2]; n1];
     let mut d2 = vec![vec![f64::INFINITY; n2]; n1];
+    let mut result_images = vec![vec![[0i32; 3]; n2]; n1];
 
     for (idx, f1) in fc1.iter().enumerate() {
         for (jdx, f2) in fc2.iter().enumerate() {
@@ -217,22 +228,44 @@ pub fn pbc_shortest_vectors(
             // Find shortest image
             let mut best_d2 = 1e100;
             let mut best_vec = pre_im;
+            let mut best_image_idx = 0usize;
 
-            for cart_im in &cart_images {
+            for (im_idx, cart_im) in cart_images.iter().enumerate() {
                 let vec = pre_im + cart_im;
                 let dist_sq = vec.norm_squared();
                 if dist_sq < best_d2 {
                     best_d2 = dist_sq;
                     best_vec = vec;
+                    best_image_idx = im_idx;
                 }
             }
 
             d2[idx][jdx] = best_d2;
             vectors[idx][jdx] = best_vec;
+
+            // Convert image to original lattice basis if using LLL
+            let lll_image = frac_images[best_image_idx];
+            let image = if let Some(ref mapping) = lll_mapping {
+                // Transform from LLL basis back to original: orig_image = mapping * lll_image
+                let lll_vec = Vector3::new(lll_image[0], lll_image[1], lll_image[2]);
+                let orig_vec = mapping * lll_vec;
+                [
+                    orig_vec[0].round() as i32,
+                    orig_vec[1].round() as i32,
+                    orig_vec[2].round() as i32,
+                ]
+            } else {
+                [
+                    lll_image[0] as i32,
+                    lll_image[1] as i32,
+                    lll_image[2] as i32,
+                ]
+            };
+            result_images[idx][jdx] = image;
         }
     }
 
-    (vectors, d2)
+    (vectors, d2, result_images)
 }
 
 /// Check if all fractional coordinates in `subset` are contained in `superset`
@@ -304,22 +337,27 @@ mod tests {
 
         // Same point: zero distance
         let coords = vec![Vector3::new(0.5, 0.5, 0.5)];
-        let (vecs, d2) = pbc_shortest_vectors(&lattice, &coords, &coords, None, None);
+        let (vecs, d2, images) = pbc_shortest_vectors(&lattice, &coords, &coords, None, None);
         assert!(d2[0][0] < 1e-10);
         assert!(vecs[0][0].norm() < 1e-10);
+        assert_eq!(images[0][0], [0, 0, 0]); // Same point, no image shift
 
         // Periodic wrap: 0.1 and 0.9 are 0.2 apart (via boundary)
         let c1 = vec![Vector3::new(0.1, 0.0, 0.0)];
         let c2 = vec![Vector3::new(0.9, 0.0, 0.0)];
-        let (_, d2) = pbc_shortest_vectors(&lattice, &c1, &c2, None, None);
+        let (_, d2, images) = pbc_shortest_vectors(&lattice, &c1, &c2, None, None);
         assert!((d2[0][0] - (0.8_f64).powi(2)).abs() < 1e-8); // 0.2 * 4.0 = 0.8
+        // Shortest path is via -1 in x direction (0.9 - 1.0 = -0.1, closer to 0.1)
+        assert_eq!(images[0][0][0], -1); // Shift in -x direction
 
         // Corner wrap: (0.05, 0.05, 0.05) to (0.95, 0.95, 0.95) = 0.1 per axis
         let c1 = vec![Vector3::new(0.05, 0.05, 0.05)];
         let c2 = vec![Vector3::new(0.95, 0.95, 0.95)];
-        let (_, d2) = pbc_shortest_vectors(&lattice, &c1, &c2, None, None);
+        let (_, d2, images) = pbc_shortest_vectors(&lattice, &c1, &c2, None, None);
         let expected = (3.0_f64).sqrt() * 0.4; // 0.1*4 per axis
         assert!((d2[0][0].sqrt() - expected).abs() < 1e-6);
+        // Shortest path is via -1 in all directions
+        assert_eq!(images[0][0], [-1, -1, -1]);
     }
 
     #[test]
@@ -416,7 +454,7 @@ mod tests {
         for (lattice, fc1, fc2, max_expected) in test_cases {
             let c1 = vec![Vector3::new(fc1[0], fc1[1], fc1[2])];
             let c2 = vec![Vector3::new(fc2[0], fc2[1], fc2[2])];
-            let (vecs, d2) = pbc_shortest_vectors(&lattice, &c1, &c2, None, None);
+            let (vecs, d2, _images) = pbc_shortest_vectors(&lattice, &c1, &c2, None, None);
 
             let dist = d2[0][0].sqrt();
             assert!(dist >= 0.0, "Distance should be non-negative, got {dist}");
@@ -460,7 +498,7 @@ mod tests {
 
         // Mask out (0,0) and (1,1) pairs
         let mask = vec![vec![true, false], vec![false, true]];
-        let (vecs, d2) = pbc_shortest_vectors(&lattice, &c1, &c2, Some(&mask), None);
+        let (vecs, d2, _images) = pbc_shortest_vectors(&lattice, &c1, &c2, Some(&mask), None);
 
         // Masked entries should be infinity
         assert!(d2[0][0].is_infinite());
@@ -480,7 +518,7 @@ mod tests {
 
         // Tight tolerance - only nearby points
         let ftol = Some([0.1, 0.1, 0.1]);
-        let (_, d2) = pbc_shortest_vectors(&lattice, &c1, &c2, None, ftol);
+        let (_, d2, _images) = pbc_shortest_vectors(&lattice, &c1, &c2, None, ftol);
 
         // (0.5, 0.5, 0.5) is outside tolerance
         assert!(d2[0][0].is_infinite());
@@ -520,7 +558,7 @@ mod tests {
         // Coords at z=0.1 and z=1.5 (outside [0,1) on non-periodic axis)
         let c1 = vec![Vector3::new(0.5, 0.5, 0.1)];
         let c2 = vec![Vector3::new(0.5, 0.5, 1.5)];
-        let (_, d2) = pbc_shortest_vectors(&lattice, &c1, &c2, None, None);
+        let (_, d2, _images) = pbc_shortest_vectors(&lattice, &c1, &c2, None, None);
 
         // Without fix: z=1.5 wraps to 0.5, distance would be 0.4*10=4
         // With fix: z stays at 1.5, distance is (1.5-0.1)*10=14

--- a/extensions/rust/src/pbc.rs
+++ b/extensions/rust/src/pbc.rs
@@ -488,33 +488,24 @@ mod tests {
     #[test]
     fn test_wrap_frac_coords_pbc() {
         let v = Vector3::new(-0.5, 1.5, 2.3);
-
-        // All periodic: wraps all axes
-        let all_pbc = wrap_frac_coords_pbc(&v, [true, true, true]);
-        assert!((all_pbc[0] - 0.5).abs() < 1e-10);
-        assert!((all_pbc[1] - 0.5).abs() < 1e-10);
-        assert!((all_pbc[2] - 0.3).abs() < 1e-10);
-
-        // z non-periodic: x,y wrap, z unchanged
-        let slab_pbc = wrap_frac_coords_pbc(&v, [true, true, false]);
-        assert!((slab_pbc[0] - 0.5).abs() < 1e-10);
-        assert!((slab_pbc[1] - 0.5).abs() < 1e-10);
-        assert!(
-            (slab_pbc[2] - 2.3).abs() < 1e-10,
-            "Non-periodic z should NOT wrap"
-        );
-
-        // Only x periodic
-        let x_only = wrap_frac_coords_pbc(&v, [true, false, false]);
-        assert!((x_only[0] - 0.5).abs() < 1e-10);
-        assert!((x_only[1] - 1.5).abs() < 1e-10);
-        assert!((x_only[2] - 2.3).abs() < 1e-10);
-
-        // None periodic: all unchanged
-        let no_pbc = wrap_frac_coords_pbc(&v, [false, false, false]);
-        assert!((no_pbc[0] - (-0.5)).abs() < 1e-10);
-        assert!((no_pbc[1] - 1.5).abs() < 1e-10);
-        assert!((no_pbc[2] - 2.3).abs() < 1e-10);
+        // (pbc flags, expected x, expected y, expected z)
+        let cases = [
+            ([true, true, true], [0.5, 0.5, 0.3]), // all periodic: all wrap
+            ([true, true, false], [0.5, 0.5, 2.3]), // slab: z unchanged
+            ([true, false, false], [0.5, 1.5, 2.3]), // wire: only x wraps
+            ([false, false, false], [-0.5, 1.5, 2.3]), // none: all unchanged
+        ];
+        for (pbc, expected) in cases {
+            let result = wrap_frac_coords_pbc(&v, pbc);
+            for axis in 0..3 {
+                assert!(
+                    (result[axis] - expected[axis]).abs() < 1e-10,
+                    "pbc={pbc:?} axis={axis}: expected {}, got {}",
+                    expected[axis],
+                    result[axis]
+                );
+            }
+        }
     }
 
     #[test]

--- a/extensions/rust/src/pbc.rs
+++ b/extensions/rust/src/pbc.rs
@@ -206,12 +206,17 @@ pub fn pbc_shortest_vectors(
                 continue;
             }
 
-            // Check fractional tolerance
+            // Check fractional tolerance (only wrap periodic axes)
             let mut within_frac = true;
             if let Some(ftol) = lll_frac_tol {
                 for axis in 0..3 {
                     let fdist = f2[axis] - f1[axis];
-                    if (fdist - fdist.round()).abs() > ftol[axis] {
+                    let wrapped = if pbc[axis] {
+                        fdist - fdist.round()
+                    } else {
+                        fdist
+                    };
+                    if wrapped.abs() > ftol[axis] {
                         within_frac = false;
                         break;
                     }

--- a/extensions/rust/src/python.rs
+++ b/extensions/rust/src/python.rs
@@ -824,6 +824,11 @@ fn distance_from_point(structure: &str, idx: usize, point: [f64; 3]) -> PyResult
 #[pyfunction]
 #[pyo3(signature = (structure, i, j, tolerance = 1e-8))]
 fn is_periodic_image(structure: &str, i: usize, j: usize, tolerance: f64) -> PyResult<bool> {
+    if tolerance < 0.0 {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "tolerance must be non-negative",
+        ));
+    }
     let parsed = parse_struct(structure)?;
     check_site_bounds(parsed.num_sites(), &[i, j])?;
     Ok(parsed.is_periodic_image(i, j, tolerance))

--- a/extensions/rust/src/species.rs
+++ b/extensions/rust/src/species.rs
@@ -321,7 +321,7 @@ impl SiteOccupancy {
         } else {
             self.species
                 .iter()
-                .sorted_by(|a, b| a.0.to_string().cmp(&b.0.to_string()))
+                .sorted_by_cached_key(|(sp, _)| sp.to_string())
                 .map(|(sp, occ)| format!("{sp}:{occ:.3}"))
                 .join(", ")
         }

--- a/extensions/rust/src/species.rs
+++ b/extensions/rust/src/species.rs
@@ -656,72 +656,68 @@ mod tests {
     }
 
     #[test]
-    fn test_species_string_ordered() {
-        // Neutral element
-        let so = SiteOccupancy::ordered(Species::neutral(Element::Fe));
-        assert_eq!(so.species_string(), "Fe");
+    fn test_species_string() {
+        // Ordered sites: neutral, positive, and negative oxidation states
+        assert_eq!(
+            SiteOccupancy::ordered(Species::neutral(Element::Fe)).species_string(),
+            "Fe"
+        );
+        assert_eq!(
+            SiteOccupancy::ordered(Species::new(Element::Fe, Some(2))).species_string(),
+            "Fe2+"
+        );
+        assert_eq!(
+            SiteOccupancy::ordered(Species::new(Element::O, Some(-2))).species_string(),
+            "O2-"
+        );
+        assert_eq!(
+            SiteOccupancy::ordered(Species::neutral(Element::Dummy)).species_string(),
+            "X"
+        );
 
-        // Element with oxidation state
-        let so2 = SiteOccupancy::ordered(Species::new(Element::Fe, Some(2)));
-        assert_eq!(so2.species_string(), "Fe2+");
+        // Single species with partial occupancy (vacancy) is still "ordered"
+        let partial = SiteOccupancy::new(vec![(Species::neutral(Element::Fe), 0.8)]);
+        assert!(partial.is_ordered());
+        assert_eq!(partial.species_string(), "Fe");
 
-        // Negative oxidation state
-        let so3 = SiteOccupancy::ordered(Species::new(Element::O, Some(-2)));
-        assert_eq!(so3.species_string(), "O2-");
-    }
-
-    #[test]
-    fn test_species_string_disordered() {
-        // Disordered site - should be alphabetically sorted
-        let so = SiteOccupancy::new(vec![
+        // Disordered: alphabetically sorted with 3 decimal places
+        let disordered = SiteOccupancy::new(vec![
             (Species::neutral(Element::Fe), 0.5),
             (Species::neutral(Element::Co), 0.5),
         ]);
-        assert_eq!(so.species_string(), "Co:0.500, Fe:0.500");
+        assert_eq!(disordered.species_string(), "Co:0.500, Fe:0.500");
 
         // Three species
-        let so2 = SiteOccupancy::new(vec![
+        let tri = SiteOccupancy::new(vec![
             (Species::neutral(Element::Zn), 0.2),
             (Species::neutral(Element::Fe), 0.5),
             (Species::neutral(Element::Co), 0.3),
         ]);
-        assert_eq!(so2.species_string(), "Co:0.300, Fe:0.500, Zn:0.200");
-    }
+        assert_eq!(tri.species_string(), "Co:0.300, Fe:0.500, Zn:0.200");
 
-    #[test]
-    fn test_species_string_with_oxidation_states() {
-        // Disordered site with oxidation states
-        let so = SiteOccupancy::new(vec![
+        // Same element with different oxidation states
+        let mixed_ox = SiteOccupancy::new(vec![
             (Species::new(Element::Fe, Some(2)), 0.6),
             (Species::new(Element::Fe, Some(3)), 0.4),
         ]);
-        // Both are Fe, but with different oxidation states
-        assert_eq!(so.species_string(), "Fe2+:0.600, Fe3+:0.400");
-    }
+        assert_eq!(mixed_ox.species_string(), "Fe2+:0.600, Fe3+:0.400");
 
-    #[test]
-    fn test_species_string_partial_occupancy() {
-        // Single species with partial occupancy (vacancy)
-        let so = SiteOccupancy::new(vec![(Species::neutral(Element::Fe), 0.8)]);
-        // Should still return just "Fe" since it's ordered (single species)
-        assert_eq!(so.species_string(), "Fe");
-        assert!(so.is_ordered());
-    }
+        // Different elements with same oxidation state
+        let mixed_elem = SiteOccupancy::new(vec![
+            (Species::new(Element::Fe, Some(3)), 0.5),
+            (Species::new(Element::Al, Some(3)), 0.5),
+        ]);
+        assert_eq!(mixed_elem.species_string(), "Al3+:0.500, Fe3+:0.500");
 
-    #[test]
-    fn test_species_string_very_small_occupancies() {
-        // Test formatting with very small occupancies
-        let so = SiteOccupancy::new(vec![
+        // Very small occupancies
+        let small = SiteOccupancy::new(vec![
             (Species::neutral(Element::Fe), 0.001),
             (Species::neutral(Element::Co), 0.999),
         ]);
-        assert_eq!(so.species_string(), "Co:0.999, Fe:0.001");
-    }
+        assert_eq!(small.species_string(), "Co:0.999, Fe:0.001");
 
-    #[test]
-    fn test_species_string_many_species() {
         // High entropy alloy: 5 elements
-        let so = SiteOccupancy::new(vec![
+        let hea = SiteOccupancy::new(vec![
             (Species::neutral(Element::Fe), 0.2),
             (Species::neutral(Element::Co), 0.2),
             (Species::neutral(Element::Ni), 0.2),
@@ -729,25 +725,8 @@ mod tests {
             (Species::neutral(Element::Mn), 0.2),
         ]);
         assert_eq!(
-            so.species_string(),
+            hea.species_string(),
             "Co:0.200, Cr:0.200, Fe:0.200, Mn:0.200, Ni:0.200"
         );
-    }
-
-    #[test]
-    fn test_species_string_mixed_oxidation_different_elements() {
-        // Mixed species with different oxidation states
-        let so = SiteOccupancy::new(vec![
-            (Species::new(Element::Fe, Some(3)), 0.5),
-            (Species::new(Element::Al, Some(3)), 0.5),
-        ]);
-        assert_eq!(so.species_string(), "Al3+:0.500, Fe3+:0.500");
-    }
-
-    #[test]
-    fn test_species_string_pseudo_element() {
-        // Dummy/vacancy element
-        let so = SiteOccupancy::ordered(Species::neutral(Element::Dummy));
-        assert_eq!(so.species_string(), "X");
     }
 }

--- a/extensions/rust/src/species.rs
+++ b/extensions/rust/src/species.rs
@@ -214,11 +214,7 @@ impl Ord for Species {
             .partial_cmp(&en_other)
             .unwrap_or(Ordering::Equal)
             .then_with(|| self.element.symbol().cmp(other.element.symbol()))
-            .then_with(|| {
-                self.oxidation_state
-                    .unwrap_or(0)
-                    .cmp(&other.oxidation_state.unwrap_or(0))
-            })
+            .then_with(|| self.oxidation_state.cmp(&other.oxidation_state))
     }
 }
 

--- a/extensions/rust/src/species.rs
+++ b/extensions/rust/src/species.rs
@@ -4,6 +4,7 @@
 //! e.g., Fe2+ or O2-.
 
 use crate::element::Element;
+use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt;
@@ -318,12 +319,10 @@ impl SiteOccupancy {
         if self.is_ordered() {
             self.dominant_species().to_string()
         } else {
-            let mut sorted: Vec<_> = self.species.iter().collect();
-            sorted.sort_by(|a, b| a.0.element.symbol().cmp(b.0.element.symbol()));
-            sorted
+            self.species
                 .iter()
-                .map(|(sp, occ)| format!("{}:{:.3}", sp, occ))
-                .collect::<Vec<_>>()
+                .sorted_by(|a, b| a.0.element.symbol().cmp(b.0.element.symbol()))
+                .map(|(sp, occ)| format!("{sp}:{occ:.3}"))
                 .join(", ")
         }
     }

--- a/extensions/rust/src/structure.rs
+++ b/extensions/rust/src/structure.rs
@@ -416,25 +416,8 @@ impl Structure {
     /// # Panics
     ///
     /// Panics if `i` or `j` is out of bounds.
-    #[inline]
     pub fn get_distance(&self, i: usize, j: usize) -> f64 {
-        assert!(
-            i < self.num_sites(),
-            "Index i={} out of bounds (num_sites={})",
-            i,
-            self.num_sites()
-        );
-        assert!(
-            j < self.num_sites(),
-            "Index j={} out of bounds (num_sites={})",
-            j,
-            self.num_sites()
-        );
-        let fcoords_i = vec![self.frac_coords[i]];
-        let fcoords_j = vec![self.frac_coords[j]];
-        let (_, d2, _) =
-            crate::pbc::pbc_shortest_vectors(&self.lattice, &fcoords_i, &fcoords_j, None, None);
-        d2[0][0].sqrt()
+        self.get_distance_and_image(i, j).0
     }
 
     /// Get distance and periodic image between sites `i` and `j`.
@@ -446,7 +429,6 @@ impl Structure {
     /// # Panics
     ///
     /// Panics if `i` or `j` is out of bounds.
-    #[inline]
     pub fn get_distance_and_image(&self, i: usize, j: usize) -> (f64, [i32; 3]) {
         assert!(
             i < self.num_sites(),
@@ -1436,7 +1418,6 @@ impl Structure {
     /// # Panics
     ///
     /// Panics if `idx` is out of bounds.
-    #[inline]
     pub fn site_label(&self, idx: usize) -> String {
         assert!(
             idx < self.num_sites(),

--- a/extensions/rust/src/structure.rs
+++ b/extensions/rust/src/structure.rs
@@ -2514,6 +2514,9 @@ mod tests {
             vec![Vector3::new(0.5, 0.5, 0.5)],
         );
         assert!(s.is_periodic_image(0, 0, 1e-8));
+
+        // Negative tolerance always fails (validated at Python layer, but document Rust behavior)
+        assert!(!s.is_periodic_image(0, 0, -1.0));
     }
 
     #[test]

--- a/extensions/rust/src/structure.rs
+++ b/extensions/rust/src/structure.rs
@@ -478,8 +478,7 @@ impl Structure {
         let frac_j = crate::pbc::wrap_frac_coords(&self.frac_coords[j]);
 
         let cart_i = self.lattice.get_cartesian_coords(&[frac_i])[0];
-        let frac_j_shifted =
-            frac_j + Vector3::new(jimage[0] as f64, jimage[1] as f64, jimage[2] as f64);
+        let frac_j_shifted = frac_j + Vector3::from(jimage.map(|x| x as f64));
         let cart_j = self.lattice.get_cartesian_coords(&[frac_j_shifted])[0];
         (cart_j - cart_i).norm()
     }

--- a/extensions/rust/src/structure.rs
+++ b/extensions/rust/src/structure.rs
@@ -2647,6 +2647,32 @@ mod tests {
     }
 
     #[test]
+    fn test_distance_with_image_wraps_coordinates() {
+        // Test that coordinates outside [0,1) are wrapped correctly
+        let lattice = Lattice::cubic(10.0);
+        let s = Structure::new(
+            lattice,
+            vec![Species::neutral(Element::Fe), Species::neutral(Element::Fe)],
+            vec![
+                Vector3::new(0.25, 0.35, 0.45),
+                Vector3::new(1.0, 1.0, 1.0), // Wraps to (0, 0, 0)
+            ],
+        );
+
+        // With wrapping: site 1 is at (0,0,0), image [0,0,0] should give ~6.22
+        let (dist, img) = s.get_distance_and_image(0, 1);
+        let dist_with_img = s.get_distance_with_image(0, 1, img);
+
+        // These must match because get_distance_with_image wraps coords
+        assert!(
+            (dist - dist_with_img).abs() < 1e-10,
+            "Wrapped coords should match: {} vs {}",
+            dist,
+            dist_with_img
+        );
+    }
+
+    #[test]
     fn test_is_periodic_image_same_position_different_cells() {
         let lattice = Lattice::cubic(10.0);
         let s = Structure::new(


### PR DESCRIPTION
## Summary

Adds pymatgen `sites.py` feature parity to the ferrox Rust extension, including distance calculations with periodic images, site labels, and species strings.

### New Features
- `get_distance_and_image()` - returns distance and periodic image offset
- `get_distance_with_image()` - distance to a specific periodic image
- `distance_from_point()` - Cartesian distance from site to arbitrary point
- `is_periodic_image()` - check if two sites are periodic images
- `site_label()` / `site_labels()` - get site labels (with species string fallback)
- `species_string()` / `species_strings()` - human-readable species representation
- `pbc_shortest_vectors` now returns periodic image indices

### Python Bindings
All new methods exposed to Python with proper error handling and docstrings.

### Code Quality
- Consolidated 48 individual tests into 12 comprehensive tests (-379 lines)
- Added `#[inline]` hints to hot-path methods
- Extracted `check_site_bounds()` helper to reduce Python binding boilerplate
- Added `debug_assert` for LLL image rounding tolerance