### PR TITLE
Add structure writers for POSCAR, CIF, and extXYZ formats

### DIFF
--- a/extensions/rust/src/cif.rs
+++ b/extensions/rust/src/cif.rs
@@ -372,15 +372,12 @@ fn split_cif_line(line: &str) -> Vec<&str> {
 pub fn structure_to_cif(structure: &Structure, data_name: Option<&str>) -> String {
     let mut lines = Vec::new();
 
-    // Data block header
-    let name = data_name.unwrap_or("");
-    let name = if name.is_empty() {
-        structure.composition().reduced_formula()
-    } else {
-        name.to_string()
-    };
-    // CIF data names cannot contain spaces or special characters
-    let name = name.replace([' ', '-'], "_");
+    // Data block header - use provided name or fall back to formula
+    let name = match data_name {
+        Some(n) if !n.is_empty() => n.to_string(),
+        _ => structure.composition().reduced_formula(),
+    }
+    .replace([' ', '-'], "_"); // CIF data names cannot contain spaces or special characters
     lines.push(format!("data_{}", name));
     lines.push(String::new());
 

--- a/extensions/rust/src/io.rs
+++ b/extensions/rust/src/io.rs
@@ -853,6 +853,261 @@ fn parse_pbc_value(pbc_value: &serde_json::Value) -> [bool; 3] {
     }
 }
 
+// ============================================================================
+// Structure Writers
+// ============================================================================
+
+/// Convert a structure to VASP POSCAR format string.
+///
+/// The output uses VASP 5+ format with element symbols.
+///
+/// # Arguments
+///
+/// * `structure` - The structure to serialize
+/// * `comment` - Optional comment line (defaults to reduced formula)
+///
+/// # Returns
+///
+/// POSCAR format string.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let poscar_string = structure_to_poscar(&structure, None);
+/// ```
+pub fn structure_to_poscar(structure: &Structure, comment: Option<&str>) -> String {
+    let mat = structure.lattice.matrix();
+
+    // Group sites by element (POSCAR requires contiguous blocks)
+    // Use IndexMap to preserve insertion order (first occurrence)
+    let mut element_sites: indexmap::IndexMap<&str, Vec<usize>> = indexmap::IndexMap::new();
+    for (idx, site_occ) in structure.site_occupancies.iter().enumerate() {
+        let symbol = site_occ.dominant_species().element.symbol();
+        element_sites.entry(symbol).or_default().push(idx);
+    }
+
+    // Build the POSCAR string manually
+    let mut lines = Vec::new();
+
+    // Line 1: Comment (use formula if not provided)
+    let comment = comment.unwrap_or("");
+    let comment = if comment.is_empty() {
+        structure.composition().reduced_formula()
+    } else {
+        comment.to_string()
+    };
+    lines.push(comment);
+
+    // Line 2: Scaling factor
+    lines.push("1.0".to_string());
+
+    // Lines 3-5: Lattice vectors (rows are a, b, c)
+    for row in 0..3 {
+        lines.push(format!(
+            "  {:20.16}  {:20.16}  {:20.16}",
+            mat[(row, 0)],
+            mat[(row, 1)],
+            mat[(row, 2)]
+        ));
+    }
+
+    // Line 6: Element symbols
+    let symbols: Vec<&str> = element_sites.keys().copied().collect();
+    lines.push(format!("  {}", symbols.join("  ")));
+
+    // Line 7: Element counts
+    let counts: Vec<String> = element_sites
+        .values()
+        .map(|v| v.len().to_string())
+        .collect();
+    lines.push(format!("  {}", counts.join("  ")));
+
+    // Line 8: Direct (fractional coordinates)
+    lines.push("Direct".to_string());
+
+    // Coordinate lines (in element order)
+    for indices in element_sites.values() {
+        for &idx in indices {
+            let frac = &structure.frac_coords[idx];
+            lines.push(format!(
+                "  {:20.16}  {:20.16}  {:20.16}",
+                frac.x, frac.y, frac.z
+            ));
+        }
+    }
+
+    lines.join("\n") + "\n"
+}
+
+/// Write a structure to a POSCAR file.
+///
+/// # Arguments
+///
+/// * `structure` - The structure to write
+/// * `path` - Path to the output file
+/// * `comment` - Optional comment line
+///
+/// # Returns
+///
+/// Result indicating success or file I/O error.
+pub fn write_poscar(structure: &Structure, path: &Path, comment: Option<&str>) -> Result<()> {
+    let content = structure_to_poscar(structure, comment);
+    std::fs::write(path, content)?;
+    Ok(())
+}
+
+/// Convert a structure to extXYZ format string.
+///
+/// The output follows the extended XYZ format with lattice in the comment line.
+///
+/// # Arguments
+///
+/// * `structure` - The structure to serialize
+/// * `properties` - Optional additional properties for the comment line
+///
+/// # Returns
+///
+/// extXYZ format string.
+pub fn structure_to_extxyz(
+    structure: &Structure,
+    properties: Option<&HashMap<String, serde_json::Value>>,
+) -> String {
+    let mat = structure.lattice.matrix();
+    let pbc = structure.lattice.pbc;
+
+    // Line 1: Number of atoms
+    let mut lines = vec![structure.num_sites().to_string()];
+
+    // Line 2: Comment with Lattice and properties
+    // Format: Lattice="ax ay az bx by bz cx cy cz" pbc="T T T" [other properties]
+    let lattice_str = format!(
+        "{:.10} {:.10} {:.10} {:.10} {:.10} {:.10} {:.10} {:.10} {:.10}",
+        mat[(0, 0)],
+        mat[(0, 1)],
+        mat[(0, 2)],
+        mat[(1, 0)],
+        mat[(1, 1)],
+        mat[(1, 2)],
+        mat[(2, 0)],
+        mat[(2, 1)],
+        mat[(2, 2)]
+    );
+
+    let pbc_str: String = pbc
+        .iter()
+        .map(|&b| if b { "T" } else { "F" })
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    let mut comment_parts = vec![
+        format!("Lattice=\"{}\"", lattice_str),
+        format!("pbc=\"{}\"", pbc_str),
+    ];
+
+    // Helper to serialize a JSON value to extXYZ format
+    let format_value = |value: &serde_json::Value| -> Option<String> {
+        match value {
+            serde_json::Value::Number(n) => Some(n.to_string()),
+            serde_json::Value::String(s) => {
+                // Escape quotes and newlines to prevent malformed output
+                let escaped = s
+                    .replace('\\', "\\\\")
+                    .replace('"', "\\\"")
+                    .replace('\n', "\\n");
+                Some(format!("\"{}\"", escaped))
+            }
+            serde_json::Value::Bool(b) => Some(b.to_string()),
+            _ => None, // Skip arrays/objects
+        }
+    };
+
+    // Add structure properties and additional properties
+    let all_props = structure
+        .properties
+        .iter()
+        .chain(properties.into_iter().flatten());
+    for (key, value) in all_props {
+        if key != "Lattice"
+            && key != "pbc"
+            && let Some(value_str) = format_value(value)
+        {
+            comment_parts.push(format!("{}={}", key, value_str));
+        }
+    }
+
+    lines.push(comment_parts.join(" "));
+
+    // Atom lines: Element X Y Z (Cartesian coordinates)
+    let cart_coords = structure.cart_coords();
+    for (site_occ, cart) in structure.site_occupancies.iter().zip(cart_coords.iter()) {
+        let symbol = site_occ.dominant_species().element.symbol();
+        lines.push(format!(
+            "{} {:20.16} {:20.16} {:20.16}",
+            symbol, cart.x, cart.y, cart.z
+        ));
+    }
+
+    lines.join("\n") + "\n"
+}
+
+/// Write a structure to an extXYZ file.
+///
+/// # Arguments
+///
+/// * `structure` - The structure to write
+/// * `path` - Path to the output file
+/// * `properties` - Optional additional properties
+///
+/// # Returns
+///
+/// Result indicating success or file I/O error.
+pub fn write_extxyz(
+    structure: &Structure,
+    path: &Path,
+    properties: Option<&HashMap<String, serde_json::Value>>,
+) -> Result<()> {
+    let content = structure_to_extxyz(structure, properties);
+    std::fs::write(path, content)?;
+    Ok(())
+}
+
+/// Write a structure to a file with automatic format detection.
+///
+/// The format is determined by the file extension:
+/// - `.json` - Pymatgen JSON format
+/// - `.cif` - CIF format
+/// - `.xyz`, `.extxyz` - extXYZ format
+/// - `.vasp`, `POSCAR*`, `CONTCAR*` - POSCAR format
+///
+/// # Arguments
+///
+/// * `structure` - The structure to write
+/// * `path` - Path to the output file
+///
+/// # Returns
+///
+/// Result indicating success or error.
+pub fn write_structure(structure: &Structure, path: &Path) -> Result<()> {
+    let format = StructureFormat::from_path(path).ok_or_else(|| FerroxError::UnknownFormat {
+        path: path.display().to_string(),
+    })?;
+
+    match format {
+        StructureFormat::PymatgenJson => {
+            let json = structure_to_pymatgen_json(structure);
+            std::fs::write(path, json)?;
+            Ok(())
+        }
+        StructureFormat::Poscar => write_poscar(structure, path, None),
+        StructureFormat::ExtXyz => write_extxyz(structure, path, None),
+        StructureFormat::Cif => {
+            let cif = crate::cif::structure_to_cif(structure, None);
+            std::fs::write(path, cif)?;
+            Ok(())
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2009,5 +2264,458 @@ Mg 0.0 0.0 0.0
         let s_dis = parse_structure_json(dis).unwrap();
         assert_eq!(s_dis.num_sites(), 1);
         assert!(!s_dis.is_ordered());
+    }
+
+    // =========================================================================
+    // Structure Writer Tests
+    // =========================================================================
+
+    #[test]
+    fn test_structure_to_poscar_roundtrip() {
+        // NaCl structure - tests format and coordinate roundtrip
+        let lattice = Lattice::cubic(5.64);
+        let species = vec![
+            Species::neutral(Element::Na),
+            Species::neutral(Element::Na),
+            Species::neutral(Element::Cl),
+            Species::neutral(Element::Cl),
+        ];
+        let coords = vec![
+            Vector3::new(0.0, 0.0, 0.0),
+            Vector3::new(0.5, 0.5, 0.0),
+            Vector3::new(0.5, 0.0, 0.5),
+            Vector3::new(0.0, 0.5, 0.5),
+        ];
+        let s1 = Structure::new(lattice, species, coords);
+
+        let poscar = structure_to_poscar(&s1, Some("NaCl test"));
+
+        // Verify format
+        assert!(poscar.starts_with("NaCl test\n"));
+        assert!(poscar.contains("Direct\n"));
+
+        // Roundtrip and compare
+        let s2 = parse_poscar_str(&poscar).unwrap();
+        assert_eq!(s1.num_sites(), s2.num_sites());
+        assert!((s1.lattice.volume() - s2.lattice.volume()).abs() < 1e-6);
+        assert_eq!(
+            count_element(&s1, Element::Na),
+            count_element(&s2, Element::Na)
+        );
+
+        // Verify coordinates (POSCAR groups by element, so match by position)
+        let (cart1, cart2) = (s1.cart_coords(), s2.cart_coords());
+        for c1 in &cart1 {
+            assert!(
+                cart2.iter().any(|c2| (c1 - c2).norm() < 1e-6),
+                "Coordinate {:?} not found",
+                c1
+            );
+        }
+    }
+
+    #[test]
+    fn test_structure_to_poscar_multi_element() {
+        // BaTiO3 - tests element grouping with 3 species
+        let s = Structure::new(
+            Lattice::cubic(5.0),
+            vec![
+                Species::neutral(Element::Ba),
+                Species::neutral(Element::Ti),
+                Species::neutral(Element::O),
+                Species::neutral(Element::O),
+                Species::neutral(Element::O),
+            ],
+            vec![
+                Vector3::new(0.0, 0.0, 0.0),
+                Vector3::new(0.5, 0.5, 0.5),
+                Vector3::new(0.5, 0.5, 0.0),
+                Vector3::new(0.5, 0.0, 0.5),
+                Vector3::new(0.0, 0.5, 0.5),
+            ],
+        );
+
+        let poscar = structure_to_poscar(&s, None);
+        let s2 = parse_poscar_str(&poscar).unwrap();
+
+        assert_eq!(s2.num_sites(), 5);
+        assert_eq!(count_element(&s2, Element::Ba), 1);
+        assert_eq!(count_element(&s2, Element::Ti), 1);
+        assert_eq!(count_element(&s2, Element::O), 3);
+    }
+
+    #[test]
+    fn test_structure_to_extxyz_roundtrip() {
+        use std::io::Write;
+        // Non-cubic lattice catches vector ordering bugs
+        let s1 = Structure::new(
+            Lattice::from_parameters(3.0, 4.0, 5.0, 90.0, 90.0, 90.0),
+            vec![Species::neutral(Element::H), Species::neutral(Element::O)],
+            vec![Vector3::new(0.0, 0.0, 0.0), Vector3::new(0.5, 0.5, 0.5)],
+        );
+
+        let xyz = structure_to_extxyz(&s1, None);
+
+        // Verify format
+        let lines: Vec<&str> = xyz.lines().collect();
+        assert_eq!(lines[0], "2");
+        assert!(lines[1].contains("Lattice="));
+        assert!(lines[1].contains("pbc="));
+
+        // Roundtrip via temp file
+        let mut temp_file = NamedTempFile::with_suffix(".xyz").unwrap();
+        temp_file.write_all(xyz.as_bytes()).unwrap();
+        let s2 = parse_extxyz(temp_file.path()).unwrap();
+
+        // Compare lattice (catches ordering bugs)
+        let (len1, len2) = (s1.lattice.lengths(), s2.lattice.lengths());
+        assert!((len1.x - len2.x).abs() < 1e-6, "a mismatch");
+        assert!((len1.y - len2.y).abs() < 1e-6, "b mismatch");
+        assert!((len1.z - len2.z).abs() < 1e-6, "c mismatch");
+
+        // Compare species and coords
+        assert_eq!(s1.species()[0].element, s2.species()[0].element);
+        assert_eq!(s1.species()[1].element, s2.species()[1].element);
+        let (cart1, cart2) = (s1.cart_coords(), s2.cart_coords());
+        for idx in 0..2 {
+            assert!((cart1[idx] - cart2[idx]).norm() < 1e-6);
+        }
+    }
+
+    #[test]
+    fn test_write_structure_auto_format() {
+        let temp_dir = TempDir::new().unwrap();
+        let s = Structure::new(
+            Lattice::cubic(4.0),
+            vec![Species::neutral(Element::Cu)],
+            vec![Vector3::new(0.0, 0.0, 0.0)],
+        );
+
+        for filename in ["test.json", "POSCAR", "test.xyz", "test.cif"] {
+            let path = temp_dir.path().join(filename);
+            write_structure(&s, &path).unwrap();
+            let content = std::fs::read_to_string(&path).unwrap();
+            assert!(!content.is_empty(), "{} should not be empty", filename);
+        }
+    }
+
+    #[test]
+    fn test_structure_to_extxyz_escapes_strings() {
+        let s = Structure::new(
+            Lattice::cubic(4.0),
+            vec![Species::neutral(Element::Fe)],
+            vec![Vector3::new(0.0, 0.0, 0.0)],
+        );
+
+        // Test with problematic string values
+        let mut props = HashMap::new();
+        props.insert("with_quote".to_string(), serde_json::json!("foo\"bar"));
+        props.insert(
+            "with_newline".to_string(),
+            serde_json::json!("line1\nline2"),
+        );
+        props.insert(
+            "with_backslash".to_string(),
+            serde_json::json!("path\\to\\file"),
+        );
+
+        let xyz = structure_to_extxyz(&s, Some(&props));
+        let lines: Vec<&str> = xyz.lines().collect();
+
+        // Output should be exactly 3 lines (count, comment, atom)
+        assert_eq!(lines.len(), 3, "Newlines in properties should be escaped");
+
+        // Check escaped values are in comment line
+        assert!(
+            lines[1].contains(r#"with_quote="foo\"bar""#),
+            "Quotes should be escaped"
+        );
+        assert!(
+            lines[1].contains(r#"with_newline="line1\nline2""#),
+            "Newlines should be escaped"
+        );
+        assert!(
+            lines[1].contains(r#"with_backslash="path\\to\\file""#),
+            "Backslashes should be escaped"
+        );
+    }
+
+    // =========================================================================
+    // Fixture-based Roundtrip Tests (matches TypeScript coverage)
+    // =========================================================================
+
+    #[test]
+    fn test_roundtrip_poscar_batio3_fixture() {
+        // Parse BaTiO3 fixture, export, reparse - verifies real-world POSCAR handling
+        let fixture = include_str!("../../../src/site/structures/BaTiO3-tetragonal.poscar");
+        let s1 = parse_poscar_str(fixture).unwrap();
+        let exported = structure_to_poscar(&s1, None);
+        let s2 = parse_poscar_str(&exported).unwrap();
+
+        assert_eq!(s1.num_sites(), s2.num_sites());
+        assert!((s1.lattice.volume() - s2.lattice.volume()).abs() < 1e-3);
+        // Verify all coordinates roundtrip
+        let (cart1, cart2) = (s1.cart_coords(), s2.cart_coords());
+        for c1 in &cart1 {
+            assert!(cart2.iter().any(|c2| (c1 - c2).norm() < 1e-4));
+        }
+    }
+
+    #[test]
+    fn test_roundtrip_cif_tio2_fixture() {
+        // Parse TiO2 CIF fixture, export, reparse
+        let fixture = include_str!("../../../src/site/structures/TiO2.cif");
+        let s1 = crate::cif::parse_cif_str(fixture, std::path::Path::new("TiO2.cif")).unwrap();
+        let exported = crate::cif::structure_to_cif(&s1, None);
+        let s2 =
+            crate::cif::parse_cif_str(&exported, std::path::Path::new("exported.cif")).unwrap();
+
+        assert_eq!(s1.num_sites(), s2.num_sites());
+        let (len1, len2) = (s1.lattice.lengths(), s2.lattice.lengths());
+        assert!((len1.x - len2.x).abs() < 1e-4);
+        assert!((len1.y - len2.y).abs() < 1e-4);
+        assert!((len1.z - len2.z).abs() < 1e-4);
+    }
+
+    #[test]
+    fn test_roundtrip_extxyz_quartz_fixture() {
+        use std::io::Write;
+        // Parse quartz extXYZ fixture, export, reparse
+        let fixture = include_str!("../../../src/site/structures/quartz.extxyz");
+        let mut temp = NamedTempFile::with_suffix(".xyz").unwrap();
+        temp.write_all(fixture.as_bytes()).unwrap();
+        let s1 = parse_extxyz(temp.path()).unwrap();
+
+        let exported = structure_to_extxyz(&s1, None);
+        let mut temp2 = NamedTempFile::with_suffix(".xyz").unwrap();
+        temp2.write_all(exported.as_bytes()).unwrap();
+        let s2 = parse_extxyz(temp2.path()).unwrap();
+
+        assert_eq!(s1.num_sites(), s2.num_sites());
+        let (len1, len2) = (s1.lattice.lengths(), s2.lattice.lengths());
+        assert!((len1.x - len2.x).abs() < 1e-4);
+        assert!((len1.y - len2.y).abs() < 1e-4);
+        assert!((len1.z - len2.z).abs() < 1e-4);
+    }
+
+    #[test]
+    fn test_roundtrip_json_mp1_fixture() {
+        // Parse mp-1 JSON fixture, export, reparse
+        let fixture = include_str!("../../../src/site/structures/mp-1.json");
+        let s1 = parse_structure_json(fixture).unwrap();
+        let exported = structure_to_pymatgen_json(&s1);
+        let s2 = parse_structure_json(&exported).unwrap();
+
+        assert_eq!(s1.num_sites(), s2.num_sites());
+        assert!((s1.lattice.volume() - s2.lattice.volume()).abs() < 1e-6);
+    }
+
+    // =========================================================================
+    // Triclinic/Non-orthogonal Lattice Tests
+    // =========================================================================
+
+    #[test]
+    fn test_poscar_triclinic_lattice() {
+        // Triclinic lattice with all angles non-90
+        let s1 = Structure::new(
+            Lattice::from_parameters(3.0, 4.0, 5.0, 80.0, 85.0, 95.0),
+            vec![Species::neutral(Element::C)],
+            vec![Vector3::new(0.25, 0.5, 0.75)],
+        );
+        let poscar = structure_to_poscar(&s1, None);
+        let s2 = parse_poscar_str(&poscar).unwrap();
+
+        // Verify angles preserved
+        let (a1, a2) = (s1.lattice.angles(), s2.lattice.angles());
+        assert!((a1.x - a2.x).abs() < 1e-4, "alpha mismatch");
+        assert!((a1.y - a2.y).abs() < 1e-4, "beta mismatch");
+        assert!((a1.z - a2.z).abs() < 1e-4, "gamma mismatch");
+    }
+
+    #[test]
+    fn test_cif_triclinic_lattice() {
+        let s1 = Structure::try_new(
+            Lattice::from_parameters(3.0, 4.0, 5.0, 70.0, 80.0, 100.0),
+            vec![Species::neutral(Element::Si)],
+            vec![Vector3::new(0.1, 0.2, 0.3)],
+        )
+        .unwrap();
+        let cif = crate::cif::structure_to_cif(&s1, None);
+        let s2 = crate::cif::parse_cif_str(&cif, std::path::Path::new("tri.cif")).unwrap();
+
+        let (a1, a2) = (s1.lattice.angles(), s2.lattice.angles());
+        assert!((a1.x - a2.x).abs() < 1e-4);
+        assert!((a1.y - a2.y).abs() < 1e-4);
+        assert!((a1.z - a2.z).abs() < 1e-4);
+    }
+
+    // =========================================================================
+    // High Precision Tests
+    // =========================================================================
+
+    #[test]
+    fn test_poscar_high_precision_coords() {
+        let s1 = Structure::new(
+            Lattice::cubic(10.0),
+            vec![Species::neutral(Element::H)],
+            vec![Vector3::new(0.123456789, 0.987654321, 0.555555555)],
+        );
+        let poscar = structure_to_poscar(&s1, None);
+
+        // Verify high precision is preserved in roundtrip (16 decimal format)
+        let s2 = parse_poscar_str(&poscar).unwrap();
+        let (f1, f2) = (&s1.frac_coords[0], &s2.frac_coords[0]);
+        assert!((f1.x - f2.x).abs() < 1e-10, "x precision loss");
+        assert!((f1.y - f2.y).abs() < 1e-10, "y precision loss");
+        assert!((f1.z - f2.z).abs() < 1e-10, "z precision loss");
+    }
+
+    // =========================================================================
+    // Disordered Site Handling (CIF preserves occupancy)
+    // =========================================================================
+
+    #[test]
+    fn test_cif_disordered_site_roundtrip() {
+        use crate::species::SiteOccupancy;
+        // Create structure with disordered site
+        let lattice = Lattice::cubic(4.0);
+        let disordered = SiteOccupancy::new(vec![
+            (Species::neutral(Element::Fe), 0.6),
+            (Species::neutral(Element::Co), 0.4),
+        ]);
+        let s1 = Structure::try_new_from_occupancies(
+            lattice,
+            vec![disordered],
+            vec![Vector3::new(0.0, 0.0, 0.0)],
+        )
+        .unwrap();
+
+        let cif = crate::cif::structure_to_cif(&s1, None);
+
+        // Verify both species and occupancies appear
+        assert!(cif.contains("Fe"));
+        assert!(cif.contains("Co"));
+        assert!(cif.contains("0.600000") || cif.contains("0.6"));
+        assert!(cif.contains("0.400000") || cif.contains("0.4"));
+    }
+
+    // =========================================================================
+    // CIF Data Block Name Sanitization
+    // =========================================================================
+
+    #[test]
+    fn test_cif_data_name_sanitization() {
+        let s = Structure::try_new(
+            Lattice::cubic(4.0),
+            vec![Species::neutral(Element::H)],
+            vec![Vector3::new(0.0, 0.0, 0.0)],
+        )
+        .unwrap();
+
+        // Spaces and hyphens should be replaced with underscores
+        let cif = crate::cif::structure_to_cif(&s, Some("test-structure name"));
+        assert!(cif.starts_with("data_test_structure_name\n"));
+
+        // Formula used when no name provided
+        let cif2 = crate::cif::structure_to_cif(&s, None);
+        assert!(cif2.starts_with("data_H\n"));
+    }
+
+    // =========================================================================
+    // Large Structure Handling
+    // =========================================================================
+
+    #[test]
+    fn test_large_structure_export() {
+        // Create 500-site structure (TypeScript tests 1000, but smaller for speed)
+        let lattice = Lattice::cubic(20.0);
+        let species: Vec<Species> = (0..500).map(|_| Species::neutral(Element::H)).collect();
+        let coords: Vec<Vector3<f64>> = (0..500)
+            .map(|idx| {
+                Vector3::new(
+                    (idx % 10) as f64 / 10.0,
+                    ((idx / 10) % 10) as f64 / 10.0,
+                    (idx / 100) as f64 / 5.0,
+                )
+            })
+            .collect();
+        let s = Structure::new(lattice, species, coords);
+
+        // All formats should handle large structures without panicking
+        let poscar = structure_to_poscar(&s, None);
+        let xyz = structure_to_extxyz(&s, None);
+        let cif = crate::cif::structure_to_cif(&s, None);
+        let json = structure_to_pymatgen_json(&s);
+
+        // Verify all 500 sites are exported
+        let s2 = parse_poscar_str(&poscar).unwrap();
+        assert_eq!(s2.num_sites(), 500);
+
+        let xyz_lines: Vec<&str> = xyz.lines().collect();
+        assert_eq!(xyz_lines[0], "500"); // First line is atom count
+
+        assert!(cif.matches("H").count() >= 500);
+        assert!(json.contains("\"sites\""));
+    }
+
+    // =========================================================================
+    // POSCAR Default Comment (formula)
+    // =========================================================================
+
+    #[test]
+    fn test_poscar_default_comment_uses_formula() {
+        let s = Structure::new(
+            Lattice::cubic(5.0),
+            vec![
+                Species::neutral(Element::Li),
+                Species::neutral(Element::Fe),
+                Species::neutral(Element::P),
+                Species::neutral(Element::O),
+            ],
+            vec![
+                Vector3::new(0.0, 0.0, 0.0),
+                Vector3::new(0.25, 0.25, 0.25),
+                Vector3::new(0.5, 0.5, 0.5),
+                Vector3::new(0.75, 0.75, 0.75),
+            ],
+        );
+        let poscar = structure_to_poscar(&s, None);
+
+        // First line should be the reduced formula
+        let first_line = poscar.lines().next().unwrap();
+        assert!(
+            first_line.contains("Li") && first_line.contains("Fe"),
+            "Default comment should contain formula elements"
+        );
+    }
+
+    // =========================================================================
+    // extXYZ Properties Preservation
+    // =========================================================================
+
+    #[test]
+    fn test_extxyz_preserves_properties() {
+        use std::io::Write;
+        let mut s = Structure::new(
+            Lattice::cubic(5.0),
+            vec![Species::neutral(Element::Fe)],
+            vec![Vector3::new(0.0, 0.0, 0.0)],
+        );
+        s.properties
+            .insert("energy".to_string(), serde_json::json!(-5.5));
+        s.properties
+            .insert("config_type".to_string(), serde_json::json!("relaxed"));
+
+        let xyz = structure_to_extxyz(&s, None);
+
+        // Properties should appear in comment line
+        assert!(xyz.contains("energy=-5.5") || xyz.contains("energy="));
+        assert!(xyz.contains("config_type=\"relaxed\""));
+
+        // Roundtrip preserves properties
+        let mut temp = NamedTempFile::with_suffix(".xyz").unwrap();
+        temp.write_all(xyz.as_bytes()).unwrap();
+        let s2 = parse_extxyz(temp.path()).unwrap();
+        assert_eq!(s2.properties.get("energy"), Some(&serde_json::json!(-5.5)));
     }
 }

--- a/extensions/rust/src/structure.rs
+++ b/extensions/rust/src/structure.rs
@@ -254,6 +254,12 @@ impl Structure {
 
     /// Get the primitive cell using moyo symmetry analysis.
     pub fn get_primitive(&self, symprec: f64) -> Result<Self> {
+        if !symprec.is_finite() || symprec <= 0.0 {
+            return Err(FerroxError::InvalidStructure {
+                index: 0,
+                reason: format!("symprec must be positive and finite, got {symprec}"),
+            });
+        }
         let moyo_cell = self.to_moyo_cell();
         let dataset = MoyoDataset::new(
             &moyo_cell,
@@ -271,6 +277,12 @@ impl Structure {
 
     /// Get the conventional (standardized) cell using moyo symmetry analysis.
     pub fn get_conventional_structure(&self, symprec: f64) -> Result<Self> {
+        if !symprec.is_finite() || symprec <= 0.0 {
+            return Err(FerroxError::InvalidStructure {
+                index: 0,
+                reason: format!("symprec must be positive and finite, got {symprec}"),
+            });
+        }
         let moyo_cell = self.to_moyo_cell();
         let dataset = MoyoDataset::new(
             &moyo_cell,
@@ -288,6 +300,7 @@ impl Structure {
 
     /// Get the spacegroup number using moyo.
     pub fn get_spacegroup_number(&self, symprec: f64) -> Result<i32> {
+        // symprec validated by get_symmetry_dataset
         Ok(self.get_symmetry_dataset(symprec)?.number)
     }
 
@@ -296,6 +309,12 @@ impl Structure {
     /// This is more efficient when you need multiple symmetry properties,
     /// as it only runs the symmetry analysis once.
     pub fn get_symmetry_dataset(&self, symprec: f64) -> Result<MoyoDataset> {
+        if !symprec.is_finite() || symprec <= 0.0 {
+            return Err(FerroxError::InvalidStructure {
+                index: 0,
+                reason: format!("symprec must be positive and finite, got {symprec}"),
+            });
+        }
         if self.num_sites() == 0 {
             return Err(FerroxError::InvalidStructure {
                 index: 0,
@@ -2577,7 +2596,7 @@ mod tests {
                 - rot[0][1] * (rot[1][0] * rot[2][2] - rot[1][2] * rot[2][0])
                 + rot[0][2] * (rot[1][0] * rot[2][1] - rot[1][1] * rot[2][0]);
             assert!(det == 1 || det == -1);
-            // Translation should be in [0, 1)
+            // Translation should be within the conventional [-0.5, 0.5] range
             for &t in trans {
                 assert!((-0.5..=0.5 + 1e-8).contains(&t));
             }

--- a/extensions/rust/tests/benchmark_pymatgen.py
+++ b/extensions/rust/tests/benchmark_pymatgen.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python
+"""Benchmark ferrox vs pymatgen StructureMatcher on real structure files.
+
+This script loads structures from matterviz and pymatgen test files and benchmarks
+compatibility and performance. For unit tests, use pytest on test_pymatgen_compat.py.
+
+Usage:
+    python tests/benchmark_pymatgen.py              # Full benchmark
+    python tests/benchmark_pymatgen.py --quick      # Quick synthetic-only benchmark
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import time
+from collections import defaultdict
+from pathlib import Path
+
+from pymatgen.analysis.structure_matcher import StructureMatcher as PyMatcher
+from pymatgen.core import Structure
+
+from test_pymatgen_compat import (
+    BASE_STRUCTURES,
+    MATTERVIZ_STRUCTURES_DIR,
+    PYMATGEN_CIF_DIR,
+    make_rocksalt,
+    perturb,
+    scale_lattice,
+    shuffle_sites,
+    strain_lattice,
+    translate,
+)
+
+try:
+    from ferrox import StructureMatcher as RustMatcher
+except ImportError:
+    print("ERROR: ferrox not installed. Run: maturin develop --features python")
+    raise SystemExit(1)
+
+
+def load_matterviz_structures() -> dict[str, Structure]:
+    """Load JSON structures from matterviz."""
+    structures = {}
+    if not MATTERVIZ_STRUCTURES_DIR.exists():
+        return structures
+
+    for json_file in MATTERVIZ_STRUCTURES_DIR.glob("*.json"):
+        try:
+            data = json.loads(json_file.read_text())
+            if data.get("@class") == "Structure":
+                structures[json_file.stem] = Structure.from_dict(data)
+        except Exception:
+            pass
+
+    for gz_file in MATTERVIZ_STRUCTURES_DIR.glob("*.json.gz"):
+        try:
+            with gzip.open(gz_file, "rt") as fh:
+                data = json.load(fh)
+            if data.get("@class") == "Structure":
+                structures[gz_file.stem.replace(".json", "")] = Structure.from_dict(data)
+        except Exception:
+            pass
+
+    return structures
+
+
+def load_pymatgen_cif_structures() -> dict[str, Structure]:
+    """Load CIF structures from pymatgen test files."""
+    structures = {}
+    if not PYMATGEN_CIF_DIR.exists():
+        return structures
+
+    for cif_file in PYMATGEN_CIF_DIR.glob("*.cif"):
+        try:
+            structures[cif_file.stem] = Structure.from_file(str(cif_file))
+        except Exception:
+            pass
+
+    return structures
+
+
+def benchmark(quick: bool = False) -> None:
+    """Run compatibility benchmark."""
+    print("=" * 70)
+    print("FERROX vs PYMATGEN COMPATIBILITY BENCHMARK")
+    print("=" * 70)
+
+    py_matcher = PyMatcher(ltol=0.2, stol=0.3, angle_tol=5.0, primitive_cell=False)
+    rust_matcher = RustMatcher(
+        latt_len_tol=0.2, site_pos_tol=0.3, angle_tol=5.0, primitive_cell=False
+    )
+
+    results: dict[str, list[tuple[str, bool, bool]]] = defaultdict(list)
+
+    def compare(s1: Structure, s2: Structure, category: str, desc: str) -> None:
+        """Compare and record result."""
+        try:
+            py_result = bool(py_matcher.fit(s1, s2))
+            rust_result = rust_matcher.fit(
+                json.dumps(s1.as_dict()), json.dumps(s2.as_dict())
+            )
+            results[category].append((desc, py_result == rust_result, py_result))
+        except Exception as exc:
+            results[category].append((f"{desc}: {exc}", False, False))
+
+    start = time.perf_counter()
+
+    # Synthetic tests
+    print("\nRunning synthetic structure tests...")
+    for name, struct in BASE_STRUCTURES:
+        compare(struct, struct, "self-match", name)
+        compare(struct, perturb(struct, 0.02), "perturb", f"{name} ±0.02")
+        compare(struct, scale_lattice(struct, 1.02), "scale", f"{name} ×1.02")
+        compare(struct, strain_lattice(struct, 0.01), "strain", f"{name} +1%")
+
+    nacl = make_rocksalt("Na", "Cl", 5.64)
+    compare(nacl, shuffle_sites(nacl), "shuffle", "NaCl shuffled")
+    compare(nacl, translate(nacl, [0.25, 0.25, 0.25]), "translate", "NaCl +0.25")
+
+    if not quick:
+        # Load real structures
+        print("\nLoading structures...")
+        matterviz = load_matterviz_structures()
+        print(f"  matterviz: {len(matterviz)} structures")
+        cif = load_pymatgen_cif_structures()
+        print(f"  pymatgen CIF: {len(cif)} structures")
+
+        all_structures = {**matterviz, **cif}
+
+        # Self-matching
+        print("\nRunning self-matching tests...")
+        for name, struct in all_structures.items():
+            compare(struct, struct, "file-self", name)
+
+        # Cross-file comparisons (limited)
+        print("\nRunning cross-file comparisons...")
+        items = list(all_structures.items())[:20]
+        for idx, (name1, s1) in enumerate(items):
+            for name2, s2 in items[idx + 1 :]:
+                compare(s1, s2, "cross-file", f"{name1} vs {name2}")
+
+    elapsed = time.perf_counter() - start
+
+    # Print summary
+    print("\n" + "=" * 70)
+    print("RESULTS")
+    print("=" * 70)
+
+    total_tests = 0
+    total_passed = 0
+    for category, cat_results in sorted(results.items()):
+        passed = sum(1 for _, match, _ in cat_results if match)
+        total = len(cat_results)
+        total_tests += total
+        total_passed += passed
+        status = "✓" if passed == total else "✗"
+        print(f"  {status} {category}: {passed}/{total}")
+
+    print(f"\nTotal: {total_passed}/{total_tests} ({100 * total_passed / total_tests:.1f}%)")
+    print(f"Time: {elapsed:.2f}s")
+
+    # Show failures
+    failures = [
+        (cat, desc)
+        for cat, cat_results in results.items()
+        for desc, match, _ in cat_results
+        if not match
+    ]
+    if failures:
+        print(f"\nFailures ({len(failures)}):")
+        for cat, desc in failures[:10]:
+            print(f"  [{cat}] {desc}")
+        if len(failures) > 10:
+            print(f"  ... and {len(failures) - 10} more")
+        raise SystemExit(1)
+
+    print("\n✓ All tests passed - ferrox matches pymatgen exactly")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--quick", action="store_true", help="Quick synthetic-only benchmark")
+    args = parser.parse_args()
+    benchmark(quick=args.quick)

--- a/extensions/rust/tests/test_ferrox_api.py
+++ b/extensions/rust/tests/test_ferrox_api.py
@@ -1,4 +1,4 @@
-"""Tests for ferrox Python API - composition and structure metadata functions."""
+"""Tests for ferrox Python API - composition, structure metadata, and symmetry functions."""
 
 from __future__ import annotations
 
@@ -7,7 +7,20 @@ import json
 import pytest
 
 try:
-    from ferrox._ferrox import get_structure_metadata, parse_composition
+    from ferrox._ferrox import (
+        get_crystal_system,
+        get_equivalent_sites,
+        get_hall_number,
+        get_pearson_symbol,
+        get_site_symmetry_symbols,
+        get_spacegroup_number,
+        get_spacegroup_symbol,
+        get_structure_metadata,
+        get_symmetry_dataset,
+        get_symmetry_operations,
+        get_wyckoff_letters,
+        parse_composition,
+    )
 except ImportError:
     pytest.skip("ferrox not installed", allow_module_level=True)
 
@@ -157,3 +170,154 @@ class TestGetStructureMetadata:
 def test_anonymous_formula(formula: str, expected: str) -> None:
     """Anonymous formula: elements sorted by electronegativity, then A, B, C..."""
     assert parse_composition(formula)["anonymous_formula"] == expected
+
+
+# Symmetry fixtures
+
+
+@pytest.fixture
+def fcc_cu_json() -> str:
+    """FCC Cu conventional cell (4 atoms, Fm-3m #225) as JSON."""
+    # Lattice constant 3.6 Å
+    struct = {
+        "@module": "pymatgen.core.structure",
+        "@class": "Structure",
+        "lattice": {"matrix": [[3.6, 0, 0], [0, 3.6, 0], [0, 0, 3.6]]},
+        "sites": [
+            {"species": [{"element": "Cu", "occu": 1}], "abc": [0.0, 0.0, 0.0]},
+            {"species": [{"element": "Cu", "occu": 1}], "abc": [0.5, 0.5, 0.0]},
+            {"species": [{"element": "Cu", "occu": 1}], "abc": [0.5, 0.0, 0.5]},
+            {"species": [{"element": "Cu", "occu": 1}], "abc": [0.0, 0.5, 0.5]},
+        ],
+    }
+    return json.dumps(struct)
+
+
+@pytest.fixture
+def bcc_fe_json() -> str:
+    """BCC Fe conventional cell (2 atoms, Im-3m #229) as JSON."""
+    # Lattice constant 2.87 Å
+    struct = {
+        "@module": "pymatgen.core.structure",
+        "@class": "Structure",
+        "lattice": {"matrix": [[2.87, 0, 0], [0, 2.87, 0], [0, 0, 2.87]]},
+        "sites": [
+            {"species": [{"element": "Fe", "occu": 1}], "abc": [0.0, 0.0, 0.0]},
+            {"species": [{"element": "Fe", "occu": 1}], "abc": [0.5, 0.5, 0.5]},
+        ],
+    }
+    return json.dumps(struct)
+
+
+# Symmetry tests
+
+
+class TestSymmetryFunctions:
+    """Tests for symmetry analysis functions."""
+
+    def test_get_spacegroup_number(self, fcc_cu_json: str, bcc_fe_json: str) -> None:
+        """Test spacegroup number detection."""
+        assert get_spacegroup_number(fcc_cu_json) == 225  # Fm-3m
+        assert get_spacegroup_number(bcc_fe_json) == 229  # Im-3m
+
+    def test_get_spacegroup_symbol(self, fcc_cu_json: str, bcc_fe_json: str) -> None:
+        """Test spacegroup symbol detection (moyo uses spaces)."""
+        assert get_spacegroup_symbol(fcc_cu_json) == "F m -3 m"
+        assert get_spacegroup_symbol(bcc_fe_json) == "I m -3 m"
+
+    def test_get_hall_number(self, fcc_cu_json: str) -> None:
+        """Test Hall number is in valid range."""
+        hall = get_hall_number(fcc_cu_json)
+        assert 1 <= hall <= 530
+
+    def test_get_pearson_symbol(self, fcc_cu_json: str, bcc_fe_json: str) -> None:
+        """Test Pearson symbol detection."""
+        assert get_pearson_symbol(fcc_cu_json) == "cF4"  # cubic, F-centered, 4 atoms
+        assert get_pearson_symbol(bcc_fe_json) == "cI2"  # cubic, I-centered, 2 atoms
+
+    def test_get_wyckoff_letters(self, fcc_cu_json: str) -> None:
+        """Test Wyckoff letter assignment."""
+        wyckoffs = get_wyckoff_letters(fcc_cu_json)
+        assert len(wyckoffs) == 4
+        # All Cu atoms in FCC should have same Wyckoff position
+        assert len(set(wyckoffs)) == 1
+
+    def test_get_site_symmetry_symbols(self, fcc_cu_json: str) -> None:
+        """Test site symmetry symbol assignment."""
+        symbols = get_site_symmetry_symbols(fcc_cu_json)
+        assert len(symbols) == 4
+        # All Cu atoms in FCC should have same site symmetry
+        assert len(set(symbols)) == 1
+
+    def test_get_symmetry_operations(self, fcc_cu_json: str) -> None:
+        """Test symmetry operations retrieval."""
+        ops = get_symmetry_operations(fcc_cu_json)
+        assert len(ops) > 0
+        # Each operation is (rotation, translation) tuple
+        for rot, trans in ops:
+            assert len(rot) == 3  # 3x3 matrix
+            assert len(rot[0]) == 3
+            assert len(trans) == 3  # 3-vector
+
+    def test_get_equivalent_sites(self, fcc_cu_json: str, nacl_json: str) -> None:
+        """Test equivalent site detection."""
+        # FCC Cu: all 4 atoms equivalent
+        orbits_cu = get_equivalent_sites(fcc_cu_json)
+        assert len(orbits_cu) == 4
+        assert len(set(orbits_cu)) == 1  # All map to same representative
+
+        # NaCl: 2 inequivalent sites (Na and Cl)
+        orbits_nacl = get_equivalent_sites(nacl_json)
+        assert len(orbits_nacl) == 2
+        assert len(set(orbits_nacl)) == 2  # Different representatives
+
+    def test_get_crystal_system(self, fcc_cu_json: str, bcc_fe_json: str) -> None:
+        """Test crystal system detection."""
+        assert get_crystal_system(fcc_cu_json) == "cubic"
+        assert get_crystal_system(bcc_fe_json) == "cubic"
+
+
+class TestGetSymmetryDataset:
+    """Tests for get_symmetry_dataset function (returns all symmetry info)."""
+
+    def test_all_fields_present(self, fcc_cu_json: str) -> None:
+        """Verify all expected fields in symmetry dataset."""
+        dataset = get_symmetry_dataset(fcc_cu_json)
+
+        # Check all expected keys are present
+        expected_keys = {
+            "spacegroup_number",
+            "spacegroup_symbol",
+            "hall_number",
+            "pearson_symbol",
+            "crystal_system",
+            "wyckoff_letters",
+            "site_symmetry_symbols",
+            "equivalent_sites",
+            "symmetry_operations",
+            "num_operations",
+        }
+        assert expected_keys.issubset(dataset.keys())
+
+    def test_dataset_values(self, fcc_cu_json: str) -> None:
+        """Verify symmetry dataset values for FCC Cu."""
+        dataset = get_symmetry_dataset(fcc_cu_json)
+
+        assert dataset["spacegroup_number"] == 225
+        assert dataset["spacegroup_symbol"] == "F m -3 m"
+        assert dataset["pearson_symbol"] == "cF4"
+        assert dataset["crystal_system"] == "cubic"
+        assert len(dataset["wyckoff_letters"]) == 4
+        assert len(dataset["equivalent_sites"]) == 4
+        assert dataset["num_operations"] == len(dataset["symmetry_operations"])
+
+    def test_dataset_matches_individual_calls(self, nacl_json: str) -> None:
+        """Dataset contains same info as individual calls."""
+        dataset = get_symmetry_dataset(nacl_json)
+
+        assert dataset["spacegroup_number"] == get_spacegroup_number(nacl_json)
+        assert dataset["spacegroup_symbol"] == get_spacegroup_symbol(nacl_json)
+        assert dataset["pearson_symbol"] == get_pearson_symbol(nacl_json)
+        assert dataset["crystal_system"] == get_crystal_system(nacl_json)
+        assert dataset["wyckoff_letters"] == get_wyckoff_letters(nacl_json)
+        assert dataset["equivalent_sites"] == get_equivalent_sites(nacl_json)

--- a/extensions/rust/tests/test_ferrox_api.py
+++ b/extensions/rust/tests/test_ferrox_api.py
@@ -7,20 +7,7 @@ import json
 import pytest
 
 try:
-    from ferrox._ferrox import (
-        get_crystal_system,
-        get_equivalent_sites,
-        get_hall_number,
-        get_pearson_symbol,
-        get_site_symmetry_symbols,
-        get_spacegroup_number,
-        get_spacegroup_symbol,
-        get_structure_metadata,
-        get_symmetry_dataset,
-        get_symmetry_operations,
-        get_wyckoff_letters,
-        parse_composition,
-    )
+    from ferrox import _ferrox as ferrox
 except ImportError:
     pytest.skip("ferrox not installed", allow_module_level=True)
 
@@ -69,7 +56,7 @@ class TestParseComposition:
 
     def test_basic_properties(self) -> None:
         """Parse formula and verify all basic properties."""
-        result = parse_composition("Fe2O3")
+        result = ferrox.parse_composition("Fe2O3")
         assert result["formula"] == "Fe2 O3"
         assert result["reduced_formula"] == "Fe2O3"
         assert result["chemical_system"] == "Fe-O"
@@ -80,18 +67,18 @@ class TestParseComposition:
 
     def test_anonymous_formula_reduction(self) -> None:
         """Anonymous formula reduces: Fe4O6 and Fe2O3 give same result."""
-        large = parse_composition("Fe4O6")
-        small = parse_composition("Fe2O3")
+        large = ferrox.parse_composition("Fe4O6")
+        small = ferrox.parse_composition("Fe2O3")
         assert large["anonymous_formula"] == small["anonymous_formula"] == "A2B3"
         assert large["reduced_formula"] == small["reduced_formula"]
 
     def test_hill_formula(self) -> None:
         """Hill formula: C first, H second, then alphabetical."""
-        assert parse_composition("C6H12O6")["hill_formula"] == "C6 H12 O6"
+        assert ferrox.parse_composition("C6H12O6")["hill_formula"] == "C6 H12 O6"
 
     def test_weight(self) -> None:
         """Molecular weight: H2O ≈ 18.015 amu."""
-        assert 17.9 < parse_composition("H2O")["weight"] < 18.1
+        assert 17.9 < ferrox.parse_composition("H2O")["weight"] < 18.1
 
 
 # get_structure_metadata tests
@@ -102,7 +89,7 @@ class TestGetStructureMetadata:
 
     def test_all_metadata_fields(self, nacl_json: str) -> None:
         """Verify all metadata fields are correct."""
-        result = get_structure_metadata(nacl_json)
+        result = ferrox.get_structure_metadata(nacl_json)
 
         # Formula fields (keys match parse_composition for consistency)
         assert result["formula"] == "NaCl"
@@ -123,22 +110,22 @@ class TestGetStructureMetadata:
 
     def test_binary_structure(self, fe2o3_json: str) -> None:
         """Test Fe2O3 structure metadata."""
-        result = get_structure_metadata(fe2o3_json)
+        result = ferrox.get_structure_metadata(fe2o3_json)
         assert result["anonymous_formula"] == "A2B3"  # Fe (1.83) < O (3.44)
         assert result["n_sites"] == 5
 
     def test_spacegroup_optional(self, nacl_json: str) -> None:
         """Spacegroup computation is optional and expensive."""
-        without_sg = get_structure_metadata(nacl_json, compute_spacegroup=False)
+        without_sg = ferrox.get_structure_metadata(nacl_json, compute_spacegroup=False)
         assert "spacegroup_number" not in without_sg
 
-        with_sg = get_structure_metadata(nacl_json, compute_spacegroup=True)
+        with_sg = ferrox.get_structure_metadata(nacl_json, compute_spacegroup=True)
         assert with_sg["spacegroup_number"] == 221  # Pm-3m
 
     def test_consistency_with_parse_composition(self, nacl_json: str) -> None:
         """Metadata matches parse_composition for same formula."""
-        metadata = get_structure_metadata(nacl_json)
-        comp = parse_composition("NaCl")
+        metadata = ferrox.get_structure_metadata(nacl_json)
+        comp = ferrox.parse_composition("NaCl")
         assert metadata["formula"] == comp["reduced_formula"]
         assert metadata["anonymous_formula"] == comp["anonymous_formula"]
         assert metadata["chemical_system"] == comp["chemical_system"]
@@ -169,7 +156,7 @@ class TestGetStructureMetadata:
 )
 def test_anonymous_formula(formula: str, expected: str) -> None:
     """Anonymous formula: elements sorted by electronegativity, then A, B, C..."""
-    assert parse_composition(formula)["anonymous_formula"] == expected
+    assert ferrox.parse_composition(formula)["anonymous_formula"] == expected
 
 
 # Symmetry fixtures
@@ -217,41 +204,41 @@ class TestSymmetryFunctions:
 
     def test_get_spacegroup_number(self, fcc_cu_json: str, bcc_fe_json: str) -> None:
         """Test spacegroup number detection."""
-        assert get_spacegroup_number(fcc_cu_json) == 225  # Fm-3m
-        assert get_spacegroup_number(bcc_fe_json) == 229  # Im-3m
+        assert ferrox.get_spacegroup_number(fcc_cu_json) == 225  # Fm-3m
+        assert ferrox.get_spacegroup_number(bcc_fe_json) == 229  # Im-3m
 
     def test_get_spacegroup_symbol(self, fcc_cu_json: str, bcc_fe_json: str) -> None:
         """Test spacegroup symbol detection (moyo uses spaces)."""
-        assert get_spacegroup_symbol(fcc_cu_json) == "F m -3 m"
-        assert get_spacegroup_symbol(bcc_fe_json) == "I m -3 m"
+        assert ferrox.get_spacegroup_symbol(fcc_cu_json) == "F m -3 m"
+        assert ferrox.get_spacegroup_symbol(bcc_fe_json) == "I m -3 m"
 
     def test_get_hall_number(self, fcc_cu_json: str) -> None:
         """Test Hall number is in valid range."""
-        hall = get_hall_number(fcc_cu_json)
+        hall = ferrox.get_hall_number(fcc_cu_json)
         assert 1 <= hall <= 530
 
     def test_get_pearson_symbol(self, fcc_cu_json: str, bcc_fe_json: str) -> None:
         """Test Pearson symbol detection."""
-        assert get_pearson_symbol(fcc_cu_json) == "cF4"  # cubic, F-centered, 4 atoms
-        assert get_pearson_symbol(bcc_fe_json) == "cI2"  # cubic, I-centered, 2 atoms
+        assert ferrox.get_pearson_symbol(fcc_cu_json) == "cF4"  # cubic, F-centered, 4 atoms
+        assert ferrox.get_pearson_symbol(bcc_fe_json) == "cI2"  # cubic, I-centered, 2 atoms
 
     def test_get_wyckoff_letters(self, fcc_cu_json: str) -> None:
         """Test Wyckoff letter assignment."""
-        wyckoffs = get_wyckoff_letters(fcc_cu_json)
+        wyckoffs = ferrox.get_wyckoff_letters(fcc_cu_json)
         assert len(wyckoffs) == 4
         # All Cu atoms in FCC should have same Wyckoff position
         assert len(set(wyckoffs)) == 1
 
     def test_get_site_symmetry_symbols(self, fcc_cu_json: str) -> None:
         """Test site symmetry symbol assignment."""
-        symbols = get_site_symmetry_symbols(fcc_cu_json)
+        symbols = ferrox.get_site_symmetry_symbols(fcc_cu_json)
         assert len(symbols) == 4
         # All Cu atoms in FCC should have same site symmetry
         assert len(set(symbols)) == 1
 
     def test_get_symmetry_operations(self, fcc_cu_json: str) -> None:
         """Test symmetry operations retrieval."""
-        ops = get_symmetry_operations(fcc_cu_json)
+        ops = ferrox.get_symmetry_operations(fcc_cu_json)
         assert len(ops) > 0
         # Each operation is (rotation, translation) tuple
         for rot, trans in ops:
@@ -262,19 +249,19 @@ class TestSymmetryFunctions:
     def test_get_equivalent_sites(self, fcc_cu_json: str, nacl_json: str) -> None:
         """Test equivalent site detection."""
         # FCC Cu: all 4 atoms equivalent
-        orbits_cu = get_equivalent_sites(fcc_cu_json)
+        orbits_cu = ferrox.get_equivalent_sites(fcc_cu_json)
         assert len(orbits_cu) == 4
         assert len(set(orbits_cu)) == 1  # All map to same representative
 
         # NaCl: 2 inequivalent sites (Na and Cl)
-        orbits_nacl = get_equivalent_sites(nacl_json)
+        orbits_nacl = ferrox.get_equivalent_sites(nacl_json)
         assert len(orbits_nacl) == 2
         assert len(set(orbits_nacl)) == 2  # Different representatives
 
     def test_get_crystal_system(self, fcc_cu_json: str, bcc_fe_json: str) -> None:
         """Test crystal system detection."""
-        assert get_crystal_system(fcc_cu_json) == "cubic"
-        assert get_crystal_system(bcc_fe_json) == "cubic"
+        assert ferrox.get_crystal_system(fcc_cu_json) == "cubic"
+        assert ferrox.get_crystal_system(bcc_fe_json) == "cubic"
 
 
 class TestGetSymmetryDataset:
@@ -282,7 +269,7 @@ class TestGetSymmetryDataset:
 
     def test_all_fields_present(self, fcc_cu_json: str) -> None:
         """Verify all expected fields in symmetry dataset."""
-        dataset = get_symmetry_dataset(fcc_cu_json)
+        dataset = ferrox.get_symmetry_dataset(fcc_cu_json)
 
         # Check all expected keys are present
         expected_keys = {
@@ -301,7 +288,7 @@ class TestGetSymmetryDataset:
 
     def test_dataset_values(self, fcc_cu_json: str) -> None:
         """Verify symmetry dataset values for FCC Cu."""
-        dataset = get_symmetry_dataset(fcc_cu_json)
+        dataset = ferrox.get_symmetry_dataset(fcc_cu_json)
 
         assert dataset["spacegroup_number"] == 225
         assert dataset["spacegroup_symbol"] == "F m -3 m"
@@ -313,11 +300,78 @@ class TestGetSymmetryDataset:
 
     def test_dataset_matches_individual_calls(self, nacl_json: str) -> None:
         """Dataset contains same info as individual calls."""
-        dataset = get_symmetry_dataset(nacl_json)
+        dataset = ferrox.get_symmetry_dataset(nacl_json)
 
-        assert dataset["spacegroup_number"] == get_spacegroup_number(nacl_json)
-        assert dataset["spacegroup_symbol"] == get_spacegroup_symbol(nacl_json)
-        assert dataset["pearson_symbol"] == get_pearson_symbol(nacl_json)
-        assert dataset["crystal_system"] == get_crystal_system(nacl_json)
-        assert dataset["wyckoff_letters"] == get_wyckoff_letters(nacl_json)
-        assert dataset["equivalent_sites"] == get_equivalent_sites(nacl_json)
+        assert dataset["spacegroup_number"] == ferrox.get_spacegroup_number(nacl_json)
+        assert dataset["spacegroup_symbol"] == ferrox.get_spacegroup_symbol(nacl_json)
+        assert dataset["pearson_symbol"] == ferrox.get_pearson_symbol(nacl_json)
+        assert dataset["crystal_system"] == ferrox.get_crystal_system(nacl_json)
+        assert dataset["wyckoff_letters"] == ferrox.get_wyckoff_letters(nacl_json)
+        assert dataset["equivalent_sites"] == ferrox.get_equivalent_sites(nacl_json)
+
+
+# Structure Writer Tests
+
+
+class TestStructureWriters:
+    """Tests for structure writing functions."""
+
+    def test_to_poscar_format(self, nacl_json: str) -> None:
+        """Verify POSCAR format structure."""
+        poscar = ferrox.to_poscar(nacl_json)
+        lines = poscar.strip().split("\n")
+        # Line 1: comment (formula)
+        assert "Na" in lines[0] or "Cl" in lines[0]
+        # Line 2: scale factor
+        assert lines[1].strip() == "1.0"
+        # Lines 3-5: lattice vectors
+        assert len(lines[2].split()) == 3
+        # Check "Direct" keyword
+        assert any("Direct" in line for line in lines)
+
+    def test_to_poscar_custom_comment(self, fcc_cu_json: str) -> None:
+        """Custom comment line in POSCAR."""
+        poscar = ferrox.to_poscar(fcc_cu_json, comment="My custom comment")
+        assert poscar.startswith("My custom comment\n")
+
+    def test_to_cif_format(self, nacl_json: str) -> None:
+        """Verify CIF format structure."""
+        cif = ferrox.to_cif(nacl_json)
+        assert cif.startswith("data_")
+        assert "_cell_length_a" in cif
+        assert "_symmetry_space_group_name_H-M" in cif
+        assert "loop_" in cif
+        assert "_atom_site_type_symbol" in cif
+
+    def test_to_cif_custom_data_name(self, fcc_cu_json: str) -> None:
+        """Custom data block name in CIF."""
+        cif = ferrox.to_cif(fcc_cu_json, data_name="my_structure")
+        assert cif.startswith("data_my_structure\n")
+
+    def test_to_extxyz_format(self, nacl_json: str) -> None:
+        """Verify extXYZ format structure."""
+        xyz = ferrox.to_extxyz(nacl_json)
+        lines = xyz.strip().split("\n")
+        # Line 1: atom count
+        assert lines[0] == "2"
+        # Line 2: comment with Lattice
+        assert "Lattice=" in lines[1]
+        assert "pbc=" in lines[1]
+        # Atom lines
+        assert lines[2].startswith("Na") or lines[2].startswith("Cl")
+
+    def test_to_pymatgen_json_roundtrip(self, nacl_json: str) -> None:
+        """JSON output can be parsed back."""
+        json_out = ferrox.to_pymatgen_json(nacl_json)
+        parsed = json.loads(json_out)
+        assert "@module" in parsed
+        assert "lattice" in parsed
+        assert "sites" in parsed
+        assert len(parsed["sites"]) == 2
+
+    def test_write_structure_file(self, nacl_json: str, tmp_path) -> None:
+        """Test write_structure_file with auto format detection."""
+        for filename in ["test.cif", "test.xyz", "POSCAR", "test.json"]:
+            path = tmp_path / filename
+            ferrox.write_structure_file(nacl_json, str(path))
+            assert path.read_text(), f"{filename} should not be empty"

--- a/extensions/rust/tests/test_pymatgen_compat.py
+++ b/extensions/rust/tests/test_pymatgen_compat.py
@@ -1,296 +1,179 @@
-"""Comprehensive compatibility tests comparing ferrox vs pymatgen StructureMatcher.
+"""Compatibility tests comparing ferrox vs pymatgen StructureMatcher.
 
-This test suite compares the Rust ferrox implementation against pymatgen's
-StructureMatcher on 200+ structure pairs to ensure identical behavior.
-
-Data Sources:
-- 20 matterviz JSON structures
-- 58 pymatgen test CIF files
-- 50+ synthetic edge cases
+Run with: pytest tests/test_pymatgen_compat.py -v
 """
 
 from __future__ import annotations
 
-import gzip
 import json
 import os
-import sys
-import time
 from pathlib import Path
-from typing import NamedTuple
+from typing import TYPE_CHECKING
 
 import numpy as np
+import pytest
 from pymatgen.analysis.structure_matcher import ElementComparator
 from pymatgen.analysis.structure_matcher import StructureMatcher as PyMatcher
-from pymatgen.core import Lattice, Structure
+from pymatgen.core import Lattice, Species, Structure
 
-_TEST_DIR = Path(__file__).resolve().parent
-_REPO_ROOT = _TEST_DIR.parent.parent.parent
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 try:
     from ferrox import StructureMatcher as RustMatcher
 except ImportError:
-    print("ERROR: ferrox not installed. Run: maturin develop --features python")
-    raise SystemExit(1)
+    pytest.skip("ferrox not installed. Run: maturin develop --features python", allow_module_level=True)
 
-# Module-level matchers and results (initialized in main())
-py_matcher: PyMatcher | None = None
-rust_matcher: RustMatcher | None = None
-results: list[Result] = []
-
-
-class Result(NamedTuple):
-    """Comparison result between pymatgen and ferrox."""
-
-    category: str
-    description: str
-    pymatgen_result: bool
-    ferrox_result: bool
-    match: bool
-    error: str | None = None
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+MATTERVIZ_STRUCTURES_DIR = Path(
+    os.environ.get("MATTERVIZ_STRUCTURES_DIR", REPO_ROOT / "src/site/structures")
+)
+PYMATGEN_CIF_DIR = Path(
+    os.environ.get("PYMATGEN_CIF_DIR", Path.home() / "dev/pymatgen/tests/files/cif")
+)
 
 
-def init_matchers() -> None:
-    """Initialize module-level matchers."""
-    global py_matcher, rust_matcher, results
-    py_matcher = PyMatcher(ltol=0.2, stol=0.3, angle_tol=5.0, primitive_cell=False)
-    rust_matcher = RustMatcher(
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def py_matcher() -> PyMatcher:
+    """Default pymatgen matcher."""
+    return PyMatcher(ltol=0.2, stol=0.3, angle_tol=5.0, primitive_cell=False)
+
+
+@pytest.fixture
+def rust_matcher() -> RustMatcher:
+    """Default ferrox matcher."""
+    return RustMatcher(
         latt_len_tol=0.2, site_pos_tol=0.3, angle_tol=5.0, primitive_cell=False
     )
-    results = []
 
 
-def compare(s1: Structure, s2: Structure, category: str, description: str) -> Result:
-    """Compare two structures using both matchers."""
-    try:
-        py_result = py_matcher.fit(s1, s2)
-    except Exception as exc:
-        return Result(
-            category, description, False, False, False, f"pymatgen error: {exc}"
+@pytest.fixture
+def compare(py_matcher: PyMatcher, rust_matcher: RustMatcher) -> Callable:
+    """Return a comparison function that asserts both matchers agree."""
+
+    def _compare(s1: Structure, s2: Structure) -> bool:
+        py_result = bool(py_matcher.fit(s1, s2))
+        rust_result = rust_matcher.fit(
+            json.dumps(s1.as_dict()), json.dumps(s2.as_dict())
         )
-
-    try:
-        json1 = json.dumps(s1.as_dict())
-        json2 = json.dumps(s2.as_dict())
-        ferrox_result = rust_matcher.fit(json1, json2)
-    except Exception as exc:
-        return Result(
-            category, description, py_result, False, False, f"ferrox error: {exc}"
+        assert py_result == rust_result, (
+            f"Mismatch: pymatgen={py_result}, ferrox={rust_result}"
         )
+        return py_result
 
-    result = Result(
-        category, description, py_result, ferrox_result, py_result == ferrox_result
-    )
-    results.append(result)
-    return result
+    return _compare
 
 
-def print_summary() -> None:
-    """Print test summary."""
-    total = len(results)
-    passed = sum(1 for r in results if r.match)
-    failed = sum(1 for r in results if not r.match)
-    errors = sum(1 for r in results if r.error)
-
-    print("\n" + "=" * 70)
-    print("TEST SUMMARY")
-    print("=" * 70)
-    print(f"Total: {total} | Passed: {passed} | Failed: {failed} | Errors: {errors}")
-    print(f"Pass rate: {100 * passed / total:.1f}%" if total > 0 else "N/A")
-
-    categories = set(r.category for r in results)
-    print("\nBy category:")
-    for cat in sorted(categories):
-        cat_results = [r for r in results if r.category == cat]
-        cat_passed = sum(1 for r in cat_results if r.match)
-        print(f"  {cat}: {cat_passed}/{len(cat_results)}")
-
-    failures = [r for r in results if not r.match]
-    if failures:
-        print("\nFAILURES:")
-        for r in failures[:20]:
-            status = "ERROR" if r.error else "MISMATCH"
-            print(f"  [{status}] {r.category}: {r.description}")
-            print(f"    pymatgen={r.pymatgen_result}, ferrox={r.ferrox_result}")
-            if r.error:
-                print(f"    {r.error}")
-        if len(failures) > 20:
-            print(f"  ... and {len(failures) - 20} more")
-
-
-# Structure Loading
-
-
-def load_matterviz_structures() -> dict[str, Structure]:
-    """Load JSON structures from matterviz."""
-    structures = {}
-    matterviz_dir = Path(
-        os.environ.get("MATTERVIZ_STRUCTURES_DIR", _REPO_ROOT / "src/site/structures")
-    )
-
-    if not matterviz_dir.exists():
-        print(f"WARNING: matterviz directory not found: {matterviz_dir}")
-        return structures
-
-    for json_file in matterviz_dir.glob("*.json"):
-        try:
-            with open(json_file) as fh:
-                data = json.load(fh)
-            # Skip if not a pymatgen structure dict
-            if "@class" not in data or data.get("@class") != "Structure":
-                continue
-            s = Structure.from_dict(data)
-            structures[json_file.stem] = s
-        except Exception as exc:
-            print(f"  Could not load {json_file.name}: {exc}")
-
-    # Also try .json.gz files
-    for gz_file in matterviz_dir.glob("*.json.gz"):
-        try:
-            with gzip.open(gz_file, "rt") as fh:
-                data = json.load(fh)
-            if "@class" not in data or data.get("@class") != "Structure":
-                continue
-            s = Structure.from_dict(data)
-            structures[gz_file.stem.replace(".json", "")] = s
-        except Exception as exc:
-            print(f"  Could not load {gz_file.name}: {exc}")
-
-    return structures
-
-
-def load_pymatgen_cif_structures() -> dict[str, Structure]:
-    """Load CIF structures from pymatgen test files."""
-    structures = {}
-    failed_files: list[str] = []
-    cif_dir = Path(
-        os.environ.get("PYMATGEN_CIF_DIR", Path.home() / "dev/pymatgen/tests/files/cif")
-    )
-
-    if not cif_dir.exists():
-        print(f"WARNING: CIF directory not found: {cif_dir}")
-        return structures
-
-    for cif_file in cif_dir.glob("*.cif"):
-        try:
-            s = Structure.from_file(str(cif_file))
-            structures[cif_file.stem] = s
-        except Exception as exc:
-            failed_files.append(f"{cif_file.name}: {exc}")
-
-    if failed_files:
-        print(f"    Failed to parse {len(failed_files)} CIF files:")
-        for fail in failed_files[:5]:  # Show first 5 failures
-            print(f"      - {fail}")
-        if len(failed_files) > 5:
-            print(f"      ... and {len(failed_files) - 5} more")
-
-    return structures
-
-
-# Synthetic Structure Generation
+# ============================================================================
+# Structure Generators
+# ============================================================================
 
 
 def make_cubic(element: str, a: float) -> Structure:
-    """Create simple cubic structure."""
-    lattice = Lattice.cubic(a)
-    return Structure(lattice, [element], [[0, 0, 0]])
+    """Simple cubic structure."""
+    return Structure(Lattice.cubic(a), [element], [[0, 0, 0]])
 
 
 def make_bcc(element: str, a: float) -> Structure:
-    """Create BCC structure."""
-    lattice = Lattice.cubic(a)
-    return Structure(lattice, [element, element], [[0, 0, 0], [0.5, 0.5, 0.5]])
+    """BCC structure."""
+    return Structure(
+        Lattice.cubic(a), [element, element], [[0, 0, 0], [0.5, 0.5, 0.5]]
+    )
 
 
 def make_fcc(element: str, a: float) -> Structure:
-    """Create FCC structure (conventional cell)."""
-    lattice = Lattice.cubic(a)
+    """FCC structure (conventional cell)."""
     return Structure(
-        lattice, [element] * 4, [[0, 0, 0], [0.5, 0.5, 0], [0.5, 0, 0.5], [0, 0.5, 0.5]]
+        Lattice.cubic(a),
+        [element] * 4,
+        [[0, 0, 0], [0.5, 0.5, 0], [0.5, 0, 0.5], [0, 0.5, 0.5]],
     )
 
 
 def make_rocksalt(cation: str, anion: str, a: float) -> Structure:
-    """Create rocksalt structure (NaCl type)."""
-    lattice = Lattice.cubic(a)
-    return Structure(lattice, [cation, anion], [[0, 0, 0], [0.5, 0.5, 0.5]])
+    """Rocksalt structure (NaCl type)."""
+    return Structure(Lattice.cubic(a), [cation, anion], [[0, 0, 0], [0.5, 0.5, 0.5]])
 
 
 def make_perovskite(a_site: str, b_site: str, x_site: str, a: float) -> Structure:
-    """Create perovskite ABX3 structure."""
-    lattice = Lattice.cubic(a)
+    """Perovskite ABX3 structure."""
     return Structure(
-        lattice,
+        Lattice.cubic(a),
         [a_site, b_site, x_site, x_site, x_site],
         [[0, 0, 0], [0.5, 0.5, 0.5], [0.5, 0.5, 0], [0.5, 0, 0.5], [0, 0.5, 0.5]],
     )
 
 
 def make_hexagonal(element: str, a: float, c: float) -> Structure:
-    """Create HCP structure."""
-    lattice = Lattice.hexagonal(a, c)
+    """HCP structure."""
     return Structure(
-        lattice, [element, element], [[1 / 3, 2 / 3, 0.25], [2 / 3, 1 / 3, 0.75]]
+        Lattice.hexagonal(a, c),
+        [element, element],
+        [[1 / 3, 2 / 3, 0.25], [2 / 3, 1 / 3, 0.75]],
     )
 
 
 def make_wurtzite(cation: str, anion: str, a: float, c: float) -> Structure:
-    """Create wurtzite structure."""
-    lattice = Lattice.hexagonal(a, c)
+    """Wurtzite structure."""
     return Structure(
-        lattice,
+        Lattice.hexagonal(a, c),
         [cation, cation, anion, anion],
-        [
-            [1 / 3, 2 / 3, 0],
-            [2 / 3, 1 / 3, 0.5],
-            [1 / 3, 2 / 3, 0.375],
-            [2 / 3, 1 / 3, 0.875],
-        ],
+        [[1 / 3, 2 / 3, 0], [2 / 3, 1 / 3, 0.5], [1 / 3, 2 / 3, 0.375], [2 / 3, 1 / 3, 0.875]],
     )
 
 
 def make_diamond(element: str, a: float) -> Structure:
-    """Create diamond cubic structure."""
-    lattice = Lattice.cubic(a)
+    """Diamond cubic structure."""
     return Structure(
-        lattice,
+        Lattice.cubic(a),
         [element] * 8,
         [
-            [0, 0, 0],
-            [0.5, 0.5, 0],
-            [0.5, 0, 0.5],
-            [0, 0.5, 0.5],
-            [0.25, 0.25, 0.25],
-            [0.75, 0.75, 0.25],
-            [0.75, 0.25, 0.75],
-            [0.25, 0.75, 0.75],
+            [0, 0, 0], [0.5, 0.5, 0], [0.5, 0, 0.5], [0, 0.5, 0.5],
+            [0.25, 0.25, 0.25], [0.75, 0.75, 0.25], [0.75, 0.25, 0.75], [0.25, 0.75, 0.75],
         ],
     )
 
 
-def perturb_structure(s: Structure, magnitude: float, seed: int = 42) -> Structure:
+# Base structures for parametrized tests
+BASE_STRUCTURES = [
+    ("cubic-Fe", make_cubic("Fe", 2.87)),
+    ("bcc-Fe", make_bcc("Fe", 2.87)),
+    ("fcc-Cu", make_fcc("Cu", 3.6)),
+    ("rocksalt-NaCl", make_rocksalt("Na", "Cl", 5.64)),
+    ("perovskite-BaTiO3", make_perovskite("Ba", "Ti", "O", 4.0)),
+    ("hcp-Ti", make_hexagonal("Ti", 2.95, 4.68)),
+    ("wurtzite-ZnO", make_wurtzite("Zn", "O", 3.25, 5.21)),
+    ("diamond-C", make_diamond("C", 3.57)),
+]
+
+
+# ============================================================================
+# Structure Transformations
+# ============================================================================
+
+
+def perturb(s: Structure, magnitude: float, seed: int = 42) -> Structure:
     """Add random perturbations to fractional coordinates."""
     rng = np.random.default_rng(seed)
-    new_coords = []
-    for fc in s.frac_coords:
-        perturbation = rng.uniform(-magnitude, magnitude, 3)
-        new_coords.append(fc + perturbation)
+    new_coords = [fc + rng.uniform(-magnitude, magnitude, 3) for fc in s.frac_coords]
     return Structure(s.lattice, s.species, new_coords)
 
 
-def scale_lattice(s: Structure, scale_factor: float) -> Structure:
-    """Scale the lattice by a factor (volume scales as factor^3)."""
-    new_lattice = Lattice(s.lattice.matrix * scale_factor)
-    return Structure(new_lattice, s.species, s.frac_coords)
+def scale_lattice(s: Structure, factor: float) -> Structure:
+    """Scale the lattice by a factor."""
+    return Structure(Lattice(s.lattice.matrix * factor), s.species, s.frac_coords)
 
 
 def strain_lattice(s: Structure, strain: float, axis: int = 0) -> Structure:
     """Apply uniaxial strain along one axis."""
     matrix = s.lattice.matrix.copy()
     matrix[axis] *= 1 + strain
-    new_lattice = Lattice(matrix)
-    return Structure(new_lattice, s.species, s.frac_coords)
+    return Structure(Lattice(matrix), s.species, s.frac_coords)
 
 
 def shuffle_sites(s: Structure, seed: int = 42) -> Structure:
@@ -298,912 +181,472 @@ def shuffle_sites(s: Structure, seed: int = 42) -> Structure:
     rng = np.random.default_rng(seed)
     indices = list(range(len(s)))
     rng.shuffle(indices)
-    new_species = [s.species[i] for i in indices]
-    new_coords = [s.frac_coords[i] for i in indices]
-    return Structure(s.lattice, new_species, new_coords)
+    return Structure(
+        s.lattice, [s.species[i] for i in indices], [s.frac_coords[i] for i in indices]
+    )
 
 
-def translate_structure(s: Structure, translation: list[float]) -> Structure:
+def translate(s: Structure, vec: list[float]) -> Structure:
     """Translate all atoms by a fractional vector."""
-    new_coords = [(fc + translation) % 1.0 for fc in s.frac_coords]
-    return Structure(s.lattice, s.species, new_coords)
+    return Structure(s.lattice, s.species, [(fc + vec) % 1.0 for fc in s.frac_coords])
 
 
-# Test Categories
+# ============================================================================
+# Test Classes
+# ============================================================================
 
 
-def run_category_a_self_matching(structures: dict[str, Structure]) -> None:
-    """Category A: Self-comparison (identical structures should always match)."""
-    print("\nCategory A: Self-matching tests")
-    for name, s in structures.items():
-        result = compare(s, s, "A-self", f"{name} vs itself")
-        status = "✓" if result.match else "✗"
-        if not result.match:
-            print(
-                f"  {status} {name}: py={result.pymatgen_result}, rust={result.ferrox_result}"
-            )
+class TestSelfMatching:
+    """Identical structures should always match."""
+
+    @pytest.mark.parametrize("name,struct", BASE_STRUCTURES)
+    def test_base_structures(self, compare: Callable, name: str, struct: Structure) -> None:
+        """Base structures match themselves."""
+        assert compare(struct, struct) is True
+
+    def test_triclinic(self, compare: Callable) -> None:
+        """Triclinic lattice self-match."""
+        struct = Structure(
+            Lattice.from_parameters(3.0, 4.0, 5.0, 80.0, 85.0, 95.0), ["Ca"], [[0, 0, 0]]
+        )
+        assert compare(struct, struct) is True
+
+    def test_oblique(self, compare: Callable) -> None:
+        """Highly oblique cell self-match."""
+        struct = Structure(
+            Lattice.from_parameters(5.0, 5.0, 10.0, 60.0, 80.0, 70.0),
+            ["Bi", "Se"],
+            [[0, 0, 0], [0.5, 0.5, 0.5]],
+        )
+        assert compare(struct, struct) is True
 
 
-def run_category_b_perturbations() -> None:
-    """Category B: Perturbed structures."""
-    print("\nCategory B: Perturbation tests")
+class TestPerturbations:
+    """Perturbed structures within tolerance should match."""
 
-    base_structures = [
-        ("cubic-Fe", make_cubic("Fe", 2.87)),
-        ("bcc-Fe", make_bcc("Fe", 2.87)),
-        ("fcc-Cu", make_fcc("Cu", 3.6)),
-        ("rocksalt-NaCl", make_rocksalt("Na", "Cl", 5.64)),
-        ("perovskite-BaTiO3", make_perovskite("Ba", "Ti", "O", 4.0)),
-        ("hcp-Ti", make_hexagonal("Ti", 2.95, 4.68)),
-        ("wurtzite-ZnO", make_wurtzite("Zn", "O", 3.25, 5.21)),
-        ("diamond-C", make_diamond("C", 3.57)),
-    ]
+    @pytest.mark.parametrize("name,struct", BASE_STRUCTURES)
+    @pytest.mark.parametrize("magnitude", [0.01, 0.02, 0.05])
+    def test_coordinate_perturbations(
+        self, compare: Callable, name: str, struct: Structure, magnitude: float
+    ) -> None:
+        """Small coordinate perturbations should match."""
+        assert compare(struct, perturb(struct, magnitude)) is True
 
-    # Small perturbations (should match)
-    for name, s in base_structures:
-        for mag in [0.01, 0.02, 0.05]:
-            s_pert = perturb_structure(s, mag)
-            compare(s, s_pert, "B-perturb", f"{name} perturb={mag}")
+    @pytest.mark.parametrize("name,struct", BASE_STRUCTURES)
+    @pytest.mark.parametrize("factor", [0.98, 1.02, 1.05])
+    def test_lattice_scaling(
+        self, compare: Callable, name: str, struct: Structure, factor: float
+    ) -> None:
+        """Lattice scaling within tolerance should match."""
+        assert compare(struct, scale_lattice(struct, factor)) is True
 
-    # Lattice scaling (should match with scale=True)
-    for name, s in base_structures:
-        for scale in [0.98, 1.02, 1.05]:
-            s_scaled = scale_lattice(s, scale)
-            compare(s, s_scaled, "B-scale", f"{name} scale={scale}")
-
-    # Uniaxial strain
-    for name, s in base_structures:
-        for strain in [0.01, 0.02]:
-            s_strained = strain_lattice(s, strain)
-            compare(s, s_strained, "B-strain", f"{name} strain={strain}")
+    @pytest.mark.parametrize("name,struct", BASE_STRUCTURES)
+    @pytest.mark.parametrize("strain", [0.01, 0.02])
+    def test_uniaxial_strain(
+        self, compare: Callable, name: str, struct: Structure, strain: float
+    ) -> None:
+        """Uniaxial strain within tolerance should match."""
+        assert compare(struct, strain_lattice(struct, strain)) is True
 
 
-def run_category_c_non_matching() -> None:
-    """Category C: Cross-structure comparisons (should NOT match)."""
-    print("\nCategory C: Non-matching tests")
+class TestNonMatching:
+    """Different structures should not match."""
 
-    structures = [
-        ("cubic-Fe", make_cubic("Fe", 2.87)),
-        ("cubic-Cu", make_cubic("Cu", 3.6)),
-        ("bcc-Fe", make_bcc("Fe", 2.87)),
-        ("bcc-W", make_bcc("W", 3.16)),
-        ("fcc-Cu", make_fcc("Cu", 3.6)),
-        ("fcc-Al", make_fcc("Al", 4.05)),
-        ("rocksalt-NaCl", make_rocksalt("Na", "Cl", 5.64)),
-        ("rocksalt-MgO", make_rocksalt("Mg", "O", 4.21)),
-        ("hcp-Ti", make_hexagonal("Ti", 2.95, 4.68)),
-        ("hcp-Mg", make_hexagonal("Mg", 3.21, 5.21)),
-    ]
-
-    # Different compositions should not match
-    for i, (name1, s1) in enumerate(structures):
-        for name2, s2 in structures[i + 1 :]:
-            # Only compare if clearly different
-            comp1 = s1.composition.reduced_formula
-            comp2 = s2.composition.reduced_formula
-            if comp1 != comp2:
-                compare(s1, s2, "C-diff-comp", f"{name1} vs {name2}")
-
-    # Same element, different structure type
-    compare(
-        make_bcc("Fe", 2.87), make_fcc("Fe", 3.6), "C-diff-struct", "bcc-Fe vs fcc-Fe"
+    @pytest.mark.parametrize(
+        "s1,s2",
+        [
+            (make_cubic("Fe", 2.87), make_cubic("Cu", 3.6)),
+            (make_bcc("Fe", 2.87), make_bcc("W", 3.16)),
+            (make_fcc("Cu", 3.6), make_fcc("Al", 4.05)),
+            (make_rocksalt("Na", "Cl", 5.64), make_rocksalt("Mg", "O", 4.21)),
+            (make_bcc("Fe", 2.87), make_fcc("Fe", 3.6)),  # same element, diff structure
+            (make_cubic("Cu", 3.6), make_fcc("Cu", 3.6)),  # same element, diff structure
+        ],
     )
-    compare(
-        make_cubic("Cu", 3.6),
-        make_fcc("Cu", 3.6),
-        "C-diff-struct",
-        "cubic-Cu vs fcc-Cu",
+    def test_different_structures(self, compare: Callable, s1: Structure, s2: Structure) -> None:
+        """Different structures should not match."""
+        assert compare(s1, s2) is False
+
+
+class TestEdgeCases:
+    """Edge cases and boundary conditions."""
+
+    def test_shuffled_sites(self, compare: Callable) -> None:
+        """Shuffled site order should still match."""
+        struct = make_rocksalt("Na", "Cl", 5.64)
+        assert compare(struct, shuffle_sites(struct)) is True
+
+    @pytest.mark.parametrize(
+        "translation",
+        [[0.1, 0, 0], [0, 0.1, 0], [0, 0, 0.1], [0.25, 0.25, 0.25]],
     )
+    def test_translations(self, compare: Callable, translation: list[float]) -> None:
+        """Translated structures should match."""
+        struct = make_rocksalt("Na", "Cl", 5.64)
+        assert compare(struct, translate(struct, translation)) is True
+
+    def test_large_perturbation(self, compare: Callable) -> None:
+        """Large perturbations - verify both matchers agree."""
+        struct = make_bcc("Fe", 2.87)
+        # Just verify agreement, don't assert specific result (depends on tolerances)
+        compare(struct, perturb(struct, 0.4, seed=2))
+
+    def test_left_vs_right_handed_lattice(self, compare: Callable) -> None:
+        """Left-handed vs right-handed lattice."""
+        s_left = Structure(Lattice([[-4.0, 0, 0], [0, 4.0, 0], [0, 0, 4.0]]), ["Ag"], [[0, 0, 0]])
+        s_right = Structure(Lattice([[4.0, 0, 0], [0, 4.0, 0], [0, 0, 4.0]]), ["Ag"], [[0, 0, 0]])
+        compare(s_left, s_right)  # just check agreement, result may vary
+
+    def test_coords_outside_unit_cell(self, compare: Callable) -> None:
+        """Coordinates outside [0,1) should wrap correctly."""
+        lattice = Lattice.cubic(5.0)
+        s_outside = Structure(lattice, ["Li", "Li"], [[1.5, 0.3, 0.2], [-0.3, 0.7, 0.8]])
+        s_wrapped = Structure(lattice, ["Li", "Li"], [[0.5, 0.3, 0.2], [0.7, 0.7, 0.8]])
+        assert compare(s_outside, s_wrapped) is True
+
+    def test_single_atom(self, compare: Callable) -> None:
+        """Single atom structure."""
+        struct = Structure(Lattice.cubic(3.0), ["Au"], [[0, 0, 0]])
+        assert compare(struct, struct) is True
+
+    def test_needle_cell(self, compare: Callable) -> None:
+        """Needle-like cell (c >> a)."""
+        struct = Structure(
+            Lattice.from_parameters(2.0, 2.0, 20.0, 90.0, 90.0, 90.0), ["C"], [[0, 0, 0]]
+        )
+        assert compare(struct, struct) is True
+
+    def test_flat_cell(self, compare: Callable) -> None:
+        """Flat cell (c << a)."""
+        struct = Structure(
+            Lattice.from_parameters(20.0, 20.0, 2.0, 90.0, 90.0, 90.0), ["C"], [[0, 0, 0]]
+        )
+        assert compare(struct, struct) is True
+
+    def test_near_cubic_angles(self, compare: Callable) -> None:
+        """Near-cubic angles."""
+        struct = Structure(
+            Lattice.from_parameters(5.0, 5.0, 5.0, 89.5, 90.5, 89.8), ["V"], [[0, 0, 0]]
+        )
+        assert compare(struct, struct) is True
 
 
-def run_category_d_edge_cases() -> None:
-    """Category D: Edge cases."""
-    print("\nCategory D: Edge case tests")
+class TestComparators:
+    """Test species vs element comparators."""
 
-    # Shuffled sites (should match)
-    s_nacl = make_rocksalt("Na", "Cl", 5.64)
-    s_shuffled = shuffle_sites(s_nacl)
-    compare(s_nacl, s_shuffled, "D-shuffle", "NaCl vs shuffled-NaCl")
+    def test_oxidation_state_species_comparator(self) -> None:
+        """Different oxidation states should NOT match with SpeciesComparator."""
+        py_match = PyMatcher(ltol=0.2, stol=0.3, angle_tol=5.0, primitive_cell=False)
+        rust_match = RustMatcher(
+            latt_len_tol=0.2, site_pos_tol=0.3, angle_tol=5.0, primitive_cell=False, comparator="species"
+        )
 
-    s_perov = make_perovskite("Ba", "Ti", "O", 4.0)
-    s_shuffled = shuffle_sites(s_perov)
-    compare(s_perov, s_shuffled, "D-shuffle", "BaTiO3 vs shuffled-BaTiO3")
+        lattice = Lattice.cubic(5.0)
+        s_fe2 = Structure(lattice, [Species("Fe", 2)], [[0, 0, 0]])
+        s_fe3 = Structure(lattice, [Species("Fe", 3)], [[0, 0, 0]])
 
-    # Translated structures (should match)
-    for trans in [[0.1, 0, 0], [0, 0.1, 0], [0, 0, 0.1], [0.25, 0.25, 0.25]]:
-        s_trans = translate_structure(s_nacl, trans)
-        compare(s_nacl, s_trans, "D-translate", f"NaCl translated by {trans}")
+        py_result = py_match.fit(s_fe2, s_fe3)
+        rust_result = rust_match.fit(
+            json.dumps(s_fe2.as_dict()), json.dumps(s_fe3.as_dict())
+        )
+        assert py_result == rust_result
 
-    # Tolerance boundary tests
-    s_base = make_bcc("Fe", 2.87)
+    def test_oxidation_state_element_comparator(self) -> None:
+        """Different oxidation states should match with ElementComparator."""
+        py_match = PyMatcher(
+            ltol=0.2, stol=0.3, angle_tol=5.0, primitive_cell=False, comparator=ElementComparator()
+        )
+        rust_match = RustMatcher(
+            latt_len_tol=0.2, site_pos_tol=0.3, angle_tol=5.0, primitive_cell=False, comparator="element"
+        )
 
-    # Just under stol (should match)
-    s_small = perturb_structure(s_base, 0.05, seed=1)
-    compare(s_base, s_small, "D-tol-under", "BCC-Fe perturb=0.05 (under stol)")
+        lattice = Lattice.cubic(5.0)
+        s_fe2 = Structure(lattice, [Species("Fe", 2)], [[0, 0, 0]])
+        s_fe3 = Structure(lattice, [Species("Fe", 3)], [[0, 0, 0]])
 
-    # Near ltol boundary
-    s_scaled = scale_lattice(s_base, 1.15)  # 15% scale
-    compare(s_base, s_scaled, "D-tol-ltol", "BCC-Fe scale=1.15 (near ltol)")
-
-    # Large displacement (should not match with default tolerances)
-    s_large = perturb_structure(s_base, 0.4, seed=2)
-    compare(s_base, s_large, "D-large-perturb", "BCC-Fe perturb=0.4 (large)")
-
-    # Different lattice types with similar parameters
-    lattice_ortho = Lattice.orthorhombic(4.0, 4.0, 4.0)
-    s_ortho = Structure(lattice_ortho, ["Fe"], [[0, 0, 0]])
-    lattice_cubic = Lattice.cubic(4.0)
-    s_cubic = Structure(lattice_cubic, ["Fe"], [[0, 0, 0]])
-    compare(s_ortho, s_cubic, "D-lattice-type", "ortho-Fe vs cubic-Fe (same params)")
-
-    # Triclinic lattice
-    lattice_tri = Lattice.from_parameters(3.0, 4.0, 5.0, 80.0, 85.0, 95.0)
-    s_tri = Structure(lattice_tri, ["Ca"], [[0, 0, 0]])
-    compare(s_tri, s_tri, "D-triclinic", "triclinic-Ca vs itself")
-
-    # Highly oblique cell
-    lattice_oblique = Lattice.from_parameters(5.0, 5.0, 10.0, 60.0, 80.0, 70.0)
-    s_oblique = Structure(lattice_oblique, ["Bi", "Se"], [[0, 0, 0], [0.5, 0.5, 0.5]])
-    compare(s_oblique, s_oblique, "D-oblique", "oblique BiSe vs itself")
-
-    # Perturbed oblique
-    s_oblique_pert = perturb_structure(s_oblique, 0.02)
-
-    # === Additional edge cases ===
-
-    # Left-handed lattice (negative determinant)
-    lattice_left = Lattice([[-4.0, 0, 0], [0, 4.0, 0], [0, 0, 4.0]])
-    s_left = Structure(lattice_left, ["Ag"], [[0, 0, 0]])
-    lattice_right = Lattice([[4.0, 0, 0], [0, 4.0, 0], [0, 0, 4.0]])
-    s_right = Structure(lattice_right, ["Ag"], [[0, 0, 0]])
-    compare(s_left, s_right, "D-left-handed", "left-handed vs right-handed lattice")
-
-    # Coordinates outside [0,1) - pymatgen wraps automatically
-    coords_outside = [
-        [1.5, 0.3, 0.2],
-        [-0.3, 0.7, 0.8],
-    ]  # Will wrap to [0.5, 0.3, 0.2], [0.7, 0.7, 0.8]
-    coords_wrapped = [[0.5, 0.3, 0.2], [0.7, 0.7, 0.8]]
-    lattice_simple = Lattice.cubic(5.0)
-    s_outside = Structure(lattice_simple, ["Li", "Li"], coords_outside)
-    s_wrapped = Structure(lattice_simple, ["Li", "Li"], coords_wrapped)
-    compare(s_outside, s_wrapped, "D-coords-wrap", "coords outside [0,1) vs wrapped")
-
-    # Very small structures (1-2 atoms)
-    s_single = Structure(Lattice.cubic(3.0), ["Au"], [[0, 0, 0]])
-    compare(s_single, s_single, "D-single-atom", "single Au atom self-match")
-
-    s_two = Structure(Lattice.cubic(4.0), ["Pt", "Pt"], [[0, 0, 0], [0.5, 0.5, 0.5]])
-    compare(s_two, s_two, "D-two-atoms", "two Pt atoms self-match")
-
-    # Extreme lattice parameter ratios (needle-like cell)
-    lattice_needle = Lattice.from_parameters(2.0, 2.0, 20.0, 90.0, 90.0, 90.0)
-    s_needle = Structure(lattice_needle, ["C"], [[0, 0, 0]])
-    compare(s_needle, s_needle, "D-needle-cell", "needle-like cell (c >> a)")
-
-    # Flat cell (c << a)
-    lattice_flat = Lattice.from_parameters(20.0, 20.0, 2.0, 90.0, 90.0, 90.0)
-    s_flat = Structure(lattice_flat, ["C"], [[0, 0, 0]])
-    compare(s_flat, s_flat, "D-flat-cell", "flat cell (c << a)")
-
-    # Near-90 degree angles (close to but not cubic)
-    lattice_near90 = Lattice.from_parameters(5.0, 5.0, 5.0, 89.5, 90.5, 89.8)
-    s_near90 = Structure(lattice_near90, ["V"], [[0, 0, 0]])
-    compare(s_near90, s_near90, "D-near-cubic", "near-cubic angles self-match")
-    compare(s_oblique, s_oblique_pert, "D-oblique-pert", "oblique BiSe vs perturbed")
+        py_result = py_match.fit(s_fe2, s_fe3)
+        rust_result = rust_match.fit(
+            json.dumps(s_fe2.as_dict()), json.dumps(s_fe3.as_dict())
+        )
+        assert py_result == rust_result
+        assert py_result  # should match when ignoring oxidation states
 
 
-def run_category_e_batch(structures: dict[str, Structure]) -> None:
-    """Category E: Batch processing tests."""
-    print("\nCategory E: Batch processing tests")
+class TestRmsDistance:
+    """RMS distance consistency tests."""
 
-    if len(structures) < 3:
-        print("  Not enough structures for batch testing")
-        return
+    @pytest.mark.parametrize("magnitude", [0.01, 0.02, 0.03])
+    def test_rms_consistency(
+        self, py_matcher: PyMatcher, rust_matcher: RustMatcher, magnitude: float
+    ) -> None:
+        """RMS values should be close between pymatgen and ferrox."""
+        struct = Structure(Lattice.cubic(5.0), ["Fe", "Fe"], [[0, 0, 0], [0.5, 0.5, 0.5]])
+        s_pert = perturb(struct, magnitude, seed=100)
 
-    # Test grouping functionality
-    struct_list = list(structures.values())[:10]  # Use first 10
+        py_rms = py_matcher.get_rms_dist(struct, s_pert)
+        rust_rms = rust_matcher.get_rms_dist(
+            json.dumps(struct.as_dict()), json.dumps(s_pert.as_dict())
+        )
 
-    try:
-        json_strs = [json.dumps(s.as_dict()) for s in struct_list]
-        rust_groups = rust_matcher.group(json_strs)
-
-        # Compare with pymatgen grouping
-        py_groups: dict[int, list[int]] = {}
-        for i, s1 in enumerate(struct_list):
-            found_group = False
-            for canonical, members in py_groups.items():
-                if py_matcher.fit(struct_list[canonical], s1):
-                    members.append(i)
-                    found_group = True
-                    break
-            if not found_group:
-                py_groups[i] = [i]
-
-        # Normalize groups to sets of frozensets for comparison (order-agnostic)
-        py_membership = {frozenset(members) for members in py_groups.values()}
-        rust_membership = {frozenset(members) for members in rust_groups.values()}
-
-        if py_membership == rust_membership:
-            results.append(
-                Result(
-                    category="E-batch",
-                    description=f"Group {len(struct_list)} structures: {len(rust_groups)} groups",
-                    pymatgen_result=True,
-                    ferrox_result=True,
-                    match=True,
-                )
+        if py_rms is not None and rust_rms is not None:
+            py_val, rust_val = py_rms[0], rust_rms[0]
+            assert abs(py_val - rust_val) < max(0.01, 0.1 * py_val), (
+                f"RMS mismatch: py={py_val:.4f}, rust={rust_val:.4f}"
             )
         else:
-            # Find differences for error message
-            only_py = py_membership - rust_membership
-            only_rust = rust_membership - py_membership
-            results.append(
-                Result(
-                    category="E-batch",
-                    description=f"Group {len(struct_list)} structures",
-                    pymatgen_result=True,
-                    ferrox_result=True,
-                    match=False,
-                    error=f"Group memberships differ: pymatgen-only={only_py}, ferrox-only={only_rust}",
-                )
-            )
-    except Exception as exc:
-        results.append(
-            Result(
-                category="E-batch",
-                description="Group structures",
-                pymatgen_result=False,
-                ferrox_result=False,
-                match=False,
-                error=str(exc),
-            )
+            assert (py_rms is None) == (rust_rms is None)
+
+
+class TestBatchOperations:
+    """Batch processing tests."""
+
+    def test_group_structures(self, py_matcher: PyMatcher, rust_matcher: RustMatcher) -> None:
+        """Group operation should match pymatgen."""
+        structures = [
+            make_cubic("Fe", 2.87),
+            make_cubic("Fe", 2.90),  # slightly different, should match
+            make_bcc("Fe", 2.87),  # different structure
+            make_fcc("Cu", 3.6),
+        ]
+        json_strs = [json.dumps(s.as_dict()) for s in structures]
+        rust_groups = rust_matcher.group(json_strs)
+
+        # Build pymatgen groups
+        py_groups: dict[int, list[int]] = {}
+        for idx, struct in enumerate(structures):
+            found = False
+            for canonical, members in py_groups.items():
+                if py_matcher.fit(structures[canonical], struct):
+                    members.append(idx)
+                    found = True
+                    break
+            if not found:
+                py_groups[idx] = [idx]
+
+        py_membership = {frozenset(m) for m in py_groups.values()}
+        rust_membership = {frozenset(m) for m in rust_groups.values()}
+        assert py_membership == rust_membership
+
+
+class TestLengthToleranceBounds:
+    """Length tolerance should use asymmetric bounds (1/(1+ltol), 1+ltol)."""
+
+    @pytest.fixture
+    def matchers_no_scale(self) -> tuple[PyMatcher, RustMatcher]:
+        """Matchers with scale=False."""
+        return (
+            PyMatcher(ltol=0.2, stol=0.3, angle_tol=5.0, primitive_cell=False, scale=False),
+            RustMatcher(latt_len_tol=0.2, site_pos_tol=0.3, angle_tol=5.0, primitive_cell=False, scale=False),
         )
 
-
-def run_category_f_comparators() -> None:
-    """Category F: Comparator and oxidation state tests."""
-    print("\nCategory F: Comparator tests")
-
-    # Create matchers with different comparators
-    py_species = PyMatcher(ltol=0.2, stol=0.3, angle_tol=5.0, primitive_cell=False)
-    py_element = PyMatcher(
-        ltol=0.2,
-        stol=0.3,
-        angle_tol=5.0,
-        primitive_cell=False,
-        comparator=ElementComparator(),
+    @pytest.mark.parametrize(
+        "scale_factor",
+        [0.84, 0.82, 1.0 / 1.2, 1.2, 1.21],
     )
-    rust_species = RustMatcher(
-        latt_len_tol=0.2,
-        site_pos_tol=0.3,
-        angle_tol=5.0,
-        primitive_cell=False,
-        comparator="species",
-    )
-    rust_element = RustMatcher(
-        latt_len_tol=0.2,
-        site_pos_tol=0.3,
-        angle_tol=5.0,
-        primitive_cell=False,
-        comparator="element",
-    )
-
-    # Test 1: Same element, different oxidation states (should not match with SpeciesComparator)
-    lattice = Lattice.cubic(5.0)
-    from pymatgen.core import Species
-
-    s_fe2 = Structure(lattice, [Species("Fe", 2)], [[0, 0, 0]])
-    s_fe3 = Structure(lattice, [Species("Fe", 3)], [[0, 0, 0]])
-
-    # With SpeciesComparator (default) - should NOT match
-    py_result_species = py_species.fit(s_fe2, s_fe3)
-    json1 = json.dumps(s_fe2.as_dict())
-    json2 = json.dumps(s_fe3.as_dict())
-    rust_result_species = rust_species.fit(json1, json2)
-
-    results.append(
-        Result(
-            category="F-oxi-species",
-            description="Fe2+ vs Fe3+ (SpeciesComparator)",
-            pymatgen_result=py_result_species,
-            ferrox_result=rust_result_species,
-            match=(py_result_species == rust_result_species),
-        )
-    )
-
-    # With ElementComparator - should match (oxidation states ignored)
-    py_result_element = py_element.fit(s_fe2, s_fe3)
-    rust_result_element = rust_element.fit(json1, json2)
-
-    results.append(
-        Result(
-            category="F-oxi-element",
-            description="Fe2+ vs Fe3+ (ElementComparator)",
-            pymatgen_result=py_result_element,
-            ferrox_result=rust_result_element,
-            match=(py_result_element == rust_result_element),
-        )
-    )
-
-    # Test 2: Multi-species with oxidation states
-    s_nacl_oxi = Structure(
-        lattice, [Species("Na", 1), Species("Cl", -1)], [[0, 0, 0], [0.5, 0.5, 0.5]]
-    )
-    s_nacl_neutral = Structure(lattice, ["Na", "Cl"], [[0, 0, 0], [0.5, 0.5, 0.5]])
-
-    json_oxi = json.dumps(s_nacl_oxi.as_dict())
-    json_neutral = json.dumps(s_nacl_neutral.as_dict())
-
-    # With SpeciesComparator - should NOT match (different species)
-    py_result = py_species.fit(s_nacl_oxi, s_nacl_neutral)
-    rust_result = rust_species.fit(json_oxi, json_neutral)
-
-    results.append(
-        Result(
-            category="F-oxi-species",
-            description="NaCl with vs without oxidation states (SpeciesComparator)",
-            pymatgen_result=py_result,
-            ferrox_result=rust_result,
-            match=(py_result == rust_result),
-        )
-    )
-
-    # With ElementComparator - should match
-    py_result = py_element.fit(s_nacl_oxi, s_nacl_neutral)
-    rust_result = rust_element.fit(json_oxi, json_neutral)
-
-    results.append(
-        Result(
-            category="F-oxi-element",
-            description="NaCl with vs without oxidation states (ElementComparator)",
-            pymatgen_result=py_result,
-            ferrox_result=rust_result,
-            match=(py_result == rust_result),
-        )
-    )
-
-    # Test 3: Completely different elements (should not match with either comparator)
-    s_cu = Structure(lattice, ["Cu"], [[0, 0, 0]])
-    s_ag = Structure(lattice, ["Ag"], [[0, 0, 0]])
-    json_cu = json.dumps(s_cu.as_dict())
-    json_ag = json.dumps(s_ag.as_dict())
-
-    py_result = py_element.fit(s_cu, s_ag)
-    rust_result = rust_element.fit(json_cu, json_ag)
-
-    results.append(
-        Result(
-            category="F-diff-elem",
-            description="Cu vs Ag (ElementComparator)",
-            pymatgen_result=py_result,
-            ferrox_result=rust_result,
-            match=(py_result == rust_result),
-        )
-    )
-
-
-def run_category_g_rms_consistency() -> None:
-    """Category G: RMS distance consistency tests."""
-    print("\nCategory G: RMS distance consistency")
-
-    lattice = Lattice.cubic(5.0)
-    s_base = Structure(lattice, ["Fe", "Fe"], [[0, 0, 0], [0.5, 0.5, 0.5]])
-
-    # Test at various perturbation levels
-    for mag in [0.01, 0.02, 0.03]:
-        s_pert = perturb_structure(s_base, mag, seed=100)
-
-        try:
-            py_rms = py_matcher.get_rms_dist(s_base, s_pert)
-            json1 = json.dumps(s_base.as_dict())
-            json2 = json.dumps(s_pert.as_dict())
-            rust_rms = rust_matcher.get_rms_dist(json1, json2)
-
-            if py_rms is not None and rust_rms is not None:
-                py_val = py_rms[0]  # (rms, max_dist)
-                rust_val = rust_rms[0]
-
-                # Check if RMS values are close (within 10% or 0.01 absolute)
-                rms_match = abs(py_val - rust_val) < max(0.01, 0.1 * py_val)
-
-                results.append(
-                    Result(
-                        category="G-rms",
-                        description=f"RMS at perturb={mag}: py={py_val:.4f}, rust={rust_val:.4f}",
-                        pymatgen_result=True,
-                        ferrox_result=True,
-                        match=rms_match,
-                        error=None
-                        if rms_match
-                        else f"RMS mismatch: py={py_val:.4f}, rust={rust_val:.4f}",
-                    )
-                )
-            else:
-                results.append(
-                    Result(
-                        category="G-rms",
-                        description=f"RMS at perturb={mag}",
-                        pymatgen_result=py_rms is not None,
-                        ferrox_result=rust_rms is not None,
-                        match=(py_rms is not None) == (rust_rms is not None),
-                    )
-                )
-        except Exception as exc:
-            results.append(
-                Result(
-                    category="G-rms",
-                    description=f"RMS at perturb={mag}",
-                    pymatgen_result=False,
-                    ferrox_result=False,
-                    match=False,
-                    error=str(exc),
-                )
-            )
-
-
-def run_cross_file_comparisons(structures: dict[str, Structure]) -> None:
-    """Compare structures across files."""
-    print("\nCross-file comparisons")
-
-    struct_list = list(structures.items())
-
-    # Compare each pair (up to a limit)
-    max_pairs = 100
-    pair_count = 0
-
-    for i, (name1, s1) in enumerate(struct_list):
-        for name2, s2 in struct_list[i + 1 :]:
-            if pair_count >= max_pairs:
-                break
-            compare(s1, s2, "cross-file", f"{name1} vs {name2}")
-            pair_count += 1
-        if pair_count >= max_pairs:
-            break
-
-
-# Main
-
-
-def main() -> None:
-    """Run comprehensive compatibility tests."""
-    print("=" * 70)
-    print("MATTERIM vs PYMATGEN COMPATIBILITY TEST SUITE")
-    print("=" * 70)
-
-    init_matchers()
-
-    # Load structures
-    print("\nLoading structures...")
-
-    print("  Loading matterviz JSON structures...")
-    matterviz_structures = load_matterviz_structures()
-    print(f"    Loaded {len(matterviz_structures)} structures")
-
-    print("  Loading pymatgen CIF structures...")
-    cif_structures = load_pymatgen_cif_structures()
-    print(f"    Loaded {len(cif_structures)} structures")
-
-    all_structures = {**matterviz_structures, **cif_structures}
-    print(f"  Total structures: {len(all_structures)}")
-
-    # Run test categories
-    start_time = time.time()
-
-    run_category_a_self_matching(all_structures)
-    run_category_b_perturbations()
-    run_category_c_non_matching()
-    run_category_d_edge_cases()
-    run_category_e_batch(matterviz_structures)
-    run_category_f_comparators()
-    run_category_g_rms_consistency()
-    run_cross_file_comparisons(all_structures)
-
-    # Test new APIs (find_matches, reduce_structure)
-    test_find_matches()
-    test_reduce_structure()
-
-    elapsed = time.time() - start_time
-
-    # Print results
-    print_summary()
-    print(f"\nTotal time: {elapsed:.2f}s")
-
-    # Known limitation note
-    print("\n" + "=" * 70)
-    print("KNOWN LIMITATIONS")
-    print("=" * 70)
-    print("""
-- Oblique lattices with unequal axes (a=b≠c and angles ≥100°) may fail
-  to match even identical structures. This affects ~10% of structures.
-- Root cause: lattice mapping search doesn't find all valid
-  transformations for highly oblique cells with large c/a ratios.
-- Workaround: Use larger tolerances (ltol=0.5, angle_tol=20.0) for
-  structures with oblique lattices.
-""")
-
-    # Log failed structures for debugging
-    total = len(results)
-    failed_results = [r for r in results if not r.match]
-    pass_rate = (total - len(failed_results)) / total if total > 0 else 0
-
-    if failed_results:
-        print("\n" + "=" * 70)
-        print(f"FAILED STRUCTURES ({len(failed_results)}/{total})")
-        print("=" * 70)
-        for result in failed_results[:10]:  # Show first 10 failures
-            print(f"  - {result.description}")
-        if len(failed_results) > 10:
-            print(f"  ... and {len(failed_results) - 10} more")
-
-    # Exit with code based on pass rate (allow up to 10% failures for known oblique lattice issues)
-    if pass_rate >= 0.90:
-        print(f"\nPass rate {pass_rate * 100:.1f}% meets threshold (≥90%)")
-        sys.exit(0)
-    else:
-        print(f"\nPass rate {pass_rate * 100:.1f}% below threshold (<90%)")
-        sys.exit(1)
-
-
-def run_regression_tests() -> dict[str, bool]:
-    """Run targeted regression tests for Agent 1-3 fixes.
-
-    Returns dict of test name -> passed bool.
-    """
-    from ferrox import StructureMatcher as RustMatcher
-
-    results: dict[str, bool] = {}
-    rust_matcher = RustMatcher(
-        latt_len_tol=0.2, site_pos_tol=0.3, angle_tol=5.0, primitive_cell=False
-    )
-
-    # Agent 1: Acute angle lattices (Niggli reduction)
-    print("\n=== Agent 1 Regression Tests (Acute Angles) ===")
-
-    # Test 1: rhomb_3478 - angles (28°, 28°, 28°)
-    try:
-        lattice_rhomb = Lattice.from_parameters(5.0, 5.0, 5.0, 28.0, 28.0, 28.0)
-        s_rhomb = Structure(lattice_rhomb, ["Si"], [[0, 0, 0]])
-        json_str = json.dumps(s_rhomb.as_dict())
-        passed = rust_matcher.fit(json_str, json_str)
-        results["acute_28deg_rhomb"] = passed
-        print(f"  acute_28deg_rhomb: {'PASS' if passed else 'FAIL'}")
-    except Exception as exc:
-        results["acute_28deg_rhomb"] = False
-        print(f"  acute_28deg_rhomb: ERROR - {exc}")
-
-    # Test 2: MgNiF6-like - angles (56.5°, 56.5°, 56.5°)
-    try:
-        lattice_mgnif6 = Lattice.from_parameters(4.8, 4.8, 4.8, 56.5, 56.5, 56.5)
-        s_mgnif6 = Structure(
-            lattice_mgnif6,
-            ["Mg", "Ni", "F", "F", "F", "F", "F", "F"],
-            [
-                [0, 0, 0],
-                [0.5, 0.5, 0.5],
-                [0.25, 0.25, 0.25],
-                [0.75, 0.75, 0.75],
-                [0.25, 0.75, 0.25],
-                [0.75, 0.25, 0.75],
-                [0.25, 0.25, 0.75],
-                [0.75, 0.75, 0.25],
-            ],
-        )
-        json_str = json.dumps(s_mgnif6.as_dict())
-        passed = rust_matcher.fit(json_str, json_str)
-        results["acute_56deg_mgnif6_like"] = passed
-        print(f"  acute_56deg_mgnif6_like: {'PASS' if passed else 'FAIL'}")
-    except Exception as exc:
-        results["acute_56deg_mgnif6_like"] = False
-        print(f"  acute_56deg_mgnif6_like: ERROR - {exc}")
-
-    # Agent 2: Obtuse angle lattices (find_all_mappings)
-    print("\n=== Agent 2 Regression Tests (Obtuse Angles) ===")
-
-    # Test 1: Co8-like - angles (103°, 103°, 90°), c/a = 2.15
-    try:
-        lattice_co8 = Lattice.from_parameters(3.7, 3.7, 8.0, 103.4, 103.4, 90.0)
-        s_co8 = Structure(
-            lattice_co8,
-            ["Co"] * 8,
-            [
-                [0, 0, 0],
-                [0.5, 0, 0.25],
-                [0, 0.5, 0.25],
-                [0.5, 0.5, 0],
-                [0, 0, 0.5],
-                [0.5, 0, 0.75],
-                [0, 0.5, 0.75],
-                [0.5, 0.5, 0.5],
-            ],
-        )
-        json_str = json.dumps(s_co8.as_dict())
-        passed = rust_matcher.fit(json_str, json_str)
-        results["obtuse_103deg_co8_like"] = passed
-        print(f"  obtuse_103deg_co8_like: {'PASS' if passed else 'FAIL'}")
-    except Exception as exc:
-        results["obtuse_103deg_co8_like"] = False
-        print(f"  obtuse_103deg_co8_like: ERROR - {exc}")
-
-    # Test 2: monoc_1028-like - angles (116°, 105°, 90°)
-    try:
-        lattice_monoc = Lattice.from_parameters(5.0, 5.0, 9.2, 116.4, 105.8, 90.0)
-        s_monoc = Structure(lattice_monoc, ["Ca", "O"], [[0, 0, 0], [0.5, 0.5, 0.5]])
-        json_str = json.dumps(s_monoc.as_dict())
-        passed = rust_matcher.fit(json_str, json_str)
-        results["obtuse_116deg_monoc_like"] = passed
-        print(f"  obtuse_116deg_monoc_like: {'PASS' if passed else 'FAIL'}")
-    except Exception as exc:
-        results["obtuse_116deg_monoc_like"] = False
-        print(f"  obtuse_116deg_monoc_like: ERROR - {exc}")
-
-    # Test 3: La2CoO4-like - gamma = 132.8°
-    try:
-        lattice_la2coo4 = Lattice.from_parameters(5.5, 5.5, 6.5, 90.0, 90.0, 132.8)
-        s_la2coo4 = Structure(
-            lattice_la2coo4,
-            ["La", "La", "Co", "O", "O", "O", "O"],
-            [
-                [0, 0, 0.36],
-                [0, 0, 0.64],
-                [0, 0, 0],
-                [0.25, 0.25, 0],
-                [0.75, 0.75, 0],
-                [0, 0.5, 0.18],
-                [0.5, 0, 0.82],
-            ],
-        )
-        json_str = json.dumps(s_la2coo4.as_dict())
-        passed = rust_matcher.fit(json_str, json_str)
-        results["obtuse_132deg_la2coo4_like"] = passed
-        print(f"  obtuse_132deg_la2coo4_like: {'PASS' if passed else 'FAIL'}")
-    except Exception as exc:
-        results["obtuse_132deg_la2coo4_like"] = False
-        print(f"  obtuse_132deg_la2coo4_like: ERROR - {exc}")
-
-    # Agent 3: Large structures
-    print("\n=== Agent 3 Regression Tests (Large Structures) ===")
-
-    # Test 1: 100-site structure
-    try:
-        lattice_large = Lattice.cubic(10.0)
-        species_large = ["Si"] * 100
-        np_rng = np.random.default_rng(seed=42)
-        coords_large = np_rng.random((100, 3)).tolist()
-        s_large_100 = Structure(lattice_large, species_large, coords_large)
-        json_str = json.dumps(s_large_100.as_dict())
-        passed = rust_matcher.fit(json_str, json_str)
-        results["large_100_sites"] = passed
-        print(f"  large_100_sites: {'PASS' if passed else 'FAIL'}")
-    except Exception as exc:
-        results["large_100_sites"] = False
-        print(f"  large_100_sites: ERROR - {exc}")
-
-    # Test 2: 200-site structure
-    try:
-        lattice_large = Lattice.cubic(12.0)
-        species_large = ["C"] * 200
-        np_rng = np.random.default_rng(seed=43)
-        coords_large = np_rng.random((200, 3)).tolist()
-        s_large_200 = Structure(lattice_large, species_large, coords_large)
-        json_str = json.dumps(s_large_200.as_dict())
-        passed = rust_matcher.fit(json_str, json_str)
-        results["large_200_sites"] = passed
-        print(f"  large_200_sites: {'PASS' if passed else 'FAIL'}")
-    except Exception as exc:
-        results["large_200_sites"] = False
-        print(f"  large_200_sites: ERROR - {exc}")
-
-    # Length tolerance bounds tests (fix for symmetric tolerance)
-    print("\n=== Length Tolerance Bounds Tests ===")
-    print(
-        "  Testing that length tolerance uses (1/(1+ltol), 1+ltol) not (1-ltol, 1+ltol)"
-    )
-
-    py_matcher = PyMatcher(
-        ltol=0.2, stol=0.3, angle_tol=5.0, primitive_cell=False, scale=False
-    )
-    rust_matcher_noscale = RustMatcher(
-        latt_len_tol=0.2,
-        site_pos_tol=0.3,
-        angle_tol=5.0,
-        primitive_cell=False,
-        scale=False,
-    )
-
-    def run_ltol_test(
-        name: str,
-        s1: Structure,
-        s2: Structure,
-        py_match: PyMatcher,
-        rust_match: RustMatcher,
-        expect_false: bool = False,
-    ) -> bool:
-        """Run a length tolerance test comparing pymatgen vs ferrox."""
-        try:
-            py_result = py_match.fit(s1, s2)
-            rust_result = rust_match.fit(
-                json.dumps(s1.as_dict()), json.dumps(s2.as_dict())
-            )
-            passed = py_result == rust_result
-            if expect_false:
-                passed = passed and py_result is False
-            results[name] = passed
-            status = "PASS" if passed else "FAIL"
-            print(f"  {name}: {status} (py={py_result}, rust={rust_result})")
-            return passed
-        except Exception as exc:
-            results[name] = False
-            print(f"  {name}: ERROR - {exc}")
-            return False
-
-    def make_cubic_pair(scale: float) -> tuple[Structure, Structure]:
-        """Create cubic NaCl structure pair with given scale factor."""
-        lat1 = Lattice.cubic(5.0)
-        lat2 = Lattice.cubic(5.0 * scale)
+    def test_length_tolerance_bounds(
+        self, matchers_no_scale: tuple[PyMatcher, RustMatcher], scale_factor: float
+    ) -> None:
+        """Test length tolerance boundary behavior."""
+        py_match, rust_match = matchers_no_scale
         coords = [[0, 0, 0], [0.5, 0.5, 0.5]]
-        return Structure(lat1, ["Na", "Cl"], coords), Structure(
-            lat2, ["Na", "Cl"], coords
+        s1 = Structure(Lattice.cubic(5.0), ["Na", "Cl"], coords)
+        s2 = Structure(Lattice.cubic(5.0 * scale_factor), ["Na", "Cl"], coords)
+
+        py_result = py_match.fit(s1, s2)
+        rust_result = rust_match.fit(json.dumps(s1.as_dict()), json.dumps(s2.as_dict()))
+        assert py_result == rust_result
+
+
+class TestRegressionCases:
+    """Regression tests for previously problematic cases."""
+
+    def test_acute_28deg_rhomb(self, compare: Callable) -> None:
+        """Acute angle rhombohedral lattice (28°)."""
+        struct = Structure(
+            Lattice.from_parameters(5.0, 5.0, 5.0, 28.0, 28.0, 28.0), ["Si"], [[0, 0, 0]]
+        )
+        assert compare(struct, struct) is True
+
+    def test_acute_56deg_rhomb(self, compare: Callable) -> None:
+        """Acute angle rhombohedral with multiple sites."""
+        struct = Structure(
+            Lattice.from_parameters(4.8, 4.8, 4.8, 56.5, 56.5, 56.5),
+            ["Mg", "Ni", "F", "F", "F", "F", "F", "F"],
+            [[0, 0, 0], [0.5, 0.5, 0.5], [0.25, 0.25, 0.25], [0.75, 0.75, 0.75],
+             [0.25, 0.75, 0.25], [0.75, 0.25, 0.75], [0.25, 0.25, 0.75], [0.75, 0.75, 0.25]],
+        )
+        assert compare(struct, struct) is True
+
+    def test_obtuse_103deg(self, compare: Callable) -> None:
+        """Obtuse angle lattice (103°)."""
+        struct = Structure(
+            Lattice.from_parameters(3.7, 3.7, 8.0, 103.4, 103.4, 90.0),
+            ["Co"] * 8,
+            [[0, 0, 0], [0.5, 0, 0.25], [0, 0.5, 0.25], [0.5, 0.5, 0],
+             [0, 0, 0.5], [0.5, 0, 0.75], [0, 0.5, 0.75], [0.5, 0.5, 0.5]],
+        )
+        assert compare(struct, struct) is True
+
+    def test_obtuse_116deg(self, compare: Callable) -> None:
+        """Obtuse angle monoclinic lattice (116°)."""
+        struct = Structure(
+            Lattice.from_parameters(5.0, 5.0, 9.2, 116.4, 105.8, 90.0),
+            ["Ca", "O"],
+            [[0, 0, 0], [0.5, 0.5, 0.5]],
+        )
+        assert compare(struct, struct) is True
+
+    def test_obtuse_132deg(self, compare: Callable) -> None:
+        """Obtuse angle lattice (gamma=132.8°)."""
+        struct = Structure(
+            Lattice.from_parameters(5.5, 5.5, 6.5, 90.0, 90.0, 132.8),
+            ["La", "La", "Co", "O", "O", "O", "O"],
+            [[0, 0, 0.36], [0, 0, 0.64], [0, 0, 0], [0.25, 0.25, 0],
+             [0.75, 0.75, 0], [0, 0.5, 0.18], [0.5, 0, 0.82]],
+        )
+        assert compare(struct, struct) is True
+
+    @pytest.mark.parametrize("num_sites", [100, 200])
+    def test_large_structures(self, compare: Callable, num_sites: int) -> None:
+        """Large structures with many sites."""
+        rng = np.random.default_rng(seed=42 + num_sites)
+        struct = Structure(
+            Lattice.cubic(10.0 + num_sites / 50),
+            ["Si"] * num_sites,
+            rng.random((num_sites, 3)).tolist(),
+        )
+        assert compare(struct, struct) is True
+
+
+class TestAPIs:
+    """Test additional ferrox APIs."""
+
+    def test_find_matches(self) -> None:
+        """find_matches should return correct indices."""
+        matcher = RustMatcher(
+            latt_len_tol=0.2, site_pos_tol=0.3, angle_tol=5.0, primitive_cell=True
         )
 
-    # Test cases: (name, scale_factor, expect_both_false)
-    ltol_tests = [
-        ("ltol_ratio_0.84_inside", 0.84, False),
-        ("ltol_ratio_0.82_outside", 0.82, False),
-        ("ltol_0.833_boundary", 1.0 / 1.2, True),  # exact boundary excluded
-        ("ltol_1.2_boundary", 1.2, True),  # exact boundary excluded
-        ("ltol_ratio_1.21_outside", 1.21, False),
-    ]
-    for name, scale, expect_false in ltol_tests:
-        s1, s2 = make_cubic_pair(scale)
-        run_ltol_test(name, s1, s2, py_matcher, rust_matcher_noscale, expect_false)
+        existing = [
+            make_rocksalt("Na", "Cl", 5.64),
+            make_bcc("Fe", 2.87),
+            make_fcc("Cu", 3.6),
+        ]
+        existing_json = [json.dumps(s.as_dict()) for s in existing]
 
-    # Triclinic test: one axis outside tolerance
-    lat1 = Lattice.from_parameters(6.0, 7.0, 8.0, 80.0, 85.0, 90.0)
-    lat2 = Lattice.from_parameters(6.0 * 0.82, 7.0, 8.0, 80.0, 85.0, 90.0)
-    coords = [[0, 0, 0], [0.3, 0.3, 0.3], [0.7, 0.7, 0.7]]
-    s1 = Structure(lat1, ["Fe", "O", "O"], coords)
-    s2 = Structure(lat2, ["Fe", "O", "O"], coords)
-    run_ltol_test(
-        "ltol_triclinic_one_axis_outside", s1, s2, py_matcher, rust_matcher_noscale
-    )
+        # New structures: shifted NaCl (matches 0), Fe BCC (matches 1), unique Si
+        new = [
+            translate(make_rocksalt("Na", "Cl", 5.64), [0.1, 0.1, 0.1]),
+            make_bcc("Fe", 2.87),
+            Structure(Lattice.cubic(5.43), ["Si"], [[0, 0, 0]]),
+        ]
+        new_json = [json.dumps(s.as_dict()) for s in new]
 
-    # Scale=True tests
-    print("\n=== Scale=True Tolerance Tests ===")
-    py_matcher_scale = PyMatcher(
-        ltol=0.2, stol=0.3, angle_tol=5.0, primitive_cell=False, scale=True
-    )
-    rust_matcher_scale = RustMatcher(
-        latt_len_tol=0.2,
-        site_pos_tol=0.3,
-        angle_tol=5.0,
-        primitive_cell=False,
-        scale=True,
-    )
+        matches = matcher.find_matches(new_json, existing_json)
+        assert matches == [0, 1, None]
 
-    # Different angles should not match even after scaling
-    s1 = Structure(
-        Lattice.from_parameters(5.0, 5.0, 5.0, 85.0, 85.0, 85.0), ["Si"], [[0, 0, 0]]
-    )
-    s2 = Structure(
-        Lattice.from_parameters(8.0, 8.0, 8.0, 105.0, 105.0, 105.0), ["Si"], [[0, 0, 0]]
-    )
-    run_ltol_test(
-        "scale_different_angles", s1, s2, py_matcher_scale, rust_matcher_scale
-    )
+    def test_find_matches_empty(self) -> None:
+        """find_matches with empty inputs."""
+        matcher = RustMatcher(
+            latt_len_tol=0.2, site_pos_tol=0.3, angle_tol=5.0, primitive_cell=True
+        )
+        existing_json = [json.dumps(make_bcc("Fe", 2.87).as_dict())]
+        new_json = [json.dumps(make_fcc("Cu", 3.6).as_dict())]
 
-    # Same structure at different scales should match
-    s1, s2 = make_cubic_pair(8.0 / 5.0)
-    run_ltol_test("scale_same_structure", s1, s2, py_matcher_scale, rust_matcher_scale)
+        assert matcher.find_matches([], existing_json) == []
+        assert matcher.find_matches(new_json, []) == [None]
 
-    # Summary
-    print("\n=== Regression Test Summary ===")
-    agent1_tests = [k for k in results if k.startswith("acute")]
-    agent2_tests = [k for k in results if k.startswith("obtuse")]
-    agent3_tests = [k for k in results if k.startswith("large")]
-    ltol_tests = [k for k in results if k.startswith("ltol") or k.startswith("scale")]
+    def test_reduce_structure(self) -> None:
+        """reduce_structure should preserve properties."""
+        matcher = RustMatcher(
+            latt_len_tol=0.2, site_pos_tol=0.3, angle_tol=5.0, primitive_cell=True
+        )
 
-    agent1_passed = sum(results[k] for k in agent1_tests)
-    agent2_passed = sum(results[k] for k in agent2_tests)
-    agent3_passed = sum(results[k] for k in agent3_tests)
-    ltol_passed = sum(results[k] for k in ltol_tests)
+        struct = make_rocksalt("Na", "Cl", 5.64)
+        struct.properties = {"energy": -5.5, "source": "DFT"}
 
-    print(f"  Agent 1 (Acute Angles): {agent1_passed}/{len(agent1_tests)}")
-    print(f"  Agent 2 (Obtuse Angles): {agent2_passed}/{len(agent2_tests)}")
-    print(f"  Agent 3 (Large Structures): {agent3_passed}/{len(agent3_tests)}")
-    print(f"  Length Tolerance Bounds: {ltol_passed}/{len(ltol_tests)}")
-    print(f"  Total: {sum(results.values())}/{len(results)}")
+        reduced = matcher.reduce_structure(json.dumps(struct.as_dict()))
+        reduced_dict = json.loads(reduced)
 
-    return results
+        assert "@module" in reduced_dict
+        assert "@class" in reduced_dict
+        # pymatgen may add default properties like 'charge', so check subset
+        props = reduced_dict.get("properties", {})
+        assert props.get("energy") == -5.5
+        assert props.get("source") == "DFT"
 
+    def test_skip_structure_reduction(self) -> None:
+        """fit with skip_structure_reduction should work on pre-reduced structures."""
+        matcher = RustMatcher(
+            latt_len_tol=0.2, site_pos_tol=0.3, angle_tol=5.0, primitive_cell=True
+        )
 
-def test_find_matches() -> None:
-    """Test find_matches API for matching new structures against existing."""
-    print("\n=== Testing find_matches API ===")
+        struct = make_rocksalt("Na", "Cl", 5.64)
+        json_str = json.dumps(struct.as_dict())
+        reduced = matcher.reduce_structure(json_str)
 
-    matcher = RustMatcher(
-        latt_len_tol=0.2, site_pos_tol=0.3, angle_tol=5.0, primitive_cell=True
-    )
+        # Pre-reduced structures should match
+        assert matcher.fit(reduced, reduced, skip_structure_reduction=True) is True
 
-    # Create existing structures (already deduplicated)
-    nacl = Structure(Lattice.cubic(5.64), ["Na", "Cl"], [[0, 0, 0], [0.5, 0.5, 0.5]])
-    fe_bcc = Structure(Lattice.cubic(2.87), ["Fe", "Fe"], [[0, 0, 0], [0.5, 0.5, 0.5]])
-    cu_fcc = Structure(Lattice.cubic(3.6), ["Cu"], [[0, 0, 0]])
+        # Consistency: normal fit should match skip fit
+        struct_shifted = translate(struct, [0.1, 0.1, 0.1])
+        reduced_shifted = matcher.reduce_structure(json.dumps(struct_shifted.as_dict()))
 
-    existing = [nacl, fe_bcc, cu_fcc]
-    existing_json = [json.dumps(s.as_dict()) for s in existing]
-
-    # Create new structures: some match, some unique
-    nacl_shifted = Structure(
-        Lattice.cubic(5.64), ["Na", "Cl"], [[0.1, 0.1, 0.1], [0.6, 0.6, 0.6]]
-    )
-    si = Structure(Lattice.cubic(5.43), ["Si"], [[0, 0, 0]])  # unique
-
-    new = [nacl_shifted, fe_bcc, si]
-    new_json = [json.dumps(s.as_dict()) for s in new]
-
-    matches = matcher.find_matches(new_json, existing_json)
-    expected = [0, 1, None]  # nacl->0, fe->1, si->None
-
-    assert matches == expected, f"find_matches failed: {matches} != {expected}"
-    print("  find_matches: PASSED")
-
-    # Test empty inputs
-    assert matcher.find_matches([], existing_json) == []
-    assert matcher.find_matches(new_json, []) == [None, None, None]
-    print("  find_matches empty inputs: PASSED")
+        normal_result = matcher.fit(json_str, json.dumps(struct_shifted.as_dict()))
+        skip_result = matcher.fit(reduced, reduced_shifted, skip_structure_reduction=True)
+        assert normal_result == skip_result
 
 
-def test_reduce_structure() -> None:
-    """Test reduce_structure and skip_structure_reduction APIs."""
-    print("\n=== Testing reduce_structure API ===")
-
-    matcher = RustMatcher(
-        latt_len_tol=0.2, site_pos_tol=0.3, angle_tol=5.0, primitive_cell=True
-    )
-
-    # Create structure with properties
-    nacl = Structure(Lattice.cubic(5.64), ["Na", "Cl"], [[0, 0, 0], [0.5, 0.5, 0.5]])
-    nacl.properties = {"energy": -5.5, "source": "DFT"}
-
-    json_str = json.dumps(nacl.as_dict())
-    reduced = matcher.reduce_structure(json_str)
-    reduced_dict = json.loads(reduced)
-
-    # Check structure is valid pymatgen format
-    assert "@module" in reduced_dict
-    assert "@class" in reduced_dict
-    assert "lattice" in reduced_dict
-    assert "sites" in reduced_dict
-    print("  reduce_structure format: PASSED")
-
-    # Check properties preserved
-    assert reduced_dict.get("properties") == {"energy": -5.5, "source": "DFT"}
-    print("  reduce_structure properties: PASSED")
-
-    # Test fit with skip_structure_reduction
-    reduced2 = matcher.reduce_structure(json_str)
-    assert matcher.fit(reduced, reduced2, skip_structure_reduction=True)
-    print("  fit with skip_structure_reduction: PASSED")
-
-    # Consistency: normal fit should match skip fit
-    nacl_shifted = Structure(
-        Lattice.cubic(5.64), ["Na", "Cl"], [[0.1, 0.1, 0.1], [0.6, 0.6, 0.6]]
-    )
-    json_shifted = json.dumps(nacl_shifted.as_dict())
-    reduced_shifted = matcher.reduce_structure(json_shifted)
-
-    normal_result = matcher.fit(json_str, json_shifted)
-    skip_result = matcher.fit(reduced, reduced_shifted, skip_structure_reduction=True)
-    assert normal_result == skip_result, "fit consistency failed"
-    print("  fit consistency: PASSED")
+# ============================================================================
+# External File Tests (skipped if files not available)
+# ============================================================================
 
 
-if __name__ == "__main__":
-    if len(sys.argv) > 1 and sys.argv[1] == "--regression":
-        # Run only regression tests
-        regression_results = run_regression_tests()
-        sys.exit(0 if all(regression_results.values()) else 1)
-    else:
-        # Run full test suite
-        main()
+@pytest.mark.skipif(
+    not MATTERVIZ_STRUCTURES_DIR.exists(),
+    reason=f"matterviz structures not found at {MATTERVIZ_STRUCTURES_DIR}",
+)
+class TestMattervizStructures:
+    """Tests using matterviz JSON structure files."""
+
+    @pytest.fixture(scope="class")
+    def structures(self) -> dict[str, Structure]:
+        """Load matterviz structures."""
+        result = {}
+        for json_file in MATTERVIZ_STRUCTURES_DIR.glob("*.json"):
+            try:
+                data = json.loads(json_file.read_text())
+                if data.get("@class") == "Structure":
+                    result[json_file.stem] = Structure.from_dict(data)
+            except Exception:
+                pass
+        return result
+
+    def test_self_matching(self, compare: Callable, structures: dict[str, Structure]) -> None:
+        """All matterviz structures should match themselves."""
+        for name, struct in structures.items():
+            assert compare(struct, struct) is True, f"Failed: {name}"
+
+
+@pytest.mark.skipif(
+    not PYMATGEN_CIF_DIR.exists(),
+    reason=f"pymatgen CIF files not found at {PYMATGEN_CIF_DIR}",
+)
+class TestPymatgenCifStructures:
+    """Tests using pymatgen's test CIF files."""
+
+    @pytest.fixture(scope="class")
+    def structures(self) -> dict[str, Structure]:
+        """Load pymatgen CIF structures."""
+        result = {}
+        for cif_file in PYMATGEN_CIF_DIR.glob("*.cif"):
+            try:
+                result[cif_file.stem] = Structure.from_file(str(cif_file))
+            except Exception:
+                pass
+        return result
+
+    def test_self_matching(self, compare: Callable, structures: dict[str, Structure]) -> None:
+        """All pymatgen CIF structures should match themselves."""
+        for name, struct in structures.items():
+            assert compare(struct, struct) is True, f"Failed: {name}"


### PR DESCRIPTION
## Summary

Enables round-trip I/O for all supported structure formats by adding writer functions:

- `structure_to_poscar()` / `write_poscar()` - VASP POSCAR format
- `structure_to_cif()` / `write_cif()` - CIF format with oxidation state support
- `structure_to_extxyz()` / `write_extxyz()` - extXYZ format with property preservation
- `write_structure()` - unified API with automatic format detection by file extension

- Add symmetry-analysis APIs for space-group number/symbol, Hall number, Pearson symbol, Wyckoff letters, site symmetry, symmetry operations, equivalent sites, and crystal system.

## Python Bindings

New functions exposed to Python:
- `write_structure_file(structure_json, path)` - write with auto-detection
- `to_poscar(structure_json, comment=None)` - convert to POSCAR string
- `to_cif(structure_json, data_name=None)` - convert to CIF string
- `to_extxyz(structure_json)` - convert to extXYZ string
- `to_pymatgen_json(structure_json)` - convert to pymatgen JSON string