### PR TITLE
Add coordination analysis module to ferrox

### DIFF
--- a/extensions/rust/.cargo/config.toml
+++ b/extensions/rust/.cargo/config.toml
@@ -1,0 +1,4 @@
+# Configuration for wasm32-unknown-unknown target
+# Required for getrandom 0.3.x which needs explicit backend configuration
+[target.wasm32-unknown-unknown]
+rustflags = ['--cfg', 'getrandom_backend="wasm_js"']

--- a/extensions/rust/Cargo.toml
+++ b/extensions/rust/Cargo.toml
@@ -30,6 +30,7 @@ getrandom = { version = "0.2", features = ["js"] }
 
 # Math
 nalgebra = "0.34"
+glam = "0.27"  # Vector math for Voronoi (compatible with meshless_voronoi)
 
 # Symmetry - same underlying Rust crate as moyopy
 moyo = "0.7"
@@ -42,10 +43,11 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 # Algorithms
-pathfinding = "4.14" # Hungarian algorithm (kuhn_munkres)
-itertools = "0.14"   # permutations for fit_anonymous
-rand = "0.8"         # random perturbations (0.8 uses getrandom 0.2 with simpler WASM support)
-regex = "1.12"       # formula parsing
+pathfinding = "4.14"      # Hungarian algorithm (kuhn_munkres)
+itertools = "0.14"        # permutations for fit_anonymous
+rand = "0.8"              # random perturbations (0.8 uses getrandom 0.2 with simpler WASM support)
+regex = "1.12"            # formula parsing
+meshless_voronoi = "0.7"  # Voronoi tessellation for coordination analysis
 
 # Utilities
 indexmap = { version = "2.13", features = ["serde"] }

--- a/extensions/rust/Cargo.toml
+++ b/extensions/rust/Cargo.toml
@@ -24,9 +24,11 @@ wasm-bindgen = { version = "0.2.108", optional = true }
 js-sys = { version = "0.3.85", optional = true }
 serde-wasm-bindgen = { version = "0.6.5", optional = true }
 console_error_panic_hook = { version = "0.1.7", optional = true }
-# WASM random number generation - need js feature for wasm32-unknown-unknown
-# This is a regular dep (not optional) so the js feature applies to rand's transitive dep
-getrandom = { version = "0.2", features = ["js"] }
+# WASM random number generation
+# getrandom 0.2.x: needs "js" feature for wasm32-unknown-unknown (used by rand 0.8)
+# getrandom 0.3.x: needs "wasm_js" feature + rustflag config in .cargo/config.toml (used by meshless_voronoi -> ahash)
+getrandom_02 = { package = "getrandom", version = "0.2", features = ["js"] }
+getrandom = { version = "0.3", features = ["wasm_js"] }
 
 # Math
 nalgebra = "0.34"

--- a/extensions/rust/src/coordination.rs
+++ b/extensions/rust/src/coordination.rs
@@ -223,11 +223,6 @@ impl Default for VoronoiConfig {
     }
 }
 
