### PR TITLE
Add comprehensive WASM bindings and Python type stubs for ferrox

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
         stages: [pre-commit, commit-msg]
         args:
           - --ignore-words-list
-          - 'te,ba,nd,ore,claus,manuel,ges,mey,curvelinear,tennant'
+          - 'te,ba,nd,ore,claus,manuel,ges,mey,curvelinear,tennant,struc'
           - --check-filenames
 
   - repo: https://github.com/igorshubovych/markdownlint-cli

--- a/extensions/rust-wasm/package.json
+++ b/extensions/rust-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matterviz/wasm",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "WASM bindings for ferrox structure matching library",
   "type": "module",
   "main": "index.js",

--- a/extensions/rust-wasm/package.json
+++ b/extensions/rust-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matterviz/wasm",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "WASM bindings for ferrox structure matching library",
   "type": "module",
   "main": "index.js",

--- a/extensions/rust-wasm/types.d.ts
+++ b/extensions/rust-wasm/types.d.ts
@@ -90,7 +90,7 @@ export function get_structure_metadata(
 // Neighbor finding
 export function get_neighbor_list(
   structure: JsCrystal,
-  r: number,
+  cutoff_radius: number,
   numerical_tol: number,
   exclude_self: boolean,
 ): WasmResult<JsNeighborList>

--- a/extensions/rust-wasm/types.d.ts
+++ b/extensions/rust-wasm/types.d.ts
@@ -206,7 +206,7 @@ export function substitute_species(
 ): WasmResult<JsCrystal>
 export function remove_species(
   structure: JsCrystal,
-  species: string,
+  species: string[],
 ): WasmResult<JsCrystal>
 export function remove_sites(
   structure: JsCrystal,

--- a/extensions/rust-wasm/types.d.ts
+++ b/extensions/rust-wasm/types.d.ts
@@ -1,335 +1,239 @@
-// Type definitions for @matterviz/wasm
-// Comprehensive types for ferrox WASM bindings
+// Type augmentation for @matterviz/wasm
+// Auto-generated types in pkg/ferrox.d.ts provide input types,
+// this file provides return type information
+
+// Re-export all types from auto-generated file
+export * from './pkg/ferrox.d.ts'
+
+// Import types for augmentation
+import type {
+  JsCrystal,
+  JsLocalEnvironment,
+  JsNeighborList,
+  JsReductionAlgo,
+  JsRmsDistResult,
+  JsStructureMetadata,
+  JsSymmetryDataset,
+  JsSymmetryOperation,
+  WasmResult,
+} from './pkg/ferrox.d.ts'
 
 // =============================================================================
-// Result Types
+// Function Return Type Declarations
+// These augment the auto-generated types with precise return types
 // =============================================================================
 
-// All WASM functions return WasmResult<T> = { ok: T } | { error: string }
-export type WasmResult<T> = { ok: T } | { error: string }
+// Structure parsing
+export function parse_cif(content: string): WasmResult<JsCrystal>
+export function parse_poscar(content: string): WasmResult<JsCrystal>
 
-// =============================================================================
-// Structure Types (pymatgen-compatible)
-// =============================================================================
-
-export interface Crystal {
-  lattice: Lattice
-  sites: Site[]
-  properties?: Record<string, unknown>
-}
-
-export interface Lattice {
-  matrix: [[number, number, number], [number, number, number], [number, number, number]]
-  a: number
-  b: number
-  c: number
-  alpha: number
-  beta: number
-  gamma: number
-  pbc: [boolean, boolean, boolean]
-  volume: number
-}
-
-export interface Site {
-  species: SpeciesOccupancy[]
-  abc: [number, number, number]
-  xyz: [number, number, number]
-  label: string
-  properties: Record<string, unknown>
-}
-
-export interface SpeciesOccupancy {
-  element: string
-  occu: number
-  oxidation_state?: number
-}
-
-// =============================================================================
-// Neighbor List Result
-// =============================================================================
-
-export interface NeighborListResult {
-  center_indices: number[]
-  neighbor_indices: number[]
-  image_offsets: [number, number, number][]
-  distances: number[]
-}
-
-// =============================================================================
-// RMS Distance Result
-// =============================================================================
-
-export interface RmsDistResult {
-  rms: number
-  max_dist: number
-}
-
-// =============================================================================
-// WasmStructureMatcher Class
-// =============================================================================
-
-export class WasmStructureMatcher {
-  constructor()
-  with_latt_len_tol(tol: number): WasmStructureMatcher
-  with_site_pos_tol(tol: number): WasmStructureMatcher
-  with_angle_tol(tol: number): WasmStructureMatcher
-  with_primitive_cell(val: boolean): WasmStructureMatcher
-  with_scale(val: boolean): WasmStructureMatcher
-  with_element_comparator(val: boolean): WasmStructureMatcher
-  fit(struct1: Crystal, struct2: Crystal): WasmResult<boolean>
-  fit_anonymous(struct1: Crystal, struct2: Crystal): WasmResult<boolean>
-  get_rms_dist(struct1: Crystal, struct2: Crystal): WasmResult<RmsDistResult | null>
-  deduplicate(structures: Crystal[]): WasmResult<number[]>
-  find_matches(
-    new_structures: Crystal[],
-    existing: Crystal[],
-  ): WasmResult<(number | null)[]>
-}
-
-// =============================================================================
-// Element Class
-// =============================================================================
-
-export class JsElement {
-  constructor(symbol: string)
-  static fromAtomicNumber(z: number): JsElement
-  readonly symbol: string
-  readonly atomicNumber: number
-  readonly name: string
-  readonly atomicMass: number
-  readonly electronegativity: number
-  readonly row: number
-  readonly group: number
-  readonly block: string
-  readonly atomicRadius: number
-  readonly covalentRadius: number
-  readonly maxOxidationState: number
-  readonly minOxidationState: number
-  isNobleGas(): boolean
-  isAlkali(): boolean
-  isAlkaline(): boolean
-  isHalogen(): boolean
-  isChalcogen(): boolean
-  isLanthanoid(): boolean
-  isActinoid(): boolean
-  isTransitionMetal(): boolean
-  isPostTransitionMetal(): boolean
-  isMetalloid(): boolean
-  isMetal(): boolean
-  isRadioactive(): boolean
-  isRareEarth(): boolean
-  isPseudo(): boolean
-  oxidationStates(): number[]
-  commonOxidationStates(): number[]
-  icsdOxidationStates(): number[]
-  ionicRadius(oxidation_state: number): number
-  shannonIonicRadius(oxidation_state: number, coordination: string, spin: string): number
-}
-
-// =============================================================================
-// Species Class
-// =============================================================================
-
-export class JsSpecies {
-  constructor(species_str: string)
-  readonly symbol: string
-  readonly atomicNumber: number
-  readonly oxidationState: number | undefined
-  readonly ionicRadius: number
-  readonly atomicRadius: number
-  readonly electronegativity: number
-  readonly covalentRadius: number
-  readonly name: string
-  toString(): string
-  shannonIonicRadius(coordination: string, spin: string): number
-}
-
-// =============================================================================
-// Structure Parsing Functions
-// =============================================================================
-
-export function parse_structure(input: unknown): WasmResult<Crystal>
-export function parse_cif(content: string): WasmResult<Crystal>
-export function parse_poscar(content: string): WasmResult<Crystal>
-
-// =============================================================================
-// Supercell Functions
-// =============================================================================
-
+// Supercell functions
 export function make_supercell_diag(
-  structure: Crystal,
+  structure: JsCrystal,
   nx: number,
   ny: number,
   nz: number,
-): WasmResult<Crystal>
-
+): WasmResult<JsCrystal>
 export function make_supercell(
-  structure: Crystal,
+  structure: JsCrystal,
   matrix: [[number, number, number], [number, number, number], [number, number, number]],
-): WasmResult<Crystal>
+): WasmResult<JsCrystal>
 
-// =============================================================================
-// Lattice Reduction Functions
-// =============================================================================
-
+// Lattice reduction
 export function get_reduced_structure(
-  structure: Crystal,
-  algo: 'niggli' | 'lll',
-): WasmResult<Crystal>
+  structure: JsCrystal,
+  algo: JsReductionAlgo,
+): WasmResult<JsCrystal>
+export function get_primitive(
+  structure: JsCrystal,
+  symprec: number,
+): WasmResult<JsCrystal>
+export function get_conventional(
+  structure: JsCrystal,
+  symprec: number,
+): WasmResult<JsCrystal>
 
-export function get_primitive(structure: Crystal, symprec: number): WasmResult<Crystal>
-
+// Symmetry analysis
 export function get_spacegroup_number(
-  structure: Crystal,
+  structure: JsCrystal,
   symprec: number,
 ): WasmResult<number>
+export function get_spacegroup_symbol(
+  structure: JsCrystal,
+  symprec: number,
+): WasmResult<string>
+export function get_crystal_system(
+  structure: JsCrystal,
+  symprec: number,
+): WasmResult<string>
+export function get_wyckoff_letters(
+  structure: JsCrystal,
+  symprec: number,
+): WasmResult<string[]>
+export function get_symmetry_operations(
+  structure: JsCrystal,
+  symprec: number,
+): WasmResult<JsSymmetryOperation[]>
+export function get_symmetry_dataset(
+  structure: JsCrystal,
+  symprec: number,
+): WasmResult<JsSymmetryDataset>
 
-export function structure_to_json(structure: Crystal): WasmResult<string>
+// Physical properties
+export function get_volume(structure: JsCrystal): WasmResult<number>
+export function get_total_mass(structure: JsCrystal): WasmResult<number>
+export function get_density(structure: JsCrystal): WasmResult<number>
+export function get_structure_metadata(
+  structure: JsCrystal,
+): WasmResult<JsStructureMetadata>
 
-// =============================================================================
-// Physical Property Functions
-// =============================================================================
-
-export function get_volume(structure: Crystal): WasmResult<number>
-export function get_total_mass(structure: Crystal): WasmResult<number>
-export function get_density(structure: Crystal): WasmResult<number>
-
-// =============================================================================
-// Neighbor Finding Functions
-// =============================================================================
-
+// Neighbor finding
 export function get_neighbor_list(
-  structure: Crystal,
+  structure: JsCrystal,
   r: number,
   numerical_tol: number,
   exclude_self: boolean,
-): WasmResult<NeighborListResult>
+): WasmResult<JsNeighborList>
+export function get_distance(
+  structure: JsCrystal,
+  i: number,
+  j: number,
+): WasmResult<number>
+export function get_distance_matrix(structure: JsCrystal): WasmResult<number[][]>
 
-export function get_distance(structure: Crystal, i: number, j: number): WasmResult<number>
+// Coordination analysis
+export function get_coordination_numbers(
+  structure: JsCrystal,
+  cutoff: number,
+): WasmResult<number[]>
+export function get_coordination_number(
+  structure: JsCrystal,
+  site_index: number,
+  cutoff: number,
+): WasmResult<number>
+export function get_local_environment(
+  structure: JsCrystal,
+  site_index: number,
+  cutoff: number,
+): WasmResult<JsLocalEnvironment>
 
-export function get_distance_matrix(structure: Crystal): WasmResult<number[][]>
-
-// =============================================================================
-// Sorting Functions
-// =============================================================================
-
+// Sorting
 export function get_sorted_structure(
-  structure: Crystal,
+  structure: JsCrystal,
   reverse: boolean,
-): WasmResult<Crystal>
-
+): WasmResult<JsCrystal>
 export function get_sorted_by_electronegativity(
-  structure: Crystal,
+  structure: JsCrystal,
   reverse: boolean,
-): WasmResult<Crystal>
+): WasmResult<JsCrystal>
 
-// =============================================================================
-// Interpolation Functions
-// =============================================================================
-
+// Interpolation
 export function interpolate_structures(
-  start: Crystal,
-  end: Crystal,
+  start: JsCrystal,
+  end: JsCrystal,
   n_images: number,
   interpolate_lattices: boolean,
   use_pbc: boolean,
-): WasmResult<Crystal[]>
+): WasmResult<JsCrystal[]>
 
-// =============================================================================
-// Copy and Wrap Functions
-// =============================================================================
+// Copy and wrap
+export function copy_structure(
+  structure: JsCrystal,
+  sanitize: boolean,
+): WasmResult<JsCrystal>
+export function wrap_to_unit_cell(structure: JsCrystal): WasmResult<JsCrystal>
 
-export function copy_structure(structure: Crystal, sanitize: boolean): WasmResult<Crystal>
-
-export function wrap_to_unit_cell(structure: Crystal): WasmResult<Crystal>
-
-// =============================================================================
-// Site Manipulation Functions
-// =============================================================================
-
+// Site manipulation
 export function translate_sites(
-  structure: Crystal,
+  structure: JsCrystal,
   indices: number[],
   vector: [number, number, number],
   fractional: boolean,
-): WasmResult<Crystal>
-
+): WasmResult<JsCrystal>
 export function perturb_structure(
-  structure: Crystal,
+  structure: JsCrystal,
   distance: number,
   min_distance?: number | null,
   seed?: bigint | null,
-): WasmResult<Crystal>
+): WasmResult<JsCrystal>
 
-// =============================================================================
-// Element Information Functions
-// =============================================================================
-
+// Element info
 export function get_atomic_mass(symbol: string): WasmResult<number>
 export function get_electronegativity(symbol: string): WasmResult<number>
 
+// Slab generation
+export function make_slab(
+  structure: JsCrystal,
+  miller_index: [number, number, number],
+  min_slab_size: number,
+  min_vacuum_size: number,
+  center_slab: boolean,
+  in_unit_planes: boolean,
+  primitive: boolean,
+  symprec: number,
+  termination_index?: number | null,
+): WasmResult<JsCrystal>
+export function generate_slabs(
+  structure: JsCrystal,
+  miller_index: [number, number, number],
+  min_slab_size: number,
+  min_vacuum_size: number,
+  center_slab: boolean,
+  in_unit_planes: boolean,
+  primitive: boolean,
+  symprec: number,
+): WasmResult<JsCrystal[]>
+
+// Transformations
+export function apply_operation(
+  structure: JsCrystal,
+  rotation: [
+    [number, number, number],
+    [number, number, number],
+    [number, number, number],
+  ],
+  translation: [number, number, number],
+  fractional: boolean,
+): WasmResult<JsCrystal>
+export function apply_inversion(
+  structure: JsCrystal,
+  fractional: boolean,
+): WasmResult<JsCrystal>
+export function substitute_species(
+  structure: JsCrystal,
+  old_species: string,
+  new_species: string,
+): WasmResult<JsCrystal>
+export function remove_species(
+  structure: JsCrystal,
+  species: string,
+): WasmResult<JsCrystal>
+export function remove_sites(
+  structure: JsCrystal,
+  indices: number[],
+): WasmResult<JsCrystal>
+
+// I/O
+export function structure_to_json(structure: JsCrystal): WasmResult<string>
+export function structure_to_cif(structure: JsCrystal): WasmResult<string>
+export function structure_to_poscar(structure: JsCrystal): WasmResult<string>
+
 // =============================================================================
-// WASM Module Interface
+// WasmStructureMatcher Method Return Types
 // =============================================================================
 
-export interface WasmModule {
-  // Default init function
-  default: (options?: { module_or_path?: string | URL }) => Promise<void>
-
-  // Classes
-  WasmStructureMatcher: typeof WasmStructureMatcher
-  JsElement: typeof JsElement
-  JsSpecies: typeof JsSpecies
-
-  // Structure parsing
-  parse_structure: typeof parse_structure
-  parse_cif: typeof parse_cif
-  parse_poscar: typeof parse_poscar
-
-  // Supercell
-  make_supercell_diag: typeof make_supercell_diag
-  make_supercell: typeof make_supercell
-
-  // Lattice reduction
-  get_reduced_structure: typeof get_reduced_structure
-  get_primitive: typeof get_primitive
-  get_spacegroup_number: typeof get_spacegroup_number
-  structure_to_json: typeof structure_to_json
-
-  // Physical properties
-  get_volume: typeof get_volume
-  get_total_mass: typeof get_total_mass
-  get_density: typeof get_density
-
-  // Neighbor finding
-  get_neighbor_list: typeof get_neighbor_list
-  get_distance: typeof get_distance
-  get_distance_matrix: typeof get_distance_matrix
-
-  // Sorting
-  get_sorted_structure: typeof get_sorted_structure
-  get_sorted_by_electronegativity: typeof get_sorted_by_electronegativity
-
-  // Interpolation
-  interpolate_structures: typeof interpolate_structures
-
-  // Copy and wrap
-  copy_structure: typeof copy_structure
-  wrap_to_unit_cell: typeof wrap_to_unit_cell
-
-  // Site manipulation
-  translate_sites: typeof translate_sites
-  perturb_structure: typeof perturb_structure
-
-  // Element info
-  get_atomic_mass: typeof get_atomic_mass
-  get_electronegativity: typeof get_electronegativity
+declare module './pkg/ferrox.d.ts' {
+  interface WasmStructureMatcher {
+    fit(struct1: JsCrystal, struct2: JsCrystal): WasmResult<boolean>
+    fit_anonymous(struct1: JsCrystal, struct2: JsCrystal): WasmResult<boolean>
+    get_rms_dist(
+      struct1: JsCrystal,
+      struct2: JsCrystal,
+    ): WasmResult<JsRmsDistResult | null>
+    deduplicate(structures: JsCrystal[]): WasmResult<number[]>
+    find_matches(
+      new_structures: JsCrystal[],
+      existing: JsCrystal[],
+    ): WasmResult<(number | null)[]>
+  }
 }
-
-// =============================================================================
-// Default Export (init function)
-// =============================================================================
-
-// Init loads pkg/ferrox.js, initializes WASM, and returns the module
-declare const init: (options?: { module_or_path?: string | URL }) => Promise<WasmModule>
-export default init

--- a/extensions/rust-wasm/types.d.ts
+++ b/extensions/rust-wasm/types.d.ts
@@ -1,57 +1,72 @@
 // Type definitions for @matterviz/wasm
-// Minimal types for the dynamic loader (index.js)
-// For detailed typed wrappers, use $lib/structure/ferrox-wasm.ts in matterviz
+// Comprehensive types for ferrox WASM bindings
 
-// The module returned by init() - all WASM exports are synchronous after init
-export interface WasmModule {
-  default: (options?: { module_or_path?: string | URL }) => Promise<void>
-  WasmStructureMatcher: typeof WasmStructureMatcher
-  parse_structure: (input: unknown) => unknown
-  parse_cif: (content: string) => unknown
-  parse_poscar: (content: string) => unknown
-  make_supercell_diag: (structure: unknown, nx: number, ny: number, nz: number) => unknown
-  make_supercell: (structure: unknown, matrix: number[][]) => unknown
-  get_reduced_structure: (structure: unknown, algo: string) => unknown
-  get_primitive: (structure: unknown, symprec: number) => unknown
-  get_spacegroup_number: (structure: unknown, symprec: number) => unknown
-  structure_to_json: (structure: unknown) => unknown
-  get_volume: (structure: unknown) => unknown
-  get_total_mass: (structure: unknown) => unknown
-  get_density: (structure: unknown) => unknown
-  get_neighbor_list: (
-    structure: unknown,
-    r: number,
-    tol: number,
-    exclude_self: boolean,
-  ) => unknown
-  get_distance: (structure: unknown, i: number, j: number) => unknown
-  get_distance_matrix: (structure: unknown) => unknown
-  get_sorted_structure: (structure: unknown, reverse: boolean) => unknown
-  get_sorted_by_electronegativity: (structure: unknown, reverse: boolean) => unknown
-  interpolate_structures: (
-    start: unknown,
-    end: unknown,
-    n_images: number,
-    interpolate_lattices: boolean,
-    use_pbc: boolean,
-  ) => unknown
-  copy_structure: (structure: unknown, sanitize: boolean) => unknown
-  wrap_to_unit_cell: (structure: unknown) => unknown
-  translate_sites: (
-    structure: unknown,
-    indices: number[],
-    vector: number[],
-    frac_coords: boolean,
-  ) => unknown
-  perturb_structure: (
-    structure: unknown,
-    distance: number,
-    min_distance?: number,
-    seed?: number,
-  ) => unknown
-  get_atomic_mass: (symbol: string) => unknown
-  get_electronegativity: (symbol: string) => unknown
+// =============================================================================
+// Result Types
+// =============================================================================
+
+// All WASM functions return WasmResult<T> = { ok: T } | { error: string }
+export type WasmResult<T> = { ok: T } | { error: string }
+
+// =============================================================================
+// Structure Types (pymatgen-compatible)
+// =============================================================================
+
+export interface Crystal {
+  lattice: Lattice
+  sites: Site[]
+  properties?: Record<string, unknown>
 }
+
+export interface Lattice {
+  matrix: [[number, number, number], [number, number, number], [number, number, number]]
+  a: number
+  b: number
+  c: number
+  alpha: number
+  beta: number
+  gamma: number
+  pbc: [boolean, boolean, boolean]
+  volume: number
+}
+
+export interface Site {
+  species: SpeciesOccupancy[]
+  abc: [number, number, number]
+  xyz: [number, number, number]
+  label: string
+  properties: Record<string, unknown>
+}
+
+export interface SpeciesOccupancy {
+  element: string
+  occu: number
+  oxidation_state?: number
+}
+
+// =============================================================================
+// Neighbor List Result
+// =============================================================================
+
+export interface NeighborListResult {
+  center_indices: number[]
+  neighbor_indices: number[]
+  image_offsets: [number, number, number][]
+  distances: number[]
+}
+
+// =============================================================================
+// RMS Distance Result
+// =============================================================================
+
+export interface RmsDistResult {
+  rms: number
+  max_dist: number
+}
+
+// =============================================================================
+// WasmStructureMatcher Class
+// =============================================================================
 
 export class WasmStructureMatcher {
   constructor()
@@ -61,14 +76,260 @@ export class WasmStructureMatcher {
   with_primitive_cell(val: boolean): WasmStructureMatcher
   with_scale(val: boolean): WasmStructureMatcher
   with_element_comparator(val: boolean): WasmStructureMatcher
-  fit(struct1: unknown, struct2: unknown): unknown
-  fit_anonymous(struct1: unknown, struct2: unknown): unknown
-  get_rms_dist(struct1: unknown, struct2: unknown): unknown
-  deduplicate(structures: unknown[]): unknown
-  find_matches(new_structures: unknown[], existing: unknown[]): unknown
+  fit(struct1: Crystal, struct2: Crystal): WasmResult<boolean>
+  fit_anonymous(struct1: Crystal, struct2: Crystal): WasmResult<boolean>
+  get_rms_dist(struct1: Crystal, struct2: Crystal): WasmResult<RmsDistResult | null>
+  deduplicate(structures: Crystal[]): WasmResult<number[]>
+  find_matches(
+    new_structures: Crystal[],
+    existing: Crystal[],
+  ): WasmResult<(number | null)[]>
 }
 
+// =============================================================================
+// Element Class
+// =============================================================================
+
+export class JsElement {
+  constructor(symbol: string)
+  static fromAtomicNumber(z: number): JsElement
+  readonly symbol: string
+  readonly atomicNumber: number
+  readonly name: string
+  readonly atomicMass: number
+  readonly electronegativity: number
+  readonly row: number
+  readonly group: number
+  readonly block: string
+  readonly atomicRadius: number
+  readonly covalentRadius: number
+  readonly maxOxidationState: number
+  readonly minOxidationState: number
+  isNobleGas(): boolean
+  isAlkali(): boolean
+  isAlkaline(): boolean
+  isHalogen(): boolean
+  isChalcogen(): boolean
+  isLanthanoid(): boolean
+  isActinoid(): boolean
+  isTransitionMetal(): boolean
+  isPostTransitionMetal(): boolean
+  isMetalloid(): boolean
+  isMetal(): boolean
+  isRadioactive(): boolean
+  isRareEarth(): boolean
+  isPseudo(): boolean
+  oxidationStates(): number[]
+  commonOxidationStates(): number[]
+  icsdOxidationStates(): number[]
+  ionicRadius(oxidation_state: number): number
+  shannonIonicRadius(oxidation_state: number, coordination: string, spin: string): number
+}
+
+// =============================================================================
+// Species Class
+// =============================================================================
+
+export class JsSpecies {
+  constructor(species_str: string)
+  readonly symbol: string
+  readonly atomicNumber: number
+  readonly oxidationState: number | undefined
+  readonly ionicRadius: number
+  readonly atomicRadius: number
+  readonly electronegativity: number
+  readonly covalentRadius: number
+  readonly name: string
+  toString(): string
+  shannonIonicRadius(coordination: string, spin: string): number
+}
+
+// =============================================================================
+// Structure Parsing Functions
+// =============================================================================
+
+export function parse_structure(input: unknown): WasmResult<Crystal>
+export function parse_cif(content: string): WasmResult<Crystal>
+export function parse_poscar(content: string): WasmResult<Crystal>
+
+// =============================================================================
+// Supercell Functions
+// =============================================================================
+
+export function make_supercell_diag(
+  structure: Crystal,
+  nx: number,
+  ny: number,
+  nz: number,
+): WasmResult<Crystal>
+
+export function make_supercell(
+  structure: Crystal,
+  matrix: [[number, number, number], [number, number, number], [number, number, number]],
+): WasmResult<Crystal>
+
+// =============================================================================
+// Lattice Reduction Functions
+// =============================================================================
+
+export function get_reduced_structure(
+  structure: Crystal,
+  algo: 'niggli' | 'lll',
+): WasmResult<Crystal>
+
+export function get_primitive(structure: Crystal, symprec: number): WasmResult<Crystal>
+
+export function get_spacegroup_number(
+  structure: Crystal,
+  symprec: number,
+): WasmResult<number>
+
+export function structure_to_json(structure: Crystal): WasmResult<string>
+
+// =============================================================================
+// Physical Property Functions
+// =============================================================================
+
+export function get_volume(structure: Crystal): WasmResult<number>
+export function get_total_mass(structure: Crystal): WasmResult<number>
+export function get_density(structure: Crystal): WasmResult<number>
+
+// =============================================================================
+// Neighbor Finding Functions
+// =============================================================================
+
+export function get_neighbor_list(
+  structure: Crystal,
+  r: number,
+  numerical_tol: number,
+  exclude_self: boolean,
+): WasmResult<NeighborListResult>
+
+export function get_distance(structure: Crystal, i: number, j: number): WasmResult<number>
+
+export function get_distance_matrix(structure: Crystal): WasmResult<number[][]>
+
+// =============================================================================
+// Sorting Functions
+// =============================================================================
+
+export function get_sorted_structure(
+  structure: Crystal,
+  reverse: boolean,
+): WasmResult<Crystal>
+
+export function get_sorted_by_electronegativity(
+  structure: Crystal,
+  reverse: boolean,
+): WasmResult<Crystal>
+
+// =============================================================================
+// Interpolation Functions
+// =============================================================================
+
+export function interpolate_structures(
+  start: Crystal,
+  end: Crystal,
+  n_images: number,
+  interpolate_lattices: boolean,
+  use_pbc: boolean,
+): WasmResult<Crystal[]>
+
+// =============================================================================
+// Copy and Wrap Functions
+// =============================================================================
+
+export function copy_structure(structure: Crystal, sanitize: boolean): WasmResult<Crystal>
+
+export function wrap_to_unit_cell(structure: Crystal): WasmResult<Crystal>
+
+// =============================================================================
+// Site Manipulation Functions
+// =============================================================================
+
+export function translate_sites(
+  structure: Crystal,
+  indices: number[],
+  vector: [number, number, number],
+  fractional: boolean,
+): WasmResult<Crystal>
+
+export function perturb_structure(
+  structure: Crystal,
+  distance: number,
+  min_distance?: number | null,
+  seed?: bigint | null,
+): WasmResult<Crystal>
+
+// =============================================================================
+// Element Information Functions
+// =============================================================================
+
+export function get_atomic_mass(symbol: string): WasmResult<number>
+export function get_electronegativity(symbol: string): WasmResult<number>
+
+// =============================================================================
+// WASM Module Interface
+// =============================================================================
+
+export interface WasmModule {
+  // Default init function
+  default: (options?: { module_or_path?: string | URL }) => Promise<void>
+
+  // Classes
+  WasmStructureMatcher: typeof WasmStructureMatcher
+  JsElement: typeof JsElement
+  JsSpecies: typeof JsSpecies
+
+  // Structure parsing
+  parse_structure: typeof parse_structure
+  parse_cif: typeof parse_cif
+  parse_poscar: typeof parse_poscar
+
+  // Supercell
+  make_supercell_diag: typeof make_supercell_diag
+  make_supercell: typeof make_supercell
+
+  // Lattice reduction
+  get_reduced_structure: typeof get_reduced_structure
+  get_primitive: typeof get_primitive
+  get_spacegroup_number: typeof get_spacegroup_number
+  structure_to_json: typeof structure_to_json
+
+  // Physical properties
+  get_volume: typeof get_volume
+  get_total_mass: typeof get_total_mass
+  get_density: typeof get_density
+
+  // Neighbor finding
+  get_neighbor_list: typeof get_neighbor_list
+  get_distance: typeof get_distance
+  get_distance_matrix: typeof get_distance_matrix
+
+  // Sorting
+  get_sorted_structure: typeof get_sorted_structure
+  get_sorted_by_electronegativity: typeof get_sorted_by_electronegativity
+
+  // Interpolation
+  interpolate_structures: typeof interpolate_structures
+
+  // Copy and wrap
+  copy_structure: typeof copy_structure
+  wrap_to_unit_cell: typeof wrap_to_unit_cell
+
+  // Site manipulation
+  translate_sites: typeof translate_sites
+  perturb_structure: typeof perturb_structure
+
+  // Element info
+  get_atomic_mass: typeof get_atomic_mass
+  get_electronegativity: typeof get_electronegativity
+}
+
+// =============================================================================
+// Default Export (init function)
+// =============================================================================
+
 // Init loads pkg/ferrox.js, initializes WASM, and returns the module
-export default function init(
-  options?: { module_or_path?: string | URL },
-): Promise<WasmModule>
+declare const init: (options?: { module_or_path?: string | URL }) => Promise<WasmModule>
+export default init

--- a/extensions/rust-wasm/types.d.ts
+++ b/extensions/rust-wasm/types.d.ts
@@ -1,11 +1,8 @@
-// Type augmentation for @matterviz/wasm
-// Auto-generated types in pkg/ferrox.d.ts provide input types,
-// this file provides return type information
+// Type augmentation for @matterviz/wasm - return type declarations
+// Auto-generated pkg/ferrox.d.ts provides input types; this adds return types
 
-// Re-export all types from auto-generated file
 export * from './pkg/ferrox.d.ts'
 
-// Import types for augmentation
 import type {
   JsCrystal,
   JsLocalEnvironment,
@@ -17,11 +14,6 @@ import type {
   JsSymmetryOperation,
   WasmResult,
 } from './pkg/ferrox.d.ts'
-
-// =============================================================================
-// Function Return Type Declarations
-// These augment the auto-generated types with precise return types
-// =============================================================================
 
 // Structure parsing
 export function parse_cif(content: string): WasmResult<JsCrystal>

--- a/extensions/rust-wasm/types.d.ts
+++ b/extensions/rust-wasm/types.d.ts
@@ -30,9 +30,9 @@ export function parse_poscar(content: string): WasmResult<JsCrystal>
 // Supercell functions
 export function make_supercell_diag(
   structure: JsCrystal,
-  nx: number,
-  ny: number,
-  nz: number,
+  scale_a: number,
+  scale_b: number,
+  scale_c: number,
 ): WasmResult<JsCrystal>
 export function make_supercell(
   structure: JsCrystal,
@@ -96,8 +96,8 @@ export function get_neighbor_list(
 ): WasmResult<JsNeighborList>
 export function get_distance(
   structure: JsCrystal,
-  i: number,
-  j: number,
+  site_idx_1: number,
+  site_idx_2: number,
 ): WasmResult<number>
 export function get_distance_matrix(structure: JsCrystal): WasmResult<number[][]>
 

--- a/extensions/rust/Cargo.toml
+++ b/extensions/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrox"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2024"
 authors = ["Janosh Riebesell <janosh@lbl.gov>"]
 description = "High-performance structure matching for crystallographic data"

--- a/extensions/rust/Cargo.toml
+++ b/extensions/rust/Cargo.toml
@@ -18,12 +18,14 @@ pyo3 = { version = "0.27.2", features = [
   "abi3-py311",
   "extension-module",
 ], optional = true }
+pyo3-stub-gen = { version = "0.7", optional = true }
 
 # WASM bindings
 wasm-bindgen = { version = "0.2.108", optional = true }
 js-sys = { version = "0.3.85", optional = true }
 serde-wasm-bindgen = { version = "0.6.5", optional = true }
 console_error_panic_hook = { version = "0.1.7", optional = true }
+tsify-next = { version = "0.5", features = ["js"], optional = true }
 # WASM random number generation
 # getrandom 0.2.x: needs "js" feature for wasm32-unknown-unknown (used by rand 0.8)
 # getrandom 0.3.x: needs "wasm_js" feature + rustflag config in .cargo/config.toml (used by meshless_voronoi -> ahash)
@@ -73,11 +75,12 @@ pyo3-build-config = { version = "0.27.2", optional = true }
 
 [features]
 default = ["rayon"]
-python = ["dep:pyo3", "dep:pyo3-build-config", "rayon"]
+python = ["dep:pyo3", "dep:pyo3-build-config", "dep:pyo3-stub-gen", "rayon"]
 wasm = [
   "dep:console_error_panic_hook",
   "dep:js-sys",
   "dep:serde-wasm-bindgen",
+  "dep:tsify-next",
   "dep:wasm-bindgen",
 ]
 rayon = ["dep:rayon"]

--- a/extensions/rust/python/ferrox/__init__.py
+++ b/extensions/rust/python/ferrox/__init__.py
@@ -1,106 +1,81 @@
-"""ferrox - High-performance crystallographic structure operations.
+"""ferrox - High-performance crystallographic structure operations in Rust.
 
-This package provides high-performance structure manipulation, symmetry analysis,
-and structure matching implemented in Rust with Python bindings.
-
-Key features:
-- Structure file I/O (CIF, POSCAR, extXYZ, JSON)
-- Structure matching and deduplication
-- Symmetry analysis (spacegroup, Wyckoff positions, etc.)
-- Coordination analysis (distance-based and Voronoi)
-- Structure transformations (supercells, primitive/conventional cells)
-- Composition parsing and analysis
+Features: I/O (CIF/POSCAR/extXYZ/JSON), structure matching, symmetry analysis,
+coordination analysis, supercells, primitive/conventional cells, composition parsing.
 """
 
+# ruff: noqa: F401 (re-exports for public API)
 from ferrox._ferrox import (
-    # Core
     StructureMatcher,
     __version__,
-    # I/O
-    parse_composition,
-    parse_structure_file,
-    parse_trajectory,
-    to_cif,
-    to_extxyz,
-    to_poscar,
-    to_pymatgen_json,
-    write_structure_file,
-    # Supercell & transformations
-    make_supercell,
-    make_supercell_diag,
-    to_conventional,
-    to_primitive,
-    # Slab generation
-    generate_slabs,
-    make_slab,
-    # Lattice reduction
-    get_reduced_structure,
-    get_reduced_structure_with_params,
-    # Symmetry analysis
-    get_crystal_system,
-    get_equivalent_sites,
-    get_hall_number,
-    get_pearson_symbol,
-    get_site_symmetry_symbols,
-    get_spacegroup_number,
-    get_spacegroup_symbol,
-    get_symmetry_dataset,
-    get_symmetry_operations,
-    get_wyckoff_letters,
-    # Structure properties
-    get_density,
-    get_structure_metadata,
-    get_total_mass,
-    get_volume,
-    # Distance & neighbor finding
+    apply_inversion,
+    apply_operation,
+    apply_translation,
+    copy_structure,
+    deform,
     distance_from_point,
     distance_matrix,
-    get_distance,
-    get_distance_and_image,
-    get_distance_with_image,
-    get_neighbor_list,
-    is_periodic_image,
-    # Coordination analysis
+    enumerate_derivatives,
+    ewald_energy,
+    generate_slabs,
+    get_all_site_properties,
     get_cn_voronoi,
     get_cn_voronoi_all,
     get_coordination_number,
     get_coordination_numbers,
+    get_crystal_system,
+    get_density,
+    get_distance,
+    get_distance_and_image,
+    get_distance_with_image,
+    get_equivalent_sites,
+    get_hall_number,
     get_local_environment,
     get_local_environment_voronoi,
+    get_neighbor_list,
     get_neighbors,
-    get_voronoi_neighbors,
-    # Sorting
+    get_pearson_symbol,
+    get_reduced_structure,
+    get_reduced_structure_with_params,
+    get_site_properties,
+    get_site_symmetry_symbols,
     get_sorted_by_electronegativity,
     get_sorted_structure,
-    # Interpolation
+    get_spacegroup_number,
+    get_spacegroup_symbol,
+    get_structure_metadata,
+    get_symmetry_dataset,
+    get_symmetry_operations,
+    get_total_mass,
+    get_volume,
+    get_voronoi_neighbors,
+    get_wyckoff_letters,
     interpolate,
-    # Matching
+    is_periodic_image,
+    make_slab,
+    make_supercell,
+    make_supercell_diag,
     matches,
-    # Copy & wrap
-    copy_structure,
-    wrap_to_unit_cell,
-    # Site manipulation
+    normalize_element_symbol,
+    order_disordered,
+    parse_composition,
+    parse_structure_file,
+    parse_trajectory,
     perturb,
     remove_sites,
     remove_species,
     set_site_property,
-    translate_sites,
-    # Site properties & labels
-    get_all_site_properties,
-    get_site_properties,
     site_label,
     site_labels,
     species_strings,
-    # Species operations
-    normalize_element_symbol,
     substitute_species,
-    # Symmetry operations
-    apply_inversion,
-    apply_operation,
-    apply_translation,
-    # Advanced transformations
-    deform,
-    enumerate_derivatives,
-    ewald_energy,
-    order_disordered,
+    to_cif,
+    to_conventional,
+    to_extxyz,
+    to_poscar,
+    to_primitive,
+    to_pymatgen_json,
+    translate_sites,
+    wrap_to_unit_cell,
+    write_structure_file,
 )

--- a/extensions/rust/python/ferrox/__init__.py
+++ b/extensions/rust/python/ferrox/__init__.py
@@ -30,12 +30,12 @@ from ferrox._ferrox import (
     make_supercell_diag,
     to_conventional,
     to_primitive,
+    # Slab generation
+    generate_slabs,
+    make_slab,
     # Lattice reduction
     get_reduced_structure,
     get_reduced_structure_with_params,
-    # Slabs
-    generate_slabs,
-    make_slab,
     # Symmetry analysis
     get_crystal_system,
     get_equivalent_sites,

--- a/extensions/rust/python/ferrox/__init__.py
+++ b/extensions/rust/python/ferrox/__init__.py
@@ -1,33 +1,106 @@
-"""ferrox - High-performance structure matching for crystallographic data."""
+"""ferrox - High-performance crystallographic structure operations.
+
+This package provides high-performance structure manipulation, symmetry analysis,
+and structure matching implemented in Rust with Python bindings.
+
+Key features:
+- Structure file I/O (CIF, POSCAR, extXYZ, JSON)
+- Structure matching and deduplication
+- Symmetry analysis (spacegroup, Wyckoff positions, etc.)
+- Coordination analysis (distance-based and Voronoi)
+- Structure transformations (supercells, primitive/conventional cells)
+- Composition parsing and analysis
+"""
 
 from ferrox._ferrox import (
+    # Core
     StructureMatcher,
     __version__,
-    copy_structure,
-    deform,
-    enumerate_derivatives,
-    ewald_energy,
-    generate_slabs,
-    get_all_site_properties,
-    get_density,
-    get_reduced_structure,
-    get_site_properties,
-    get_sorted_structure,
-    get_structure_metadata,
-    get_total_mass,
-    get_volume,
-    make_slab,
-    make_supercell,
-    normalize_element_symbol,
-    order_disordered,
+    # I/O
     parse_composition,
     parse_structure_file,
     parse_trajectory,
+    to_cif,
+    to_extxyz,
+    to_poscar,
+    to_pymatgen_json,
+    write_structure_file,
+    # Supercell & transformations
+    make_supercell,
+    make_supercell_diag,
+    to_conventional,
+    to_primitive,
+    # Lattice reduction
+    get_reduced_structure,
+    get_reduced_structure_with_params,
+    # Slabs
+    generate_slabs,
+    make_slab,
+    # Symmetry analysis
+    get_crystal_system,
+    get_equivalent_sites,
+    get_hall_number,
+    get_pearson_symbol,
+    get_site_symmetry_symbols,
+    get_spacegroup_number,
+    get_spacegroup_symbol,
+    get_symmetry_dataset,
+    get_symmetry_operations,
+    get_wyckoff_letters,
+    # Structure properties
+    get_density,
+    get_structure_metadata,
+    get_total_mass,
+    get_volume,
+    # Distance & neighbor finding
+    distance_from_point,
+    distance_matrix,
+    get_distance,
+    get_distance_and_image,
+    get_distance_with_image,
+    get_neighbor_list,
+    is_periodic_image,
+    # Coordination analysis
+    get_cn_voronoi,
+    get_cn_voronoi_all,
+    get_coordination_number,
+    get_coordination_numbers,
+    get_local_environment,
+    get_local_environment_voronoi,
+    get_neighbors,
+    get_voronoi_neighbors,
+    # Sorting
+    get_sorted_by_electronegativity,
+    get_sorted_structure,
+    # Interpolation
+    interpolate,
+    # Matching
+    matches,
+    # Copy & wrap
+    copy_structure,
+    wrap_to_unit_cell,
+    # Site manipulation
+    perturb,
     remove_sites,
     remove_species,
     set_site_property,
+    translate_sites,
+    # Site properties & labels
+    get_all_site_properties,
+    get_site_properties,
+    site_label,
+    site_labels,
+    species_strings,
+    # Species operations
+    normalize_element_symbol,
     substitute_species,
-    to_conventional,
-    to_primitive,
-    wrap_to_unit_cell,
+    # Symmetry operations
+    apply_inversion,
+    apply_operation,
+    apply_translation,
+    # Advanced transformations
+    deform,
+    enumerate_derivatives,
+    ewald_energy,
+    order_disordered,
 )

--- a/extensions/rust/python/ferrox/_ferrox.pyi
+++ b/extensions/rust/python/ferrox/_ferrox.pyi
@@ -1,0 +1,1342 @@
+"""Type stubs for ferrox._ferrox Rust extension module.
+
+This module provides high-performance crystallographic structure operations
+implemented in Rust with Python bindings via PyO3.
+"""
+
+from typing import Any, Literal
+
+# Type aliases for better readability
+StructureJson = str  # JSON string from pymatgen Structure.as_dict()
+StructureDict = dict[str, Any]  # pymatgen-compatible structure dict
+Matrix3x3 = list[list[float]]  # 3x3 matrix as nested list
+IntMatrix3x3 = list[list[int]]  # 3x3 integer matrix
+Vector3 = list[float]  # 3-element vector [x, y, z]
+IntVector3 = list[int]  # 3-element integer vector [a, b, c]
+RotationMatrix = list[list[int]]  # 3x3 integer rotation matrix
+TranslationVector = list[float]  # 3-element translation vector
+
+__version__: str
+
+class StructureMatcher:
+    """High-performance structure matcher for crystallographic comparisons.
+
+    Compares crystal structures accounting for lattice transformations,
+    periodic boundary conditions, and optional volume scaling.
+
+    Accepts structures as JSON strings (from pymatgen's Structure.as_dict()).
+
+    Attributes:
+        latt_len_tol: Fractional length tolerance for lattice vectors.
+        site_pos_tol: Site position tolerance, normalized.
+        angle_tol: Angle tolerance in degrees.
+        primitive_cell: Whether to reduce to primitive cell before matching.
+        scale: Whether to scale volumes to match.
+        attempt_supercell: Whether to try supercell matching.
+    """
+
+    # Properties (read-only)
+    @property
+    def latt_len_tol(self) -> float: ...
+    @property
+    def site_pos_tol(self) -> float: ...
+    @property
+    def angle_tol(self) -> float: ...
+    @property
+    def primitive_cell(self) -> bool: ...
+    @property
+    def scale(self) -> bool: ...
+    @property
+    def attempt_supercell(self) -> bool: ...
+    def __init__(
+        self,
+        latt_len_tol: float = 0.2,
+        site_pos_tol: float = 0.3,
+        angle_tol: float = 5.0,
+        primitive_cell: bool = True,
+        scale: bool = True,
+        attempt_supercell: bool = False,
+        comparator: Literal["species", "element"] = "species",
+    ) -> None:
+        """Create a new StructureMatcher.
+
+        Args:
+            latt_len_tol: Fractional length tolerance for lattice vectors.
+            site_pos_tol: Site position tolerance, normalized.
+            angle_tol: Angle tolerance in degrees.
+            primitive_cell: Whether to reduce to primitive cell.
+            scale: Whether to scale volumes to match.
+            attempt_supercell: Whether to try supercell matching.
+            comparator: "species" to match oxidation states, "element" to ignore them.
+        """
+        ...
+    def fit(
+        self,
+        struct1: StructureJson,
+        struct2: StructureJson,
+        skip_structure_reduction: bool = False,
+    ) -> bool:
+        """Check if two structures match.
+
+        Args:
+            struct1: First structure as JSON string.
+            struct2: Second structure as JSON string.
+            skip_structure_reduction: If True, skip Niggli/primitive reduction
+                (use with pre-reduced structures from reduce_structure()).
+
+        Returns:
+            True if structures match within tolerances.
+        """
+        ...
+    def get_rms_dist(
+        self, struct1: StructureJson, struct2: StructureJson
+    ) -> tuple[float, float] | None:
+        """Get RMS distance between two structures.
+
+        Args:
+            struct1: First structure as JSON string.
+            struct2: Second structure as JSON string.
+
+        Returns:
+            Tuple of (rms, max_dist) if structures match, None otherwise.
+        """
+        ...
+    def fit_anonymous(self, struct1: StructureJson, struct2: StructureJson) -> bool:
+        """Check if two structures match under any species permutation.
+
+        Useful for comparing structure prototypes (e.g., NaCl vs MgO both
+        have the rocksalt structure).
+
+        Args:
+            struct1: First structure as JSON string.
+            struct2: Second structure as JSON string.
+
+        Returns:
+            True if structures match under some species permutation.
+        """
+        ...
+    def deduplicate(self, structures: list[StructureJson]) -> list[int]:
+        """Deduplicate a list of structures.
+
+        Args:
+            structures: List of structure JSON strings.
+
+        Returns:
+            List where result[i] is the index of the first structure matching structure i.
+        """
+        ...
+    def group(self, structures: list[StructureJson]) -> dict[int, list[int]]:
+        """Group structures into equivalence classes.
+
+        Args:
+            structures: List of structure JSON strings.
+
+        Returns:
+            Dict mapping canonical index to list of equivalent structure indices.
+        """
+        ...
+    def get_unique_indices(self, structures: list[StructureJson]) -> list[int]:
+        """Get indices of unique structures from a list.
+
+        Args:
+            structures: List of structure JSON strings.
+
+        Returns:
+            List of indices of unique (first occurrence) structures.
+        """
+        ...
+    def find_matches(
+        self,
+        new_structures: list[StructureJson],
+        existing_structures: list[StructureJson],
+    ) -> list[int | None]:
+        """Find matches for new structures against existing (already-deduplicated) structures.
+
+        Optimized for comparing a small batch of new structures against a large
+        set of existing deduplicated structures.
+
+        Args:
+            new_structures: List of new structure JSON strings to check.
+            existing_structures: List of existing structure JSON strings.
+
+        Returns:
+            List where result[i] is the index of matching existing structure, or None.
+        """
+        ...
+    def reduce_structure(self, structure: StructureJson) -> StructureJson:
+        """Apply Niggli reduction and optionally primitive cell reduction.
+
+        Use this to pre-reduce structures before calling fit(..., skip_structure_reduction=True).
+
+        Args:
+            structure: Structure as JSON string.
+
+        Returns:
+            Reduced structure as JSON string (pymatgen-compatible).
+        """
+        ...
+    def __repr__(self) -> str: ...
+
+# =============================================================================
+# I/O Functions - Reading
+# =============================================================================
+
+def parse_structure_file(path: str) -> StructureDict:
+    """Parse a structure file (auto-detects format from extension).
+
+    Supports: .json (pymatgen), .cif, .xyz/.extxyz, POSCAR*/CONTCAR*/.vasp
+
+    Args:
+        path: Path to the structure file.
+
+    Returns:
+        Structure as a Python dict compatible with pymatgen's Structure.from_dict().
+    """
+    ...
+
+def parse_trajectory(path: str) -> list[StructureDict]:
+    """Parse trajectory file (extXYZ format).
+
+    Args:
+        path: Path to the trajectory file (.xyz/.extxyz format).
+
+    Returns:
+        List of pymatgen-compatible structure dicts, one per frame.
+    """
+    ...
+
+# =============================================================================
+# I/O Functions - Writing
+# =============================================================================
+
+def write_structure_file(structure: StructureJson, path: str) -> None:
+    """Write a structure to a file with automatic format detection.
+
+    Format determined by extension: .json, .cif, .xyz/.extxyz, .vasp/POSCAR*/CONTCAR*
+
+    Args:
+        structure: Structure as JSON string.
+        path: Path to the output file.
+    """
+    ...
+
+def to_poscar(structure: StructureJson, comment: str | None = None) -> str:
+    """Convert a structure to POSCAR format string.
+
+    Args:
+        structure: Structure as JSON string.
+        comment: Optional comment line (defaults to formula).
+
+    Returns:
+        POSCAR format string.
+    """
+    ...
+
+def to_cif(structure: StructureJson, data_name: str | None = None) -> str:
+    """Convert a structure to CIF format string.
+
+    Args:
+        structure: Structure as JSON string.
+        data_name: Optional data block name (defaults to formula).
+
+    Returns:
+        CIF format string.
+    """
+    ...
+
+def to_extxyz(structure: StructureJson) -> str:
+    """Convert a structure to extXYZ format string.
+
+    Args:
+        structure: Structure as JSON string.
+
+    Returns:
+        extXYZ format string.
+    """
+    ...
+
+def to_pymatgen_json(structure: StructureJson) -> str:
+    """Convert a structure to pymatgen JSON format string.
+
+    Args:
+        structure: Structure as JSON string.
+
+    Returns:
+        JSON format string compatible with pymatgen's Structure.from_dict().
+    """
+    ...
+
+# =============================================================================
+# Supercell Functions
+# =============================================================================
+
+def make_supercell(
+    structure: StructureJson, scaling_matrix: tuple[tuple[int, int, int], ...]
+) -> StructureDict:
+    """Create a supercell from a structure.
+
+    Args:
+        structure: Structure as JSON string.
+        scaling_matrix: 3x3 integer scaling matrix [[a1,a2,a3],[b1,b2,b3],[c1,c2,c3]].
+            Negative values allowed (create mirror transformations).
+
+    Returns:
+        Supercell structure as pymatgen-compatible dict.
+    """
+    ...
+
+def make_supercell_diag(
+    structure: StructureJson, nx: int, ny: int, nz: int
+) -> StructureDict:
+    """Create a diagonal supercell (nx × ny × nz).
+
+    Args:
+        structure: Structure as JSON string.
+        nx: Scaling factor along a-axis.
+        ny: Scaling factor along b-axis.
+        nz: Scaling factor along c-axis.
+
+    Returns:
+        Supercell structure as pymatgen-compatible dict.
+    """
+    ...
+
+# =============================================================================
+# Lattice Reduction Functions
+# =============================================================================
+
+def get_reduced_structure(
+    structure: StructureJson, algo: Literal["niggli", "lll"]
+) -> StructureDict:
+    """Get a structure with reduced lattice (Niggli or LLL).
+
+    Atomic positions are preserved in Cartesian space; only the lattice
+    basis changes. Fractional coordinates are wrapped to [0, 1).
+
+    Args:
+        structure: Structure as JSON string.
+        algo: Reduction algorithm - "niggli" or "lll".
+
+    Returns:
+        Reduced structure as pymatgen-compatible dict.
+    """
+    ...
+
+def get_reduced_structure_with_params(
+    structure: StructureJson,
+    algo: Literal["niggli", "lll"],
+    niggli_tol: float = 1e-5,
+    lll_delta: float = 0.75,
+) -> StructureDict:
+    """Get reduced structure with custom parameters.
+
+    Args:
+        structure: Structure as JSON string.
+        algo: Reduction algorithm.
+        niggli_tol: Tolerance for Niggli reduction (ignored for LLL).
+        lll_delta: Delta parameter for LLL reduction (ignored for Niggli).
+
+    Returns:
+        Reduced structure as pymatgen-compatible dict.
+    """
+    ...
+
+# =============================================================================
+# Neighbor Finding and Distance Functions
+# =============================================================================
+
+def get_neighbor_list(
+    structure: StructureJson,
+    r: float,
+    numerical_tol: float = 1e-8,
+    exclude_self: bool = True,
+) -> tuple[list[int], list[int], list[tuple[int, int, int]], list[float]]:
+    """Get neighbor list for a structure.
+
+    Finds all atom pairs within cutoff radius using periodic boundary conditions.
+
+    Args:
+        structure: Structure as JSON string.
+        r: Cutoff radius in Angstroms.
+        numerical_tol: Tolerance for distance comparisons.
+        exclude_self: If True, exclude self-pairs (distance ~0).
+
+    Returns:
+        Tuple of (center_indices, neighbor_indices, image_offsets, distances).
+    """
+    ...
+
+def get_distance(structure: StructureJson, i: int, j: int) -> float:
+    """Get distance between two sites using minimum image convention.
+
+    Args:
+        structure: Structure as JSON string.
+        i: First site index.
+        j: Second site index.
+
+    Returns:
+        Distance in Angstroms.
+    """
+    ...
+
+def get_distance_and_image(
+    structure: StructureJson, i: int, j: int
+) -> tuple[float, tuple[int, int, int]]:
+    """Get distance and periodic image between two sites.
+
+    Args:
+        structure: Structure as JSON string.
+        i: First site index.
+        j: Second site index.
+
+    Returns:
+        Tuple of (distance, [da, db, dc]) where image tells which periodic
+        image of site j is closest to site i.
+    """
+    ...
+
+def get_distance_with_image(
+    structure: StructureJson,
+    i: int,
+    j: int,
+    jimage: tuple[int, int, int],
+) -> float:
+    """Get distance to a specific periodic image of site j.
+
+    Args:
+        structure: Structure as JSON string.
+        i: First site index.
+        j: Second site index.
+        jimage: Lattice translation [da, db, dc].
+
+    Returns:
+        Distance to the specified periodic image.
+    """
+    ...
+
+def distance_from_point(
+    structure: StructureJson, idx: int, point: tuple[float, float, float]
+) -> float:
+    """Get Cartesian distance from a site to an arbitrary point.
+
+    Simple Euclidean distance, not using periodic boundary conditions.
+
+    Args:
+        structure: Structure as JSON string.
+        idx: Site index.
+        point: Cartesian coordinates [x, y, z].
+
+    Returns:
+        Distance in Angstroms.
+    """
+    ...
+
+def distance_matrix(structure: StructureJson) -> list[list[float]]:
+    """Get the full distance matrix between all sites.
+
+    Args:
+        structure: Structure as JSON string.
+
+    Returns:
+        n × n distance matrix where n = num_sites.
+    """
+    ...
+
+def is_periodic_image(
+    structure: StructureJson, i: int, j: int, tolerance: float = 1e-8
+) -> bool:
+    """Check if two sites are periodic images of each other.
+
+    Sites are periodic images if they have the same species and their
+    fractional coordinates differ by integers (within tolerance).
+
+    Args:
+        structure: Structure as JSON string.
+        i: First site index.
+        j: Second site index.
+        tolerance: Tolerance for coordinate comparison.
+
+    Returns:
+        True if sites are periodic images.
+    """
+    ...
+
+# =============================================================================
+# Site Label and Species Functions
+# =============================================================================
+
+def site_label(structure: StructureJson, idx: int) -> str:
+    """Get label for a specific site.
+
+    Returns explicit label if set, otherwise the species string.
+
+    Args:
+        structure: Structure as JSON string.
+        idx: Site index.
+
+    Returns:
+        Site label.
+    """
+    ...
+
+def site_labels(structure: StructureJson) -> list[str]:
+    """Get labels for all sites.
+
+    Args:
+        structure: Structure as JSON string.
+
+    Returns:
+        List of site labels.
+    """
+    ...
+
+def species_strings(structure: StructureJson) -> list[str]:
+    """Get species strings for all sites.
+
+    For ordered sites: "Fe" or "Fe2+". For disordered: "Co:0.500, Fe:0.500".
+
+    Args:
+        structure: Structure as JSON string.
+
+    Returns:
+        List of species strings.
+    """
+    ...
+
+# =============================================================================
+# Interpolation Functions
+# =============================================================================
+
+def interpolate(
+    struct1: StructureJson,
+    struct2: StructureJson,
+    n_images: int,
+    interpolate_lattices: bool = False,
+    use_pbc: bool = True,
+) -> list[StructureDict]:
+    """Interpolate between two structures for NEB calculations.
+
+    Generates n_images + 1 structures from start to end with linearly
+    interpolated coordinates.
+
+    Args:
+        struct1: Start structure as JSON string.
+        struct2: End structure as JSON string.
+        n_images: Number of intermediate images (total returned = n_images + 1).
+        interpolate_lattices: If True, also interpolate lattice parameters.
+        use_pbc: If True, use minimum image convention for interpolation.
+
+    Returns:
+        List of structure dicts from start to end.
+    """
+    ...
+
+# =============================================================================
+# Matching Convenience Functions
+# =============================================================================
+
+def matches(
+    struct1: StructureJson, struct2: StructureJson, anonymous: bool = False
+) -> bool:
+    """Check if two structures match using default matcher settings.
+
+    Args:
+        struct1: First structure as JSON string.
+        struct2: Second structure as JSON string.
+        anonymous: If True, allows any species permutation (prototype matching).
+
+    Returns:
+        True if structures match, False otherwise.
+    """
+    ...
+
+# =============================================================================
+# Sorting Functions
+# =============================================================================
+
+def get_sorted_structure(
+    structure: StructureJson, reverse: bool = False
+) -> StructureDict:
+    """Get a sorted copy of the structure by atomic number.
+
+    Args:
+        structure: Structure as JSON string.
+        reverse: If True, sort in descending order.
+
+    Returns:
+        Sorted structure as pymatgen-compatible dict.
+    """
+    ...
+
+def get_sorted_by_electronegativity(
+    structure: StructureJson, reverse: bool = False
+) -> StructureDict:
+    """Get a sorted copy of the structure by electronegativity.
+
+    Args:
+        structure: Structure as JSON string.
+        reverse: If True, sort in descending order.
+
+    Returns:
+        Sorted structure as pymatgen-compatible dict.
+    """
+    ...
+
+# =============================================================================
+# Copy/Sanitization Functions
+# =============================================================================
+
+def copy_structure(
+    structure: StructureJson, sanitize: bool = False
+) -> StructureDict:
+    """Create a copy of the structure, optionally sanitized.
+
+    Sanitization applies:
+    1. LLL lattice reduction
+    2. Sort sites by electronegativity
+    3. Wrap fractional coords to [0, 1)
+
+    Args:
+        structure: Structure as JSON string.
+        sanitize: If True, apply sanitization steps.
+
+    Returns:
+        Copy of structure as pymatgen-compatible dict.
+    """
+    ...
+
+def wrap_to_unit_cell(structure: StructureJson) -> StructureDict:
+    """Wrap all fractional coordinates to [0, 1).
+
+    Args:
+        structure: Structure as JSON string.
+
+    Returns:
+        Structure with wrapped coordinates as pymatgen-compatible dict.
+    """
+    ...
+
+# =============================================================================
+# Symmetry Operation Functions
+# =============================================================================
+
+def apply_operation(
+    structure: StructureJson,
+    rotation: tuple[tuple[float, float, float], ...],
+    translation: tuple[float, float, float],
+    fractional: bool = True,
+) -> StructureDict:
+    """Apply a symmetry operation to a structure.
+
+    The transformation is: new = rotation × old + translation
+
+    Args:
+        structure: Structure as JSON string.
+        rotation: 3x3 rotation matrix.
+        translation: Translation vector [t1, t2, t3].
+        fractional: If True, operation is in fractional coords; else Cartesian.
+
+    Returns:
+        Transformed structure as pymatgen-compatible dict.
+    """
+    ...
+
+def apply_inversion(
+    structure: StructureJson, fractional: bool = True
+) -> StructureDict:
+    """Apply inversion through the origin.
+
+    Args:
+        structure: Structure as JSON string.
+        fractional: If True, operation is in fractional coords; else Cartesian.
+
+    Returns:
+        Inverted structure as pymatgen-compatible dict.
+    """
+    ...
+
+def apply_translation(
+    structure: StructureJson,
+    translation: tuple[float, float, float],
+    fractional: bool = True,
+) -> StructureDict:
+    """Apply a translation to all sites.
+
+    Args:
+        structure: Structure as JSON string.
+        translation: Translation vector [t1, t2, t3].
+        fractional: If True, translation is in fractional coords; else Cartesian.
+
+    Returns:
+        Translated structure as pymatgen-compatible dict.
+    """
+    ...
+
+# =============================================================================
+# Structure Property Functions
+# =============================================================================
+
+def get_volume(structure: StructureJson) -> float:
+    """Get the volume of the unit cell in Angstrom³.
+
+    Args:
+        structure: Structure as JSON string.
+
+    Returns:
+        Volume in Angstrom³.
+    """
+    ...
+
+def get_total_mass(structure: StructureJson) -> float:
+    """Get the total mass of the structure in atomic mass units (u).
+
+    Args:
+        structure: Structure as JSON string.
+
+    Returns:
+        Total mass in amu.
+    """
+    ...
+
+def get_density(structure: StructureJson) -> float | None:
+    """Get the density of the structure in g/cm³.
+
+    Args:
+        structure: Structure as JSON string.
+
+    Returns:
+        Density in g/cm³, or None if volume is zero.
+    """
+    ...
+
+def get_structure_metadata(
+    structure: StructureJson,
+    compute_spacegroup: bool = False,
+    symprec: float = 0.01,
+) -> dict[str, Any]:
+    """Get all queryable metadata from a structure in a single call.
+
+    More efficient than calling individual functions when you need
+    multiple properties, as it only parses the structure once.
+
+    Args:
+        structure: Structure as JSON string.
+        compute_spacegroup: Whether to compute spacegroup (expensive).
+        symprec: Symmetry precision for spacegroup detection.
+
+    Returns:
+        Metadata dict with keys: formula, anonymous_formula, hill_formula,
+        chemical_system, elements, n_elements, n_sites, volume, density,
+        mass, is_ordered, spacegroup_number (optional).
+    """
+    ...
+
+# =============================================================================
+# Symmetry Analysis Functions
+# =============================================================================
+
+def get_spacegroup_number(structure: StructureJson, symprec: float = 0.01) -> int:
+    """Get the spacegroup number of a structure.
+
+    Args:
+        structure: Structure as JSON string.
+        symprec: Symmetry precision.
+
+    Returns:
+        Spacegroup number (1-230).
+    """
+    ...
+
+def get_spacegroup_symbol(structure: StructureJson, symprec: float = 0.01) -> str:
+    """Get the Hermann-Mauguin spacegroup symbol (e.g., "Fm-3m", "P2_1/c").
+
+    Args:
+        structure: Structure as JSON string.
+        symprec: Symmetry precision.
+
+    Returns:
+        Hermann-Mauguin symbol.
+    """
+    ...
+
+def get_hall_number(structure: StructureJson, symprec: float = 0.01) -> int:
+    """Get the Hall number (1-530) identifying the specific spacegroup setting.
+
+    Args:
+        structure: Structure as JSON string.
+        symprec: Symmetry precision.
+
+    Returns:
+        Hall number.
+    """
+    ...
+
+def get_pearson_symbol(structure: StructureJson, symprec: float = 0.01) -> str:
+    """Get the Pearson symbol (e.g., "cF8" for FCC Cu).
+
+    The Pearson symbol encodes the crystal system, centering type, and
+    number of atoms in the conventional cell.
+
+    Args:
+        structure: Structure as JSON string.
+        symprec: Symmetry precision.
+
+    Returns:
+        Pearson symbol.
+    """
+    ...
+
+def get_wyckoff_letters(
+    structure: StructureJson, symprec: float = 0.01
+) -> list[str]:
+    """Get Wyckoff letters for each site in the structure.
+
+    Wyckoff positions describe the site symmetry and multiplicity.
+    Sites with the same letter have equivalent positions under the space group.
+
+    Args:
+        structure: Structure as JSON string.
+        symprec: Symmetry precision.
+
+    Returns:
+        Wyckoff letters for each site (single-character strings).
+    """
+    ...
+
+def get_site_symmetry_symbols(
+    structure: StructureJson, symprec: float = 0.01
+) -> list[str]:
+    """Get site symmetry symbols for each site (e.g., "m..", "-1", "4mm").
+
+    The site symmetry describes the point group symmetry at each atomic site.
+
+    Args:
+        structure: Structure as JSON string.
+        symprec: Symmetry precision.
+
+    Returns:
+        Site symmetry symbols for each site.
+    """
+    ...
+
+def get_symmetry_operations(
+    structure: StructureJson, symprec: float = 0.01
+) -> list[tuple[list[list[int]], list[float]]]:
+    """Get symmetry operations in the input cell.
+
+    A symmetry operation transforms a point r to: R @ r + t
+
+    Args:
+        structure: Structure as JSON string.
+        symprec: Symmetry precision.
+
+    Returns:
+        List of (rotation, translation) pairs.
+    """
+    ...
+
+def get_equivalent_sites(
+    structure: StructureJson, symprec: float = 0.01
+) -> list[int]:
+    """Get equivalent sites (crystallographic orbits).
+
+    Returns a list where orbits[i] is the index of the representative site
+    that site i is equivalent to.
+
+    Args:
+        structure: Structure as JSON string.
+        symprec: Symmetry precision.
+
+    Returns:
+        Orbit indices for each site.
+    """
+    ...
+
+def get_crystal_system(structure: StructureJson, symprec: float = 0.01) -> str:
+    """Get the crystal system based on the spacegroup.
+
+    Returns one of: "triclinic", "monoclinic", "orthorhombic",
+    "tetragonal", "trigonal", "hexagonal", "cubic".
+
+    Args:
+        structure: Structure as JSON string.
+        symprec: Symmetry precision.
+
+    Returns:
+        Crystal system name.
+    """
+    ...
+
+def get_symmetry_dataset(
+    structure: StructureJson, symprec: float = 0.01
+) -> dict[str, Any]:
+    """Get full symmetry dataset for a structure.
+
+    More efficient when you need multiple symmetry properties.
+
+    Args:
+        structure: Structure as JSON string.
+        symprec: Symmetry precision.
+
+    Returns:
+        Dict with keys: spacegroup_number, spacegroup_symbol, hall_number,
+        pearson_symbol, crystal_system, wyckoff_letters, site_symmetry_symbols,
+        equivalent_sites, symmetry_operations, num_operations.
+    """
+    ...
+
+# =============================================================================
+# Site Manipulation Functions
+# =============================================================================
+
+def translate_sites(
+    structure: StructureJson,
+    indices: list[int],
+    vector: tuple[float, float, float],
+    fractional: bool = True,
+) -> StructureDict:
+    """Translate specific sites by a vector.
+
+    Args:
+        structure: Structure as JSON string.
+        indices: Site indices to translate.
+        vector: Translation vector [x, y, z].
+        fractional: If True, vector is in fractional coords; else Cartesian.
+
+    Returns:
+        Structure with translated sites as pymatgen-compatible dict.
+    """
+    ...
+
+def perturb(
+    structure: StructureJson,
+    distance: float,
+    min_distance: float | None = None,
+    seed: int | None = None,
+) -> StructureDict:
+    """Perturb all sites by random vectors.
+
+    Each site is translated by a random vector with magnitude uniformly
+    distributed in [min_distance, distance].
+
+    Args:
+        structure: Structure as JSON string.
+        distance: Maximum perturbation distance in Angstroms.
+        min_distance: Minimum perturbation distance (default: 0).
+        seed: Random seed for reproducibility.
+
+    Returns:
+        Perturbed structure as pymatgen-compatible dict.
+    """
+    ...
+
+# =============================================================================
+# Normalization and Site Property Functions
+# =============================================================================
+
+def normalize_element_symbol(symbol: str) -> dict[str, Any]:
+    """Normalize an element symbol string.
+
+    Parses various element symbol formats and extracts the base element,
+    oxidation state, and metadata (POTCAR suffix, labels, etc.).
+
+    Args:
+        symbol: Element symbol (e.g., "Fe", "Fe2+", "Ca_pv", "Fe1_oct").
+
+    Returns:
+        Dict with keys: element (str), oxidation_state (int | None), metadata (dict).
+    """
+    ...
+
+def get_site_properties(structure: StructureJson, idx: int) -> dict[str, Any]:
+    """Get site properties for a specific site.
+
+    Args:
+        structure: Structure as JSON string.
+        idx: Site index.
+
+    Returns:
+        Site properties as a dict.
+    """
+    ...
+
+def get_all_site_properties(structure: StructureJson) -> list[dict[str, Any]]:
+    """Get all site properties for a structure.
+
+    Args:
+        structure: Structure as JSON string.
+
+    Returns:
+        List of site property dicts (parallel to sites).
+    """
+    ...
+
+def set_site_property(
+    structure: StructureJson, idx: int, key: str, value: Any
+) -> StructureDict:
+    """Set a site property.
+
+    Args:
+        structure: Structure as JSON string.
+        idx: Site index.
+        key: Property key.
+        value: Property value (must be JSON-serializable).
+
+    Returns:
+        Updated structure as pymatgen-compatible dict.
+    """
+    ...
+
+# =============================================================================
+# Composition Functions
+# =============================================================================
+
+def parse_composition(formula: str) -> dict[str, Any]:
+    """Parse a chemical formula and return composition data.
+
+    Args:
+        formula: Chemical formula string (e.g., "LiFePO4", "Ca3(PO4)2").
+
+    Returns:
+        Dict with keys: species (dict[str, float]), formula, reduced_formula,
+        anonymous_formula, hill_formula, alphabetical_formula, chemical_system,
+        num_atoms, num_elements, weight, is_element, average_electroneg,
+        total_electrons.
+    """
+    ...
+
+# =============================================================================
+# Slab Functions
+# =============================================================================
+
+def make_slab(
+    structure: StructureJson,
+    miller_index: tuple[int, int, int],
+    min_slab_size: float,
+    min_vacuum_size: float,
+    max_normal_search: int | None = None,
+    center_slab: bool = True,
+    in_unit_planes: bool = False,
+    primitive: bool = True,
+    lll_reduce: bool = False,
+    reorient_lattice: bool = True,
+) -> StructureDict:
+    """Create a slab from a bulk structure.
+
+    Args:
+        structure: Bulk structure as JSON string.
+        miller_index: Miller indices (h, k, l) for the surface.
+        min_slab_size: Minimum slab thickness in Angstroms.
+        min_vacuum_size: Minimum vacuum thickness in Angstroms.
+        max_normal_search: Max normal search depth (None for automatic).
+        center_slab: Whether to center the slab in the cell.
+        in_unit_planes: If True, min_slab_size is in unit planes.
+        primitive: Whether to reduce to primitive cell.
+        lll_reduce: Whether to apply LLL reduction.
+        reorient_lattice: Whether to reorient lattice vectors.
+
+    Returns:
+        Slab structure as pymatgen-compatible dict.
+    """
+    ...
+
+def generate_slabs(
+    structure: StructureJson,
+    miller_index: tuple[int, int, int],
+    min_slab_size: float,
+    min_vacuum_size: float,
+    max_normal_search: int | None = None,
+    center_slab: bool = True,
+    in_unit_planes: bool = False,
+    primitive: bool = True,
+    lll_reduce: bool = False,
+    symmetrize: bool = False,
+) -> list[StructureDict]:
+    """Generate all terminations of a slab.
+
+    Args:
+        structure: Bulk structure as JSON string.
+        miller_index: Miller indices (h, k, l) for the surface.
+        min_slab_size: Minimum slab thickness in Angstroms.
+        min_vacuum_size: Minimum vacuum thickness in Angstroms.
+        max_normal_search: Max normal search depth (None for automatic).
+        center_slab: Whether to center the slab in the cell.
+        in_unit_planes: If True, min_slab_size is in unit planes.
+        primitive: Whether to reduce to primitive cell.
+        lll_reduce: Whether to apply LLL reduction.
+        symmetrize: Whether to symmetrize the slab.
+
+    Returns:
+        List of slab structures for all unique terminations.
+    """
+    ...
+
+# =============================================================================
+# Transformation Functions
+# =============================================================================
+
+def to_primitive(structure: StructureJson, symprec: float = 0.01) -> StructureDict:
+    """Get the primitive cell of a structure.
+
+    Uses symmetry analysis to find the smallest unit cell that generates
+    the original structure through translational symmetry.
+
+    Args:
+        structure: Structure as JSON string.
+        symprec: Symmetry precision.
+
+    Returns:
+        Primitive structure as pymatgen-compatible dict.
+    """
+    ...
+
+def to_conventional(structure: StructureJson, symprec: float = 0.01) -> StructureDict:
+    """Get the conventional cell of a structure.
+
+    Uses symmetry analysis to find the conventional unit cell based on
+    the spacegroup's standard setting.
+
+    Args:
+        structure: Structure as JSON string.
+        symprec: Symmetry precision.
+
+    Returns:
+        Conventional structure as pymatgen-compatible dict.
+    """
+    ...
+
+def substitute_species(
+    structure: StructureJson, from_species: str, to_species: str
+) -> StructureDict:
+    """Substitute species throughout a structure.
+
+    Args:
+        structure: Structure as JSON string.
+        from_species: Species to replace (e.g., "Fe", "Fe2+").
+        to_species: Replacement species.
+
+    Returns:
+        Structure with substituted species.
+    """
+    ...
+
+def remove_species(structure: StructureJson, species: list[str]) -> StructureDict:
+    """Remove all sites containing specified species.
+
+    Args:
+        structure: Structure as JSON string.
+        species: Species to remove (e.g., ["Li", "Na"]).
+
+    Returns:
+        Structure with species removed.
+    """
+    ...
+
+def remove_sites(structure: StructureJson, indices: list[int]) -> StructureDict:
+    """Remove sites by index.
+
+    Args:
+        structure: Structure as JSON string.
+        indices: Site indices to remove.
+
+    Returns:
+        Structure with sites removed.
+    """
+    ...
+
+def deform(
+    structure: StructureJson,
+    gradient: tuple[tuple[float, float, float], ...],
+) -> StructureDict:
+    """Apply a deformation gradient to the lattice.
+
+    Args:
+        structure: Structure as JSON string.
+        gradient: 3x3 deformation gradient matrix.
+
+    Returns:
+        Deformed structure.
+    """
+    ...
+
+def ewald_energy(
+    structure: StructureJson, accuracy: float = 1e-5, real_cutoff: float = 10.0
+) -> float:
+    """Compute Ewald energy of an ionic structure.
+
+    Args:
+        structure: Structure as JSON string (must have oxidation states).
+        accuracy: Accuracy parameter for Ewald summation.
+        real_cutoff: Real-space cutoff in Angstroms.
+
+    Returns:
+        Coulomb energy in eV.
+    """
+    ...
+
+def order_disordered(
+    structure: StructureJson,
+    max_structures: int | None = None,
+    sort_by_energy: bool = True,
+) -> list[StructureDict]:
+    """Enumerate orderings of a disordered structure.
+
+    Takes a structure with disordered sites and returns all possible
+    ordered configurations, optionally ranked by Ewald energy.
+
+    Args:
+        structure: Structure as JSON string.
+        max_structures: Maximum number of structures to return.
+        sort_by_energy: Whether to sort by Ewald energy.
+
+    Returns:
+        List of ordered structures as pymatgen-compatible dicts.
+    """
+    ...
+
+def enumerate_derivatives(
+    structure: StructureJson, min_size: int = 1, max_size: int = 4
+) -> list[StructureDict]:
+    """Enumerate derivative structures from a parent structure.
+
+    Generates all symmetrically unique supercells up to a given size.
+
+    Args:
+        structure: Parent structure as JSON string.
+        min_size: Minimum supercell size (number of formula units).
+        max_size: Maximum supercell size.
+
+    Returns:
+        List of derivative structures.
+    """
+    ...
+
+# =============================================================================
+# Coordination Analysis Functions
+# =============================================================================
+
+def get_coordination_numbers(structure: StructureJson, cutoff: float) -> list[int]:
+    """Get coordination numbers for all sites using a distance cutoff.
+
+    Counts neighbors within the cutoff distance using periodic boundary conditions.
+
+    Args:
+        structure: Structure as JSON string.
+        cutoff: Maximum distance in Angstroms.
+
+    Returns:
+        Coordination numbers for each site.
+    """
+    ...
+
+def get_coordination_number(
+    structure: StructureJson, site_idx: int, cutoff: float
+) -> int:
+    """Get coordination number for a single site using a distance cutoff.
+
+    Args:
+        structure: Structure as JSON string.
+        site_idx: Index of the site to analyze.
+        cutoff: Maximum distance in Angstroms.
+
+    Returns:
+        Coordination number for the specified site.
+    """
+    ...
+
+def get_local_environment(
+    structure: StructureJson, site_idx: int, cutoff: float
+) -> list[dict[str, Any]]:
+    """Get the local environment (neighbor information) for a site.
+
+    Args:
+        structure: Structure as JSON string.
+        site_idx: Index of the site to analyze.
+        cutoff: Maximum distance in Angstroms.
+
+    Returns:
+        List of neighbor dicts with keys: element, species, distance, image, site_idx.
+    """
+    ...
+
+def get_neighbors(
+    structure: StructureJson, site_idx: int, cutoff: float
+) -> list[tuple[int, float, tuple[int, int, int]]]:
+    """Get neighbors for a site as (site_idx, distance, image) tuples.
+
+    A simpler alternative to get_local_environment without element/species info.
+
+    Args:
+        structure: Structure as JSON string.
+        site_idx: Index of the site to analyze.
+        cutoff: Maximum distance in Angstroms.
+
+    Returns:
+        List of (neighbor_idx, distance, [da, db, dc]) tuples.
+    """
+    ...
+
+def get_cn_voronoi_all(
+    structure: StructureJson, min_solid_angle: float = 0.01
+) -> list[float]:
+    """Get Voronoi-weighted coordination numbers for all sites.
+
+    Uses Voronoi tessellation to determine neighbors based on solid angle.
+
+    Args:
+        structure: Structure as JSON string.
+        min_solid_angle: Minimum solid angle fraction to count a neighbor.
+
+    Returns:
+        Effective coordination numbers for each site.
+    """
+    ...
+
+def get_cn_voronoi(
+    structure: StructureJson, site_idx: int, min_solid_angle: float = 0.01
+) -> float:
+    """Get Voronoi-weighted coordination number for a single site.
+
+    Args:
+        structure: Structure as JSON string.
+        site_idx: Index of the site to analyze.
+        min_solid_angle: Minimum solid angle fraction to count a neighbor.
+
+    Returns:
+        Effective coordination number for the site.
+    """
+    ...
+
+def get_voronoi_neighbors(
+    structure: StructureJson, site_idx: int, min_solid_angle: float = 0.01
+) -> list[tuple[int, float]]:
+    """Get Voronoi neighbors with their solid angle fractions for a site.
+
+    Returns neighbors sorted by solid angle (largest first).
+
+    Args:
+        structure: Structure as JSON string.
+        site_idx: Index of the site to analyze.
+        min_solid_angle: Minimum solid angle fraction to include.
+
+    Returns:
+        List of (neighbor_idx, solid_angle_fraction) tuples.
+    """
+    ...
+
+def get_local_environment_voronoi(
+    structure: StructureJson, site_idx: int, min_solid_angle: float = 0.01
+) -> list[dict[str, Any]]:
+    """Get local environment using Voronoi tessellation.
+
+    Similar to get_local_environment but uses Voronoi faces instead of distance cutoff.
+
+    Args:
+        structure: Structure as JSON string.
+        site_idx: Index of the site to analyze.
+        min_solid_angle: Minimum solid angle fraction to include.
+
+    Returns:
+        List of neighbor dicts with keys: element, species, distance, site_idx, solid_angle.
+    """
+    ...

--- a/extensions/rust/python/ferrox/_ferrox.pyi
+++ b/extensions/rust/python/ferrox/_ferrox.pyi
@@ -7,8 +7,8 @@ implemented in Rust with Python bindings via PyO3.
 from typing import Any, Literal
 
 # Type aliases for better readability
-StructureJson = str  # JSON string from pymatgen Structure.as_dict()
 StructureDict = dict[str, Any]  # pymatgen-compatible structure dict
+StructureJson = str | StructureDict  # JSON string or dict (both accepted by Rust)
 Matrix3x3 = list[list[float]]  # 3x3 matrix as nested list
 IntMatrix3x3 = list[list[int]]  # 3x3 integer matrix
 Vector3 = list[float]  # 3-element vector [x, y, z]
@@ -24,7 +24,7 @@ class StructureMatcher:
     Compares crystal structures accounting for lattice transformations,
     periodic boundary conditions, and optional volume scaling.
 
-    Accepts structures as JSON strings (from pymatgen's Structure.as_dict()).
+    Accepts structures as JSON strings or dicts (from pymatgen's Structure.as_dict()).
 
     Attributes:
         latt_len_tol: Fractional length tolerance for lattice vectors.
@@ -177,9 +177,7 @@ class StructureMatcher:
         ...
     def __repr__(self) -> str: ...
 
-# =============================================================================
-# I/O Functions - Reading
-# =============================================================================
+# === I/O Functions - Reading ===
 
 def parse_structure_file(path: str) -> StructureDict:
     """Parse a structure file (auto-detects format from extension).
@@ -205,9 +203,7 @@ def parse_trajectory(path: str) -> list[StructureDict]:
     """
     ...
 
-# =============================================================================
-# I/O Functions - Writing
-# =============================================================================
+# === I/O Functions - Writing ===
 
 def write_structure_file(structure: StructureJson, path: str) -> None:
     """Write a structure to a file with automatic format detection.
@@ -266,9 +262,7 @@ def to_pymatgen_json(structure: StructureJson) -> str:
     """
     ...
 
-# =============================================================================
-# Supercell Functions
-# =============================================================================
+# === Supercell Functions ===
 
 def make_supercell(
     structure: StructureJson, scaling_matrix: tuple[tuple[int, int, int], ...]
@@ -301,9 +295,7 @@ def make_supercell_diag(
     """
     ...
 
-# =============================================================================
-# Lattice Reduction Functions
-# =============================================================================
+# === Lattice Reduction Functions ===
 
 def get_reduced_structure(
     structure: StructureJson, algo: Literal["niggli", "lll"]
@@ -341,9 +333,7 @@ def get_reduced_structure_with_params(
     """
     ...
 
-# =============================================================================
-# Neighbor Finding and Distance Functions
-# =============================================================================
+# === Neighbor Finding and Distance Functions ===
 
 def get_neighbor_list(
     structure: StructureJson,
@@ -461,9 +451,7 @@ def is_periodic_image(
     """
     ...
 
-# =============================================================================
-# Site Label and Species Functions
-# =============================================================================
+# === Site Label and Species Functions ===
 
 def site_label(structure: StructureJson, idx: int) -> str:
     """Get label for a specific site.
@@ -503,9 +491,7 @@ def species_strings(structure: StructureJson) -> list[str]:
     """
     ...
 
-# =============================================================================
-# Interpolation Functions
-# =============================================================================
+# === Interpolation Functions ===
 
 def interpolate(
     struct1: StructureJson,
@@ -531,9 +517,7 @@ def interpolate(
     """
     ...
 
-# =============================================================================
-# Matching Convenience Functions
-# =============================================================================
+# === Matching Convenience Functions ===
 
 def matches(
     struct1: StructureJson, struct2: StructureJson, anonymous: bool = False
@@ -550,9 +534,7 @@ def matches(
     """
     ...
 
-# =============================================================================
-# Sorting Functions
-# =============================================================================
+# === Sorting Functions ===
 
 def get_sorted_structure(
     structure: StructureJson, reverse: bool = False
@@ -582,9 +564,7 @@ def get_sorted_by_electronegativity(
     """
     ...
 
-# =============================================================================
-# Copy/Sanitization Functions
-# =============================================================================
+# === Copy/Sanitization Functions ===
 
 def copy_structure(
     structure: StructureJson, sanitize: bool = False
@@ -616,9 +596,7 @@ def wrap_to_unit_cell(structure: StructureJson) -> StructureDict:
     """
     ...
 
-# =============================================================================
-# Symmetry Operation Functions
-# =============================================================================
+# === Symmetry Operation Functions ===
 
 def apply_operation(
     structure: StructureJson,
@@ -672,9 +650,7 @@ def apply_translation(
     """
     ...
 
-# =============================================================================
-# Structure Property Functions
-# =============================================================================
+# === Structure Property Functions ===
 
 def get_volume(structure: StructureJson) -> float:
     """Get the volume of the unit cell in Angstrom³.
@@ -731,9 +707,7 @@ def get_structure_metadata(
     """
     ...
 
-# =============================================================================
-# Symmetry Analysis Functions
-# =============================================================================
+# === Symmetry Analysis Functions ===
 
 def get_spacegroup_number(structure: StructureJson, symprec: float = 0.01) -> int:
     """Get the spacegroup number of a structure.
@@ -885,9 +859,7 @@ def get_symmetry_dataset(
     """
     ...
 
-# =============================================================================
-# Site Manipulation Functions
-# =============================================================================
+# === Site Manipulation Functions ===
 
 def translate_sites(
     structure: StructureJson,
@@ -930,9 +902,7 @@ def perturb(
     """
     ...
 
-# =============================================================================
-# Normalization and Site Property Functions
-# =============================================================================
+# === Normalization and Site Property Functions ===
 
 def normalize_element_symbol(symbol: str) -> dict[str, Any]:
     """Normalize an element symbol string.
@@ -987,9 +957,7 @@ def set_site_property(
     """
     ...
 
-# =============================================================================
-# Composition Functions
-# =============================================================================
+# === Composition Functions ===
 
 def parse_composition(formula: str) -> dict[str, Any]:
     """Parse a chemical formula and return composition data.
@@ -1005,9 +973,7 @@ def parse_composition(formula: str) -> dict[str, Any]:
     """
     ...
 
-# =============================================================================
-# Slab Functions
-# =============================================================================
+# === Slab Functions ===
 
 def make_slab(
     structure: StructureJson,
@@ -1061,9 +1027,7 @@ def generate_slabs(
     """
     ...
 
-# =============================================================================
-# Transformation Functions
-# =============================================================================
+# === Transformation Functions ===
 
 def to_primitive(structure: StructureJson, symprec: float = 0.01) -> StructureDict:
     """Get the primitive cell of a structure.
@@ -1201,9 +1165,7 @@ def enumerate_derivatives(
     """
     ...
 
-# =============================================================================
-# Coordination Analysis Functions
-# =============================================================================
+# === Coordination Analysis Functions ===
 
 def get_coordination_numbers(structure: StructureJson, cutoff: float) -> list[int]:
     """Get coordination numbers for all sites using a distance cutoff.

--- a/extensions/rust/python/ferrox/_ferrox.pyi
+++ b/extensions/rust/python/ferrox/_ferrox.pyi
@@ -725,7 +725,7 @@ def get_structure_metadata(
         symprec: Symmetry precision for spacegroup detection.
 
     Returns:
-        Metadata dict with keys: formula, anonymous_formula, hill_formula,
+        Metadata dict with keys: formula, formula_anonymous, formula_hill,
         chemical_system, elements, n_elements, n_sites, volume, density,
         mass, is_ordered, spacegroup_number (optional).
     """
@@ -999,7 +999,7 @@ def parse_composition(formula: str) -> dict[str, Any]:
 
     Returns:
         Dict with keys: species (dict[str, float]), formula, reduced_formula,
-        anonymous_formula, hill_formula, alphabetical_formula, chemical_system,
+        formula_anonymous, formula_hill, alphabetical_formula, chemical_system,
         num_atoms, num_elements, weight, is_element, average_electroneg,
         total_electrons.
     """
@@ -1012,14 +1012,12 @@ def parse_composition(formula: str) -> dict[str, Any]:
 def make_slab(
     structure: StructureJson,
     miller_index: tuple[int, int, int],
-    min_slab_size: float,
-    min_vacuum_size: float,
-    max_normal_search: int | None = None,
+    min_slab_size: float = 10.0,
+    min_vacuum_size: float = 10.0,
     center_slab: bool = True,
     in_unit_planes: bool = False,
-    primitive: bool = True,
-    lll_reduce: bool = False,
-    reorient_lattice: bool = True,
+    symprec: float = 0.01,
+    termination_index: int = 0,
 ) -> StructureDict:
     """Create a slab from a bulk structure.
 
@@ -1028,12 +1026,10 @@ def make_slab(
         miller_index: Miller indices (h, k, l) for the surface.
         min_slab_size: Minimum slab thickness in Angstroms.
         min_vacuum_size: Minimum vacuum thickness in Angstroms.
-        max_normal_search: Max normal search depth (None for automatic).
         center_slab: Whether to center the slab in the cell.
         in_unit_planes: If True, min_slab_size is in unit planes.
-        primitive: Whether to reduce to primitive cell.
-        lll_reduce: Whether to apply LLL reduction.
-        reorient_lattice: Whether to reorient lattice vectors.
+        symprec: Symmetry precision for termination detection.
+        termination_index: Which termination to use (0 = first).
 
     Returns:
         Slab structure as pymatgen-compatible dict.
@@ -1043,14 +1039,11 @@ def make_slab(
 def generate_slabs(
     structure: StructureJson,
     miller_index: tuple[int, int, int],
-    min_slab_size: float,
-    min_vacuum_size: float,
-    max_normal_search: int | None = None,
+    min_slab_size: float = 10.0,
+    min_vacuum_size: float = 10.0,
     center_slab: bool = True,
     in_unit_planes: bool = False,
-    primitive: bool = True,
-    lll_reduce: bool = False,
-    symmetrize: bool = False,
+    symprec: float = 0.01,
 ) -> list[StructureDict]:
     """Generate all terminations of a slab.
 
@@ -1059,12 +1052,9 @@ def generate_slabs(
         miller_index: Miller indices (h, k, l) for the surface.
         min_slab_size: Minimum slab thickness in Angstroms.
         min_vacuum_size: Minimum vacuum thickness in Angstroms.
-        max_normal_search: Max normal search depth (None for automatic).
         center_slab: Whether to center the slab in the cell.
         in_unit_planes: If True, min_slab_size is in unit planes.
-        primitive: Whether to reduce to primitive cell.
-        lll_reduce: Whether to apply LLL reduction.
-        symmetrize: Whether to symmetrize the slab.
+        symprec: Symmetry precision for unique termination detection.
 
     Returns:
         List of slab structures for all unique terminations.
@@ -1337,6 +1327,6 @@ def get_local_environment_voronoi(
         min_solid_angle: Minimum solid angle fraction to include.
 
     Returns:
-        List of neighbor dicts with keys: element, species, distance, site_idx, solid_angle.
+        List of neighbor dicts with keys: element, species, distance, image, site_idx, solid_angle.
     """
     ...

--- a/extensions/rust/python/ferrox/_ferrox.pyi
+++ b/extensions/rust/python/ferrox/_ferrox.pyi
@@ -4,17 +4,18 @@ This module provides high-performance crystallographic structure operations
 implemented in Rust with Python bindings via PyO3.
 """
 
+from collections.abc import Sequence
 from typing import Any, Literal
 
 # Type aliases for better readability
 StructureDict = dict[str, Any]  # pymatgen-compatible structure dict
 StructureJson = str | StructureDict  # JSON string or dict (both accepted by Rust)
-Matrix3x3 = list[list[float]]  # 3x3 matrix as nested list
-IntMatrix3x3 = list[list[int]]  # 3x3 integer matrix
-Vector3 = list[float]  # 3-element vector [x, y, z]
-IntVector3 = list[int]  # 3-element integer vector [a, b, c]
-RotationMatrix = list[list[int]]  # 3x3 integer rotation matrix
-TranslationVector = list[float]  # 3-element translation vector
+Matrix3x3 = Sequence[Sequence[float]]  # 3x3 matrix (list or tuple)
+IntMatrix3x3 = Sequence[Sequence[int]]  # 3x3 integer matrix
+Vector3 = Sequence[float]  # 3-element vector [x, y, z]
+IntVector3 = Sequence[int]  # 3-element integer vector [a, b, c]
+RotationMatrix = Sequence[Sequence[int]]  # 3x3 integer rotation matrix
+TranslationVector = Sequence[float]  # 3-element translation vector
 
 __version__: str
 
@@ -265,7 +266,7 @@ def to_pymatgen_json(structure: StructureJson) -> str:
 # === Supercell Functions ===
 
 def make_supercell(
-    structure: StructureJson, scaling_matrix: tuple[tuple[int, int, int], ...]
+    structure: StructureJson, scaling_matrix: IntMatrix3x3
 ) -> StructureDict:
     """Create a supercell from a structure.
 
@@ -404,9 +405,7 @@ def get_distance_with_image(
     """
     ...
 
-def distance_from_point(
-    structure: StructureJson, idx: int, point: tuple[float, float, float]
-) -> float:
+def distance_from_point(structure: StructureJson, idx: int, point: Vector3) -> float:
     """Get Cartesian distance from a site to an arbitrary point.
 
     Simple Euclidean distance, not using periodic boundary conditions.
@@ -566,9 +565,7 @@ def get_sorted_by_electronegativity(
 
 # === Copy/Sanitization Functions ===
 
-def copy_structure(
-    structure: StructureJson, sanitize: bool = False
-) -> StructureDict:
+def copy_structure(structure: StructureJson, sanitize: bool = False) -> StructureDict:
     """Create a copy of the structure, optionally sanitized.
 
     Sanitization applies:
@@ -600,8 +597,8 @@ def wrap_to_unit_cell(structure: StructureJson) -> StructureDict:
 
 def apply_operation(
     structure: StructureJson,
-    rotation: tuple[tuple[float, float, float], ...],
-    translation: tuple[float, float, float],
+    rotation: Matrix3x3,
+    translation: TranslationVector,
     fractional: bool = True,
 ) -> StructureDict:
     """Apply a symmetry operation to a structure.
@@ -619,9 +616,7 @@ def apply_operation(
     """
     ...
 
-def apply_inversion(
-    structure: StructureJson, fractional: bool = True
-) -> StructureDict:
+def apply_inversion(structure: StructureJson, fractional: bool = True) -> StructureDict:
     """Apply inversion through the origin.
 
     Args:
@@ -635,7 +630,7 @@ def apply_inversion(
 
 def apply_translation(
     structure: StructureJson,
-    translation: tuple[float, float, float],
+    translation: TranslationVector,
     fractional: bool = True,
 ) -> StructureDict:
     """Apply a translation to all sites.
@@ -760,9 +755,7 @@ def get_pearson_symbol(structure: StructureJson, symprec: float = 0.01) -> str:
     """
     ...
 
-def get_wyckoff_letters(
-    structure: StructureJson, symprec: float = 0.01
-) -> list[str]:
+def get_wyckoff_letters(structure: StructureJson, symprec: float = 0.01) -> list[str]:
     """Get Wyckoff letters for each site in the structure.
 
     Wyckoff positions describe the site symmetry and multiplicity.
@@ -809,9 +802,7 @@ def get_symmetry_operations(
     """
     ...
 
-def get_equivalent_sites(
-    structure: StructureJson, symprec: float = 0.01
-) -> list[int]:
+def get_equivalent_sites(structure: StructureJson, symprec: float = 0.01) -> list[int]:
     """Get equivalent sites (crystallographic orbits).
 
     Returns a list where orbits[i] is the index of the representative site
@@ -863,8 +854,8 @@ def get_symmetry_dataset(
 
 def translate_sites(
     structure: StructureJson,
-    indices: list[int],
-    vector: tuple[float, float, float],
+    indices: Sequence[int],
+    vector: Vector3,
     fractional: bool = True,
 ) -> StructureDict:
     """Translate specific sites by a vector.
@@ -977,7 +968,7 @@ def parse_composition(formula: str) -> dict[str, Any]:
 
 def make_slab(
     structure: StructureJson,
-    miller_index: tuple[int, int, int],
+    miller_index: IntVector3,
     min_slab_size: float = 10.0,
     min_vacuum_size: float = 10.0,
     center_slab: bool = True,
@@ -1004,7 +995,7 @@ def make_slab(
 
 def generate_slabs(
     structure: StructureJson,
-    miller_index: tuple[int, int, int],
+    miller_index: IntVector3,
     min_slab_size: float = 10.0,
     min_vacuum_size: float = 10.0,
     center_slab: bool = True,
@@ -1100,7 +1091,7 @@ def remove_sites(structure: StructureJson, indices: list[int]) -> StructureDict:
 
 def deform(
     structure: StructureJson,
-    gradient: tuple[tuple[float, float, float], ...],
+    gradient: Matrix3x3,
 ) -> StructureDict:
     """Apply a deformation gradient to the lattice.
 

--- a/extensions/rust/src/batch.rs
+++ b/extensions/rust/src/batch.rs
@@ -412,9 +412,7 @@ mod tests {
     use crate::species::Species;
     use nalgebra::Vector3;
 
-    // ========================================================================
-    // Union-Find Tests
-    // ========================================================================
+    // === Union-Find Tests ===
 
     #[test]
     fn test_union_find_basic() {
@@ -469,9 +467,7 @@ mod tests {
         assert_eq!(group_1.len(), 2);
     }
 
-    // ========================================================================
-    // Helper functions for batch tests
-    // ========================================================================
+    // === Helper functions for batch tests ===
 
     fn make_nacl() -> Structure {
         let lattice = Lattice::cubic(5.64);
@@ -511,9 +507,7 @@ mod tests {
         Structure::new(lattice, species, coords)
     }
 
-    // ========================================================================
-    // Batch Processing Tests
-    // ========================================================================
+    // === Batch Processing Tests ===
 
     #[test]
     fn test_deduplicate_identical() {
@@ -635,9 +629,7 @@ mod tests {
         assert_eq!(groups.len(), 3);
     }
 
-    // ========================================================================
-    // find_matches Tests
-    // ========================================================================
+    // === find_matches Tests ===
 
     #[test]
     fn test_find_matches_basic() {
@@ -708,9 +700,7 @@ mod tests {
         assert_eq!(matches, vec![Some(0), Some(0), Some(1)]);
     }
 
-    // ========================================================================
-    // Concurrent Stress Tests
-    // ========================================================================
+    // === Concurrent Stress Tests ===
 
     #[test]
     fn test_union_find_concurrent_stress() {

--- a/extensions/rust/src/lib.rs
+++ b/extensions/rust/src/lib.rs
@@ -71,6 +71,9 @@ use pyo3::prelude::*;
 #[cfg(feature = "wasm")]
 pub mod wasm;
 
+#[cfg(feature = "wasm")]
+pub mod wasm_types;
+
 /// Python module entry point.
 #[cfg(feature = "python")]
 #[pymodule]

--- a/extensions/rust/src/wasm.rs
+++ b/extensions/rust/src/wasm.rs
@@ -22,9 +22,7 @@ use crate::wasm_types::{
     JsSymmetryOperation, JsVector3, WasmResult,
 };
 
-// =============================================================================
-// Element WASM bindings
-// =============================================================================
+// === Element WASM bindings ===
 
 /// JavaScript-accessible Element wrapper.
 #[wasm_bindgen]
@@ -253,9 +251,7 @@ impl JsElement {
     }
 }
 
-// =============================================================================
-// Species WASM bindings
-// =============================================================================
+// === Species WASM bindings ===
 
 /// JavaScript-accessible Species wrapper.
 #[wasm_bindgen]
@@ -336,9 +332,7 @@ impl JsSpecies {
     }
 }
 
-// =============================================================================
-// StructureMatcher WASM bindings
-// =============================================================================
+// === StructureMatcher WASM bindings ===
 
 /// JavaScript-accessible StructureMatcher wrapper with builder pattern.
 #[wasm_bindgen]
@@ -497,9 +491,7 @@ impl Default for WasmStructureMatcher {
     }
 }
 
-// =============================================================================
-// Structure Parsing Functions
-// =============================================================================
+// === Structure Parsing Functions ===
 
 /// Parse a structure from CIF format string.
 #[wasm_bindgen]
@@ -519,9 +511,7 @@ pub fn parse_poscar(content: &str) -> WasmResult<JsCrystal> {
     result.into()
 }
 
-// =============================================================================
-// Supercell Functions
-// =============================================================================
+// === Supercell Functions ===
 
 /// Create a diagonal supercell (nx × ny × nz).
 #[wasm_bindgen]
@@ -557,88 +547,82 @@ pub fn make_supercell(structure: JsCrystal, matrix: JsIntMatrix3x3) -> WasmResul
     result.into()
 }
 
-// =============================================================================
-// Lattice Reduction Functions
-// =============================================================================
+// === Lattice Reduction Functions ===
 
 /// Get structure with reduced lattice (Niggli or LLL algorithm).
 #[wasm_bindgen]
 pub fn get_reduced_structure(structure: JsCrystal, algo: JsReductionAlgo) -> WasmResult<JsCrystal> {
-    let result: Result<JsCrystal, String> = (|| {
-        let struc = structure.to_structure()?;
-        let reduced = struc
-            .get_reduced_structure(algo.to_internal())
-            .map_err(|err| err.to_string())?;
-        Ok(JsCrystal::from_structure(&reduced))
-    })();
-    result.into()
+    structure
+        .to_structure()
+        .and_then(|struc| {
+            struc
+                .get_reduced_structure(algo.to_internal())
+                .map_err(|e| e.to_string())
+        })
+        .map(|reduced| JsCrystal::from_structure(&reduced))
+        .into()
 }
 
 /// Get the primitive cell of a structure.
 #[wasm_bindgen]
 pub fn get_primitive(structure: JsCrystal, symprec: f64) -> WasmResult<JsCrystal> {
-    let result: Result<JsCrystal, String> = (|| {
-        let struc = structure.to_structure()?;
-        let primitive = struc
-            .get_primitive(symprec)
-            .map_err(|err| err.to_string())?;
-        Ok(JsCrystal::from_structure(&primitive))
-    })();
-    result.into()
+    structure
+        .to_structure()
+        .and_then(|struc| struc.get_primitive(symprec).map_err(|e| e.to_string()))
+        .map(|prim| JsCrystal::from_structure(&prim))
+        .into()
 }
 
 /// Get the conventional cell of a structure.
 #[wasm_bindgen]
 pub fn get_conventional(structure: JsCrystal, symprec: f64) -> WasmResult<JsCrystal> {
-    let result: Result<JsCrystal, String> = (|| {
-        let struc = structure.to_structure()?;
-        let conventional = struc
-            .get_conventional_structure(symprec)
-            .map_err(|err| err.to_string())?;
-        Ok(JsCrystal::from_structure(&conventional))
-    })();
-    result.into()
+    structure
+        .to_structure()
+        .and_then(|struc| {
+            struc
+                .get_conventional_structure(symprec)
+                .map_err(|e| e.to_string())
+        })
+        .map(|conv| JsCrystal::from_structure(&conv))
+        .into()
 }
 
-// =============================================================================
-// Symmetry Functions
-// =============================================================================
+// === Symmetry Functions ===
 
 /// Get the spacegroup number of a structure.
 #[wasm_bindgen]
 pub fn get_spacegroup_number(structure: JsCrystal, symprec: f64) -> WasmResult<u16> {
-    let result: Result<u16, String> = (|| {
-        let struc = structure.to_structure()?;
-        let sg = struc
-            .get_spacegroup_number(symprec)
-            .map_err(|err| err.to_string())?;
-        Ok(sg as u16)
-    })();
-    result.into()
+    structure
+        .to_structure()
+        .and_then(|struc| {
+            struc
+                .get_spacegroup_number(symprec)
+                .map_err(|e| e.to_string())
+        })
+        .map(|sg| sg as u16)
+        .into()
 }
 
 /// Get the spacegroup symbol of a structure.
 #[wasm_bindgen]
 pub fn get_spacegroup_symbol(structure: JsCrystal, symprec: f64) -> WasmResult<String> {
-    let result: Result<String, String> = (|| {
-        let struc = structure.to_structure()?;
-        struc
-            .get_spacegroup_symbol(symprec)
-            .map_err(|err| err.to_string())
-    })();
-    result.into()
+    structure
+        .to_structure()
+        .and_then(|struc| {
+            struc
+                .get_spacegroup_symbol(symprec)
+                .map_err(|e| e.to_string())
+        })
+        .into()
 }
 
 /// Get the crystal system of a structure.
 #[wasm_bindgen]
 pub fn get_crystal_system(structure: JsCrystal, symprec: f64) -> WasmResult<String> {
-    let result: Result<String, String> = (|| {
-        let struc = structure.to_structure()?;
-        struc
-            .get_crystal_system(symprec)
-            .map_err(|err| err.to_string())
-    })();
-    result.into()
+    structure
+        .to_structure()
+        .and_then(|struc| struc.get_crystal_system(symprec).map_err(|e| e.to_string()))
+        .into()
 }
 
 /// Get Wyckoff letters for each site in the structure.
@@ -714,9 +698,7 @@ pub fn get_symmetry_dataset(structure: JsCrystal, symprec: f64) -> WasmResult<Js
     result.into()
 }
 
-// =============================================================================
-// Physical Property Functions
-// =============================================================================
+// === Physical Property Functions ===
 
 /// Get the volume of the unit cell in Angstrom³.
 #[wasm_bindgen]
@@ -747,42 +729,41 @@ pub fn get_density(structure: JsCrystal) -> WasmResult<f64> {
 /// Get metadata about a structure (formula, volume, etc.).
 #[wasm_bindgen]
 pub fn get_structure_metadata(structure: JsCrystal) -> WasmResult<JsStructureMetadata> {
-    let result: Result<JsStructureMetadata, String> = (|| {
-        let struc = structure.to_structure()?;
-        let lattice_lengths = struc.lattice.lengths();
-        let lattice_angles = struc.lattice.angles();
-        Ok(JsStructureMetadata {
-            num_sites: struc.num_sites() as u32,
-            formula: struc.composition().reduced_formula(),
-            volume: struc.volume(),
-            density: struc.density(),
-            lattice_params: [lattice_lengths.x, lattice_lengths.y, lattice_lengths.z],
-            lattice_angles: [lattice_angles.x, lattice_angles.y, lattice_angles.z],
-            is_ordered: struc.is_ordered(),
+    structure
+        .to_structure()
+        .map(|struc| {
+            let lengths = struc.lattice.lengths();
+            let angles = struc.lattice.angles();
+            JsStructureMetadata {
+                num_sites: struc.num_sites() as u32,
+                formula: struc.composition().reduced_formula(),
+                volume: struc.volume(),
+                density: struc.density(),
+                lattice_params: [lengths.x, lengths.y, lengths.z],
+                lattice_angles: [angles.x, angles.y, angles.z],
+                is_ordered: struc.is_ordered(),
+            }
         })
-    })();
-    result.into()
+        .into()
 }
 
-// =============================================================================
-// Neighbor Finding Functions
-// =============================================================================
+// === Neighbor Finding Functions ===
 
 /// Get neighbor list for a structure.
 #[wasm_bindgen]
 pub fn get_neighbor_list(
     structure: JsCrystal,
-    r: f64,
+    cutoff_radius: f64,
     numerical_tol: f64,
     exclude_self: bool,
 ) -> WasmResult<JsNeighborList> {
     let result: Result<JsNeighborList, String> = (|| {
-        if r < 0.0 {
+        if cutoff_radius < 0.0 {
             return Err("Cutoff radius must be non-negative".to_string());
         }
         let struc = structure.to_structure()?;
         let (center_indices, neighbor_indices, image_offsets, distances) =
-            struc.get_neighbor_list(r, numerical_tol, exclude_self);
+            struc.get_neighbor_list(cutoff_radius, numerical_tol, exclude_self);
         Ok(JsNeighborList {
             center_indices: center_indices.into_iter().map(|idx| idx as u32).collect(),
             neighbor_indices: neighbor_indices.into_iter().map(|idx| idx as u32).collect(),
@@ -820,19 +801,24 @@ pub fn get_distance_matrix(structure: JsCrystal) -> WasmResult<Vec<Vec<f64>>> {
     result.into()
 }
 
-// =============================================================================
-// Coordination Analysis Functions
-// =============================================================================
+// === Coordination Analysis Functions ===
 
 /// Get coordination numbers for all sites using cutoff-based method.
 #[wasm_bindgen]
 pub fn get_coordination_numbers(structure: JsCrystal, cutoff: f64) -> WasmResult<Vec<u32>> {
-    let result: Result<Vec<u32>, String> = (|| {
-        let struc = structure.to_structure()?;
-        let cns = struc.get_coordination_numbers(cutoff);
-        Ok(cns.into_iter().map(|cn| cn as u32).collect())
-    })();
-    result.into()
+    if cutoff < 0.0 {
+        return WasmResult::err("Cutoff must be non-negative");
+    }
+    structure
+        .to_structure()
+        .map(|struc| {
+            struc
+                .get_coordination_numbers(cutoff)
+                .into_iter()
+                .map(|cn| cn as u32)
+                .collect()
+        })
+        .into()
 }
 
 /// Get coordination number for a specific site.
@@ -893,19 +879,15 @@ pub fn get_local_environment(
     result.into()
 }
 
-// =============================================================================
-// Sorting Functions
-// =============================================================================
+// === Sorting Functions ===
 
 /// Get a sorted copy of the structure by atomic number.
 #[wasm_bindgen]
 pub fn get_sorted_structure(structure: JsCrystal, reverse: bool) -> WasmResult<JsCrystal> {
-    let result: Result<JsCrystal, String> = (|| {
-        let struc = structure.to_structure()?;
-        let sorted = struc.get_sorted_structure(reverse);
-        Ok(JsCrystal::from_structure(&sorted))
-    })();
-    result.into()
+    structure
+        .to_structure()
+        .map(|struc| JsCrystal::from_structure(&struc.get_sorted_structure(reverse)))
+        .into()
 }
 
 /// Get a sorted copy of the structure by electronegativity.
@@ -914,17 +896,13 @@ pub fn get_sorted_by_electronegativity(
     structure: JsCrystal,
     reverse: bool,
 ) -> WasmResult<JsCrystal> {
-    let result: Result<JsCrystal, String> = (|| {
-        let struc = structure.to_structure()?;
-        let sorted = struc.get_sorted_by_electronegativity(reverse);
-        Ok(JsCrystal::from_structure(&sorted))
-    })();
-    result.into()
+    structure
+        .to_structure()
+        .map(|struc| JsCrystal::from_structure(&struc.get_sorted_by_electronegativity(reverse)))
+        .into()
 }
 
-// =============================================================================
-// Interpolation Functions
-// =============================================================================
+// === Interpolation Functions ===
 
 /// Interpolate between two structures.
 #[wasm_bindgen]
@@ -946,35 +924,30 @@ pub fn interpolate_structures(
     result.into()
 }
 
-// =============================================================================
-// Copy and Wrap Functions
-// =============================================================================
+// === Copy and Wrap Functions ===
 
 /// Create a copy of the structure, optionally sanitized.
 #[wasm_bindgen]
 pub fn copy_structure(structure: JsCrystal, sanitize: bool) -> WasmResult<JsCrystal> {
-    let result: Result<JsCrystal, String> = (|| {
-        let struc = structure.to_structure()?;
-        let copied = struc.copy(sanitize);
-        Ok(JsCrystal::from_structure(&copied))
-    })();
-    result.into()
+    structure
+        .to_structure()
+        .map(|struc| JsCrystal::from_structure(&struc.copy(sanitize)))
+        .into()
 }
 
 /// Wrap all fractional coordinates to [0, 1).
 #[wasm_bindgen]
 pub fn wrap_to_unit_cell(structure: JsCrystal) -> WasmResult<JsCrystal> {
-    let result: Result<JsCrystal, String> = (|| {
-        let mut struc = structure.to_structure()?;
-        struc.wrap_to_unit_cell();
-        Ok(JsCrystal::from_structure(&struc))
-    })();
-    result.into()
+    structure
+        .to_structure()
+        .map(|mut struc| {
+            struc.wrap_to_unit_cell();
+            JsCrystal::from_structure(&struc)
+        })
+        .into()
 }
 
-// =============================================================================
-// Site Manipulation Functions
-// =============================================================================
+// === Site Manipulation Functions ===
 
 /// Translate specific sites by a vector.
 #[wasm_bindgen]
@@ -1032,9 +1005,7 @@ pub fn perturb_structure(
     result.into()
 }
 
-// =============================================================================
-// Element Information Functions
-// =============================================================================
+// === Element Information Functions ===
 
 /// Get atomic mass for an element by symbol.
 #[wasm_bindgen]
@@ -1057,9 +1028,7 @@ pub fn get_electronegativity(symbol: &str) -> WasmResult<f64> {
     result.into()
 }
 
-// =============================================================================
-// Slab Generation Functions
-// =============================================================================
+// === Slab Generation Functions ===
 
 /// Generate a single slab from a bulk structure.
 #[wasm_bindgen]
@@ -1130,9 +1099,7 @@ pub fn generate_slabs(
     result.into()
 }
 
-// =============================================================================
-// Transformation Functions
-// =============================================================================
+// === Transformation Functions ===
 
 /// Apply a symmetry operation to the structure.
 /// The rotation matrix should be a 3x3 float matrix, and translation is a 3D vector.
@@ -1147,38 +1114,29 @@ pub fn apply_operation(
     use crate::structure::SymmOp;
     use nalgebra::Matrix3;
 
-    let result: Result<JsCrystal, String> = (|| {
-        let struc = structure.to_structure()?;
-        let rot_mat = Matrix3::from_row_slice(&[
-            rotation.0[0][0],
-            rotation.0[0][1],
-            rotation.0[0][2],
-            rotation.0[1][0],
-            rotation.0[1][1],
-            rotation.0[1][2],
-            rotation.0[2][0],
-            rotation.0[2][1],
-            rotation.0[2][2],
-        ]);
-        let trans_vec = Vector3::from(translation.0);
-        let op = SymmOp::new(rot_mat, trans_vec);
-        let transformed = struc.apply_operation_copy(&op, fractional);
-        Ok(JsCrystal::from_structure(&transformed))
-    })();
-    result.into()
+    structure
+        .to_structure()
+        .map(|struc| {
+            let r = &rotation.0;
+            let rot_mat = Matrix3::from_row_slice(&[
+                r[0][0], r[0][1], r[0][2], r[1][0], r[1][1], r[1][2], r[2][0], r[2][1], r[2][2],
+            ]);
+            let op = SymmOp::new(rot_mat, Vector3::from(translation.0));
+            JsCrystal::from_structure(&struc.apply_operation_copy(&op, fractional))
+        })
+        .into()
 }
 
 /// Apply inversion symmetry to the structure.
 #[wasm_bindgen]
 pub fn apply_inversion(structure: JsCrystal, fractional: bool) -> WasmResult<JsCrystal> {
     use crate::structure::SymmOp;
-
-    let result: Result<JsCrystal, String> = (|| {
-        let struc = structure.to_structure()?;
-        let inverted = struc.apply_operation_copy(&SymmOp::inversion(), fractional);
-        Ok(JsCrystal::from_structure(&inverted))
-    })();
-    result.into()
+    structure
+        .to_structure()
+        .map(|struc| {
+            JsCrystal::from_structure(&struc.apply_operation_copy(&SymmOp::inversion(), fractional))
+        })
+        .into()
 }
 
 /// Substitute one species with another throughout the structure.
@@ -1219,42 +1177,45 @@ pub fn remove_sites(structure: JsCrystal, indices: Vec<u32>) -> WasmResult<JsCry
     let result: Result<JsCrystal, String> = (|| {
         let struc = structure.to_structure()?;
         let idx: Vec<usize> = indices.into_iter().map(|idx| idx as usize).collect();
+        let num_sites = struc.num_sites();
+        for &site_idx in &idx {
+            if site_idx >= num_sites {
+                return Err(format!(
+                    "Index {site_idx} out of bounds for structure with {num_sites} sites"
+                ));
+            }
+        }
         let new_s = struc.remove_sites(&idx).map_err(|err| err.to_string())?;
         Ok(JsCrystal::from_structure(&new_s))
     })();
     result.into()
 }
 
-// =============================================================================
-// I/O Functions
-// =============================================================================
+// === I/O Functions ===
 
 /// Serialize structure to pymatgen-compatible JSON string.
 #[wasm_bindgen]
 pub fn structure_to_json(structure: JsCrystal) -> WasmResult<String> {
-    let result: Result<String, String> = (|| {
-        let struc = structure.to_structure()?;
-        Ok(crate::io::structure_to_pymatgen_json(&struc))
-    })();
-    result.into()
+    structure
+        .to_structure()
+        .map(|struc| crate::io::structure_to_pymatgen_json(&struc))
+        .into()
 }
 
 /// Convert structure to CIF format string.
 #[wasm_bindgen]
 pub fn structure_to_cif(structure: JsCrystal) -> WasmResult<String> {
-    let result: Result<String, String> = (|| {
-        let struc = structure.to_structure()?;
-        Ok(crate::cif::structure_to_cif(&struc, None))
-    })();
-    result.into()
+    structure
+        .to_structure()
+        .map(|struc| crate::cif::structure_to_cif(&struc, None))
+        .into()
 }
 
 /// Convert structure to POSCAR format string.
 #[wasm_bindgen]
 pub fn structure_to_poscar(structure: JsCrystal) -> WasmResult<String> {
-    let result: Result<String, String> = (|| {
-        let struc = structure.to_structure()?;
-        Ok(crate::io::structure_to_poscar(&struc, None))
-    })();
-    result.into()
+    structure
+        .to_structure()
+        .map(|struc| crate::io::structure_to_poscar(&struc, None))
+        .into()
 }

--- a/extensions/rust/src/wasm.rs
+++ b/extensions/rust/src/wasm.rs
@@ -517,18 +517,18 @@ pub fn parse_poscar(content: &str) -> WasmResult<JsCrystal> {
 #[wasm_bindgen]
 pub fn make_supercell_diag(
     structure: JsCrystal,
-    nx: i32,
-    ny: i32,
-    nz: i32,
+    scale_a: i32,
+    scale_b: i32,
+    scale_c: i32,
 ) -> WasmResult<JsCrystal> {
     let result: Result<JsCrystal, String> = (|| {
-        if nx <= 0 || ny <= 0 || nz <= 0 {
+        if scale_a <= 0 || scale_b <= 0 || scale_c <= 0 {
             return Err(format!(
-                "Supercell factors must be positive, got [{nx}, {ny}, {nz}]"
+                "Supercell factors must be positive, got [{scale_a}, {scale_b}, {scale_c}]"
             ));
         }
         let struc = structure.to_structure()?;
-        let supercell = struc.make_supercell_diag([nx, ny, nz]);
+        let supercell = struc.make_supercell_diag([scale_a, scale_b, scale_c]);
         Ok(JsCrystal::from_structure(&supercell))
     })();
     result.into()
@@ -776,18 +776,18 @@ pub fn get_neighbor_list(
 
 /// Get distance between two sites using minimum image convention.
 #[wasm_bindgen]
-pub fn get_distance(structure: JsCrystal, i: u32, j: u32) -> WasmResult<f64> {
+pub fn get_distance(structure: JsCrystal, site_idx_1: u32, site_idx_2: u32) -> WasmResult<f64> {
     let result: Result<f64, String> = (|| {
         let struc = structure.to_structure()?;
-        let n = struc.num_sites();
-        let i = i as usize;
-        let j = j as usize;
-        if i >= n || j >= n {
+        let num_sites = struc.num_sites();
+        let idx_1 = site_idx_1 as usize;
+        let idx_2 = site_idx_2 as usize;
+        if idx_1 >= num_sites || idx_2 >= num_sites {
             return Err(format!(
-                "Site indices ({i}, {j}) out of bounds for structure with {n} sites"
+                "Site indices ({idx_1}, {idx_2}) out of bounds for structure with {num_sites} sites"
             ));
         }
-        Ok(struc.get_distance(i, j))
+        Ok(struc.get_distance(idx_1, idx_2))
     })();
     result.into()
 }
@@ -828,6 +828,9 @@ pub fn get_coordination_number(
     site_index: u32,
     cutoff: f64,
 ) -> WasmResult<u32> {
+    if cutoff < 0.0 {
+        return WasmResult::err("Cutoff must be non-negative");
+    }
     let result: Result<u32, String> = (|| {
         let struc = structure.to_structure()?;
         let idx = site_index as usize;
@@ -849,6 +852,9 @@ pub fn get_local_environment(
     site_index: u32,
     cutoff: f64,
 ) -> WasmResult<JsLocalEnvironment> {
+    if cutoff < 0.0 {
+        return WasmResult::err("Cutoff must be non-negative");
+    }
     let result: Result<JsLocalEnvironment, String> = (|| {
         let struc = structure.to_structure()?;
         let idx = site_index as usize;

--- a/extensions/rust/src/wasm.rs
+++ b/extensions/rust/src/wasm.rs
@@ -1,12 +1,111 @@
 //! WASM bindings for ferrox types.
 //!
 //! This module provides JavaScript-accessible wrappers for Element, Species,
-//! and Composition types via wasm-bindgen.
+//! Structure, and StructureMatcher types via wasm-bindgen.
+//!
+//! All structure functions accept and return JS values that can be serialized
+//! with serde. Results are returned as `{ ok: T }` or `{ error: string }`.
 
+use std::path::Path;
+
+use nalgebra::Vector3;
+use serde::Serialize;
 use wasm_bindgen::prelude::*;
 
+use crate::cif::parse_cif_str;
 use crate::element::Element;
+use crate::io::{parse_poscar_str, parse_structure_json, structure_to_pymatgen_json};
+use crate::matcher::{ComparatorType, StructureMatcher};
 use crate::species::Species;
+use crate::structure::{ReductionAlgo, Structure};
+
+// =============================================================================
+// Result Type for WASM (matches TypeScript WasmResult<T>)
+// =============================================================================
+
+/// Result wrapper that serializes to { ok: T } | { error: string }
+#[derive(Serialize)]
+#[serde(untagged)]
+enum WasmResult<T: Serialize> {
+    Ok { ok: T },
+    Err { error: String },
+}
+
+impl<T: Serialize> WasmResult<T> {
+    fn ok(value: T) -> Self {
+        WasmResult::Ok { ok: value }
+    }
+
+    fn err(msg: impl Into<String>) -> Self {
+        WasmResult::Err { error: msg.into() }
+    }
+}
+
+/// Convert a Result to WasmResult
+fn to_wasm_result<T: Serialize, E: std::fmt::Display>(result: Result<T, E>) -> WasmResult<T> {
+    match result {
+        Ok(value) => WasmResult::ok(value),
+        Err(e) => WasmResult::err(e.to_string()),
+    }
+}
+
+/// Serialize WasmResult to JsValue
+fn serialize_result<T: Serialize>(result: WasmResult<T>) -> JsValue {
+    serde_wasm_bindgen::to_value(&result).unwrap_or_else(|e| {
+        let err: WasmResult<()> = WasmResult::err(format!("Serialization error: {e}"));
+        serde_wasm_bindgen::to_value(&err).unwrap()
+    })
+}
+
+// =============================================================================
+// Structure Parsing Helpers
+// =============================================================================
+
+/// Parse a JS value as a Structure (from pymatgen-style JSON object)
+fn parse_structure_from_js(value: &JsValue) -> Result<Structure, String> {
+    let json_str = js_sys::JSON::stringify(value)
+        .map_err(|_| "Failed to stringify JS value")?
+        .as_string()
+        .ok_or("Failed to convert to string")?;
+    parse_structure_json(&json_str).map_err(|e| e.to_string())
+}
+
+/// Convert Structure to JS value (pymatgen-style JSON object)
+fn structure_to_js(structure: &Structure) -> Result<JsValue, String> {
+    let json_str = structure_to_pymatgen_json(structure);
+    let parsed: serde_json::Value = serde_json::from_str(&json_str).map_err(|e| e.to_string())?;
+    serde_wasm_bindgen::to_value(&parsed).map_err(|e| e.to_string())
+}
+
+/// Parse a JS array of structures
+fn parse_js_array(arr: &JsValue) -> Result<Vec<Structure>, String> {
+    js_sys::Array::from(arr)
+        .iter()
+        .map(|item| parse_structure_from_js(&item))
+        .collect()
+}
+
+// =============================================================================
+// Neighbor List Result Type
+// =============================================================================
+
+#[derive(Serialize)]
+struct NeighborListResult {
+    center_indices: Vec<usize>,
+    neighbor_indices: Vec<usize>,
+    image_offsets: Vec<[i32; 3]>,
+    distances: Vec<f64>,
+}
+
+// =============================================================================
+// RMS Distance Result Type
+// =============================================================================
+
+#[derive(Serialize)]
+struct RmsDistResult {
+    rms: f64,
+    max_dist: f64,
+}
 
 // =============================================================================
 // Element WASM bindings
@@ -316,4 +415,504 @@ impl JsSpecies {
     pub fn name(&self) -> String {
         self.inner.name().to_string()
     }
+}
+
+// =============================================================================
+// StructureMatcher WASM bindings
+// =============================================================================
+
+/// JavaScript-accessible StructureMatcher wrapper with builder pattern.
+#[wasm_bindgen]
+pub struct WasmStructureMatcher {
+    inner: StructureMatcher,
+}
+
+#[wasm_bindgen]
+impl WasmStructureMatcher {
+    /// Create a new StructureMatcher with default settings.
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> WasmStructureMatcher {
+        WasmStructureMatcher {
+            inner: StructureMatcher::new(),
+        }
+    }
+
+    /// Set the lattice length tolerance (fractional).
+    #[wasm_bindgen]
+    pub fn with_latt_len_tol(mut self, tol: f64) -> WasmStructureMatcher {
+        self.inner = self.inner.with_latt_len_tol(tol);
+        self
+    }
+
+    /// Set the site position tolerance (normalized).
+    #[wasm_bindgen]
+    pub fn with_site_pos_tol(mut self, tol: f64) -> WasmStructureMatcher {
+        self.inner = self.inner.with_site_pos_tol(tol);
+        self
+    }
+
+    /// Set the angle tolerance (degrees).
+    #[wasm_bindgen]
+    pub fn with_angle_tol(mut self, tol: f64) -> WasmStructureMatcher {
+        self.inner = self.inner.with_angle_tol(tol);
+        self
+    }
+
+    /// Set whether to reduce to primitive cell before matching.
+    #[wasm_bindgen]
+    pub fn with_primitive_cell(mut self, val: bool) -> WasmStructureMatcher {
+        self.inner = self.inner.with_primitive_cell(val);
+        self
+    }
+
+    /// Set whether to scale volumes to match.
+    #[wasm_bindgen]
+    pub fn with_scale(mut self, val: bool) -> WasmStructureMatcher {
+        self.inner = self.inner.with_scale(val);
+        self
+    }
+
+    /// Set whether to use element-only comparison (ignores oxidation states).
+    #[wasm_bindgen]
+    pub fn with_element_comparator(mut self, val: bool) -> WasmStructureMatcher {
+        let comparator = if val {
+            ComparatorType::Element
+        } else {
+            ComparatorType::Species
+        };
+        self.inner = self.inner.with_comparator(comparator);
+        self
+    }
+
+    /// Check if two structures match.
+    #[wasm_bindgen]
+    pub fn fit(&self, struct1: &JsValue, struct2: &JsValue) -> JsValue {
+        let result: Result<bool, String> = (|| {
+            let s1 = parse_structure_from_js(struct1)?;
+            let s2 = parse_structure_from_js(struct2)?;
+            Ok(self.inner.fit(&s1, &s2))
+        })();
+        serialize_result(to_wasm_result(result))
+    }
+
+    /// Check if two structures match under any species permutation.
+    #[wasm_bindgen]
+    pub fn fit_anonymous(&self, struct1: &JsValue, struct2: &JsValue) -> JsValue {
+        let result: Result<bool, String> = (|| {
+            let s1 = parse_structure_from_js(struct1)?;
+            let s2 = parse_structure_from_js(struct2)?;
+            Ok(self.inner.fit_anonymous(&s1, &s2))
+        })();
+        serialize_result(to_wasm_result(result))
+    }
+
+    /// Get RMS distance between two structures.
+    #[wasm_bindgen]
+    pub fn get_rms_dist(&self, struct1: &JsValue, struct2: &JsValue) -> JsValue {
+        let result: Result<Option<RmsDistResult>, String> = (|| {
+            let s1 = parse_structure_from_js(struct1)?;
+            let s2 = parse_structure_from_js(struct2)?;
+            Ok(self
+                .inner
+                .get_rms_dist(&s1, &s2)
+                .map(|(rms, max_dist)| RmsDistResult { rms, max_dist }))
+        })();
+        serialize_result(to_wasm_result(result))
+    }
+
+    /// Deduplicate a list of structures.
+    /// Returns array where result[i] is the index of the first matching structure.
+    #[wasm_bindgen]
+    pub fn deduplicate(&self, structures: &JsValue) -> JsValue {
+        let result = parse_js_array(structures)
+            .and_then(|parsed| self.inner.deduplicate(&parsed).map_err(|e| e.to_string()));
+        serialize_result(to_wasm_result(result))
+    }
+
+    /// Find matches for new structures against existing structures.
+    /// Returns array where result[i] is the index of matching existing structure or null.
+    #[wasm_bindgen]
+    pub fn find_matches(&self, new_structures: &JsValue, existing_structures: &JsValue) -> JsValue {
+        let result = parse_js_array(new_structures).and_then(|new_parsed| {
+            parse_js_array(existing_structures).and_then(|existing_parsed| {
+                self.inner
+                    .find_matches(&new_parsed, &existing_parsed)
+                    .map_err(|e| e.to_string())
+            })
+        });
+        serialize_result(to_wasm_result(result))
+    }
+}
+
+impl Default for WasmStructureMatcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// =============================================================================
+// Structure Parsing Functions
+// =============================================================================
+
+/// Helper to wrap Result<JsValue, String> as { ok: value } or { error: string }
+fn wrap_js_result(result: Result<JsValue, String>) -> JsValue {
+    let obj = js_sys::Object::new();
+    match result {
+        Ok(value) => {
+            js_sys::Reflect::set(&obj, &"ok".into(), &value).unwrap();
+        }
+        Err(e) => {
+            js_sys::Reflect::set(&obj, &"error".into(), &e.into()).unwrap();
+        }
+    }
+    obj.into()
+}
+
+/// Parse a structure from a pymatgen-style JSON object.
+#[wasm_bindgen]
+pub fn parse_structure(input: &JsValue) -> JsValue {
+    wrap_js_result(parse_structure_from_js(input).and_then(|s| structure_to_js(&s)))
+}
+
+/// Parse a structure from CIF format string.
+#[wasm_bindgen]
+pub fn parse_cif(content: &str) -> JsValue {
+    wrap_js_result(
+        parse_cif_str(content, Path::new("inline.cif"))
+            .map_err(|e| e.to_string())
+            .and_then(|s| structure_to_js(&s)),
+    )
+}
+
+/// Parse a structure from POSCAR format string.
+#[wasm_bindgen]
+pub fn parse_poscar(content: &str) -> JsValue {
+    wrap_js_result(
+        parse_poscar_str(content)
+            .map_err(|e| e.to_string())
+            .and_then(|s| structure_to_js(&s)),
+    )
+}
+
+// =============================================================================
+// Supercell Functions
+// =============================================================================
+
+/// Create a diagonal supercell (nx × ny × nz).
+#[wasm_bindgen]
+pub fn make_supercell_diag(structure: &JsValue, nx: i32, ny: i32, nz: i32) -> JsValue {
+    wrap_js_result((|| {
+        if nx <= 0 || ny <= 0 || nz <= 0 {
+            return Err(format!(
+                "Supercell factors must be positive, got [{nx}, {ny}, {nz}]"
+            ));
+        }
+        let s = parse_structure_from_js(structure)?;
+        let supercell = s.make_supercell_diag([nx, ny, nz]);
+        structure_to_js(&supercell)
+    })())
+}
+
+/// Create a supercell using a 3x3 transformation matrix.
+#[wasm_bindgen]
+pub fn make_supercell(structure: &JsValue, matrix: &JsValue) -> JsValue {
+    wrap_js_result((|| {
+        let s = parse_structure_from_js(structure)?;
+        let mat: [[i32; 3]; 3] =
+            serde_wasm_bindgen::from_value(matrix.clone()).map_err(|e| e.to_string())?;
+        let supercell = s.make_supercell(mat).map_err(|e| e.to_string())?;
+        structure_to_js(&supercell)
+    })())
+}
+
+// =============================================================================
+// Lattice Reduction Functions
+// =============================================================================
+
+/// Get structure with reduced lattice (Niggli or LLL algorithm).
+#[wasm_bindgen]
+pub fn get_reduced_structure(structure: &JsValue, algo: &str) -> JsValue {
+    wrap_js_result((|| {
+        let s = parse_structure_from_js(structure)?;
+        let algo = match algo.to_lowercase().as_str() {
+            "niggli" => ReductionAlgo::Niggli,
+            "lll" => ReductionAlgo::LLL,
+            _ => return Err(format!("Invalid algorithm: {algo}. Use 'niggli' or 'lll'")),
+        };
+        let reduced = s.get_reduced_structure(algo).map_err(|e| e.to_string())?;
+        structure_to_js(&reduced)
+    })())
+}
+
+/// Get the primitive cell of a structure.
+#[wasm_bindgen]
+pub fn get_primitive(structure: &JsValue, symprec: f64) -> JsValue {
+    wrap_js_result((|| {
+        let s = parse_structure_from_js(structure)?;
+        let primitive = s.get_primitive(symprec).map_err(|e| e.to_string())?;
+        structure_to_js(&primitive)
+    })())
+}
+
+/// Get the spacegroup number of a structure.
+#[wasm_bindgen]
+pub fn get_spacegroup_number(structure: &JsValue, symprec: f64) -> JsValue {
+    let result = (|| {
+        let s = parse_structure_from_js(structure)?;
+        s.get_spacegroup_number(symprec).map_err(|e| e.to_string())
+    })();
+    serialize_result(to_wasm_result(result))
+}
+
+/// Serialize structure to pymatgen-compatible JSON string.
+#[wasm_bindgen]
+pub fn structure_to_json(structure: &JsValue) -> JsValue {
+    let result: Result<String, String> = (|| {
+        let s = parse_structure_from_js(structure)?;
+        Ok(structure_to_pymatgen_json(&s))
+    })();
+    serialize_result(to_wasm_result(result))
+}
+
+// =============================================================================
+// Physical Property Functions
+// =============================================================================
+
+/// Get the volume of the unit cell in Angstrom³.
+#[wasm_bindgen]
+pub fn get_volume(structure: &JsValue) -> JsValue {
+    let result = parse_structure_from_js(structure).map(|s| s.volume());
+    serialize_result(to_wasm_result(result))
+}
+
+/// Get the total mass of the structure in atomic mass units.
+#[wasm_bindgen]
+pub fn get_total_mass(structure: &JsValue) -> JsValue {
+    let result = parse_structure_from_js(structure).map(|s| s.total_mass());
+    serialize_result(to_wasm_result(result))
+}
+
+/// Get the density of the structure in g/cm³.
+#[wasm_bindgen]
+pub fn get_density(structure: &JsValue) -> JsValue {
+    let result = (|| {
+        let s = parse_structure_from_js(structure)?;
+        s.density()
+            .ok_or_else(|| "Cannot compute density for zero-volume structure".to_string())
+    })();
+    serialize_result(to_wasm_result(result))
+}
+
+// =============================================================================
+// Neighbor Finding Functions
+// =============================================================================
+
+/// Get neighbor list for a structure.
+#[wasm_bindgen]
+pub fn get_neighbor_list(
+    structure: &JsValue,
+    r: f64,
+    numerical_tol: f64,
+    exclude_self: bool,
+) -> JsValue {
+    let result = (|| {
+        if r < 0.0 {
+            return Err("Cutoff radius must be non-negative".to_string());
+        }
+        let s = parse_structure_from_js(structure)?;
+        let (center_indices, neighbor_indices, image_offsets, distances) =
+            s.get_neighbor_list(r, numerical_tol, exclude_self);
+        Ok(NeighborListResult {
+            center_indices,
+            neighbor_indices,
+            image_offsets,
+            distances,
+        })
+    })();
+    serialize_result(to_wasm_result(result))
+}
+
+/// Get distance between two sites using minimum image convention.
+#[wasm_bindgen]
+pub fn get_distance(structure: &JsValue, i: usize, j: usize) -> JsValue {
+    let result = (|| {
+        let s = parse_structure_from_js(structure)?;
+        let n = s.num_sites();
+        if i >= n || j >= n {
+            return Err(format!(
+                "Site indices ({i}, {j}) out of bounds for structure with {n} sites"
+            ));
+        }
+        Ok(s.get_distance(i, j))
+    })();
+    serialize_result(to_wasm_result(result))
+}
+
+/// Get the full distance matrix between all sites.
+#[wasm_bindgen]
+pub fn get_distance_matrix(structure: &JsValue) -> JsValue {
+    let result = parse_structure_from_js(structure).map(|s| s.distance_matrix());
+    serialize_result(to_wasm_result(result))
+}
+
+// =============================================================================
+// Sorting Functions
+// =============================================================================
+
+/// Get a sorted copy of the structure by atomic number.
+#[wasm_bindgen]
+pub fn get_sorted_structure(structure: &JsValue, reverse: bool) -> JsValue {
+    wrap_js_result((|| {
+        let s = parse_structure_from_js(structure)?;
+        let sorted = s.get_sorted_structure(reverse);
+        structure_to_js(&sorted)
+    })())
+}
+
+/// Get a sorted copy of the structure by electronegativity.
+#[wasm_bindgen]
+pub fn get_sorted_by_electronegativity(structure: &JsValue, reverse: bool) -> JsValue {
+    wrap_js_result((|| {
+        let s = parse_structure_from_js(structure)?;
+        let sorted = s.get_sorted_by_electronegativity(reverse);
+        structure_to_js(&sorted)
+    })())
+}
+
+// =============================================================================
+// Interpolation Functions
+// =============================================================================
+
+/// Interpolate between two structures.
+#[wasm_bindgen]
+pub fn interpolate_structures(
+    start: &JsValue,
+    end: &JsValue,
+    n_images: usize,
+    interpolate_lattices: bool,
+    use_pbc: bool,
+) -> JsValue {
+    let result = (|| {
+        let s1 = parse_structure_from_js(start)?;
+        let s2 = parse_structure_from_js(end)?;
+        let images = s1
+            .interpolate(&s2, n_images, interpolate_lattices, use_pbc)
+            .map_err(|e| e.to_string())?;
+        let arr = js_sys::Array::new();
+        for img in &images {
+            arr.push(&structure_to_js(img)?);
+        }
+        Ok(arr.into())
+    })();
+    wrap_js_result(result)
+}
+
+// =============================================================================
+// Copy and Wrap Functions
+// =============================================================================
+
+/// Create a copy of the structure, optionally sanitized.
+#[wasm_bindgen]
+pub fn copy_structure(structure: &JsValue, sanitize: bool) -> JsValue {
+    wrap_js_result((|| {
+        let s = parse_structure_from_js(structure)?;
+        let copied = s.copy(sanitize);
+        structure_to_js(&copied)
+    })())
+}
+
+/// Wrap all fractional coordinates to [0, 1).
+#[wasm_bindgen]
+pub fn wrap_to_unit_cell(structure: &JsValue) -> JsValue {
+    wrap_js_result((|| {
+        let mut s = parse_structure_from_js(structure)?;
+        s.wrap_to_unit_cell();
+        structure_to_js(&s)
+    })())
+}
+
+// =============================================================================
+// Site Manipulation Functions
+// =============================================================================
+
+/// Translate specific sites by a vector.
+#[wasm_bindgen]
+pub fn translate_sites(
+    structure: &JsValue,
+    indices: &JsValue,
+    vector: &JsValue,
+    fractional: bool,
+) -> JsValue {
+    wrap_js_result((|| {
+        let mut s = parse_structure_from_js(structure)?;
+        let idx: Vec<usize> =
+            serde_wasm_bindgen::from_value(indices.clone()).map_err(|e| e.to_string())?;
+        let vec: [f64; 3] =
+            serde_wasm_bindgen::from_value(vector.clone()).map_err(|e| e.to_string())?;
+
+        let n = s.num_sites();
+        for &i in &idx {
+            if i >= n {
+                return Err(format!(
+                    "Index {i} out of bounds for structure with {n} sites"
+                ));
+            }
+        }
+
+        s.translate_sites(&idx, Vector3::from(vec), fractional);
+        structure_to_js(&s)
+    })())
+}
+
+/// Perturb all sites by random vectors.
+#[wasm_bindgen]
+pub fn perturb_structure(
+    structure: &JsValue,
+    distance: f64,
+    min_distance: Option<f64>,
+    seed: Option<u64>,
+) -> JsValue {
+    wrap_js_result((|| {
+        if distance < 0.0 {
+            return Err("distance must be non-negative".to_string());
+        }
+        if let Some(min_dist) = min_distance {
+            if min_dist < 0.0 {
+                return Err("min_distance must be non-negative".to_string());
+            }
+            if min_dist > distance {
+                return Err(format!(
+                    "distance ({distance}) must be >= min_distance ({min_dist})"
+                ));
+            }
+        }
+        let mut s = parse_structure_from_js(structure)?;
+        s.perturb(distance, min_distance, seed);
+        structure_to_js(&s)
+    })())
+}
+
+// =============================================================================
+// Element Information Functions
+// =============================================================================
+
+/// Get atomic mass for an element by symbol.
+#[wasm_bindgen]
+pub fn get_atomic_mass(symbol: &str) -> JsValue {
+    let result = Element::from_symbol(symbol)
+        .map(|e| e.atomic_mass())
+        .ok_or_else(|| format!("Unknown element: {symbol}"));
+    serialize_result(to_wasm_result(result))
+}
+
+/// Get electronegativity for an element by symbol.
+#[wasm_bindgen]
+pub fn get_electronegativity(symbol: &str) -> JsValue {
+    let result = Element::from_symbol(symbol)
+        .ok_or_else(|| format!("Unknown element: {symbol}"))
+        .and_then(|e| {
+            e.electronegativity()
+                .ok_or_else(|| format!("No electronegativity data for {symbol}"))
+        });
+    serialize_result(to_wasm_result(result))
 }

--- a/extensions/rust/src/wasm_types.rs
+++ b/extensions/rust/src/wasm_types.rs
@@ -6,9 +6,7 @@
 use serde::{Deserialize, Serialize};
 use tsify_next::Tsify;
 
-// =============================================================================
-// Result Types
-// =============================================================================
+// === Result Types ===
 
 /// Result wrapper that serializes to `{ ok: T }` on success or `{ error: string }` on failure.
 /// TypeScript: `WasmResult<T> = { ok: T } | { error: string }`
@@ -49,9 +47,7 @@ impl<T, E: std::fmt::Display> From<Result<T, E>> for WasmResult<T> {
     }
 }
 
-// =============================================================================
-// Vector and Matrix Types
-// =============================================================================
+// === Vector and Matrix Types ===
 
 /// 3x3 matrix represented as nested arrays (row-major).
 pub type Matrix3x3 = [[f64; 3]; 3];
@@ -91,9 +87,7 @@ fn default_pbc() -> [bool; 3] {
     [true, true, true]
 }
 
-// =============================================================================
-// Species Types
-// =============================================================================
+// === Species Types ===
 
 /// Species occupancy at a site (element + occupancy + optional oxidation state).
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
@@ -113,9 +107,7 @@ fn default_occupancy() -> f64 {
     1.0
 }
 
-// =============================================================================
-// Site Types
-// =============================================================================
+// === Site Types ===
 
 /// A crystallographic site with species, coordinates, and properties.
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
@@ -136,9 +128,7 @@ pub struct JsSite {
     pub properties: serde_json::Map<String, serde_json::Value>,
 }
 
-// =============================================================================
-// Structure Types
-// =============================================================================
+// === Structure Types ===
 
 /// A crystal structure matching pymatgen's JSON format.
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
@@ -153,9 +143,7 @@ pub struct JsCrystal {
     pub properties: serde_json::Map<String, serde_json::Value>,
 }
 
-// =============================================================================
-// Neighbor List Types
-// =============================================================================
+// === Neighbor List Types ===
 
 /// Result of neighbor list calculation.
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
@@ -171,9 +159,7 @@ pub struct JsNeighborList {
     pub distances: Vec<f64>,
 }
 
-// =============================================================================
-// RMS Distance Types
-// =============================================================================
+// === RMS Distance Types ===
 
 /// Result of RMS distance calculation between two structures.
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
@@ -185,9 +171,7 @@ pub struct JsRmsDistResult {
     pub max_dist: f64,
 }
 
-// =============================================================================
-// Symmetry Types
-// =============================================================================
+// === Symmetry Types ===
 
 /// A symmetry operation (rotation + translation in fractional coordinates).
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
@@ -221,9 +205,7 @@ pub struct JsSymmetryDataset {
     pub operations: Vec<JsSymmetryOperation>,
 }
 
-// =============================================================================
-// Coordination Types
-// =============================================================================
+// === Coordination Types ===
 
 /// Information about a neighboring atom in coordination analysis.
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
@@ -253,39 +235,7 @@ pub struct JsLocalEnvironment {
     pub neighbors: Vec<JsNeighborInfo>,
 }
 
-// =============================================================================
-// Composition Types
-// =============================================================================
-
-/// Element count in a composition.
-#[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
-pub struct JsElementCount {
-    /// Element symbol
-    pub element: String,
-    /// Count (can be fractional for disordered structures)
-    pub count: f64,
-}
-
-/// Chemical composition of a structure.
-#[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi)]
-pub struct JsComposition {
-    /// List of elements and their counts
-    pub elements: Vec<JsElementCount>,
-    /// Reduced formula (e.g., "Fe2O3")
-    pub reduced_formula: String,
-    /// Total number of atoms
-    pub num_atoms: f64,
-}
-
-// =============================================================================
-// Slab Types (Miller index defined above as JsMillerIndex)
-// =============================================================================
-
-// =============================================================================
-// Structure Metadata Types
-// =============================================================================
+// === Structure Metadata Types ===
 
 /// Metadata about a crystal structure.
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
@@ -295,7 +245,7 @@ pub struct JsStructureMetadata {
     pub num_sites: u32,
     /// Reduced chemical formula
     pub formula: String,
-    /// Volume in Ų
+    /// Volume in Å³
     pub volume: f64,
     /// Density in g/cm³ (null if zero volume)
     pub density: Option<f64>,
@@ -307,9 +257,7 @@ pub struct JsStructureMetadata {
     pub is_ordered: bool,
 }
 
-// =============================================================================
-// Reduction Algorithm Enum
-// =============================================================================
+// === Reduction Algorithm Enum ===
 
 /// Lattice reduction algorithm.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Tsify)]
@@ -322,9 +270,7 @@ pub enum JsReductionAlgo {
     Lll,
 }
 
-// =============================================================================
-// Conversion Utilities
-// =============================================================================
+// === Conversion Utilities ===
 
 use crate::element::Element;
 use crate::lattice::Lattice;
@@ -336,7 +282,7 @@ use std::collections::HashMap;
 impl JsCrystal {
     /// Convert from internal Structure type to JS-compatible type
     pub fn from_structure(structure: &Structure) -> Self {
-        let lattice_matrix = structure.lattice.matrix();
+        let mat = structure.lattice.matrix();
         let cart_coords = structure.cart_coords();
 
         let sites: Vec<JsSite> = structure
@@ -381,21 +327,9 @@ impl JsCrystal {
         JsCrystal {
             lattice: JsLattice {
                 matrix: [
-                    [
-                        lattice_matrix[(0, 0)],
-                        lattice_matrix[(0, 1)],
-                        lattice_matrix[(0, 2)],
-                    ],
-                    [
-                        lattice_matrix[(1, 0)],
-                        lattice_matrix[(1, 1)],
-                        lattice_matrix[(1, 2)],
-                    ],
-                    [
-                        lattice_matrix[(2, 0)],
-                        lattice_matrix[(2, 1)],
-                        lattice_matrix[(2, 2)],
-                    ],
+                    [mat[(0, 0)], mat[(0, 1)], mat[(0, 2)]],
+                    [mat[(1, 0)], mat[(1, 1)], mat[(1, 2)]],
+                    [mat[(2, 0)], mat[(2, 1)], mat[(2, 2)]],
                 ],
                 pbc: structure.lattice.pbc,
             },
@@ -406,16 +340,9 @@ impl JsCrystal {
 
     /// Convert to internal Structure type
     pub fn to_structure(&self) -> Result<Structure, String> {
+        let m = &self.lattice.matrix;
         let lattice_matrix = nalgebra::Matrix3::from_row_slice(&[
-            self.lattice.matrix[0][0],
-            self.lattice.matrix[0][1],
-            self.lattice.matrix[0][2],
-            self.lattice.matrix[1][0],
-            self.lattice.matrix[1][1],
-            self.lattice.matrix[1][2],
-            self.lattice.matrix[2][0],
-            self.lattice.matrix[2][1],
-            self.lattice.matrix[2][2],
+            m[0][0], m[0][1], m[0][2], m[1][0], m[1][1], m[1][2], m[2][0], m[2][1], m[2][2],
         ]);
         let mut lattice = Lattice::new(lattice_matrix);
         lattice.pbc = self.lattice.pbc;

--- a/extensions/rust/src/wasm_types.rs
+++ b/extensions/rust/src/wasm_types.rs
@@ -243,8 +243,12 @@ pub struct JsLocalEnvironment {
 pub struct JsStructureMetadata {
     /// Number of sites
     pub num_sites: u32,
-    /// Reduced chemical formula
+    /// Reduced chemical formula (e.g., "Fe2O3")
     pub formula: String,
+    /// Anonymous formula with elements replaced by A, B, C... (e.g., "A2B3")
+    pub formula_anonymous: String,
+    /// Hill notation formula (C and H first if present, then alphabetical)
+    pub formula_hill: String,
     /// Volume in Å³
     pub volume: f64,
     /// Density in g/cm³ (null if zero volume)

--- a/extensions/rust/src/wasm_types.rs
+++ b/extensions/rust/src/wasm_types.rs
@@ -1,0 +1,484 @@
+//! TypeScript-compatible types for WASM bindings.
+//!
+//! These types use `tsify` to auto-generate precise TypeScript definitions.
+//! All types match pymatgen's JSON structure for interoperability.
+
+use serde::{Deserialize, Serialize};
+use tsify_next::Tsify;
+
+// =============================================================================
+// Result Types
+// =============================================================================
+
+/// Result wrapper that serializes to `{ ok: T }` on success or `{ error: string }` on failure.
+/// TypeScript: `WasmResult<T> = { ok: T } | { error: string }`
+#[derive(Debug, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi)]
+#[serde(untagged)]
+pub enum WasmResult<T> {
+    /// Success variant
+    Ok {
+        /// The successful result value
+        ok: T,
+    },
+    /// Error variant
+    Err {
+        /// Error message describing what went wrong
+        error: String,
+    },
+}
+
+impl<T> WasmResult<T> {
+    /// Create a success result
+    pub fn ok(value: T) -> Self {
+        WasmResult::Ok { ok: value }
+    }
+
+    /// Create an error result
+    pub fn err(msg: impl Into<String>) -> Self {
+        WasmResult::Err { error: msg.into() }
+    }
+}
+
+impl<T, E: std::fmt::Display> From<Result<T, E>> for WasmResult<T> {
+    fn from(result: Result<T, E>) -> Self {
+        match result {
+            Ok(value) => WasmResult::ok(value),
+            Err(err) => WasmResult::err(err.to_string()),
+        }
+    }
+}
+
+// =============================================================================
+// Vector and Matrix Types
+// =============================================================================
+
+/// 3x3 matrix represented as nested arrays (row-major).
+pub type Matrix3x3 = [[f64; 3]; 3];
+
+/// 3x3 integer matrix for supercell transformations.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct JsIntMatrix3x3(pub [[i32; 3]; 3]);
+
+/// 3D vector of floats.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct JsVector3(pub [f64; 3]);
+
+/// Miller index (3D integer vector).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct JsMillerIndex(pub [i32; 3]);
+
+/// 3x3 float matrix for transformations.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct JsMatrix3x3(pub [[f64; 3]; 3]);
+
+/// Lattice structure matching pymatgen's JSON format.
+#[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct JsLattice {
+    /// 3x3 lattice matrix with lattice vectors as rows (Ångströms)
+    pub matrix: Matrix3x3,
+    /// Periodic boundary conditions along each axis
+    #[serde(default = "default_pbc")]
+    pub pbc: [bool; 3],
+}
+
+fn default_pbc() -> [bool; 3] {
+    [true, true, true]
+}
+
+// =============================================================================
+// Species Types
+// =============================================================================
+
+/// Species occupancy at a site (element + occupancy + optional oxidation state).
+#[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct JsSpeciesOccupancy {
+    /// Element symbol (e.g., "Fe", "O", "Li")
+    pub element: String,
+    /// Site occupancy (0.0 to 1.0, typically 1.0 for ordered sites)
+    #[serde(default = "default_occupancy")]
+    pub occu: f64,
+    /// Optional oxidation state (e.g., 2 for Fe²⁺, -2 for O²⁻)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub oxidation_state: Option<i8>,
+}
+
+fn default_occupancy() -> f64 {
+    1.0
+}
+
+// =============================================================================
+// Site Types
+// =============================================================================
+
+/// A crystallographic site with species, coordinates, and properties.
+#[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct JsSite {
+    /// Species at this site (can have multiple for disordered sites)
+    pub species: Vec<JsSpeciesOccupancy>,
+    /// Fractional coordinates [a, b, c] in range [0, 1)
+    pub abc: [f64; 3],
+    /// Cartesian coordinates [x, y, z] in Ångströms (optional, computed if missing)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub xyz: Option<[f64; 3]>,
+    /// Site label (defaults to element symbol)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    /// Site-specific properties (e.g., magnetic moment, charge)
+    #[serde(default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub properties: serde_json::Map<String, serde_json::Value>,
+}
+
+// =============================================================================
+// Structure Types
+// =============================================================================
+
+/// A crystal structure matching pymatgen's JSON format.
+#[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct JsCrystal {
+    /// The crystal lattice
+    pub lattice: JsLattice,
+    /// List of crystallographic sites
+    pub sites: Vec<JsSite>,
+    /// Structure-level properties
+    #[serde(default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub properties: serde_json::Map<String, serde_json::Value>,
+}
+
+// =============================================================================
+// Neighbor List Types
+// =============================================================================
+
+/// Result of neighbor list calculation.
+#[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi)]
+pub struct JsNeighborList {
+    /// Indices of center atoms
+    pub center_indices: Vec<u32>,
+    /// Indices of neighbor atoms
+    pub neighbor_indices: Vec<u32>,
+    /// Periodic image offsets [h, k, l] for each neighbor
+    pub image_offsets: Vec<[i32; 3]>,
+    /// Distances from center to neighbor (Ångströms)
+    pub distances: Vec<f64>,
+}
+
+// =============================================================================
+// RMS Distance Types
+// =============================================================================
+
+/// Result of RMS distance calculation between two structures.
+#[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi)]
+pub struct JsRmsDistResult {
+    /// Root mean square distance between matched sites (Ångströms)
+    pub rms: f64,
+    /// Maximum distance between any pair of matched sites (Ångströms)
+    pub max_dist: f64,
+}
+
+// =============================================================================
+// Symmetry Types
+// =============================================================================
+
+/// A symmetry operation (rotation + translation in fractional coordinates).
+#[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi)]
+pub struct JsSymmetryOperation {
+    /// 3x3 rotation matrix (integer elements in fractional basis)
+    pub rotation: [[i32; 3]; 3],
+    /// Translation vector in fractional coordinates
+    pub translation: [f64; 3],
+}
+
+/// Full symmetry dataset for a structure.
+#[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi)]
+pub struct JsSymmetryDataset {
+    /// International space group number (1-230)
+    pub spacegroup_number: u16,
+    /// Space group symbol (e.g., "Fm-3m")
+    pub spacegroup_symbol: String,
+    /// Hall number
+    pub hall_number: u16,
+    /// Crystal system (e.g., "cubic", "hexagonal")
+    pub crystal_system: String,
+    /// Wyckoff letters for each site
+    pub wyckoff_letters: Vec<String>,
+    /// Site symmetry symbols for each site
+    pub site_symmetry_symbols: Vec<String>,
+    /// Equivalent atoms mapping
+    pub equivalent_atoms: Vec<u32>,
+    /// Symmetry operations
+    pub operations: Vec<JsSymmetryOperation>,
+}
+
+// =============================================================================
+// Coordination Types
+// =============================================================================
+
+/// Information about a neighboring atom in coordination analysis.
+#[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi)]
+pub struct JsNeighborInfo {
+    /// Index of the neighboring site
+    pub site_index: u32,
+    /// Element symbol of neighbor
+    pub element: String,
+    /// Distance to neighbor (Ångströms)
+    pub distance: f64,
+    /// Periodic image offset
+    pub image: [i32; 3],
+}
+
+/// Local coordination environment for a site.
+#[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi)]
+pub struct JsLocalEnvironment {
+    /// Index of the central site
+    pub center_index: u32,
+    /// Element at the center
+    pub center_element: String,
+    /// Coordination number
+    pub coordination_number: u32,
+    /// List of coordinating neighbors
+    pub neighbors: Vec<JsNeighborInfo>,
+}
+
+// =============================================================================
+// Composition Types
+// =============================================================================
+
+/// Element count in a composition.
+#[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct JsElementCount {
+    /// Element symbol
+    pub element: String,
+    /// Count (can be fractional for disordered structures)
+    pub count: f64,
+}
+
+/// Chemical composition of a structure.
+#[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi)]
+pub struct JsComposition {
+    /// List of elements and their counts
+    pub elements: Vec<JsElementCount>,
+    /// Reduced formula (e.g., "Fe2O3")
+    pub reduced_formula: String,
+    /// Total number of atoms
+    pub num_atoms: f64,
+}
+
+// =============================================================================
+// Slab Types (Miller index defined above as JsMillerIndex)
+// =============================================================================
+
+// =============================================================================
+// Structure Metadata Types
+// =============================================================================
+
+/// Metadata about a crystal structure.
+#[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi)]
+pub struct JsStructureMetadata {
+    /// Number of sites
+    pub num_sites: u32,
+    /// Reduced chemical formula
+    pub formula: String,
+    /// Volume in Ų
+    pub volume: f64,
+    /// Density in g/cm³ (null if zero volume)
+    pub density: Option<f64>,
+    /// Lattice parameters [a, b, c] in Ångströms
+    pub lattice_params: [f64; 3],
+    /// Lattice angles [alpha, beta, gamma] in degrees
+    pub lattice_angles: [f64; 3],
+    /// Whether structure is ordered (no partial occupancies)
+    pub is_ordered: bool,
+}
+
+// =============================================================================
+// Reduction Algorithm Enum
+// =============================================================================
+
+/// Lattice reduction algorithm.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(rename_all = "lowercase")]
+pub enum JsReductionAlgo {
+    /// Niggli reduction - produces unique reduced cell
+    Niggli,
+    /// LLL reduction - produces nearly orthogonal basis
+    Lll,
+}
+
+// =============================================================================
+// Conversion Utilities
+// =============================================================================
+
+use crate::element::Element;
+use crate::lattice::Lattice;
+use crate::species::{SiteOccupancy, Species};
+use crate::structure::Structure;
+use nalgebra::Vector3;
+use std::collections::HashMap;
+
+impl JsCrystal {
+    /// Convert from internal Structure type to JS-compatible type
+    pub fn from_structure(structure: &Structure) -> Self {
+        let lattice_matrix = structure.lattice.matrix();
+        let cart_coords = structure.cart_coords();
+
+        let sites: Vec<JsSite> = structure
+            .site_occupancies
+            .iter()
+            .zip(structure.frac_coords.iter())
+            .zip(cart_coords.iter())
+            .enumerate()
+            .map(|(site_idx, ((site_occ, frac_coord), cart_coord))| {
+                let species: Vec<JsSpeciesOccupancy> = site_occ
+                    .species
+                    .iter()
+                    .map(|(species_item, occupancy)| JsSpeciesOccupancy {
+                        element: species_item.element.symbol().to_string(),
+                        occu: *occupancy,
+                        oxidation_state: species_item.oxidation_state,
+                    })
+                    .collect();
+
+                let site_props = structure.site_properties(site_idx);
+                let properties: serde_json::Map<String, serde_json::Value> = site_props
+                    .iter()
+                    .map(|(key, val)| (key.clone(), val.clone()))
+                    .collect();
+
+                JsSite {
+                    species,
+                    abc: [frac_coord.x, frac_coord.y, frac_coord.z],
+                    xyz: Some([cart_coord.x, cart_coord.y, cart_coord.z]),
+                    label: Some(site_occ.species_string()),
+                    properties,
+                }
+            })
+            .collect();
+
+        let properties: serde_json::Map<String, serde_json::Value> = structure
+            .properties
+            .iter()
+            .map(|(key, val)| (key.clone(), val.clone()))
+            .collect();
+
+        JsCrystal {
+            lattice: JsLattice {
+                matrix: [
+                    [
+                        lattice_matrix[(0, 0)],
+                        lattice_matrix[(0, 1)],
+                        lattice_matrix[(0, 2)],
+                    ],
+                    [
+                        lattice_matrix[(1, 0)],
+                        lattice_matrix[(1, 1)],
+                        lattice_matrix[(1, 2)],
+                    ],
+                    [
+                        lattice_matrix[(2, 0)],
+                        lattice_matrix[(2, 1)],
+                        lattice_matrix[(2, 2)],
+                    ],
+                ],
+                pbc: structure.lattice.pbc,
+            },
+            sites,
+            properties,
+        }
+    }
+
+    /// Convert to internal Structure type
+    pub fn to_structure(&self) -> Result<Structure, String> {
+        let lattice_matrix = nalgebra::Matrix3::from_row_slice(&[
+            self.lattice.matrix[0][0],
+            self.lattice.matrix[0][1],
+            self.lattice.matrix[0][2],
+            self.lattice.matrix[1][0],
+            self.lattice.matrix[1][1],
+            self.lattice.matrix[1][2],
+            self.lattice.matrix[2][0],
+            self.lattice.matrix[2][1],
+            self.lattice.matrix[2][2],
+        ]);
+        let mut lattice = Lattice::new(lattice_matrix);
+        lattice.pbc = self.lattice.pbc;
+
+        let mut site_occupancies = Vec::with_capacity(self.sites.len());
+        let mut frac_coords = Vec::with_capacity(self.sites.len());
+
+        for (site_idx, site) in self.sites.iter().enumerate() {
+            if site.species.is_empty() {
+                return Err(format!("Site {site_idx} has no species"));
+            }
+
+            let species: Vec<(Species, f64)> = site
+                .species
+                .iter()
+                .map(|species_occ| {
+                    let element = Element::from_symbol(&species_occ.element)
+                        .ok_or_else(|| format!("Unknown element: {}", species_occ.element))?;
+                    let species = if let Some(oxi) = species_occ.oxidation_state {
+                        Species::new(element, Some(oxi))
+                    } else {
+                        Species::neutral(element)
+                    };
+                    Ok((species, species_occ.occu))
+                })
+                .collect::<Result<Vec<_>, String>>()?;
+
+            // Convert site properties from serde_json::Map to HashMap
+            let site_props: HashMap<String, serde_json::Value> = site
+                .properties
+                .iter()
+                .map(|(key, val)| (key.clone(), val.clone()))
+                .collect();
+
+            site_occupancies.push(SiteOccupancy {
+                species,
+                properties: site_props,
+            });
+            frac_coords.push(Vector3::new(site.abc[0], site.abc[1], site.abc[2]));
+        }
+
+        let properties: HashMap<String, serde_json::Value> = self
+            .properties
+            .iter()
+            .map(|(key, val)| (key.clone(), val.clone()))
+            .collect();
+
+        Structure::try_new_from_occupancies_with_properties(
+            lattice,
+            site_occupancies,
+            frac_coords,
+            properties,
+        )
+        .map_err(|err| err.to_string())
+    }
+}
+
+impl JsReductionAlgo {
+    /// Convert to internal ReductionAlgo type
+    pub fn to_internal(&self) -> crate::structure::ReductionAlgo {
+        match self {
+            JsReductionAlgo::Niggli => crate::structure::ReductionAlgo::Niggli,
+            JsReductionAlgo::Lll => crate::structure::ReductionAlgo::LLL,
+        }
+    }
+}

--- a/extensions/rust/src/wasm_types.rs
+++ b/extensions/rust/src/wasm_types.rs
@@ -1,12 +1,8 @@
-//! TypeScript-compatible types for WASM bindings.
-//!
-//! These types use `tsify` to auto-generate precise TypeScript definitions.
+//! TypeScript-compatible types for WASM bindings using `tsify`.
 //! All types match pymatgen's JSON structure for interoperability.
 
 use serde::{Deserialize, Serialize};
 use tsify_next::Tsify;
-
-// === Result Types ===
 
 /// Result wrapper that serializes to `{ ok: T }` on success or `{ error: string }` on failure.
 /// TypeScript: `WasmResult<T> = { ok: T } | { error: string }`

--- a/extensions/rust/tests/conftest.py
+++ b/extensions/rust/tests/conftest.py
@@ -3,74 +3,82 @@
 from __future__ import annotations
 
 import json
-
 import pytest
 
 
-def make_structure(lattice_a: float, sites: list[dict]) -> str:
+def _cubic(a: float, sites: list[dict]) -> str:
     """Create structure JSON with cubic lattice."""
     return json.dumps({
         "@module": "pymatgen.core.structure",
         "@class": "Structure",
-        "lattice": {"matrix": [[lattice_a, 0, 0], [0, lattice_a, 0], [0, 0, lattice_a]]},
+        "lattice": {"matrix": [[a, 0, 0], [0, a, 0], [0, 0, a]]},
         "sites": sites,
     })
 
 
-def site(element: str, abc: list[float], oxi: int | None = None) -> dict:
-    """Create a site dict."""
-    species = {"element": element, "occu": 1}
+def _s(el: str, abc: list[float], oxi: int | None = None) -> dict:
+    """Create site dict with optional oxidation state."""
+    species = {"element": el, "occu": 1}
     if oxi is not None:
         species["oxidation_state"] = oxi
     return {"species": [species], "abc": abc}
 
 
-# Common structure fixtures
+# === Fixtures ===
+
 @pytest.fixture
 def nacl_json() -> str:
-    """NaCl rocksalt (Pm-3m #221), 2 sites."""
-    return make_structure(5.64, [site("Na", [0, 0, 0]), site("Cl", [0.5, 0.5, 0.5])])
+    """NaCl primitive (Pm-3m #221), 2 sites."""
+    return _cubic(5.64, [_s("Na", [0, 0, 0]), _s("Cl", [0.5, 0.5, 0.5])])
 
 
 @pytest.fixture
 def nacl_with_oxi_json() -> str:
     """NaCl with oxidation states (Na+, Cl-)."""
-    return make_structure(5.64, [site("Na", [0, 0, 0], oxi=1), site("Cl", [0.5, 0.5, 0.5], oxi=-1)])
+    return _cubic(5.64, [_s("Na", [0, 0, 0], 1), _s("Cl", [0.5, 0.5, 0.5], -1)])
+
+
+@pytest.fixture
+def rocksalt_nacl_json() -> str:
+    """NaCl conventional cell, 8 sites, CN=6."""
+    return _cubic(5.64, [
+        _s("Na", [0, 0, 0]), _s("Na", [0.5, 0.5, 0]), _s("Na", [0.5, 0, 0.5]), _s("Na", [0, 0.5, 0.5]),
+        _s("Cl", [0.5, 0, 0]), _s("Cl", [0, 0.5, 0]), _s("Cl", [0, 0, 0.5]), _s("Cl", [0.5, 0.5, 0.5]),
+    ])
 
 
 @pytest.fixture
 def fcc_cu_json() -> str:
-    """FCC Cu conventional cell (Fm-3m #225), 4 sites, CN=12."""
-    return make_structure(3.6, [
-        site("Cu", [0, 0, 0]), site("Cu", [0.5, 0.5, 0]),
-        site("Cu", [0.5, 0, 0.5]), site("Cu", [0, 0.5, 0.5]),
+    """FCC Cu (Fm-3m #225), 4 sites, CN=12."""
+    return _cubic(3.6, [
+        _s("Cu", [0, 0, 0]), _s("Cu", [0.5, 0.5, 0]), _s("Cu", [0.5, 0, 0.5]), _s("Cu", [0, 0.5, 0.5]),
     ])
 
 
 @pytest.fixture
 def bcc_fe_json() -> str:
-    """BCC Fe conventional cell (Im-3m #229), 2 sites, CN=8."""
-    return make_structure(2.87, [site("Fe", [0, 0, 0]), site("Fe", [0.5, 0.5, 0.5])])
-
-
-@pytest.fixture
-def fe2o3_json() -> str:
-    """Fe2O3 structure, 5 sites."""
-    return json.dumps({
-        "@module": "pymatgen.core.structure",
-        "@class": "Structure",
-        "lattice": {"matrix": [[5.0, 0, 0], [0, 5.0, 0], [0, 0, 13.7]]},
-        "sites": [
-            site("Fe", [0, 0, 0.35]), site("Fe", [0, 0, 0.65]),
-            site("O", [0.3, 0, 0.25]), site("O", [0.7, 0, 0.25]), site("O", [0, 0.3, 0.25]),
-        ],
-    })
+    """BCC Fe (Im-3m #229), 2 sites, CN=8."""
+    return _cubic(2.87, [_s("Fe", [0, 0, 0]), _s("Fe", [0.5, 0.5, 0.5])])
 
 
 @pytest.fixture
 def single_fe_json() -> str:
     """Single Fe atom in BCC lattice."""
-    return make_structure(2.87, [site("Fe", [0, 0, 0])])
+    return _cubic(2.87, [_s("Fe", [0, 0, 0])])
+
+
+@pytest.fixture
+def fe2o3_json() -> str:
+    """Fe2O3, 5 sites, non-cubic."""
+    return json.dumps({
+        "@module": "pymatgen.core.structure",
+        "@class": "Structure",
+        "lattice": {"matrix": [[5, 0, 0], [0, 5, 0], [0, 0, 13.7]]},
+        "sites": [
+            _s("Fe", [0, 0, 0.35]), _s("Fe", [0, 0, 0.65]),
+            _s("O", [0.3, 0, 0.25]), _s("O", [0.7, 0, 0.25]), _s("O", [0, 0.3, 0.25]),
+        ],
+    })
 
 
 @pytest.fixture
@@ -80,13 +88,10 @@ def disordered_json() -> str:
         "@module": "pymatgen.core.structure",
         "@class": "Structure",
         "lattice": {"matrix": [[2.87, 0, 0], [0, 2.87, 0], [0, 0, 2.87]]},
-        "sites": [{
-            "species": [
-                {"element": "Fe", "oxidation_state": 2, "occu": 0.5},
-                {"element": "Co", "oxidation_state": 2, "occu": 0.5},
-            ],
-            "abc": [0, 0, 0],
-        }],
+        "sites": [{"species": [
+            {"element": "Fe", "oxidation_state": 2, "occu": 0.5},
+            {"element": "Co", "oxidation_state": 2, "occu": 0.5},
+        ], "abc": [0, 0, 0]}],
     })
 
 
@@ -96,22 +101,11 @@ def lifepo4_json() -> str:
     return json.dumps({
         "@module": "pymatgen.core.structure",
         "@class": "Structure",
-        "lattice": {"matrix": [[10.3, 0, 0], [0, 6.0, 0], [0, 0, 4.7]]},
+        "lattice": {"matrix": [[10.3, 0, 0], [0, 6, 0], [0, 0, 4.7]]},
         "sites": [
-            site("Li", [0.0, 0.0, 0.0]), site("Li", [0.5, 0.0, 0.5]),
-            site("Fe", [0.25, 0.25, 0.0]), site("Fe", [0.75, 0.75, 0.0]),
-            site("P", [0.1, 0.25, 0.25]), site("P", [0.9, 0.75, 0.75]),
-            site("O", [0.1, 0.25, 0.75]), site("O", [0.2, 0.5, 0.25]),
+            _s("Li", [0, 0, 0]), _s("Li", [0.5, 0, 0.5]),
+            _s("Fe", [0.25, 0.25, 0]), _s("Fe", [0.75, 0.75, 0]),
+            _s("P", [0.1, 0.25, 0.25]), _s("P", [0.9, 0.75, 0.75]),
+            _s("O", [0.1, 0.25, 0.75]), _s("O", [0.2, 0.5, 0.25]),
         ],
     })
-
-
-@pytest.fixture
-def rocksalt_nacl_json() -> str:
-    """NaCl rocksalt conventional cell, 8 sites, CN=6."""
-    return make_structure(5.64, [
-        site("Na", [0, 0, 0]), site("Na", [0.5, 0.5, 0]),
-        site("Na", [0.5, 0, 0.5]), site("Na", [0, 0.5, 0.5]),
-        site("Cl", [0.5, 0, 0]), site("Cl", [0, 0.5, 0]),
-        site("Cl", [0, 0, 0.5]), site("Cl", [0.5, 0.5, 0.5]),
-    ])

--- a/extensions/rust/tests/conftest.py
+++ b/extensions/rust/tests/conftest.py
@@ -1,0 +1,117 @@
+"""Shared fixtures for ferrox tests."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+def make_structure(lattice_a: float, sites: list[dict]) -> str:
+    """Create structure JSON with cubic lattice."""
+    return json.dumps({
+        "@module": "pymatgen.core.structure",
+        "@class": "Structure",
+        "lattice": {"matrix": [[lattice_a, 0, 0], [0, lattice_a, 0], [0, 0, lattice_a]]},
+        "sites": sites,
+    })
+
+
+def site(element: str, abc: list[float], oxi: int | None = None) -> dict:
+    """Create a site dict."""
+    species = {"element": element, "occu": 1}
+    if oxi is not None:
+        species["oxidation_state"] = oxi
+    return {"species": [species], "abc": abc}
+
+
+# Common structure fixtures
+@pytest.fixture
+def nacl_json() -> str:
+    """NaCl rocksalt (Pm-3m #221), 2 sites."""
+    return make_structure(5.64, [site("Na", [0, 0, 0]), site("Cl", [0.5, 0.5, 0.5])])
+
+
+@pytest.fixture
+def nacl_with_oxi_json() -> str:
+    """NaCl with oxidation states (Na+, Cl-)."""
+    return make_structure(5.64, [site("Na", [0, 0, 0], oxi=1), site("Cl", [0.5, 0.5, 0.5], oxi=-1)])
+
+
+@pytest.fixture
+def fcc_cu_json() -> str:
+    """FCC Cu conventional cell (Fm-3m #225), 4 sites, CN=12."""
+    return make_structure(3.6, [
+        site("Cu", [0, 0, 0]), site("Cu", [0.5, 0.5, 0]),
+        site("Cu", [0.5, 0, 0.5]), site("Cu", [0, 0.5, 0.5]),
+    ])
+
+
+@pytest.fixture
+def bcc_fe_json() -> str:
+    """BCC Fe conventional cell (Im-3m #229), 2 sites, CN=8."""
+    return make_structure(2.87, [site("Fe", [0, 0, 0]), site("Fe", [0.5, 0.5, 0.5])])
+
+
+@pytest.fixture
+def fe2o3_json() -> str:
+    """Fe2O3 structure, 5 sites."""
+    return json.dumps({
+        "@module": "pymatgen.core.structure",
+        "@class": "Structure",
+        "lattice": {"matrix": [[5.0, 0, 0], [0, 5.0, 0], [0, 0, 13.7]]},
+        "sites": [
+            site("Fe", [0, 0, 0.35]), site("Fe", [0, 0, 0.65]),
+            site("O", [0.3, 0, 0.25]), site("O", [0.7, 0, 0.25]), site("O", [0, 0.3, 0.25]),
+        ],
+    })
+
+
+@pytest.fixture
+def single_fe_json() -> str:
+    """Single Fe atom in BCC lattice."""
+    return make_structure(2.87, [site("Fe", [0, 0, 0])])
+
+
+@pytest.fixture
+def disordered_json() -> str:
+    """Disordered Fe0.5Co0.5 alloy."""
+    return json.dumps({
+        "@module": "pymatgen.core.structure",
+        "@class": "Structure",
+        "lattice": {"matrix": [[2.87, 0, 0], [0, 2.87, 0], [0, 0, 2.87]]},
+        "sites": [{
+            "species": [
+                {"element": "Fe", "oxidation_state": 2, "occu": 0.5},
+                {"element": "Co", "oxidation_state": 2, "occu": 0.5},
+            ],
+            "abc": [0, 0, 0],
+        }],
+    })
+
+
+@pytest.fixture
+def lifepo4_json() -> str:
+    """Simplified LiFePO4, 8 sites."""
+    return json.dumps({
+        "@module": "pymatgen.core.structure",
+        "@class": "Structure",
+        "lattice": {"matrix": [[10.3, 0, 0], [0, 6.0, 0], [0, 0, 4.7]]},
+        "sites": [
+            site("Li", [0.0, 0.0, 0.0]), site("Li", [0.5, 0.0, 0.5]),
+            site("Fe", [0.25, 0.25, 0.0]), site("Fe", [0.75, 0.75, 0.0]),
+            site("P", [0.1, 0.25, 0.25]), site("P", [0.9, 0.75, 0.75]),
+            site("O", [0.1, 0.25, 0.75]), site("O", [0.2, 0.5, 0.25]),
+        ],
+    })
+
+
+@pytest.fixture
+def rocksalt_nacl_json() -> str:
+    """NaCl rocksalt conventional cell, 8 sites, CN=6."""
+    return make_structure(5.64, [
+        site("Na", [0, 0, 0]), site("Na", [0.5, 0.5, 0]),
+        site("Na", [0.5, 0, 0.5]), site("Na", [0, 0.5, 0.5]),
+        site("Cl", [0.5, 0, 0]), site("Cl", [0, 0.5, 0]),
+        site("Cl", [0, 0, 0.5]), site("Cl", [0.5, 0.5, 0.5]),
+    ])

--- a/extensions/rust/tests/test_coordination.py
+++ b/extensions/rust/tests/test_coordination.py
@@ -11,46 +11,8 @@ try:
 except ImportError:
     pytest.skip("ferrox not installed", allow_module_level=True)
 
-
-def make_structure(lattice_a: float, sites: list[dict]) -> str:
-    """Helper to create structure JSON."""
-    return json.dumps({
-        "@module": "pymatgen.core.structure",
-        "@class": "Structure",
-        "lattice": {"matrix": [[lattice_a, 0, 0], [0, lattice_a, 0], [0, 0, lattice_a]]},
-        "sites": sites,
-    })
-
-
-def site(element: str, abc: list[float]) -> dict:
-    """Helper to create a site dict."""
-    return {"species": [{"element": element, "occu": 1}], "abc": abc}
-
-
-@pytest.fixture
-def fcc_cu_json() -> str:
-    """FCC Cu conventional cell (4 atoms, CN=12)."""
-    return make_structure(3.61, [
-        site("Cu", [0.0, 0.0, 0.0]), site("Cu", [0.5, 0.5, 0.0]),
-        site("Cu", [0.5, 0.0, 0.5]), site("Cu", [0.0, 0.5, 0.5]),
-    ])
-
-
-@pytest.fixture
-def bcc_fe_json() -> str:
-    """BCC Fe conventional cell (2 atoms, CN=8 for first shell)."""
-    return make_structure(2.87, [site("Fe", [0.0, 0.0, 0.0]), site("Fe", [0.5, 0.5, 0.5])])
-
-
-@pytest.fixture
-def rocksalt_nacl_json() -> str:
-    """NaCl rocksalt conventional cell (8 atoms, CN=6)."""
-    return make_structure(5.64, [
-        site("Na", [0.0, 0.0, 0.0]), site("Na", [0.5, 0.5, 0.0]),
-        site("Na", [0.5, 0.0, 0.5]), site("Na", [0.0, 0.5, 0.5]),
-        site("Cl", [0.5, 0.0, 0.0]), site("Cl", [0.0, 0.5, 0.0]),
-        site("Cl", [0.0, 0.0, 0.5]), site("Cl", [0.5, 0.5, 0.5]),
-    ])
+# Import helpers and fixtures from conftest.py
+from conftest import make_structure, site
 
 
 class TestCutoffCoordination:

--- a/extensions/rust/tests/test_coordination.py
+++ b/extensions/rust/tests/test_coordination.py
@@ -11,8 +11,22 @@ try:
 except ImportError:
     pytest.skip("ferrox not installed", allow_module_level=True)
 
-# Import helpers and fixtures from conftest.py
-from conftest import make_structure, site
+# Helpers (fixtures auto-discovered from conftest.py)
+
+
+def make_structure(lattice_a: float, sites: list[dict]) -> str:
+    """Create structure JSON with cubic lattice."""
+    return json.dumps({
+        "@module": "pymatgen.core.structure",
+        "@class": "Structure",
+        "lattice": {"matrix": [[lattice_a, 0, 0], [0, lattice_a, 0], [0, 0, lattice_a]]},
+        "sites": sites,
+    })
+
+
+def site(element: str, abc: list[float]) -> dict:
+    """Create a site dict."""
+    return {"species": [{"element": element, "occu": 1}], "abc": abc}
 
 
 class TestCutoffCoordination:

--- a/extensions/rust/tests/test_pymatgen_compat.py
+++ b/extensions/rust/tests/test_pymatgen_compat.py
@@ -37,9 +37,7 @@ PYMATGEN_CIF_DIR = Path(
 )
 
 
-# ============================================================================
-# Fixtures
-# ============================================================================
+# === Fixtures ===
 
 
 @pytest.fixture
@@ -73,9 +71,7 @@ def compare(py_matcher: PyMatcher, rust_matcher: RustMatcher) -> Callable:
     return _compare
 
 
-# ============================================================================
-# Structure Generators
-# ============================================================================
+# === Structure Generators ===
 
 
 def make_cubic(element: str, a: float) -> Structure:
@@ -167,9 +163,7 @@ BASE_STRUCTURE_IDS = [name for name, _ in _BASE_STRUCTURE_DATA]
 BASE_STRUCTURES = [struct for _, struct in _BASE_STRUCTURE_DATA]
 
 
-# ============================================================================
-# Structure Transformations
-# ============================================================================
+# === Structure Transformations ===
 
 
 def perturb(s: Structure, magnitude: float, seed: int = 42) -> Structure:
@@ -206,16 +200,16 @@ def translate(s: Structure, vec: list[float]) -> Structure:
     return Structure(s.lattice, s.species, [(fc + vec) % 1.0 for fc in s.frac_coords])
 
 
-# ============================================================================
-# Test Classes
-# ============================================================================
+# === Test Classes ===
 
 
 class TestSelfMatching:
     """Identical structures should always match."""
 
     @pytest.mark.parametrize(("name", "struct"), _BASE_STRUCTURE_DATA)
-    def test_base_structures(self, compare: Callable, name: str, struct: Structure) -> None:
+    def test_base_structures(
+        self, compare: Callable, name: str, struct: Structure
+    ) -> None:
         """Base structures match themselves."""
         assert compare(struct, struct) is True, f"{name} should self-match"
 
@@ -247,7 +241,9 @@ class TestPerturbations:
         self, compare: Callable, name: str, struct: Structure, magnitude: float
     ) -> None:
         """Small coordinate perturbations should match."""
-        assert compare(struct, perturb(struct, magnitude)) is True, f"{name} +/-{magnitude}"
+        assert compare(struct, perturb(struct, magnitude)) is True, (
+            f"{name} +/-{magnitude}"
+        )
 
     @pytest.mark.parametrize(("name", "struct"), _BASE_STRUCTURE_DATA)
     @pytest.mark.parametrize("factor", [0.98, 1.02, 1.05])
@@ -255,7 +251,9 @@ class TestPerturbations:
         self, compare: Callable, name: str, struct: Structure, factor: float
     ) -> None:
         """Lattice scaling within tolerance should match."""
-        assert compare(struct, scale_lattice(struct, factor)) is True, f"{name} x{factor}"
+        assert compare(struct, scale_lattice(struct, factor)) is True, (
+            f"{name} x{factor}"
+        )
 
     @pytest.mark.parametrize(("name", "struct"), _BASE_STRUCTURE_DATA)
     @pytest.mark.parametrize("strain", [0.01, 0.02])
@@ -682,9 +680,7 @@ class TestAPIs:
         assert normal_result == skip_result
 
 
-# ============================================================================
-# External File Tests (skipped if files not available)
-# ============================================================================
+# === External File Tests (skipped if files not available) ===
 
 
 @pytest.mark.skipif(
@@ -703,7 +699,13 @@ class TestMattervizStructures:
                 data = json.loads(json_file.read_text())
                 if data.get("@class") == "Structure":
                     result[json_file.stem] = Structure.from_dict(data)
-            except (json.JSONDecodeError, ValueError, TypeError, KeyError, OSError) as exc:
+            except (
+                json.JSONDecodeError,
+                ValueError,
+                TypeError,
+                KeyError,
+                OSError,
+            ) as exc:
                 warnings.warn(f"Failed to load {json_file.stem}: {exc}", stacklevel=2)
         return result
 

--- a/extensions/rust/tests/test_transformations.py
+++ b/extensions/rust/tests/test_transformations.py
@@ -11,129 +11,19 @@ try:
 except ImportError:
     pytest.skip("ferrox not installed", allow_module_level=True)
 
-
-# ============================================================================
-# Fixtures
-# ============================================================================
+# Fixtures from conftest.py: nacl_json, nacl_with_oxi_json, fcc_cu_json, lifepo4_json,
+#                            disordered_json, single_fe_json
 
 
-@pytest.fixture
-def nacl_json() -> str:
-    """NaCl in rocksalt structure as JSON."""
-    struct = {
-        "@module": "pymatgen.core.structure",
-        "@class": "Structure",
-        "lattice": {"matrix": [[5.64, 0, 0], [0, 5.64, 0], [0, 0, 5.64]]},
-        "sites": [
-            {"species": [{"element": "Na", "occu": 1}], "abc": [0, 0, 0]},
-            {"species": [{"element": "Cl", "occu": 1}], "abc": [0.5, 0.5, 0.5]},
-        ],
-    }
-    return json.dumps(struct)
-
-
-@pytest.fixture
-def nacl_with_oxi_json() -> str:
-    """NaCl with oxidation states as JSON."""
-    struct = {
-        "@module": "pymatgen.core.structure",
-        "@class": "Structure",
-        "lattice": {"matrix": [[5.64, 0, 0], [0, 5.64, 0], [0, 0, 5.64]]},
-        "sites": [
-            {
-                "species": [{"element": "Na", "oxidation_state": 1, "occu": 1}],
-                "abc": [0, 0, 0],
-            },
-            {
-                "species": [{"element": "Cl", "oxidation_state": -1, "occu": 1}],
-                "abc": [0.5, 0.5, 0.5],
-            },
-        ],
-    }
-    return json.dumps(struct)
-
-
-@pytest.fixture
-def fcc_copper_json() -> str:
-    """FCC Cu (conventional cell) as JSON."""
-    struct = {
-        "@module": "pymatgen.core.structure",
-        "@class": "Structure",
-        "lattice": {"matrix": [[3.6, 0, 0], [0, 3.6, 0], [0, 0, 3.6]]},
-        "sites": [
-            {"species": [{"element": "Cu", "occu": 1}], "abc": [0, 0, 0]},
-            {"species": [{"element": "Cu", "occu": 1}], "abc": [0.5, 0.5, 0]},
-            {"species": [{"element": "Cu", "occu": 1}], "abc": [0.5, 0, 0.5]},
-            {"species": [{"element": "Cu", "occu": 1}], "abc": [0, 0.5, 0.5]},
-        ],
-    }
-    return json.dumps(struct)
-
-
-@pytest.fixture
-def lifepo4_json() -> str:
-    """Simplified LiFePO4 structure."""
-    struct = {
-        "@module": "pymatgen.core.structure",
-        "@class": "Structure",
-        "lattice": {"matrix": [[10.3, 0, 0], [0, 6.0, 0], [0, 0, 4.7]]},
-        "sites": [
-            {"species": [{"element": "Li", "occu": 1}], "abc": [0.0, 0.0, 0.0]},
-            {"species": [{"element": "Li", "occu": 1}], "abc": [0.5, 0.0, 0.5]},
-            {"species": [{"element": "Fe", "occu": 1}], "abc": [0.25, 0.25, 0.0]},
-            {"species": [{"element": "Fe", "occu": 1}], "abc": [0.75, 0.75, 0.0]},
-            {"species": [{"element": "P", "occu": 1}], "abc": [0.1, 0.25, 0.25]},
-            {"species": [{"element": "P", "occu": 1}], "abc": [0.9, 0.75, 0.75]},
-            {"species": [{"element": "O", "occu": 1}], "abc": [0.1, 0.25, 0.75]},
-            {"species": [{"element": "O", "occu": 1}], "abc": [0.2, 0.5, 0.25]},
-        ],
-    }
-    return json.dumps(struct)
-
-
-@pytest.fixture
-def disordered_json() -> str:
-    """Disordered Fe0.5Co0.5 alloy as JSON."""
-    struct = {
-        "@module": "pymatgen.core.structure",
-        "@class": "Structure",
-        "lattice": {"matrix": [[2.87, 0, 0], [0, 2.87, 0], [0, 0, 2.87]]},
-        "sites": [
-            {
-                "species": [
-                    {"element": "Fe", "oxidation_state": 2, "occu": 0.5},
-                    {"element": "Co", "oxidation_state": 2, "occu": 0.5},
-                ],
-                "abc": [0, 0, 0],
-            },
-        ],
-    }
-    return json.dumps(struct)
-
-
-@pytest.fixture
-def single_fe_json() -> str:
-    """Single Fe atom structure as JSON."""
-    struct = {
-        "@module": "pymatgen.core.structure",
-        "@class": "Structure",
-        "lattice": {"matrix": [[2.87, 0, 0], [0, 2.87, 0], [0, 0, 2.87]]},
-        "sites": [{"species": [{"element": "Fe", "occu": 1}], "abc": [0, 0, 0]}],
-    }
-    return json.dumps(struct)
-
-
-# ============================================================================
 # to_primitive Tests
-# ============================================================================
 
 
 class TestToPrimitive:
     """Tests for to_primitive function."""
 
-    def test_fcc_reduces_to_primitive(self, fcc_copper_json: str) -> None:
+    def test_fcc_reduces_to_primitive(self, fcc_cu_json: str) -> None:
         """FCC conventional cell with 4 atoms should reduce to primitive with 1."""
-        result = ferrox.to_primitive(fcc_copper_json)
+        result = ferrox.to_primitive(fcc_cu_json)
         # Primitive FCC has 1 atom
         assert len(result["sites"]) < 4
 
@@ -144,18 +34,14 @@ class TestToPrimitive:
         # Should have same number of sites (already primitive)
         assert len(result["sites"]) <= len(original["sites"])
 
-    def test_symprec_parameter(self, fcc_copper_json: str) -> None:
+    def test_symprec_parameter(self, fcc_cu_json: str) -> None:
         """Different symprec should work."""
-        result_tight = ferrox.to_primitive(fcc_copper_json, symprec=0.001)
-        result_loose = ferrox.to_primitive(fcc_copper_json, symprec=0.1)
+        result_tight = ferrox.to_primitive(fcc_cu_json, symprec=0.001)
+        result_loose = ferrox.to_primitive(fcc_cu_json, symprec=0.1)
         # Both should reduce the cell
         assert len(result_tight["sites"]) < 4
         assert len(result_loose["sites"]) < 4
 
-
-# ============================================================================
-# to_conventional Tests
-# ============================================================================
 
 
 class TestToConventional:
@@ -167,10 +53,6 @@ class TestToConventional:
         assert "lattice" in result
         assert "sites" in result
 
-
-# ============================================================================
-# substitute_species Tests
-# ============================================================================
 
 
 class TestSubstituteSpecies:
@@ -198,10 +80,6 @@ class TestSubstituteSpecies:
         assert elements == {"Na", "Cl"}
 
 
-# ============================================================================
-# remove_species Tests
-# ============================================================================
-
 
 class TestRemoveSpecies:
     """Tests for remove_species function."""
@@ -225,10 +103,6 @@ class TestRemoveSpecies:
         assert len(result["sites"]) == 0
 
 
-# ============================================================================
-# remove_sites Tests
-# ============================================================================
-
 
 class TestRemoveSites:
     """Tests for remove_sites function."""
@@ -238,9 +112,9 @@ class TestRemoveSites:
         result = ferrox.remove_sites(nacl_json, [0])
         assert len(result["sites"]) == 1
 
-    def test_remove_multiple_sites(self, fcc_copper_json: str) -> None:
+    def test_remove_multiple_sites(self, fcc_cu_json: str) -> None:
         """Remove multiple sites."""
-        result = ferrox.remove_sites(fcc_copper_json, [0, 1])
+        result = ferrox.remove_sites(fcc_cu_json, [0, 1])
         assert len(result["sites"]) == 2
 
     def test_remove_all_sites(self, nacl_json: str) -> None:
@@ -248,10 +122,6 @@ class TestRemoveSites:
         result = ferrox.remove_sites(nacl_json, [0, 1])
         assert len(result["sites"]) == 0
 
-
-# ============================================================================
-# deform Tests
-# ============================================================================
 
 
 class TestDeform:
@@ -285,23 +155,13 @@ class TestDeform:
     def test_identity_deformation(self, nacl_json: str) -> None:
         """Identity deformation should preserve structure."""
         original = json.loads(nacl_json)
-        gradient = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
-        result = ferrox.deform(nacl_json, gradient)
+        result = ferrox.deform(nacl_json, [[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+        for row_idx in range(3):
+            for col_idx in range(3):
+                orig_val = original["lattice"]["matrix"][row_idx][col_idx]
+                new_val = result["lattice"]["matrix"][row_idx][col_idx]
+                assert abs(new_val - orig_val) < 1e-10
 
-        for idx in range(3):
-            for jdx in range(3):
-                assert (
-                    abs(
-                        result["lattice"]["matrix"][idx][jdx]
-                        - original["lattice"]["matrix"][idx][jdx]
-                    )
-                    < 1e-10
-                )
-
-
-# ============================================================================
-# ewald_energy Tests
-# ============================================================================
 
 
 class TestEwaldEnergy:
@@ -325,10 +185,6 @@ class TestEwaldEnergy:
         # Results should be similar
         assert abs(energy1 - energy2) < 0.5
 
-
-# ============================================================================
-# order_disordered Tests
-# ============================================================================
 
 
 class TestOrderDisordered:
@@ -359,10 +215,6 @@ class TestOrderDisordered:
         assert len(results) == 1
 
 
-# ============================================================================
-# enumerate_derivatives Tests
-# ============================================================================
-
 
 class TestEnumerateDerivatives:
     """Tests for enumerate_derivatives function."""
@@ -385,10 +237,6 @@ class TestEnumerateDerivatives:
         assert len(results[0]["sites"]) == 1
 
 
-# ============================================================================
-# Integration Tests
-# ============================================================================
-
 
 class TestTransformationChains:
     """Tests for chaining multiple transformations."""
@@ -400,18 +248,14 @@ class TestTransformationChains:
         assert len(step2["sites"]) == 1
         assert step2["sites"][0]["species"][0]["element"] == "Cl"
 
-    def test_primitive_then_supercell(self, fcc_copper_json: str) -> None:
+    def test_primitive_then_supercell(self, fcc_cu_json: str) -> None:
         """Get primitive, then make supercell."""
-        primitive = ferrox.to_primitive(fcc_copper_json)
+        primitive = ferrox.to_primitive(fcc_cu_json)
         # Make 2x2x2 supercell using make_supercell
         supercell = ferrox.make_supercell(json.dumps(primitive), [[2, 0, 0], [0, 2, 0], [0, 0, 2]])
         # Should have 8x more atoms than primitive
         assert len(supercell["sites"]) == 8 * len(primitive["sites"])
 
-
-# ============================================================================
-# Edge Cases
-# ============================================================================
 
 
 class TestEdgeCases:


### PR DESCRIPTION
## Summary

This PR adds comprehensive WASM bindings and Python type stubs to make ferrox a first-class citizen for both JavaScript/TypeScript and Python developers.

- Expand the Python API with slab generation, cutoff/Voronoi coordination helpers, and `StructureJson` inputs.

### WASM Bindings (`wasm.rs`)
- **WasmStructureMatcher** class with builder pattern for structure comparison
- Structure parsing: `parse_structure`, `parse_cif`, `parse_poscar`
- Supercell: `make_supercell`, `make_supercell_diag`
- Lattice reduction: `get_reduced_structure`, `get_primitive`
- Symmetry: `get_spacegroup_number`
- Properties: `get_volume`, `get_total_mass`, `get_density`
- Neighbor finding: `get_neighbor_list`, `get_distance`, `get_distance_matrix`
- Sorting: `get_sorted_structure`, `get_sorted_by_electronegativity`
- Interpolation: `interpolate_structures`
- Copy/wrap: `copy_structure`, `wrap_to_unit_cell`
- Site manipulation: `translate_sites`, `perturb_structure`
- Element info: `get_atomic_mass`, `get_electronegativity`

All WASM functions return `WasmResult<T> = { ok: T } | { error: string }` for consistent error handling.

### TypeScript Types (`types.d.ts`)
- Comprehensive type definitions for `Crystal`, `Lattice`, `Site`, `SpeciesOccupancy`
- Result types: `WasmResult<T>`, `NeighborListResult`, `RmsDistResult`
- Full type signatures for all exported functions and classes

### Python Type Stubs (`_ferrox.pyi`)
- 1300+ lines of comprehensive type stubs with docstrings
- Covers all 90+ exported functions and the StructureMatcher class
- PEP 561 compliant with `py.typed` marker

### Other Changes
- Reorganized `__init__.py` exports into logical groups
- Synced `package.json` version to `0.0.2` to match `Cargo.toml`