-/// Get config or default.
-fn voronoi_config(config: Option<&VoronoiConfig>) -> VoronoiConfig {
-    config.copied().unwrap_or_default()
-}
-
 /// Build a Voronoi tessellation from a structure with periodic boundary conditions.
 fn build_voronoi(structure: &Structure) -> Option<Voronoi> {
     if structure.num_sites() == 0 {
@@ -315,7 +310,7 @@ pub fn get_cn_voronoi(
     config: Option<&VoronoiConfig>,
 ) -> f64 {
     check_site_idx(structure, site_idx);
-    let config = voronoi_config(config);
+    let config = config.copied().unwrap_or_default();
     let Some(voronoi) = build_voronoi(structure) else {
         return 0.0;
     };
@@ -332,7 +327,7 @@ pub fn get_cn_voronoi(
 
 /// Get Voronoi-weighted coordination numbers for all sites.
 pub fn get_cn_voronoi_all(structure: &Structure, config: Option<&VoronoiConfig>) -> Vec<f64> {
-    let config = voronoi_config(config);
+    let config = config.copied().unwrap_or_default();
     let Some(voronoi) = build_voronoi(structure) else {
         return vec![];
     };
@@ -364,7 +359,7 @@ pub fn get_voronoi_neighbors(
     config: Option<&VoronoiConfig>,
 ) -> Vec<(usize, f64)> {
     check_site_idx(structure, site_idx);
-    let config = voronoi_config(config);
+    let config = config.copied().unwrap_or_default();
     let Some(voronoi) = build_voronoi(structure) else {
         return vec![];
     };
@@ -393,7 +388,7 @@ pub fn get_local_environment_voronoi(
     config: Option<&VoronoiConfig>,
 ) -> Vec<LocalEnvNeighbor> {
     check_site_idx(structure, site_idx);
-    let config = voronoi_config(config);
+    let config = config.copied().unwrap_or_default();
     let Some(voronoi) = build_voronoi(structure) else {
         return vec![];
     };
@@ -515,7 +510,6 @@ mod tests {
         let expected_dist = 3.61 / 2.0_f64.sqrt();
         for n in &neighbors {
             assert_eq!(n.element(), Element::Cu);
-            assert_eq!(n.element(), n.species.element);
             assert!((n.distance - expected_dist).abs() < 0.1);
         }
 

--- a/extensions/rust/src/coordination.rs
+++ b/extensions/rust/src/coordination.rs
@@ -1,0 +1,645 @@
+//! Coordination analysis for crystal structures.
+//!
+//! This module provides methods to calculate coordination numbers and analyze
+//! local environments around atomic sites in crystal structures.
+//!
+//! # Coordination Number Methods
+//!
+//! - **Cutoff-based**: Count neighbors within a distance threshold
+//! - **Voronoi-based**: Use solid angle weights from Voronoi tessellation
+//!
+//! # Limitations
+//!
+//! The Voronoi-based methods use a rectangular bounding box (via `meshless_voronoi`),
+//! which is only geometrically correct for orthogonal lattices (cubic, tetragonal,
+//! orthorhombic). For non-orthogonal cells (triclinic, monoclinic, rhombohedral),
+//! the periodic boundary conditions will be incorrect, leading to wrong coordination
+//! numbers. Use cutoff-based methods for non-orthogonal cells.
+//!
+//! # Examples
+//!
+//! ```rust,ignore
+//! use ferrox::Structure;
+//! use ferrox::coordination::{get_coordination_numbers, get_local_environment};
+//!
+//! let structure = Structure::from_json(json_str)?;
+//!
+//! // Cutoff-based coordination numbers
+//! let cns = get_coordination_numbers(&structure, 3.0);
+//!
+//! // Local environment for site 0
+//! let neighbors = get_local_environment(&structure, 0, 3.0);
+//! for n in neighbors {
+//!     println!("{} at {:.2} Å", n.element().symbol(), n.distance);
+//! }
+//! ```
+
+use crate::element::Element;
+use crate::species::Species;
+use crate::structure::Structure;
+
+// Tolerance for neighbor list distance comparisons
+const NEIGHBOR_TOL: f64 = 1e-8;
+// Tolerance for geometric comparisons (face area, distance)
+const GEOM_TOL: f64 = 1e-10;
+
+/// Information about a neighbor in the local environment of a site.
+#[derive(Debug, Clone)]
+pub struct LocalEnvNeighbor {
+    /// The species at this neighbor site (element + optional oxidation state).
+    pub species: Species,
+    /// Distance from the central site in Angstroms.
+    pub distance: f64,
+    /// Periodic image offset [da, db, dc] in lattice vector units.
+    pub image: [i32; 3],
+    /// Index of the neighbor site in the structure.
+    pub site_idx: usize,
+    /// Solid angle fraction (only filled for Voronoi-based analysis).
+    pub solid_angle: Option<f64>,
+}
+
+impl LocalEnvNeighbor {
+    /// The chemical element at this neighbor site.
+    pub fn element(&self) -> Element {
+        self.species.element
+    }
+}
+
+/// Helper to check site index bounds.
+fn check_site_idx(structure: &Structure, site_idx: usize) {
+    assert!(
+        site_idx < structure.num_sites(),
+        "site_idx {site_idx} out of bounds (num_sites={})",
+        structure.num_sites()
+    );
+}
+
+// ============================================================================
+// Cutoff-Based Coordination Methods
+// ============================================================================
+
+/// Get coordination numbers for all sites using a distance cutoff.
+///
+/// Counts the number of neighbors within the specified cutoff distance for each site.
+/// Uses periodic boundary conditions.
+///
+/// # Arguments
+///
+/// * `structure` - The crystal structure to analyze
+/// * `cutoff` - Maximum distance (in Angstroms) to consider a site as a neighbor
+///
+/// # Returns
+///
+/// A vector of coordination numbers, one for each site in the structure.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// // FCC Cu has 12 nearest neighbors at ~2.55 Å
+/// let cns = get_coordination_numbers(&fcc_cu, 3.0);
+/// assert!(cns.iter().all(|&cn| cn == 12));
+/// ```
+pub fn get_coordination_numbers(structure: &Structure, cutoff: f64) -> Vec<usize> {
+    if structure.num_sites() == 0 || cutoff <= 0.0 {
+        return vec![];
+    }
+
+    let (centers, _, _, _) = structure.get_neighbor_list(cutoff, NEIGHBOR_TOL, true);
+    let mut counts = vec![0usize; structure.num_sites()];
+    for center in centers {
+        counts[center] += 1;
+    }
+    counts
+}
+
+/// Get coordination number for a single site using a distance cutoff.
+///
+/// # Panics
+///
+/// Panics if `site_idx` is out of bounds.
+pub fn get_coordination_number(structure: &Structure, site_idx: usize, cutoff: f64) -> usize {
+    check_site_idx(structure, site_idx);
+    if cutoff <= 0.0 {
+        return 0;
+    }
+    let (centers, _, _, _) = structure.get_neighbor_list(cutoff, NEIGHBOR_TOL, true);
+    centers.iter().filter(|&&c| c == site_idx).count()
+}
+
+/// Get the local environment (detailed neighbor information) for a site.
+///
+/// Returns detailed information about each neighbor including species, distance,
+/// and periodic image offset.
+///
+/// # Panics
+///
+/// Panics if `site_idx` is out of bounds.
+pub fn get_local_environment(
+    structure: &Structure,
+    site_idx: usize,
+    cutoff: f64,
+) -> Vec<LocalEnvNeighbor> {
+    check_site_idx(structure, site_idx);
+    if cutoff <= 0.0 {
+        return vec![];
+    }
+
+    let (centers, neighbors, images, distances) =
+        structure.get_neighbor_list(cutoff, NEIGHBOR_TOL, true);
+
+    let mut result: Vec<LocalEnvNeighbor> = centers
+        .iter()
+        .enumerate()
+        .filter(|(_, center)| **center == site_idx)
+        .map(|(idx, _)| {
+            let neighbor_idx = neighbors[idx];
+            let species = *structure.site_occupancies[neighbor_idx].dominant_species();
+            LocalEnvNeighbor {
+                species,
+                distance: distances[idx],
+                image: images[idx],
+                site_idx: neighbor_idx,
+                solid_angle: None,
+            }
+        })
+        .collect();
+
+    result.sort_by(|a, b| a.distance.partial_cmp(&b.distance).unwrap());
+    result
+}
+
+/// Get neighbors for a site within cutoff as `(site_idx, distance, image)` tuples.
+///
+/// A simpler alternative to `get_local_environment` that returns only indices and distances.
+pub fn get_neighbors(
+    structure: &Structure,
+    site_idx: usize,
+    cutoff: f64,
+) -> Vec<(usize, f64, [i32; 3])> {
+    check_site_idx(structure, site_idx);
+    if cutoff <= 0.0 {
+        return vec![];
+    }
+
+    let (centers, neighbors, images, distances) =
+        structure.get_neighbor_list(cutoff, NEIGHBOR_TOL, true);
+
+    let mut result: Vec<_> = centers
+        .iter()
+        .enumerate()
+        .filter(|(_, c)| **c == site_idx)
+        .map(|(idx, _)| (neighbors[idx], distances[idx], images[idx]))
+        .collect();
+
+    result.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+    result
+}
+
+// ============================================================================
+// Voronoi-Based Coordination Methods
+// ============================================================================
+
+use glam::DVec3;
+use meshless_voronoi::{Dimensionality, Voronoi};
+
+/// Configuration for Voronoi-based coordination analysis.
+#[derive(Debug, Clone, Copy)]
+pub struct VoronoiConfig {
+    /// Minimum solid angle fraction to consider a neighbor (default: 0.01).
+    pub min_solid_angle: f64,
+}
+
+impl Default for VoronoiConfig {
+    fn default() -> Self {
+        Self {
+            min_solid_angle: 0.01,
+        }
+    }
+}
+
+/// Get config or default.
+fn voronoi_config(config: Option<&VoronoiConfig>) -> VoronoiConfig {
+    config.copied().unwrap_or_default()
+}
+
+/// Build a Voronoi tessellation from a structure with periodic boundary conditions.
+fn build_voronoi(structure: &Structure) -> Option<Voronoi> {
+    if structure.num_sites() == 0 {
+        return None;
+    }
+
+    let cart_coords = structure.cart_coords();
+    let positions: Vec<DVec3> = cart_coords
+        .iter()
+        .map(|v| DVec3::new(v.x, v.y, v.z))
+        .collect();
+
+    // Compute lattice vector lengths for box dimensions
+    let matrix = structure.lattice.matrix();
+    let width = DVec3::new(
+        matrix.row(0).norm(),
+        matrix.row(1).norm(),
+        matrix.row(2).norm(),
+    );
+
+    Some(Voronoi::build(
+        &positions,
+        DVec3::ZERO,
+        width,
+        Dimensionality::ThreeD,
+        true, // periodic
+    ))
+}
+
+/// Helper to compute solid angle fraction from a face.
+/// Returns (neighbor_idx, solid_angle_fraction) or None if it's a boundary face.
+fn compute_face_solid_angle(
+    face: &meshless_voronoi::VoronoiFace,
+    cell_idx: usize,
+    cart_coords: &[nalgebra::Vector3<f64>],
+    num_sites: usize,
+) -> Option<(usize, f64)> {
+    // Determine if we're on the left or right side of this face
+    let is_left = face.left() == cell_idx;
+
+    // Get the neighbor index - right() returns None for boundary faces
+    let neighbor_idx = if is_left { face.right()? } else { face.left() };
+
+    // Handle periodic images: neighbor index might be >= num_sites
+    let actual_neighbor_idx = neighbor_idx % num_sites;
+
+    let face_area = face.area();
+    if face_area < GEOM_TOL {
+        return None;
+    }
+
+    // Compute distance using face centroid - this correctly handles periodic images
+    // The centroid is in the geometric frame where the face exists
+    let center_pos = &cart_coords[cell_idx];
+    let face_centroid = face.centroid();
+    let centroid_vec = nalgebra::Vector3::new(face_centroid.x, face_centroid.y, face_centroid.z);
+
+    // Distance from cell center to face centroid, doubled to approximate neighbor distance
+    // (face sits at midpoint between cell and neighbor in Voronoi tessellation)
+    let dist_to_face = (centroid_vec - center_pos).norm();
+    let dist = 2.0 * dist_to_face;
+    let dist_sq = dist * dist;
+
+    if dist_sq < GEOM_TOL {
+        return None;
+    }
+
+    // Solid angle approximation: Ω ≈ A / r²
+    // Solid angle fraction: Ω / (4π)
+    let solid_angle_fraction = face_area / (4.0 * std::f64::consts::PI * dist_sq);
+
+    Some((actual_neighbor_idx, solid_angle_fraction))
+}
+
+/// Get Voronoi-weighted coordination number for a single site.
+///
+/// Counts Voronoi faces with solid angle fractions above the threshold.
+///
+/// # Panics
+///
+/// Panics if `site_idx` is out of bounds.
+pub fn get_cn_voronoi(
+    structure: &Structure,
+    site_idx: usize,
+    config: Option<&VoronoiConfig>,
+) -> f64 {
+    check_site_idx(structure, site_idx);
+    let config = voronoi_config(config);
+    let Some(voronoi) = build_voronoi(structure) else {
+        return 0.0;
+    };
+
+    let cart_coords = structure.cart_coords();
+    let num_sites = structure.num_sites();
+
+    voronoi.cells()[site_idx]
+        .faces(&voronoi)
+        .filter_map(|face| compute_face_solid_angle(face, site_idx, &cart_coords, num_sites))
+        .filter(|(_, solid_angle)| *solid_angle >= config.min_solid_angle)
+        .count() as f64
+}
+
+/// Get Voronoi-weighted coordination numbers for all sites.
+pub fn get_cn_voronoi_all(structure: &Structure, config: Option<&VoronoiConfig>) -> Vec<f64> {
+    let config = voronoi_config(config);
+    let Some(voronoi) = build_voronoi(structure) else {
+        return vec![];
+    };
+
+    let cart_coords = structure.cart_coords();
+    let num_sites = structure.num_sites();
+
+    voronoi
+        .cells()
+        .iter()
+        .enumerate()
+        .map(|(site_idx, cell)| {
+            cell.faces(&voronoi)
+                .filter_map(|face| {
+                    compute_face_solid_angle(face, site_idx, &cart_coords, num_sites)
+                })
+                .filter(|(_, solid_angle)| *solid_angle >= config.min_solid_angle)
+                .count() as f64
+        })
+        .collect()
+}
+
+/// Get Voronoi neighbors with their solid angle fractions for a site.
+///
+/// Returns neighbors sorted by solid angle (largest first).
+pub fn get_voronoi_neighbors(
+    structure: &Structure,
+    site_idx: usize,
+    config: Option<&VoronoiConfig>,
+) -> Vec<(usize, f64)> {
+    check_site_idx(structure, site_idx);
+    let config = voronoi_config(config);
+    let Some(voronoi) = build_voronoi(structure) else {
+        return vec![];
+    };
+
+    let cart_coords = structure.cart_coords();
+    let num_sites = structure.num_sites();
+
+    let mut neighbors: Vec<_> = voronoi.cells()[site_idx]
+        .faces(&voronoi)
+        .filter_map(|face| compute_face_solid_angle(face, site_idx, &cart_coords, num_sites))
+        .filter(|(_, solid_angle)| *solid_angle >= config.min_solid_angle)
+        .collect();
+
+    neighbors.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+    neighbors
+}
+
+/// Get local environment using Voronoi tessellation.
+///
+/// Uses Voronoi faces to determine neighbors instead of a distance cutoff.
+/// Includes solid angle information.
+pub fn get_local_environment_voronoi(
+    structure: &Structure,
+    site_idx: usize,
+    config: Option<&VoronoiConfig>,
+) -> Vec<LocalEnvNeighbor> {
+    check_site_idx(structure, site_idx);
+    let config = voronoi_config(config);
+    let Some(voronoi) = build_voronoi(structure) else {
+        return vec![];
+    };
+
+    let cart_coords = structure.cart_coords();
+    let num_sites = structure.num_sites();
+    let center_pos = &cart_coords[site_idx];
+
+    let mut neighbors: Vec<LocalEnvNeighbor> = voronoi.cells()[site_idx]
+        .faces(&voronoi)
+        .filter_map(|face| compute_face_solid_angle(face, site_idx, &cart_coords, num_sites))
+        .filter(|(_, solid_angle)| *solid_angle >= config.min_solid_angle)
+        .map(|(neighbor_idx, solid_angle)| {
+            let distance = (cart_coords[neighbor_idx] - center_pos).norm();
+            let species = *structure.site_occupancies[neighbor_idx].dominant_species();
+            LocalEnvNeighbor {
+                species,
+                distance,
+                image: [0, 0, 0], // Voronoi doesn't track periodic images
+                site_idx: neighbor_idx,
+                solid_angle: Some(solid_angle),
+            }
+        })
+        .collect();
+
+    // Sort by solid angle (largest first)
+    neighbors.sort_by(|a, b| b.solid_angle.partial_cmp(&a.solid_angle).unwrap());
+    neighbors
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lattice::Lattice;
+    use nalgebra::Vector3;
+
+    fn make_fcc(element: Element, a: f64) -> Structure {
+        let lattice = Lattice::cubic(a);
+        let species = vec![Species::neutral(element); 4];
+        let frac_coords = vec![
+            Vector3::new(0.0, 0.0, 0.0),
+            Vector3::new(0.5, 0.5, 0.0),
+            Vector3::new(0.5, 0.0, 0.5),
+            Vector3::new(0.0, 0.5, 0.5),
+        ];
+        Structure::new(lattice, species, frac_coords)
+    }
+
+    fn make_bcc(element: Element, a: f64) -> Structure {
+        let lattice = Lattice::cubic(a);
+        let species = vec![Species::neutral(element); 2];
+        let frac_coords = vec![Vector3::new(0.0, 0.0, 0.0), Vector3::new(0.5, 0.5, 0.5)];
+        Structure::new(lattice, species, frac_coords)
+    }
+
+    fn make_rocksalt(cation: Element, anion: Element, a: f64) -> Structure {
+        let lattice = Lattice::cubic(a);
+        let species = [
+            vec![Species::neutral(cation); 4],
+            vec![Species::neutral(anion); 4],
+        ]
+        .concat();
+        let frac_coords = vec![
+            Vector3::new(0.0, 0.0, 0.0),
+            Vector3::new(0.5, 0.5, 0.0),
+            Vector3::new(0.5, 0.0, 0.5),
+            Vector3::new(0.0, 0.5, 0.5),
+            Vector3::new(0.5, 0.0, 0.0),
+            Vector3::new(0.0, 0.5, 0.0),
+            Vector3::new(0.0, 0.0, 0.5),
+            Vector3::new(0.5, 0.5, 0.5),
+        ];
+        Structure::new(lattice, species, frac_coords)
+    }
+
+    // Helper to verify all CNs match expected value
+    fn assert_all_cn(cns: &[usize], expected: usize) {
+        assert!(
+            cns.iter().all(|&cn| cn == expected),
+            "Expected CN={expected}, got {cns:?}"
+        );
+    }
+
+    #[test]
+    fn test_coordination_numbers() {
+        // FCC Cu: CN=12 with cutoff 3.0 Å
+        let fcc = make_fcc(Element::Cu, 3.61);
+        let cns = get_coordination_numbers(&fcc, 3.0);
+        assert_eq!(cns.len(), 4);
+        assert_all_cn(&cns, 12);
+
+        // BCC Fe: CN=8 (first shell only at 2.6 Å), CN=14 (both shells at 3.0 Å)
+        let bcc = make_bcc(Element::Fe, 2.87);
+        assert_all_cn(&get_coordination_numbers(&bcc, 2.6), 8);
+        assert_all_cn(&get_coordination_numbers(&bcc, 3.0), 14);
+
+        // Rocksalt NaCl: CN=6
+        let nacl = make_rocksalt(Element::Na, Element::Cl, 5.64);
+        let cns = get_coordination_numbers(&nacl, 3.5);
+        assert_eq!(cns.len(), 8);
+        assert_all_cn(&cns, 6);
+    }
+
+    #[test]
+    fn test_single_site_and_get_neighbors() {
+        let fcc = make_fcc(Element::Cu, 3.61);
+        assert_eq!(get_coordination_number(&fcc, 0, 3.0), 12);
+
+        let bcc = make_bcc(Element::Fe, 2.87);
+        let neighbors = get_neighbors(&bcc, 0, 2.6);
+        assert_eq!(neighbors.len(), 8);
+        assert!(neighbors.iter().all(|(_, d, _)| *d > 2.0 && *d < 2.7));
+    }
+
+    #[test]
+    fn test_local_environment() {
+        let fcc = make_fcc(Element::Cu, 3.61);
+        let neighbors = get_local_environment(&fcc, 0, 3.0);
+
+        assert_eq!(neighbors.len(), 12);
+        let expected_dist = 3.61 / 2.0_f64.sqrt();
+        for n in &neighbors {
+            assert_eq!(n.element(), Element::Cu);
+            assert_eq!(n.element(), n.species.element);
+            assert!((n.distance - expected_dist).abs() < 0.1);
+        }
+
+        // Verify sorted by distance
+        let distances: Vec<f64> = neighbors.iter().map(|n| n.distance).collect();
+        assert!(distances.windows(2).all(|w| w[0] <= w[1]));
+
+        // Has periodic images
+        assert!(neighbors.iter().any(|n| n.image != [0, 0, 0]));
+    }
+
+    #[test]
+    fn test_rocksalt_element_types() {
+        let nacl = make_rocksalt(Element::Na, Element::Cl, 5.64);
+
+        // Na (site 0) neighbors are all Cl
+        let na_neighbors = get_local_environment(&nacl, 0, 3.5);
+        assert_eq!(na_neighbors.len(), 6);
+        assert!(na_neighbors.iter().all(|n| n.element() == Element::Cl));
+
+        // Cl (site 4) neighbors are all Na
+        let cl_neighbors = get_local_environment(&nacl, 4, 3.5);
+        assert_eq!(cl_neighbors.len(), 6);
+        assert!(cl_neighbors.iter().all(|n| n.element() == Element::Na));
+    }
+
+    #[test]
+    fn test_edge_cases() {
+        let fcc = make_fcc(Element::Cu, 3.61);
+
+        // Zero/negative cutoff
+        assert!(
+            get_coordination_numbers(&fcc, 0.0)
+                .iter()
+                .all(|&cn| cn == 0)
+        );
+        assert!(get_coordination_numbers(&fcc, -1.0).is_empty());
+
+        // Empty structure
+        let empty = Structure::new(Lattice::cubic(5.0), vec![], vec![]);
+        assert!(get_coordination_numbers(&empty, 3.0).is_empty());
+    }
+
+    #[test]
+    fn test_voronoi_fcc() {
+        let fcc = make_fcc(Element::Cu, 3.61);
+
+        // All sites should have ~12 Voronoi neighbors
+        let cns = get_cn_voronoi_all(&fcc, None);
+        assert_eq!(cns.len(), 4);
+        for cn in cns {
+            assert!(
+                (10.0..=14.0).contains(&cn),
+                "FCC Voronoi CN={cn}, expected ~12"
+            );
+        }
+
+        // Single site
+        let cn = get_cn_voronoi(&fcc, 0, None);
+        assert!(
+            (10.0..=14.0).contains(&cn),
+            "FCC Voronoi CN={cn}, expected ~12"
+        );
+    }
+
+    #[test]
+    fn test_voronoi_neighbors() {
+        let fcc = make_fcc(Element::Cu, 3.61);
+        let neighbors = get_voronoi_neighbors(&fcc, 0, None);
+
+        assert!(!neighbors.is_empty());
+        // Valid solid angles, sorted descending
+        let angles: Vec<f64> = neighbors.iter().map(|(_, sa)| *sa).collect();
+        assert!(angles.iter().all(|&sa| (0.0..=1.0).contains(&sa)));
+        assert!(angles.windows(2).all(|w| w[0] >= w[1]));
+    }
+
+    #[test]
+    fn test_voronoi_local_environment() {
+        let fcc = make_fcc(Element::Cu, 3.61);
+        let neighbors = get_local_environment_voronoi(&fcc, 0, None);
+
+        assert!(!neighbors.is_empty());
+        for n in &neighbors {
+            assert_eq!(n.element(), Element::Cu);
+            assert!(n.solid_angle.is_some());
+        }
+    }
+
+    #[test]
+    fn test_voronoi_min_solid_angle_filter() {
+        let fcc = make_fcc(Element::Cu, 3.61);
+        let low = get_voronoi_neighbors(
+            &fcc,
+            0,
+            Some(&VoronoiConfig {
+                min_solid_angle: 0.0,
+            }),
+        );
+        let high = get_voronoi_neighbors(
+            &fcc,
+            0,
+            Some(&VoronoiConfig {
+                min_solid_angle: 0.5,
+            }),
+        );
+        assert!(low.len() >= high.len());
+    }
+
+    #[test]
+    fn test_simple_cubic_voronoi() {
+        let lattice = Lattice::cubic(3.0);
+        let sc = Structure::new(
+            lattice,
+            vec![Species::neutral(Element::Cu)],
+            vec![Vector3::zeros()],
+        );
+        assert_eq!(get_cn_voronoi(&sc, 0, None), 6.0);
+    }
+
+    #[test]
+    #[should_panic(expected = "out of bounds")]
+    fn test_site_bounds_cutoff() {
+        get_coordination_number(&make_fcc(Element::Cu, 3.61), 100, 3.0);
+    }
+
+    #[test]
+    #[should_panic(expected = "out of bounds")]
+    fn test_site_bounds_voronoi() {
+        get_cn_voronoi(&make_fcc(Element::Cu, 3.61), 100, None);
+    }
+}

--- a/extensions/rust/src/lib.rs
+++ b/extensions/rust/src/lib.rs
@@ -42,6 +42,7 @@ pub mod structure;
 // Algorithms
 pub mod algorithms;
 pub mod batch;
+pub mod coordination;
 pub mod matcher;
 pub mod pbc;
 

--- a/extensions/rust/src/python.rs
+++ b/extensions/rust/src/python.rs
@@ -2198,9 +2198,9 @@ fn get_neighbors(
 
 /// Validate and create VoronoiConfig from min_solid_angle.
 fn make_voronoi_config(min_solid_angle: f64) -> PyResult<crate::coordination::VoronoiConfig> {
-    if min_solid_angle < 0.0 {
+    if !(0.0..=1.0).contains(&min_solid_angle) {
         return Err(PyValueError::new_err(
-            "min_solid_angle must be non-negative",
+            "min_solid_angle must be between 0.0 and 1.0 inclusive",
         ));
     }
     Ok(crate::coordination::VoronoiConfig { min_solid_angle })

--- a/extensions/rust/src/structure.rs
+++ b/extensions/rust/src/structure.rs
@@ -320,7 +320,10 @@ impl Structure {
         })
     }
 
-    /// Get the Hermann-Mauguin spacegroup symbol (e.g., "Fm-3m", "P2_1/c").
+    /// Get the Hermann-Mauguin spacegroup symbol (e.g., "F m -3 m", "P 2_1/c").
+    ///
+    /// Note: Returns space-separated tokens as provided by the underlying
+    /// symmetry library (moyo). For condensed symbols, post-process by removing spaces.
     pub fn get_spacegroup_symbol(&self, symprec: f64) -> Result<String> {
         Ok(self.get_symmetry_dataset(symprec)?.hm_symbol)
     }

--- a/extensions/rust/src/structure.rs
+++ b/extensions/rust/src/structure.rs
@@ -759,6 +759,7 @@ impl Structure {
     /// # Arguments
     ///
     /// * `site_idx` - Index of the site to analyze
+    /// * `config` - Optional configuration (min_solid_angle threshold)
     ///
     /// # Returns
     ///
@@ -767,8 +768,12 @@ impl Structure {
     /// # Panics
     ///
     /// Panics if `site_idx` is out of bounds.
-    pub fn get_cn_voronoi(&self, site_idx: usize) -> f64 {
-        crate::coordination::get_cn_voronoi(self, site_idx, None)
+    pub fn get_cn_voronoi(
+        &self,
+        site_idx: usize,
+        config: Option<&crate::coordination::VoronoiConfig>,
+    ) -> f64 {
+        crate::coordination::get_cn_voronoi(self, site_idx, config)
     }
 
     /// Get Voronoi-weighted coordination numbers for all sites.
@@ -778,11 +783,18 @@ impl Structure {
     /// **Note**: Results are only geometrically correct for orthogonal lattices
     /// (cubic/tetragonal/orthorhombic). Use cutoff-based methods for non-orthogonal cells.
     ///
+    /// # Arguments
+    ///
+    /// * `config` - Optional configuration (min_solid_angle threshold)
+    ///
     /// # Returns
     ///
     /// A vector of effective coordination numbers, one for each site.
-    pub fn get_cn_voronoi_all(&self) -> Vec<f64> {
-        crate::coordination::get_cn_voronoi_all(self, None)
+    pub fn get_cn_voronoi_all(
+        &self,
+        config: Option<&crate::coordination::VoronoiConfig>,
+    ) -> Vec<f64> {
+        crate::coordination::get_cn_voronoi_all(self, config)
     }
 
     /// Get Voronoi neighbors with their solid angle fractions for a site.
@@ -795,12 +807,17 @@ impl Structure {
     /// # Arguments
     ///
     /// * `site_idx` - Index of the site to analyze
+    /// * `config` - Optional configuration (min_solid_angle threshold)
     ///
     /// # Returns
     ///
     /// A vector of tuples `(neighbor_idx, solid_angle_fraction)`.
-    pub fn get_voronoi_neighbors(&self, site_idx: usize) -> Vec<(usize, f64)> {
-        crate::coordination::get_voronoi_neighbors(self, site_idx, None)
+    pub fn get_voronoi_neighbors(
+        &self,
+        site_idx: usize,
+        config: Option<&crate::coordination::VoronoiConfig>,
+    ) -> Vec<(usize, f64)> {
+        crate::coordination::get_voronoi_neighbors(self, site_idx, config)
     }
 
     // =========================================================================

--- a/extensions/rust/src/structure.rs
+++ b/extensions/rust/src/structure.rs
@@ -753,6 +753,9 @@ impl Structure {
     ///
     /// Uses Voronoi tessellation to determine neighbors based on solid angle.
     ///
+    /// **Note**: Results are only geometrically correct for orthogonal lattices
+    /// (cubic/tetragonal/orthorhombic). Use cutoff-based methods for non-orthogonal cells.
+    ///
     /// # Arguments
     ///
     /// * `site_idx` - Index of the site to analyze
@@ -772,6 +775,9 @@ impl Structure {
     ///
     /// Uses Voronoi tessellation to determine neighbors based on solid angle.
     ///
+    /// **Note**: Results are only geometrically correct for orthogonal lattices
+    /// (cubic/tetragonal/orthorhombic). Use cutoff-based methods for non-orthogonal cells.
+    ///
     /// # Returns
     ///
     /// A vector of effective coordination numbers, one for each site.
@@ -782,6 +788,9 @@ impl Structure {
     /// Get Voronoi neighbors with their solid angle fractions for a site.
     ///
     /// Returns neighbors sorted by solid angle (largest first).
+    ///
+    /// **Note**: Results are only geometrically correct for orthogonal lattices
+    /// (cubic/tetragonal/orthorhombic). Use cutoff-based methods for non-orthogonal cells.
     ///
     /// # Arguments
     ///

--- a/extensions/rust/src/structure.rs
+++ b/extensions/rust/src/structure.rs
@@ -687,6 +687,114 @@ impl Structure {
     }
 
     // =========================================================================
+    // Coordination Analysis
+    // =========================================================================
+
+    /// Get coordination numbers for all sites using a distance cutoff.
+    ///
+    /// Counts the number of neighbors within the specified cutoff distance for each site.
+    /// Uses periodic boundary conditions.
+    ///
+    /// # Arguments
+    ///
+    /// * `cutoff` - Maximum distance (in Angstroms) to consider a site as a neighbor
+    ///
+    /// # Returns
+    ///
+    /// A vector of coordination numbers, one for each site in the structure.
+    pub fn get_coordination_numbers(&self, cutoff: f64) -> Vec<usize> {
+        crate::coordination::get_coordination_numbers(self, cutoff)
+    }
+
+    /// Get coordination number for a single site using a distance cutoff.
+    ///
+    /// # Arguments
+    ///
+    /// * `site_idx` - Index of the site to analyze
+    /// * `cutoff` - Maximum distance (in Angstroms) to consider a site as a neighbor
+    ///
+    /// # Returns
+    ///
+    /// The coordination number for the specified site.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `site_idx` is out of bounds.
+    pub fn get_coordination_number(&self, site_idx: usize, cutoff: f64) -> usize {
+        crate::coordination::get_coordination_number(self, site_idx, cutoff)
+    }
+
+    /// Get the local environment (detailed neighbor information) for a site.
+    ///
+    /// Returns detailed information about each neighbor including species, distance,
+    /// and periodic image offset.
+    ///
+    /// # Arguments
+    ///
+    /// * `site_idx` - Index of the site to analyze
+    /// * `cutoff` - Maximum distance (in Angstroms) to consider a site as a neighbor
+    ///
+    /// # Returns
+    ///
+    /// A vector of `LocalEnvNeighbor` structs describing each neighbor.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `site_idx` is out of bounds.
+    pub fn get_local_environment(
+        &self,
+        site_idx: usize,
+        cutoff: f64,
+    ) -> Vec<crate::coordination::LocalEnvNeighbor> {
+        crate::coordination::get_local_environment(self, site_idx, cutoff)
+    }
+
+    /// Get Voronoi-weighted coordination number for a single site.
+    ///
+    /// Uses Voronoi tessellation to determine neighbors based on solid angle.
+    ///
+    /// # Arguments
+    ///
+    /// * `site_idx` - Index of the site to analyze
+    ///
+    /// # Returns
+    ///
+    /// The effective coordination number (can be fractional).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `site_idx` is out of bounds.
+    pub fn get_cn_voronoi(&self, site_idx: usize) -> f64 {
+        crate::coordination::get_cn_voronoi(self, site_idx, None)
+    }
+
+    /// Get Voronoi-weighted coordination numbers for all sites.
+    ///
+    /// Uses Voronoi tessellation to determine neighbors based on solid angle.
+    ///
+    /// # Returns
+    ///
+    /// A vector of effective coordination numbers, one for each site.
+    pub fn get_cn_voronoi_all(&self) -> Vec<f64> {
+        crate::coordination::get_cn_voronoi_all(self, None)
+    }
+
+    /// Get Voronoi neighbors with their solid angle fractions for a site.
+    ///
+    /// Returns neighbors sorted by solid angle (largest first).
+    ///
+    /// # Arguments
+    ///
+    /// * `site_idx` - Index of the site to analyze
+    ///
+    /// # Returns
+    ///
+    /// A vector of tuples `(neighbor_idx, solid_angle_fraction)`.
+    pub fn get_voronoi_neighbors(&self, site_idx: usize) -> Vec<(usize, f64)> {
+        crate::coordination::get_voronoi_neighbors(self, site_idx, None)
+    }
+
+    // =========================================================================
     // Structure Interpolation (NEB)
     // =========================================================================
 

--- a/extensions/rust/tests/benchmark_pymatgen.py
+++ b/extensions/rust/tests/benchmark_pymatgen.py
@@ -16,11 +16,9 @@ import json
 import time
 import warnings
 from collections import defaultdict
-from pathlib import Path
 
 from pymatgen.analysis.structure_matcher import StructureMatcher as PyMatcher
 from pymatgen.core import Structure
-
 from test_pymatgen_compat import (
     BASE_STRUCTURES,
     MATTERVIZ_STRUCTURES_DIR,
@@ -59,7 +57,9 @@ def load_matterviz_structures() -> dict[str, Structure]:
             with gzip.open(gz_file, "rt") as fh:
                 data = json.load(fh)
             if data.get("@class") == "Structure":
-                structures[gz_file.stem.replace(".json", "")] = Structure.from_dict(data)
+                structures[gz_file.stem.replace(".json", "")] = Structure.from_dict(
+                    data
+                )
         except Exception as exc:
             warnings.warn(f"Failed to load {gz_file.stem}: {exc}", stacklevel=2)
 
@@ -158,7 +158,9 @@ def benchmark(quick: bool = False) -> None:
         status = "✓" if passed == total else "✗"
         print(f"  {status} {category}: {passed}/{total}")
 
-    print(f"\nTotal: {total_passed}/{total_tests} ({100 * total_passed / total_tests:.1f}%)")
+    print(
+        f"\nTotal: {total_passed}/{total_tests} ({100 * total_passed / total_tests:.1f}%)"
+    )
     print(f"Time: {elapsed:.2f}s")
 
     # Show failures
@@ -181,6 +183,8 @@ def benchmark(quick: bool = False) -> None:
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--quick", action="store_true", help="Quick synthetic-only benchmark")
+    parser.add_argument(
+        "--quick", action="store_true", help="Quick synthetic-only benchmark"
+    )
     args = parser.parse_args()
     benchmark(quick=args.quick)

--- a/extensions/rust/tests/benchmark_pymatgen.py
+++ b/extensions/rust/tests/benchmark_pymatgen.py
@@ -158,9 +158,8 @@ def benchmark(quick: bool = False) -> None:
         status = "✓" if passed == total else "✗"
         print(f"  {status} {category}: {passed}/{total}")
 
-    print(
-        f"\nTotal: {total_passed}/{total_tests} ({100 * total_passed / total_tests:.1f}%)"
-    )
+    pct = 100 * total_passed / total_tests if total_tests else 0.0
+    print(f"\nTotal: {total_passed}/{total_tests} ({pct:.1f}%)")
     print(f"Time: {elapsed:.2f}s")
 
     # Show failures

--- a/extensions/rust/tests/test_coordination.py
+++ b/extensions/rust/tests/test_coordination.py
@@ -217,12 +217,12 @@ class TestVoronoiErrors:
 class TestRocksaltElementTypes:
     """Verify correct element identification in mixed structures."""
 
-    @pytest.mark.parametrize(("site_idx", "expected_element", "expected_neighbor"), [
-        (0, "Na", "Cl"),  # Na at origin
-        (4, "Cl", "Na"),  # Cl at (0.5,0,0)
+    @pytest.mark.parametrize(("site_idx", "expected_neighbor"), [
+        (0, "Cl"),  # Na at origin has Cl neighbors
+        (4, "Na"),  # Cl at (0.5,0,0) has Na neighbors
     ])
     def test_neighbor_elements(
-        self, rocksalt_nacl_json: str, site_idx: int, expected_element: str, expected_neighbor: str
+        self, rocksalt_nacl_json: str, site_idx: int, expected_neighbor: str
     ) -> None:
         """Each site has 6 neighbors of the opposite element type."""
         neighbors = ferrox.get_local_environment(rocksalt_nacl_json, site_idx, 3.5)

--- a/extensions/rust/tests/test_coordination.py
+++ b/extensions/rust/tests/test_coordination.py
@@ -146,7 +146,7 @@ class TestVoronoiCoordination:
     def test_simple_cubic_voronoi(self) -> None:
         """Simple cubic: CN=6 (cube faces)."""
         sc_json = make_structure(3.0, [site("Cu", [0.0, 0.0, 0.0])])
-        assert ferrox.get_cn_voronoi(sc_json, 0) == 6.0
+        assert ferrox.get_cn_voronoi(sc_json, 0) == pytest.approx(6.0, abs=1e-6)
 
     @pytest.mark.parametrize("func", [
         pytest.param(lambda s: ferrox.get_cn_voronoi(s, 0, min_solid_angle=-0.1), id="cn"),

--- a/extensions/rust/tests/test_coordination.py
+++ b/extensions/rust/tests/test_coordination.py
@@ -1,0 +1,259 @@
+"""Tests for ferrox coordination analysis functions."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+try:
+    from ferrox import _ferrox as ferrox
+except ImportError:
+    pytest.skip("ferrox not installed", allow_module_level=True)
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+def make_structure(lattice_a: float, sites: list[dict]) -> str:
+    """Helper to create structure JSON."""
+    return json.dumps({
+        "@module": "pymatgen.core.structure",
+        "@class": "Structure",
+        "lattice": {"matrix": [[lattice_a, 0, 0], [0, lattice_a, 0], [0, 0, lattice_a]]},
+        "sites": sites,
+    })
+
+
+def site(element: str, abc: list[float]) -> dict:
+    """Helper to create a site dict."""
+    return {"species": [{"element": element, "occu": 1}], "abc": abc}
+
+
+@pytest.fixture
+def fcc_cu_json() -> str:
+    """FCC Cu conventional cell (4 atoms, CN=12)."""
+    return make_structure(3.61, [
+        site("Cu", [0.0, 0.0, 0.0]), site("Cu", [0.5, 0.5, 0.0]),
+        site("Cu", [0.5, 0.0, 0.5]), site("Cu", [0.0, 0.5, 0.5]),
+    ])
+
+
+@pytest.fixture
+def bcc_fe_json() -> str:
+    """BCC Fe conventional cell (2 atoms, CN=8 for first shell)."""
+    return make_structure(2.87, [site("Fe", [0.0, 0.0, 0.0]), site("Fe", [0.5, 0.5, 0.5])])
+
+
+@pytest.fixture
+def rocksalt_nacl_json() -> str:
+    """NaCl rocksalt conventional cell (8 atoms, CN=6)."""
+    return make_structure(5.64, [
+        # Na FCC positions
+        site("Na", [0.0, 0.0, 0.0]), site("Na", [0.5, 0.5, 0.0]),
+        site("Na", [0.5, 0.0, 0.5]), site("Na", [0.0, 0.5, 0.5]),
+        # Cl FCC positions shifted
+        site("Cl", [0.5, 0.0, 0.0]), site("Cl", [0.0, 0.5, 0.0]),
+        site("Cl", [0.0, 0.0, 0.5]), site("Cl", [0.5, 0.5, 0.5]),
+    ])
+
+
+# ============================================================================
+# Cutoff-based coordination tests
+# ============================================================================
+
+
+class TestCutoffCoordination:
+    """Tests for cutoff-based coordination number functions."""
+
+    @pytest.mark.parametrize(("fixture", "cutoff", "num_sites", "expected_cn"), [
+        ("fcc_cu_json", 3.0, 4, 12),
+        ("bcc_fe_json", 2.6, 2, 8),  # first shell only
+        ("bcc_fe_json", 3.0, 2, 14),  # both shells
+        ("rocksalt_nacl_json", 3.5, 8, 6),
+    ])
+    def test_coordination_numbers(
+        self, fixture: str, cutoff: float, num_sites: int, expected_cn: int, request: pytest.FixtureRequest
+    ) -> None:
+        """Verify coordination numbers for standard structures."""
+        struct_json = request.getfixturevalue(fixture)
+        cns = ferrox.get_coordination_numbers(struct_json, cutoff)
+        assert len(cns) == num_sites
+        assert all(cn == expected_cn for cn in cns), f"Expected CN={expected_cn}, got {cns}"
+
+    def test_single_site_coordination(self, fcc_cu_json: str) -> None:
+        """get_coordination_number returns single site CN."""
+        assert ferrox.get_coordination_number(fcc_cu_json, 0, 3.0) == 12
+
+    def test_zero_cutoff(self, fcc_cu_json: str) -> None:
+        """Zero cutoff gives CN=0."""
+        assert all(cn == 0 for cn in ferrox.get_coordination_numbers(fcc_cu_json, 0.0))
+
+    def test_negative_cutoff_error(self, fcc_cu_json: str) -> None:
+        """Negative cutoff raises ValueError."""
+        with pytest.raises(ValueError, match="non-negative"):
+            ferrox.get_coordination_numbers(fcc_cu_json, -1.0)
+
+
+class TestLocalEnvironment:
+    """Tests for get_local_environment function."""
+
+    def test_local_environment_fcc(self, fcc_cu_json: str) -> None:
+        """Local environment returns correct neighbors with required fields."""
+        neighbors = ferrox.get_local_environment(fcc_cu_json, 0, 3.0)
+        assert len(neighbors) == 12
+
+        # Check structure and values
+        expected_dist = 3.61 / 2**0.5  # a/sqrt(2) ≈ 2.55 Å
+        for n in neighbors:
+            assert n["element"] == "Cu"
+            assert abs(n["distance"] - expected_dist) < 0.1
+            assert len(n["image"]) == 3
+            assert all(isinstance(i, int) for i in n["image"])
+            assert isinstance(n["species"], str) and "Cu" in n["species"]
+
+    def test_distances_sorted(self, fcc_cu_json: str) -> None:
+        """Neighbors are sorted by distance."""
+        neighbors = ferrox.get_local_environment(fcc_cu_json, 0, 5.0)
+        distances = [n["distance"] for n in neighbors]
+        assert distances == sorted(distances)
+
+    def test_periodic_images_present(self, fcc_cu_json: str) -> None:
+        """FCC has neighbors in periodic images."""
+        neighbors = ferrox.get_local_environment(fcc_cu_json, 0, 3.0)
+        assert any(any(i != 0 for i in n["image"]) for n in neighbors)
+
+    def test_site_bounds_error(self, fcc_cu_json: str) -> None:
+        """Out of bounds site raises error."""
+        with pytest.raises((ValueError, IndexError)):
+            ferrox.get_local_environment(fcc_cu_json, 100, 3.0)
+
+
+# ============================================================================
+# Voronoi-based coordination tests
+# ============================================================================
+
+
+class TestVoronoiCoordination:
+    """Tests for Voronoi-based coordination number functions."""
+
+    def test_voronoi_fcc(self, fcc_cu_json: str) -> None:
+        """FCC Cu has ~12 Voronoi neighbors."""
+        cns = ferrox.get_cn_voronoi_all(fcc_cu_json)
+        assert len(cns) == 4
+        assert all(10 <= cn <= 14 for cn in cns)
+
+        # Single site agrees
+        assert 10 <= ferrox.get_cn_voronoi(fcc_cu_json, 0) <= 14
+
+    def test_voronoi_neighbors(self, fcc_cu_json: str) -> None:
+        """Voronoi neighbors have valid structure and are sorted by solid angle."""
+        neighbors = ferrox.get_voronoi_neighbors(fcc_cu_json, 0)
+        assert len(neighbors) > 0
+
+        solid_angles = []
+        for site_idx, solid_angle in neighbors:
+            assert isinstance(site_idx, int)
+            assert 0 <= solid_angle <= 1.0
+            solid_angles.append(solid_angle)
+
+        # Sorted descending by solid angle
+        assert solid_angles == sorted(solid_angles, reverse=True)
+
+    def test_voronoi_local_environment(self, fcc_cu_json: str) -> None:
+        """Voronoi local environment has solid angles and species."""
+        neighbors = ferrox.get_local_environment_voronoi(fcc_cu_json, 0)
+        assert len(neighbors) > 0
+
+        for n in neighbors:
+            assert n["element"] == "Cu"
+            assert n["solid_angle"] > 0
+            assert isinstance(n["species"], str)
+
+    def test_min_solid_angle_filter(self, fcc_cu_json: str) -> None:
+        """Higher min_solid_angle filters more neighbors."""
+        low = ferrox.get_voronoi_neighbors(fcc_cu_json, 0, min_solid_angle=0.0)
+        default = ferrox.get_voronoi_neighbors(fcc_cu_json, 0)  # 0.01
+        high = ferrox.get_voronoi_neighbors(fcc_cu_json, 0, min_solid_angle=0.1)
+        assert len(low) >= len(default) >= len(high)
+
+    def test_simple_cubic_voronoi(self) -> None:
+        """Single atom simple cubic has CN=6 (cube with 6 faces)."""
+        sc_json = make_structure(3.0, [site("Cu", [0.0, 0.0, 0.0])])
+        assert ferrox.get_cn_voronoi(sc_json, 0) == 6.0
+
+
+class TestVoronoiErrors:
+    """Tests for Voronoi method error handling."""
+
+    @pytest.mark.parametrize("func", [
+        lambda s: ferrox.get_cn_voronoi(s, 0, min_solid_angle=-0.1),
+        lambda s: ferrox.get_cn_voronoi_all(s, min_solid_angle=-0.1),
+        lambda s: ferrox.get_voronoi_neighbors(s, 0, min_solid_angle=-0.1),
+    ])
+    def test_negative_solid_angle_error(self, fcc_cu_json: str, func) -> None:
+        """Negative min_solid_angle raises ValueError."""
+        with pytest.raises(ValueError, match="non-negative"):
+            func(fcc_cu_json)
+
+    @pytest.mark.parametrize("func", [
+        lambda s: ferrox.get_cn_voronoi(s, 100),
+        lambda s: ferrox.get_voronoi_neighbors(s, 100),
+        lambda s: ferrox.get_local_environment_voronoi(s, 100),
+    ])
+    def test_site_bounds_error(self, fcc_cu_json: str, func) -> None:
+        """Out of bounds site raises error."""
+        with pytest.raises((ValueError, IndexError)):
+            func(fcc_cu_json)
+
+
+# ============================================================================
+# Rocksalt element type tests
+# ============================================================================
+
+
+class TestRocksaltElementTypes:
+    """Verify correct element identification in mixed structures."""
+
+    @pytest.mark.parametrize(("site_idx", "expected_element", "expected_neighbor"), [
+        (0, "Na", "Cl"),  # Na at origin
+        (4, "Cl", "Na"),  # Cl at (0.5,0,0)
+    ])
+    def test_neighbor_elements(
+        self, rocksalt_nacl_json: str, site_idx: int, expected_element: str, expected_neighbor: str
+    ) -> None:
+        """Each site has 6 neighbors of the opposite element type."""
+        neighbors = ferrox.get_local_environment(rocksalt_nacl_json, site_idx, 3.5)
+        assert len(neighbors) == 6
+        assert all(n["element"] == expected_neighbor for n in neighbors)
+
+    def test_voronoi_element_types(self, rocksalt_nacl_json: str) -> None:
+        """Voronoi also identifies correct neighbor elements."""
+        neighbors = ferrox.get_local_environment_voronoi(rocksalt_nacl_json, 0)
+        cl_count = sum(1 for n in neighbors if n["element"] == "Cl")
+        assert cl_count >= 4  # Na should have mostly Cl neighbors
+
+
+# ============================================================================
+# Edge cases
+# ============================================================================
+
+
+class TestEdgeCases:
+    """Edge case and boundary condition tests."""
+
+    def test_empty_structure(self) -> None:
+        """Empty structure returns empty results."""
+        empty_json = make_structure(5.0, [])
+        assert ferrox.get_coordination_numbers(empty_json, 3.0) == []
+        assert ferrox.get_cn_voronoi_all(empty_json) == []
+
+    def test_methods_consistent(self, fcc_cu_json: str) -> None:
+        """Cutoff and Voronoi methods give similar results for FCC."""
+        cutoff_cns = ferrox.get_coordination_numbers(fcc_cu_json, 3.0)
+        voronoi_cns = ferrox.get_cn_voronoi_all(fcc_cu_json)
+
+        assert all(cn == 12 for cn in cutoff_cns)
+        assert all(abs(cn - 12) <= 2 for cn in voronoi_cns)

--- a/extensions/rust/tests/test_coordination.py
+++ b/extensions/rust/tests/test_coordination.py
@@ -130,6 +130,15 @@ class TestLocalEnvironment:
         with pytest.raises((ValueError, IndexError)):
             ferrox.get_local_environment(fcc_cu_json, 100, 3.0)
 
+    def test_get_neighbors(self, bcc_fe_json: str) -> None:
+        """get_neighbors returns (site_idx, distance, image) tuples."""
+        neighbors = ferrox.get_neighbors(bcc_fe_json, 0, 2.6)
+        assert len(neighbors) == 8
+        for site_idx, dist, image in neighbors:
+            assert isinstance(site_idx, int)
+            assert 2.0 < dist < 2.7
+            assert len(image) == 3
+
 
 # ============================================================================
 # Voronoi-based coordination tests
@@ -189,9 +198,9 @@ class TestVoronoiErrors:
     """Tests for Voronoi method error handling."""
 
     @pytest.mark.parametrize("func", [
-        lambda s: ferrox.get_cn_voronoi(s, 0, min_solid_angle=-0.1),
-        lambda s: ferrox.get_cn_voronoi_all(s, min_solid_angle=-0.1),
-        lambda s: ferrox.get_voronoi_neighbors(s, 0, min_solid_angle=-0.1),
+        pytest.param(lambda s: ferrox.get_cn_voronoi(s, 0, min_solid_angle=-0.1), id="get_cn_voronoi"),
+        pytest.param(lambda s: ferrox.get_cn_voronoi_all(s, min_solid_angle=-0.1), id="get_cn_voronoi_all"),
+        pytest.param(lambda s: ferrox.get_voronoi_neighbors(s, 0, min_solid_angle=-0.1), id="get_voronoi_neighbors"),
     ])
     def test_negative_solid_angle_error(self, fcc_cu_json: str, func) -> None:
         """Negative min_solid_angle raises ValueError."""
@@ -199,9 +208,9 @@ class TestVoronoiErrors:
             func(fcc_cu_json)
 
     @pytest.mark.parametrize("func", [
-        lambda s: ferrox.get_cn_voronoi(s, 100),
-        lambda s: ferrox.get_voronoi_neighbors(s, 100),
-        lambda s: ferrox.get_local_environment_voronoi(s, 100),
+        pytest.param(lambda s: ferrox.get_cn_voronoi(s, 100), id="get_cn_voronoi"),
+        pytest.param(lambda s: ferrox.get_voronoi_neighbors(s, 100), id="get_voronoi_neighbors"),
+        pytest.param(lambda s: ferrox.get_local_environment_voronoi(s, 100), id="get_local_environment_voronoi"),
     ])
     def test_site_bounds_error(self, fcc_cu_json: str, func) -> None:
         """Out of bounds site raises error."""
@@ -233,7 +242,7 @@ class TestRocksaltElementTypes:
         """Voronoi also identifies correct neighbor elements."""
         neighbors = ferrox.get_local_environment_voronoi(rocksalt_nacl_json, 0)
         cl_count = sum(1 for n in neighbors if n["element"] == "Cl")
-        assert cl_count >= 4  # Na should have mostly Cl neighbors
+        assert cl_count >= 5  # Na should have 6 Cl neighbors in rocksalt
 
 
 # ============================================================================

--- a/extensions/rust/tests/test_coordination.py
+++ b/extensions/rust/tests/test_coordination.py
@@ -155,7 +155,7 @@ class TestVoronoiCoordination:
     ])
     def test_negative_solid_angle_error(self, fcc_cu_json: str, func) -> None:
         """Negative min_solid_angle raises ValueError."""
-        with pytest.raises(ValueError, match="non-negative"):
+        with pytest.raises(ValueError, match="0.0 and 1.0"):
             func(fcc_cu_json)
 
     @pytest.mark.parametrize("func", [

--- a/extensions/rust/tests/test_pymatgen_compat.py
+++ b/extensions/rust/tests/test_pymatgen_compat.py
@@ -1,6 +1,6 @@
 """Compatibility tests comparing ferrox vs pymatgen StructureMatcher.
 
-Run with: pytest tests/test_pymatgen_compat.py -v
+Run with: pytest extensions/rust/tests/test_pymatgen_compat.py -v
 """
 
 from __future__ import annotations
@@ -707,7 +707,7 @@ class TestMattervizStructures:
                 data = json.loads(json_file.read_text())
                 if data.get("@class") == "Structure":
                     result[json_file.stem] = Structure.from_dict(data)
-            except Exception as exc:
+            except (json.JSONDecodeError, ValueError, TypeError, KeyError, OSError) as exc:
                 warnings.warn(f"Failed to load {json_file.stem}: {exc}", stacklevel=2)
         return result
 
@@ -733,7 +733,7 @@ class TestPymatgenCifStructures:
         for cif_file in PYMATGEN_CIF_DIR.glob("*.cif"):
             try:
                 result[cif_file.stem] = Structure.from_file(str(cif_file))
-            except Exception as exc:
+            except (ValueError, TypeError, KeyError, OSError) as exc:
                 warnings.warn(f"Failed to load {cif_file.stem}: {exc}", stacklevel=2)
         return result
 

--- a/extensions/rust/tests/test_pymatgen_compat.py
+++ b/extensions/rust/tests/test_pymatgen_compat.py
@@ -23,7 +23,10 @@ if TYPE_CHECKING:
 try:
     from ferrox import StructureMatcher as RustMatcher
 except ImportError:
-    pytest.skip("ferrox not installed. Run: maturin develop --features python", allow_module_level=True)
+    pytest.skip(
+        "ferrox not installed. Run: maturin develop --features python",
+        allow_module_level=True,
+    )
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 MATTERVIZ_STRUCTURES_DIR = Path(
@@ -82,9 +85,7 @@ def make_cubic(element: str, a: float) -> Structure:
 
 def make_bcc(element: str, a: float) -> Structure:
     """BCC structure."""
-    return Structure(
-        Lattice.cubic(a), [element, element], [[0, 0, 0], [0.5, 0.5, 0.5]]
-    )
+    return Structure(Lattice.cubic(a), [element, element], [[0, 0, 0], [0.5, 0.5, 0.5]])
 
 
 def make_fcc(element: str, a: float) -> Structure:
@@ -124,7 +125,12 @@ def make_wurtzite(cation: str, anion: str, a: float, c: float) -> Structure:
     return Structure(
         Lattice.hexagonal(a, c),
         [cation, cation, anion, anion],
-        [[1 / 3, 2 / 3, 0], [2 / 3, 1 / 3, 0.5], [1 / 3, 2 / 3, 0.375], [2 / 3, 1 / 3, 0.875]],
+        [
+            [1 / 3, 2 / 3, 0],
+            [2 / 3, 1 / 3, 0.5],
+            [1 / 3, 2 / 3, 0.375],
+            [2 / 3, 1 / 3, 0.875],
+        ],
     )
 
 
@@ -134,8 +140,14 @@ def make_diamond(element: str, a: float) -> Structure:
         Lattice.cubic(a),
         [element] * 8,
         [
-            [0, 0, 0], [0.5, 0.5, 0], [0.5, 0, 0.5], [0, 0.5, 0.5],
-            [0.25, 0.25, 0.25], [0.75, 0.75, 0.25], [0.75, 0.25, 0.75], [0.25, 0.75, 0.75],
+            [0, 0, 0],
+            [0.5, 0.5, 0],
+            [0.5, 0, 0.5],
+            [0, 0.5, 0.5],
+            [0.25, 0.25, 0.25],
+            [0.75, 0.75, 0.25],
+            [0.75, 0.25, 0.75],
+            [0.25, 0.75, 0.75],
         ],
     )
 
@@ -205,12 +217,14 @@ class TestSelfMatching:
     @pytest.mark.parametrize("struct", BASE_STRUCTURES, ids=BASE_STRUCTURE_IDS)
     def test_base_structures(self, compare: Callable, struct: Structure) -> None:
         """Base structures match themselves."""
-        assert compare(struct, struct) is True
+        assert compare(struct, struct) is True, f"{name} should self-match"
 
     def test_triclinic(self, compare: Callable) -> None:
         """Triclinic lattice self-match."""
         struct = Structure(
-            Lattice.from_parameters(3.0, 4.0, 5.0, 80.0, 85.0, 95.0), ["Ca"], [[0, 0, 0]]
+            Lattice.from_parameters(3.0, 4.0, 5.0, 80.0, 85.0, 95.0),
+            ["Ca"],
+            [[0, 0, 0]],
         )
         assert compare(struct, struct) is True
 
@@ -233,7 +247,9 @@ class TestPerturbations:
         self, compare: Callable, struct: Structure, magnitude: float
     ) -> None:
         """Small coordinate perturbations should match."""
-        assert compare(struct, perturb(struct, magnitude)) is True
+        assert compare(struct, perturb(struct, magnitude)) is True, (
+            f"{name} ±{magnitude}"
+        )
 
     @pytest.mark.parametrize("struct", BASE_STRUCTURES, ids=BASE_STRUCTURE_IDS)
     @pytest.mark.parametrize("factor", [0.98, 1.02, 1.05])
@@ -241,7 +257,9 @@ class TestPerturbations:
         self, compare: Callable, struct: Structure, factor: float
     ) -> None:
         """Lattice scaling within tolerance should match."""
-        assert compare(struct, scale_lattice(struct, factor)) is True
+        assert compare(struct, scale_lattice(struct, factor)) is True, (
+            f"{name} ×{factor}"
+        )
 
     @pytest.mark.parametrize("struct", BASE_STRUCTURES, ids=BASE_STRUCTURE_IDS)
     @pytest.mark.parametrize("strain", [0.01, 0.02])
@@ -249,7 +267,9 @@ class TestPerturbations:
         self, compare: Callable, struct: Structure, strain: float
     ) -> None:
         """Uniaxial strain within tolerance should match."""
-        assert compare(struct, strain_lattice(struct, strain)) is True
+        assert compare(struct, strain_lattice(struct, strain)) is True, (
+            f"{name} +{strain}"
+        )
 
 
 class TestNonMatching:
@@ -263,10 +283,15 @@ class TestNonMatching:
             (make_fcc("Cu", 3.6), make_fcc("Al", 4.05)),
             (make_rocksalt("Na", "Cl", 5.64), make_rocksalt("Mg", "O", 4.21)),
             (make_bcc("Fe", 2.87), make_fcc("Fe", 3.6)),  # same element, diff structure
-            (make_cubic("Cu", 3.6), make_fcc("Cu", 3.6)),  # same element, diff structure
+            (
+                make_cubic("Cu", 3.6),
+                make_fcc("Cu", 3.6),
+            ),  # same element, diff structure
         ],
     )
-    def test_different_structures(self, compare: Callable, s1: Structure, s2: Structure) -> None:
+    def test_different_structures(
+        self, compare: Callable, s1: Structure, s2: Structure
+    ) -> None:
         """Different structures should not match."""
         assert compare(s1, s2) is False
 
@@ -296,14 +321,20 @@ class TestEdgeCases:
 
     def test_left_vs_right_handed_lattice(self, compare: Callable) -> None:
         """Left-handed vs right-handed lattice."""
-        s_left = Structure(Lattice([[-4.0, 0, 0], [0, 4.0, 0], [0, 0, 4.0]]), ["Ag"], [[0, 0, 0]])
-        s_right = Structure(Lattice([[4.0, 0, 0], [0, 4.0, 0], [0, 0, 4.0]]), ["Ag"], [[0, 0, 0]])
+        s_left = Structure(
+            Lattice([[-4.0, 0, 0], [0, 4.0, 0], [0, 0, 4.0]]), ["Ag"], [[0, 0, 0]]
+        )
+        s_right = Structure(
+            Lattice([[4.0, 0, 0], [0, 4.0, 0], [0, 0, 4.0]]), ["Ag"], [[0, 0, 0]]
+        )
         compare(s_left, s_right)  # just check agreement, result may vary
 
     def test_coords_outside_unit_cell(self, compare: Callable) -> None:
         """Coordinates outside [0,1) should wrap correctly."""
         lattice = Lattice.cubic(5.0)
-        s_outside = Structure(lattice, ["Li", "Li"], [[1.5, 0.3, 0.2], [-0.3, 0.7, 0.8]])
+        s_outside = Structure(
+            lattice, ["Li", "Li"], [[1.5, 0.3, 0.2], [-0.3, 0.7, 0.8]]
+        )
         s_wrapped = Structure(lattice, ["Li", "Li"], [[0.5, 0.3, 0.2], [0.7, 0.7, 0.8]])
         assert compare(s_outside, s_wrapped) is True
 
@@ -315,14 +346,18 @@ class TestEdgeCases:
     def test_needle_cell(self, compare: Callable) -> None:
         """Needle-like cell (c >> a)."""
         struct = Structure(
-            Lattice.from_parameters(2.0, 2.0, 20.0, 90.0, 90.0, 90.0), ["C"], [[0, 0, 0]]
+            Lattice.from_parameters(2.0, 2.0, 20.0, 90.0, 90.0, 90.0),
+            ["C"],
+            [[0, 0, 0]],
         )
         assert compare(struct, struct) is True
 
     def test_flat_cell(self, compare: Callable) -> None:
         """Flat cell (c << a)."""
         struct = Structure(
-            Lattice.from_parameters(20.0, 20.0, 2.0, 90.0, 90.0, 90.0), ["C"], [[0, 0, 0]]
+            Lattice.from_parameters(20.0, 20.0, 2.0, 90.0, 90.0, 90.0),
+            ["C"],
+            [[0, 0, 0]],
         )
         assert compare(struct, struct) is True
 
@@ -341,7 +376,11 @@ class TestComparators:
         """Different oxidation states should NOT match with SpeciesComparator."""
         py_match = PyMatcher(ltol=0.2, stol=0.3, angle_tol=5.0, primitive_cell=False)
         rust_match = RustMatcher(
-            latt_len_tol=0.2, site_pos_tol=0.3, angle_tol=5.0, primitive_cell=False, comparator="species"
+            latt_len_tol=0.2,
+            site_pos_tol=0.3,
+            angle_tol=5.0,
+            primitive_cell=False,
+            comparator="species",
         )
 
         lattice = Lattice.cubic(5.0)
@@ -357,10 +396,18 @@ class TestComparators:
     def test_oxidation_state_element_comparator(self) -> None:
         """Different oxidation states should match with ElementComparator."""
         py_match = PyMatcher(
-            ltol=0.2, stol=0.3, angle_tol=5.0, primitive_cell=False, comparator=ElementComparator()
+            ltol=0.2,
+            stol=0.3,
+            angle_tol=5.0,
+            primitive_cell=False,
+            comparator=ElementComparator(),
         )
         rust_match = RustMatcher(
-            latt_len_tol=0.2, site_pos_tol=0.3, angle_tol=5.0, primitive_cell=False, comparator="element"
+            latt_len_tol=0.2,
+            site_pos_tol=0.3,
+            angle_tol=5.0,
+            primitive_cell=False,
+            comparator="element",
         )
 
         lattice = Lattice.cubic(5.0)
@@ -383,7 +430,9 @@ class TestRmsDistance:
         self, py_matcher: PyMatcher, rust_matcher: RustMatcher, magnitude: float
     ) -> None:
         """RMS values should be close between pymatgen and ferrox."""
-        struct = Structure(Lattice.cubic(5.0), ["Fe", "Fe"], [[0, 0, 0], [0.5, 0.5, 0.5]])
+        struct = Structure(
+            Lattice.cubic(5.0), ["Fe", "Fe"], [[0, 0, 0], [0.5, 0.5, 0.5]]
+        )
         s_pert = perturb(struct, magnitude, seed=100)
 
         py_rms = py_matcher.get_rms_dist(struct, s_pert)
@@ -403,7 +452,9 @@ class TestRmsDistance:
 class TestBatchOperations:
     """Batch processing tests."""
 
-    def test_group_structures(self, py_matcher: PyMatcher, rust_matcher: RustMatcher) -> None:
+    def test_group_structures(
+        self, py_matcher: PyMatcher, rust_matcher: RustMatcher
+    ) -> None:
         """Group operation should match pymatgen."""
         structures = [
             make_cubic("Fe", 2.87),
@@ -438,8 +489,16 @@ class TestLengthToleranceBounds:
     def matchers_no_scale(self) -> tuple[PyMatcher, RustMatcher]:
         """Matchers with scale=False."""
         return (
-            PyMatcher(ltol=0.2, stol=0.3, angle_tol=5.0, primitive_cell=False, scale=False),
-            RustMatcher(latt_len_tol=0.2, site_pos_tol=0.3, angle_tol=5.0, primitive_cell=False, scale=False),
+            PyMatcher(
+                ltol=0.2, stol=0.3, angle_tol=5.0, primitive_cell=False, scale=False
+            ),
+            RustMatcher(
+                latt_len_tol=0.2,
+                site_pos_tol=0.3,
+                angle_tol=5.0,
+                primitive_cell=False,
+                scale=False,
+            ),
         )
 
     @pytest.mark.parametrize(
@@ -466,7 +525,9 @@ class TestRegressionCases:
     def test_acute_28deg_rhomb(self, compare: Callable) -> None:
         """Acute angle rhombohedral lattice (28°)."""
         struct = Structure(
-            Lattice.from_parameters(5.0, 5.0, 5.0, 28.0, 28.0, 28.0), ["Si"], [[0, 0, 0]]
+            Lattice.from_parameters(5.0, 5.0, 5.0, 28.0, 28.0, 28.0),
+            ["Si"],
+            [[0, 0, 0]],
         )
         assert compare(struct, struct) is True
 
@@ -475,8 +536,16 @@ class TestRegressionCases:
         struct = Structure(
             Lattice.from_parameters(4.8, 4.8, 4.8, 56.5, 56.5, 56.5),
             ["Mg", "Ni", "F", "F", "F", "F", "F", "F"],
-            [[0, 0, 0], [0.5, 0.5, 0.5], [0.25, 0.25, 0.25], [0.75, 0.75, 0.75],
-             [0.25, 0.75, 0.25], [0.75, 0.25, 0.75], [0.25, 0.25, 0.75], [0.75, 0.75, 0.25]],
+            [
+                [0, 0, 0],
+                [0.5, 0.5, 0.5],
+                [0.25, 0.25, 0.25],
+                [0.75, 0.75, 0.75],
+                [0.25, 0.75, 0.25],
+                [0.75, 0.25, 0.75],
+                [0.25, 0.25, 0.75],
+                [0.75, 0.75, 0.25],
+            ],
         )
         assert compare(struct, struct) is True
 
@@ -485,8 +554,16 @@ class TestRegressionCases:
         struct = Structure(
             Lattice.from_parameters(3.7, 3.7, 8.0, 103.4, 103.4, 90.0),
             ["Co"] * 8,
-            [[0, 0, 0], [0.5, 0, 0.25], [0, 0.5, 0.25], [0.5, 0.5, 0],
-             [0, 0, 0.5], [0.5, 0, 0.75], [0, 0.5, 0.75], [0.5, 0.5, 0.5]],
+            [
+                [0, 0, 0],
+                [0.5, 0, 0.25],
+                [0, 0.5, 0.25],
+                [0.5, 0.5, 0],
+                [0, 0, 0.5],
+                [0.5, 0, 0.75],
+                [0, 0.5, 0.75],
+                [0.5, 0.5, 0.5],
+            ],
         )
         assert compare(struct, struct) is True
 
@@ -504,8 +581,15 @@ class TestRegressionCases:
         struct = Structure(
             Lattice.from_parameters(5.5, 5.5, 6.5, 90.0, 90.0, 132.8),
             ["La", "La", "Co", "O", "O", "O", "O"],
-            [[0, 0, 0.36], [0, 0, 0.64], [0, 0, 0], [0.25, 0.25, 0],
-             [0.75, 0.75, 0], [0, 0.5, 0.18], [0.5, 0, 0.82]],
+            [
+                [0, 0, 0.36],
+                [0, 0, 0.64],
+                [0, 0, 0],
+                [0.25, 0.25, 0],
+                [0.75, 0.75, 0],
+                [0, 0.5, 0.18],
+                [0.5, 0, 0.82],
+            ],
         )
         assert compare(struct, struct) is True
 
@@ -596,7 +680,9 @@ class TestAPIs:
         reduced_shifted = matcher.reduce_structure(json.dumps(struct_shifted.as_dict()))
 
         normal_result = matcher.fit(json_str, json.dumps(struct_shifted.as_dict()))
-        skip_result = matcher.fit(reduced, reduced_shifted, skip_structure_reduction=True)
+        skip_result = matcher.fit(
+            reduced, reduced_shifted, skip_structure_reduction=True
+        )
         assert normal_result == skip_result
 
 
@@ -625,7 +711,9 @@ class TestMattervizStructures:
                 warnings.warn(f"Failed to load {json_file.stem}: {exc}", stacklevel=2)
         return result
 
-    def test_self_matching(self, compare: Callable, structures: dict[str, Structure]) -> None:
+    def test_self_matching(
+        self, compare: Callable, structures: dict[str, Structure]
+    ) -> None:
         """All matterviz structures should match themselves."""
         for name, struct in structures.items():
             assert compare(struct, struct) is True, f"Failed: {name}"
@@ -649,7 +737,9 @@ class TestPymatgenCifStructures:
                 warnings.warn(f"Failed to load {cif_file.stem}: {exc}", stacklevel=2)
         return result
 
-    def test_self_matching(self, compare: Callable, structures: dict[str, Structure]) -> None:
+    def test_self_matching(
+        self, compare: Callable, structures: dict[str, Structure]
+    ) -> None:
         """All pymatgen CIF structures should match themselves."""
         for name, struct in structures.items():
             assert compare(struct, struct) is True, f"Failed: {name}"

--- a/extensions/rust/tests/test_pymatgen_compat.py
+++ b/extensions/rust/tests/test_pymatgen_compat.py
@@ -214,8 +214,8 @@ def translate(s: Structure, vec: list[float]) -> Structure:
 class TestSelfMatching:
     """Identical structures should always match."""
 
-    @pytest.mark.parametrize("struct", BASE_STRUCTURES, ids=BASE_STRUCTURE_IDS)
-    def test_base_structures(self, compare: Callable, struct: Structure) -> None:
+    @pytest.mark.parametrize(("name", "struct"), _BASE_STRUCTURE_DATA)
+    def test_base_structures(self, compare: Callable, name: str, struct: Structure) -> None:
         """Base structures match themselves."""
         assert compare(struct, struct) is True, f"{name} should self-match"
 
@@ -241,30 +241,26 @@ class TestSelfMatching:
 class TestPerturbations:
     """Perturbed structures within tolerance should match."""
 
-    @pytest.mark.parametrize("struct", BASE_STRUCTURES, ids=BASE_STRUCTURE_IDS)
+    @pytest.mark.parametrize(("name", "struct"), _BASE_STRUCTURE_DATA)
     @pytest.mark.parametrize("magnitude", [0.01, 0.02, 0.05])
     def test_coordinate_perturbations(
-        self, compare: Callable, struct: Structure, magnitude: float
+        self, compare: Callable, name: str, struct: Structure, magnitude: float
     ) -> None:
         """Small coordinate perturbations should match."""
-        assert compare(struct, perturb(struct, magnitude)) is True, (
-            f"{name} ±{magnitude}"
-        )
+        assert compare(struct, perturb(struct, magnitude)) is True, f"{name} +/-{magnitude}"
 
-    @pytest.mark.parametrize("struct", BASE_STRUCTURES, ids=BASE_STRUCTURE_IDS)
+    @pytest.mark.parametrize(("name", "struct"), _BASE_STRUCTURE_DATA)
     @pytest.mark.parametrize("factor", [0.98, 1.02, 1.05])
     def test_lattice_scaling(
-        self, compare: Callable, struct: Structure, factor: float
+        self, compare: Callable, name: str, struct: Structure, factor: float
     ) -> None:
         """Lattice scaling within tolerance should match."""
-        assert compare(struct, scale_lattice(struct, factor)) is True, (
-            f"{name} ×{factor}"
-        )
+        assert compare(struct, scale_lattice(struct, factor)) is True, f"{name} x{factor}"
 
-    @pytest.mark.parametrize("struct", BASE_STRUCTURES, ids=BASE_STRUCTURE_IDS)
+    @pytest.mark.parametrize(("name", "struct"), _BASE_STRUCTURE_DATA)
     @pytest.mark.parametrize("strain", [0.01, 0.02])
     def test_uniaxial_strain(
-        self, compare: Callable, struct: Structure, strain: float
+        self, compare: Callable, name: str, struct: Structure, strain: float
     ) -> None:
         """Uniaxial strain within tolerance should match."""
         assert compare(struct, strain_lattice(struct, strain)) is True, (


### PR DESCRIPTION
## Summary

Adds a new `coordination` module to ferrox for analyzing coordination numbers and local atomic environments in crystal structures.

### Features

**Cutoff-based methods:**
- `get_coordination_numbers(structure, cutoff)` - CN for all sites
- `get_coordination_number(structure, site_idx, cutoff)` - CN for single site
- `get_local_environment(structure, site_idx, cutoff)` - detailed neighbor info
- `get_neighbors(structure, site_idx, cutoff)` - simplified neighbor tuples

**Voronoi-based methods:**
- `get_cn_voronoi_all(structure)` - Voronoi CN for all sites
- `get_cn_voronoi(structure, site_idx)` - Voronoi CN for single site
- `get_voronoi_neighbors(structure, site_idx)` - neighbors with solid angles
- `get_local_environment_voronoi(structure, site_idx)` - detailed Voronoi neighbors

### Data structures

- `LocalEnvNeighbor` - neighbor info with species, distance, image offset, solid angle
- `VoronoiConfig` - configuration for min_solid_angle filtering

### Dependencies

- `meshless_voronoi = "0.7"` - 3D Voronoi tessellation with periodic boundaries
- `glam = "0.27"` - vector types for meshless_voronoi

### Limitations

Voronoi methods use a rectangular bounding box and are only geometrically correct for orthogonal lattices (cubic, tetragonal, orthorhombic). For non-orthogonal cells, use cutoff-based methods.