### PR TITLE
Add RDF calculation module to ferrox

### DIFF
--- a/extensions/rust-wasm/.npmignore
+++ b/extensions/rust-wasm/.npmignore
@@ -1,0 +1,8 @@
+# Don't exclude pkg/ (overrides .gitignore)
+!pkg/
+
+# Exclude dev/test files from npm package
+tests/
+tsconfig.json
+vitest.config.ts
+*.test.ts

--- a/extensions/rust-wasm/package.json
+++ b/extensions/rust-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matterviz-wasm",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "WASM bindings for ferrox structure matching library",
   "type": "module",
   "main": "index.js",
@@ -18,8 +18,8 @@
     "pkg/"
   ],
   "scripts": {
-    "build": "cd ../rust && wasm-pack build --target web --features wasm --no-default-features && cd ../rust-wasm && rm -rf pkg && cp -r ../rust/pkg .",
-    "build:dev": "cd ../rust && wasm-pack build --target web --features wasm --no-default-features --dev && cd ../rust-wasm && rm -rf pkg && cp -r ../rust/pkg .",
+    "build": "cd ../rust && wasm-pack build --target web --features wasm --no-default-features && cd ../rust-wasm && rm -rf pkg && cp -r ../rust/pkg . && rm -f pkg/.gitignore",
+    "build:dev": "cd ../rust && wasm-pack build --target web --features wasm --no-default-features --dev && cd ../rust-wasm && rm -rf pkg && cp -r ../rust/pkg . && rm -f pkg/.gitignore",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/extensions/rust-wasm/tests/ferrox.test.ts
+++ b/extensions/rust-wasm/tests/ferrox.test.ts
@@ -232,3 +232,77 @@ describe(`WasmStructureMatcher`, () => {
     expect(matches[0]).toBe(1)
   })
 })
+
+// Test structures for get_rms_dist - perturbed NaCl with shifted sites
+const nacl_perturbed = {
+  lattice: { matrix: [[5.64, 0, 0], [0, 5.64, 0], [0, 0, 5.64]] },
+  sites: [
+    { species: [{ element: `Na`, occu: 1 }], abc: [0.05, 0.0, 0.0] },
+    { species: [{ element: `Cl`, occu: 1 }], abc: [0.55, 0.5, 0.5] },
+  ],
+}
+
+describe(`WasmStructureMatcher.get_rms_dist`, () => {
+  it.each([
+    [`nacl`, nacl_json],
+    [`fcc_cu`, fcc_cu_json],
+    [`bcc_fe`, bcc_fe_json],
+  ])(`returns rms=0 for identical %s structures`, (_, struct) => {
+    const result = unwrap(new wasm.WasmStructureMatcher().get_rms_dist(struct, struct))
+    if (!result) throw new Error(`expected result`)
+    expect(result.rms).toBeCloseTo(0, 14)
+    expect(result.max_dist).toBeCloseTo(0, 14)
+  })
+
+  it(`returns non-zero rms for perturbed structures`, () => {
+    const result = unwrap(
+      new wasm.WasmStructureMatcher().get_rms_dist(nacl_json, nacl_perturbed),
+    )
+    if (!result) throw new Error(`expected result`)
+    expect(result.rms).toBeGreaterThan(0)
+    expect(result.rms).toBeLessThan(0.2)
+  })
+
+  it(`is symmetric`, () => {
+    const matcher = new wasm.WasmStructureMatcher()
+    const r1 = unwrap(matcher.get_rms_dist(nacl_json, nacl_perturbed))
+    const r2 = unwrap(matcher.get_rms_dist(nacl_perturbed, nacl_json))
+    if (!r1 || !r2) throw new Error(`expected results`)
+    expect(r1.rms).toBeCloseTo(r2.rms, 10)
+  })
+
+  it(`returns falsy for incompatible structures`, () => {
+    const matcher = new wasm.WasmStructureMatcher()
+    expect(unwrap(matcher.get_rms_dist(nacl_json, fcc_cu_json))).toBeFalsy()
+  })
+})
+
+describe(`WasmStructureMatcher.getStructureDistance`, () => {
+  it(`returns 0 for identical structures`, () => {
+    const matcher = new wasm.WasmStructureMatcher()
+    const dist = unwrap(matcher.getStructureDistance(nacl_json, nacl_json))
+    expect(dist).toBeCloseTo(0, 10)
+  })
+
+  it(`is symmetric`, () => {
+    const matcher = new wasm.WasmStructureMatcher()
+    const d12 = unwrap(matcher.getStructureDistance(nacl_json, nacl_perturbed))
+    const d21 = unwrap(matcher.getStructureDistance(nacl_perturbed, nacl_json))
+    expect(d12).toBeCloseTo(d21, 10)
+  })
+
+  it(`returns finite value for incompatible structures (unlike get_rms_dist)`, () => {
+    const matcher = new wasm.WasmStructureMatcher()
+    const dist = unwrap(matcher.getStructureDistance(nacl_json, fcc_cu_json))
+    expect(Number.isFinite(dist)).toBe(true)
+    expect(dist).toBeGreaterThan(0)
+  })
+
+  it(`returns larger distance for different compositions`, () => {
+    const matcher = new wasm.WasmStructureMatcher()
+    const dist_same_comp = unwrap(matcher.getStructureDistance(nacl_json, nacl_perturbed))
+    const dist_diff_comp = unwrap(matcher.getStructureDistance(nacl_json, fcc_cu_json))
+    // Different composition should always be further than same composition
+    expect(dist_diff_comp).toBeGreaterThan(dist_same_comp)
+  })
+})

--- a/extensions/rust-wasm/tests/ferrox.test.ts
+++ b/extensions/rust-wasm/tests/ferrox.test.ts
@@ -233,7 +233,7 @@ describe(`WasmStructureMatcher`, () => {
   })
 })
 
-// Test structures for get_rms_dist - perturbed NaCl with shifted sites
+// Perturbed NaCl with shifted sites (for testing non-zero distances)
 const nacl_perturbed = {
   lattice: { matrix: [[5.64, 0, 0], [0, 5.64, 0], [0, 0, 5.64]] },
   sites: [
@@ -247,62 +247,42 @@ describe(`WasmStructureMatcher.get_rms_dist`, () => {
     [`nacl`, nacl_json],
     [`fcc_cu`, fcc_cu_json],
     [`bcc_fe`, bcc_fe_json],
-  ])(`returns rms=0 for identical %s structures`, (_, struct) => {
-    const result = unwrap(new wasm.WasmStructureMatcher().get_rms_dist(struct, struct))
+  ])(`returns rms=0, symmetric for identical %s structures`, (_, struct) => {
+    const matcher = new wasm.WasmStructureMatcher()
+    const result = unwrap(matcher.get_rms_dist(struct, struct))
     if (!result) throw new Error(`expected result`)
     expect(result.rms).toBeCloseTo(0, 14)
     expect(result.max_dist).toBeCloseTo(0, 14)
   })
 
-  it(`returns non-zero rms for perturbed structures`, () => {
-    const result = unwrap(
-      new wasm.WasmStructureMatcher().get_rms_dist(nacl_json, nacl_perturbed),
-    )
-    if (!result) throw new Error(`expected result`)
-    expect(result.rms).toBeGreaterThan(0)
-    expect(result.rms).toBeLessThan(0.2)
-  })
-
-  it(`is symmetric`, () => {
+  it(`perturbed: non-zero rms, symmetric`, () => {
     const matcher = new wasm.WasmStructureMatcher()
     const r1 = unwrap(matcher.get_rms_dist(nacl_json, nacl_perturbed))
     const r2 = unwrap(matcher.get_rms_dist(nacl_perturbed, nacl_json))
     if (!r1 || !r2) throw new Error(`expected results`)
+    expect(r1.rms).toBeGreaterThan(0)
+    expect(r1.rms).toBeLessThan(0.2)
     expect(r1.rms).toBeCloseTo(r2.rms, 10)
   })
 
   it(`returns falsy for incompatible structures`, () => {
-    const matcher = new wasm.WasmStructureMatcher()
-    expect(unwrap(matcher.get_rms_dist(nacl_json, fcc_cu_json))).toBeFalsy()
+    expect(unwrap(new wasm.WasmStructureMatcher().get_rms_dist(nacl_json, fcc_cu_json)))
+      .toBeFalsy()
   })
 })
 
 describe(`WasmStructureMatcher.getStructureDistance`, () => {
-  it(`returns 0 for identical structures`, () => {
+  it(`identical=0, symmetric, finite for incompatible`, () => {
     const matcher = new wasm.WasmStructureMatcher()
-    const dist = unwrap(matcher.getStructureDistance(nacl_json, nacl_json))
-    expect(dist).toBeCloseTo(0, 10)
-  })
-
-  it(`is symmetric`, () => {
-    const matcher = new wasm.WasmStructureMatcher()
+    // Identical = 0
+    expect(unwrap(matcher.getStructureDistance(nacl_json, nacl_json))).toBeCloseTo(0, 10)
+    // Symmetric
     const d12 = unwrap(matcher.getStructureDistance(nacl_json, nacl_perturbed))
     const d21 = unwrap(matcher.getStructureDistance(nacl_perturbed, nacl_json))
     expect(d12).toBeCloseTo(d21, 10)
-  })
-
-  it(`returns finite value for incompatible structures (unlike get_rms_dist)`, () => {
-    const matcher = new wasm.WasmStructureMatcher()
-    const dist = unwrap(matcher.getStructureDistance(nacl_json, fcc_cu_json))
-    expect(Number.isFinite(dist)).toBe(true)
-    expect(dist).toBeGreaterThan(0)
-  })
-
-  it(`returns larger distance for different compositions`, () => {
-    const matcher = new wasm.WasmStructureMatcher()
-    const dist_same_comp = unwrap(matcher.getStructureDistance(nacl_json, nacl_perturbed))
-    const dist_diff_comp = unwrap(matcher.getStructureDistance(nacl_json, fcc_cu_json))
-    // Different composition should always be further than same composition
-    expect(dist_diff_comp).toBeGreaterThan(dist_same_comp)
+    // Incompatible returns finite (unlike get_rms_dist which returns null)
+    const dist_diff = unwrap(matcher.getStructureDistance(nacl_json, fcc_cu_json))
+    expect(Number.isFinite(dist_diff)).toBe(true)
+    expect(dist_diff).toBeGreaterThan(d12) // Different composition > same composition
   })
 })

--- a/extensions/rust-wasm/types.d.ts
+++ b/extensions/rust-wasm/types.d.ts
@@ -3,6 +3,20 @@
 
 export * from './pkg/ferrox.d.ts'
 
+// Default export: init function that returns the WASM module
+import type { InitInput } from './pkg/ferrox.d.ts'
+import * as ferrox from './pkg/ferrox.d.ts'
+
+// The module returned by init() has all exports from pkg/ferrox.js
+export type FerroxModule = typeof ferrox
+
+export default function init(
+  options?:
+    | { module_or_path?: InitInput | Promise<InitInput> }
+    | InitInput
+    | Promise<InitInput>,
+): Promise<FerroxModule>
+
 import type {
   JsCrystal,
   JsLocalEnvironment,

--- a/extensions/rust-wasm/types.d.ts
+++ b/extensions/rust-wasm/types.d.ts
@@ -236,6 +236,12 @@ declare module './pkg/ferrox.d.ts' {
       struct1: JsCrystal,
       struct2: JsCrystal,
     ): WasmResult<JsRmsDistResult | null>
+    // Universal structure distance - always returns a value (never null)
+    // Suitable for consistent ranking of structures by similarity
+    getStructureDistance(
+      struct1: JsCrystal,
+      struct2: JsCrystal,
+    ): WasmResult<number>
     deduplicate(structures: JsCrystal[]): WasmResult<number[]>
     find_matches(
       new_structures: JsCrystal[],

--- a/extensions/rust/benches/matcher_bench.rs
+++ b/extensions/rust/benches/matcher_bench.rs
@@ -8,9 +8,9 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use ferrox::element::Element;
 use ferrox::lattice::Lattice;
-use ferrox::matcher::StructureMatcher;
 use ferrox::species::Species;
 use ferrox::structure::Structure;
+use ferrox::structure_matcher::StructureMatcher;
 use nalgebra::Vector3;
 use std::hint::black_box;
 

--- a/extensions/rust/python/ferrox/_ferrox.pyi
+++ b/extensions/rust/python/ferrox/_ferrox.pyi
@@ -102,6 +102,24 @@ class StructureMatcher:
             Tuple of (rms, max_dist) if structures match, None otherwise.
         """
         ...
+    def get_structure_distance(
+        self, struct1: StructureJson, struct2: StructureJson
+    ) -> float:
+        """Compute universal distance between any two structures.
+
+        Unlike get_rms_dist which returns None for incompatible structures,
+        this method always returns a finite distance value, making it suitable
+        for consistent ranking of structures by similarity.
+
+        Args:
+            struct1: First structure as JSON string or dict.
+            struct2: Second structure as JSON string or dict.
+
+        Returns:
+            Finite distance in [0, 1e9]. Identical structures return 0.0.
+            Empty vs non-empty structures return 1e9.
+        """
+        ...
     def fit_anonymous(self, struct1: StructureJson, struct2: StructureJson) -> bool:
         """Check if two structures match under any species permutation.
 

--- a/extensions/rust/python/ferrox/_ferrox.pyi
+++ b/extensions/rust/python/ferrox/_ferrox.pyi
@@ -1283,3 +1283,82 @@ def get_local_environment_voronoi(
         List of neighbor dicts with keys: element, species, distance, image, site_idx, solid_angle.
     """
     ...
+
+def compute_rdf(
+    structure: StructureJson,
+    r_max: float = 15.0,
+    n_bins: int = 75,
+    normalize: bool = True,
+    auto_expand: bool = True,
+    expansion_factor: float = 2.0,
+) -> tuple[list[float], list[float]]:
+    """Compute the total radial distribution function for all atom pairs.
+
+    Args:
+        structure: Structure as JSON string or dict.
+        r_max: Maximum distance in Angstroms.
+        n_bins: Number of histogram bins.
+        normalize: Whether to normalize by ideal gas density.
+        auto_expand: Whether to auto-expand structure to avoid finite-size effects.
+        expansion_factor: Minimum lattice dimension = r_max × factor.
+
+    Returns:
+        Tuple of (r, g_r) where r is bin centers and g_r is RDF values.
+    """
+    ...
+
+def compute_element_rdf(
+    structure: StructureJson,
+    element_a: str,
+    element_b: str,
+    r_max: float = 15.0,
+    n_bins: int = 75,
+    normalize: bool = True,
+    auto_expand: bool = True,
+    expansion_factor: float = 2.0,
+) -> tuple[list[float], list[float]]:
+    """Compute element-resolved radial distribution function.
+
+    Calculates g(r) for a specific element pair, counting distances from
+    atoms of element_a to atoms of element_b.
+
+    Args:
+        structure: Structure as JSON string or dict.
+        element_a: Center element symbol (e.g., "Fe").
+        element_b: Neighbor element symbol (e.g., "O").
+        r_max: Maximum distance in Angstroms.
+        n_bins: Number of histogram bins.
+        normalize: Whether to normalize by ideal gas density.
+        auto_expand: Whether to auto-expand structure.
+        expansion_factor: Minimum lattice dimension = r_max × factor.
+
+    Returns:
+        Tuple of (r, g_r) where r is bin centers and g_r is RDF values.
+    """
+    ...
+
+def compute_all_element_rdfs(
+    structure: StructureJson,
+    r_max: float = 15.0,
+    n_bins: int = 75,
+    normalize: bool = True,
+    auto_expand: bool = True,
+    expansion_factor: float = 2.0,
+) -> list[dict[str, Any]]:
+    """Compute RDF for all unique element pairs in the structure.
+
+    Returns one RDF for each unique (element_a, element_b) pair where
+    element_a <= element_b (by atomic number), avoiding duplicates.
+
+    Args:
+        structure: Structure as JSON string or dict.
+        r_max: Maximum distance in Angstroms.
+        n_bins: Number of histogram bins.
+        normalize: Whether to normalize by ideal gas density.
+        auto_expand: Whether to auto-expand structure.
+        expansion_factor: Minimum lattice dimension = r_max × factor.
+
+    Returns:
+        List of dicts, each with keys: element_a, element_b, r, g_r.
+    """
+    ...

--- a/extensions/rust/src/batch.rs
+++ b/extensions/rust/src/batch.rs
@@ -6,8 +6,8 @@
 
 use crate::error::{FerroxError, Result};
 use crate::io::parse_structure_json;
-use crate::matcher::StructureMatcher;
 use crate::structure::Structure;
+use crate::structure_matcher::StructureMatcher;
 use indexmap::IndexMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 

--- a/extensions/rust/src/lib.rs
+++ b/extensions/rust/src/lib.rs
@@ -43,9 +43,9 @@ pub mod structure;
 pub mod algorithms;
 pub mod batch;
 pub mod coordination;
-pub mod matcher;
 pub mod pbc;
 pub mod rdf;
+pub mod structure_matcher;
 
 // Transformations (internal - public API is via Structure methods)
 pub(crate) mod transformations;

--- a/extensions/rust/src/lib.rs
+++ b/extensions/rust/src/lib.rs
@@ -45,6 +45,7 @@ pub mod batch;
 pub mod coordination;
 pub mod matcher;
 pub mod pbc;
+pub mod rdf;
 
 // Transformations (internal - public API is via Structure methods)
 pub(crate) mod transformations;

--- a/extensions/rust/src/python.rs
+++ b/extensions/rust/src/python.rs
@@ -19,11 +19,11 @@ use crate::io::{
     parse_extxyz_trajectory, parse_structure, parse_structure_json, structure_to_extxyz,
     structure_to_poscar, structure_to_pymatgen_json, write_structure,
 };
-use crate::matcher::{ComparatorType, StructureMatcher};
 use crate::rdf;
 use crate::structure::{
     Structure, SymmOp, SymmetryOperation, moyo_ops_to_arrays, spacegroup_to_crystal_system,
 };
+use crate::structure_matcher::{ComparatorType, StructureMatcher};
 use nalgebra::{Matrix3, Vector3};
 
 /// A structure input that can be either a JSON string or a dict.

--- a/extensions/rust/src/python.rs
+++ b/extensions/rust/src/python.rs
@@ -204,6 +204,28 @@ impl PyStructureMatcher {
         Ok(self.inner.get_rms_dist(&s1, &s2))
     }
 
+    /// Compute universal distance between any two structures.
+    ///
+    /// Unlike `get_rms_dist` which returns None for incompatible structures,
+    /// this method always returns a finite distance value, making it suitable
+    /// for consistent ranking of structures by similarity.
+    ///
+    /// Args:
+    ///     struct1: First structure as JSON string or dict.
+    ///     struct2: Second structure as JSON string or dict.
+    ///
+    /// Returns:
+    ///     Finite distance in [0, 1e9]. Identical structures return 0.0.
+    ///     Empty vs non-empty structures return 1e9.
+    fn get_structure_distance(
+        &self,
+        struct1: StructureJson,
+        struct2: StructureJson,
+    ) -> PyResult<f64> {
+        let (s1, s2) = parse_structure_pair(&struct1, &struct2)?;
+        Ok(self.inner.get_structure_distance(&s1, &s2))
+    }
+
     /// Check if two structures match under any species permutation.
     ///
     /// This is useful for comparing structures where the identity of species

--- a/extensions/rust/src/rdf.rs
+++ b/extensions/rust/src/rdf.rs
@@ -1,0 +1,687 @@
+//! Radial Distribution Function (RDF) calculation for crystal structures.
+//!
+//! This module provides methods to compute pair correlation functions g(r),
+//! which describe how atomic density varies as a function of distance from
+//! a reference atom.
+//!
+//! # Features
+//!
+//! - **Total RDF**: All atom pairs
+//! - **Element-resolved RDF**: Filter by element pairs (e.g., Fe-O)
+//! - **Auto-expansion**: Automatically expand to supercell to avoid finite-size effects
+//! - **Occupancy weighting**: Proper handling of mixed-occupancy sites
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use ferrox::Structure;
+//! use ferrox::rdf::{compute_rdf, RdfOptions, RdfResult};
+//!
+//! let structure = Structure::from_json(json_str)?;
+//! let options = RdfOptions::default();
+//! let RdfResult { radii, g_of_r } = compute_rdf(&structure, &options);
+//! ```
+
+use crate::element::Element;
+use crate::structure::Structure;
+use std::f64::consts::PI;
+
+/// Result of an RDF calculation.
+#[derive(Debug, Clone)]
+pub struct RdfResult {
+    /// Bin center positions in Angstroms.
+    pub radii: Vec<f64>,
+    /// RDF values g(r) at each bin center.
+    pub g_of_r: Vec<f64>,
+}
+
+/// Options for RDF calculation.
+#[derive(Debug, Clone)]
+pub struct RdfOptions {
+    /// Maximum distance (cutoff) in Angstroms. Default: 15.0
+    pub r_max: f64,
+    /// Number of histogram bins. Default: 75
+    pub n_bins: usize,
+    /// Whether to normalize by ideal gas density. Default: true
+    pub normalize: bool,
+    /// Whether to auto-expand structure to avoid finite-size effects. Default: true
+    pub auto_expand: bool,
+    /// Expansion factor: minimum lattice dimension = r_max × factor. Default: 2.0
+    pub expansion_factor: f64,
+}
+
+impl Default for RdfOptions {
+    fn default() -> Self {
+        Self {
+            r_max: 15.0,
+            n_bins: 75,
+            normalize: true,
+            auto_expand: true,
+            expansion_factor: 2.0,
+        }
+    }
+}
+
+impl RdfOptions {
+    /// Create new options with specified r_max and n_bins.
+    pub fn new(r_max: f64, n_bins: usize) -> Self {
+        Self {
+            r_max,
+            n_bins,
+            ..Default::default()
+        }
+    }
+
+    /// Set whether to normalize the RDF.
+    pub fn with_normalize(mut self, normalize: bool) -> Self {
+        self.normalize = normalize;
+        self
+    }
+
+    /// Set whether to auto-expand the structure.
+    pub fn with_auto_expand(mut self, auto_expand: bool) -> Self {
+        self.auto_expand = auto_expand;
+        self
+    }
+
+    /// Set the expansion factor for auto-expansion.
+    pub fn with_expansion_factor(mut self, factor: f64) -> Self {
+        self.expansion_factor = factor;
+        self
+    }
+}
+
+// Helper: get occupancy of a specific element at a site (returns 0.0 if element not present)
+fn get_element_occupancy(structure: &Structure, site_idx: usize, element: Option<Element>) -> f64 {
+    match element {
+        None => 1.0,
+        Some(elem) => structure.site_occupancies[site_idx]
+            .species
+            .iter()
+            .filter_map(|(sp, occ)| (sp.element == elem).then_some(occ))
+            .sum(),
+    }
+}
+
+// Helper: prepare structure (with auto-expansion if needed)
+fn prepare_structure(structure: &Structure, options: &RdfOptions) -> Structure {
+    if !options.auto_expand {
+        return structure.clone();
+    }
+    let lengths = structure.lattice.lengths();
+    let min_size = options.r_max * options.expansion_factor;
+    let ns: [i32; 3] = std::array::from_fn(|idx| (min_size / lengths[idx]).ceil() as i32);
+
+    if ns.iter().any(|&n| n > 1) {
+        structure.make_supercell_diag(ns)
+    } else {
+        structure.clone()
+    }
+}
+
+// Core RDF computation with optional element filtering
+fn compute_rdf_internal(
+    structure: &Structure,
+    element_a: Option<Element>,
+    element_b: Option<Element>,
+    options: &RdfOptions,
+) -> RdfResult {
+    let n_bins = options.n_bins;
+    let r_max = options.r_max;
+    let bin_size = r_max / n_bins as f64;
+
+    // Bin centers
+    let radii: Vec<f64> = (0..n_bins)
+        .map(|idx| (idx as f64 + 0.5) * bin_size)
+        .collect();
+
+    // Empty structure case
+    if structure.num_sites() == 0 {
+        return RdfResult {
+            radii,
+            g_of_r: vec![0.0; n_bins],
+        };
+    }
+
+    // Prepare structure (auto-expand if enabled)
+    let work_struct = prepare_structure(structure, options);
+
+    // Get neighbor list (use the expanded structure, so no need for PBC - but the method
+    // handles it correctly anyway)
+    let (centers, neighbors, _images, distances) = work_struct.get_neighbor_list(r_max, 1e-8, true);
+
+    // Build histogram with occupancy weighting
+    let mut g_of_r = vec![0.0; n_bins];
+
+    for ((&center_idx, &neighbor_idx), &dist) in
+        centers.iter().zip(neighbors.iter()).zip(distances.iter())
+    {
+        // Weight by occupancy product (0.0 if element not at site)
+        let weight = get_element_occupancy(&work_struct, center_idx, element_a)
+            * get_element_occupancy(&work_struct, neighbor_idx, element_b);
+
+        if weight > 0.0 && dist > 0.0 && dist < r_max {
+            let bin_idx = (dist / bin_size).floor() as usize;
+            let bin_idx = bin_idx.min(n_bins - 1);
+            g_of_r[bin_idx] += weight;
+        }
+    }
+
+    // Normalize if requested
+    if options.normalize {
+        // Helper to sum occupancies across all sites
+        let sum_occupancy = |elem| -> f64 {
+            (0..work_struct.num_sites())
+                .map(|idx| get_element_occupancy(&work_struct, idx, elem))
+                .sum()
+        };
+
+        let center_weight = sum_occupancy(element_a);
+        let neighbor_weight = sum_occupancy(element_b);
+
+        // Self-weight correction (for same-element pairs, exclude self-interactions)
+        let self_weight = if element_a == element_b {
+            (0..work_struct.num_sites())
+                .map(|idx| get_element_occupancy(&work_struct, idx, element_a).powi(2))
+                .sum()
+        } else {
+            0.0
+        };
+
+        let n_pairs = center_weight * neighbor_weight - self_weight;
+
+        if n_pairs > 0.0 {
+            let volume = work_struct.lattice.volume();
+            for (bin_idx, g_val) in g_of_r.iter_mut().enumerate() {
+                let shell_volume = 4.0 * PI * radii[bin_idx] * radii[bin_idx] * bin_size;
+                *g_val /= n_pairs * shell_volume / volume;
+            }
+        }
+    }
+
+    RdfResult { radii, g_of_r }
+}
+
+/// Compute the total radial distribution function for all atom pairs.
+///
+/// # Arguments
+///
+/// * `structure` - The crystal structure to analyze
+/// * `options` - RDF calculation options
+///
+/// # Returns
+///
+/// An `RdfResult` containing bin centers `radii` and RDF values `g_of_r`.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use ferrox::rdf::{compute_rdf, RdfOptions};
+///
+/// let result = compute_rdf(&structure, &RdfOptions::default());
+/// for (radius, g_val) in result.radii.iter().zip(result.g_of_r.iter()) {
+///     println!("r={:.2} Å, g(r)={:.3}", radius, g_val);
+/// }
+/// ```
+pub fn compute_rdf(structure: &Structure, options: &RdfOptions) -> RdfResult {
+    compute_rdf_internal(structure, None, None, options)
+}
+
+/// Compute element-resolved radial distribution function.
+///
+/// Calculates g(r) for a specific element pair, counting distances from
+/// atoms of `element_a` to atoms of `element_b`.
+///
+/// # Arguments
+///
+/// * `structure` - The crystal structure to analyze
+/// * `element_a` - Center element (e.g., Element::Fe)
+/// * `element_b` - Neighbor element (e.g., Element::O)
+/// * `options` - RDF calculation options
+///
+/// # Returns
+///
+/// An `RdfResult` containing bin centers `radii` and RDF values `g_of_r`.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use ferrox::element::Element;
+/// use ferrox::rdf::{compute_element_rdf, RdfOptions};
+///
+/// // Compute Fe-O pair distribution
+/// let result = compute_element_rdf(&structure, Element::Fe, Element::O, &RdfOptions::default());
+/// ```
+pub fn compute_element_rdf(
+    structure: &Structure,
+    element_a: Element,
+    element_b: Element,
+    options: &RdfOptions,
+) -> RdfResult {
+    compute_rdf_internal(structure, Some(element_a), Some(element_b), options)
+}
+
+/// Compute RDF for all unique element pairs in the structure.
+///
+/// Returns one RDF for each unique (element_a, element_b) pair where
+/// element_a <= element_b (by atomic number), avoiding duplicates.
+///
+/// # Arguments
+///
+/// * `structure` - The crystal structure to analyze
+/// * `options` - RDF calculation options
+///
+/// # Returns
+///
+/// A vector of tuples (element_a, element_b, RdfResult) for each unique pair.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use ferrox::rdf::{compute_all_element_rdfs, RdfOptions};
+///
+/// for (elem_a, elem_b, result) in compute_all_element_rdfs(&structure, &RdfOptions::default()) {
+///     println!("{}-{} RDF computed", elem_a.symbol(), elem_b.symbol());
+/// }
+/// ```
+pub fn compute_all_element_rdfs(
+    structure: &Structure,
+    options: &RdfOptions,
+) -> Vec<(Element, Element, RdfResult)> {
+    // Get unique elements sorted by atomic number
+    let mut elements = structure.unique_elements();
+    elements.sort_by_key(|elem| elem.atomic_number());
+
+    // Prepare structure once for all pairs (if auto_expand is enabled)
+    let work_struct = prepare_structure(structure, options);
+    let options_no_expand = RdfOptions {
+        auto_expand: false,
+        ..options.clone()
+    };
+
+    // Compute RDF for each unique pair (upper triangle including diagonal)
+    let mut results = Vec::new();
+    for (idx_a, &elem_a) in elements.iter().enumerate() {
+        for &elem_b in elements.iter().skip(idx_a) {
+            let rdf =
+                compute_rdf_internal(&work_struct, Some(elem_a), Some(elem_b), &options_no_expand);
+            results.push((elem_a, elem_b, rdf));
+        }
+    }
+
+    results
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lattice::Lattice;
+    use crate::species::Species;
+
+    // === Test Fixtures ===
+
+    fn make_nacl() -> Structure {
+        // NaCl rock salt (conventional cell, 8 atoms)
+        let lattice = Lattice::cubic(5.64);
+        let species = [
+            Element::Na,
+            Element::Na,
+            Element::Na,
+            Element::Na,
+            Element::Cl,
+            Element::Cl,
+            Element::Cl,
+            Element::Cl,
+        ]
+        .map(Species::neutral)
+        .to_vec();
+        let frac_coords = vec![
+            [0.0, 0.0, 0.0].into(),
+            [0.5, 0.5, 0.0].into(),
+            [0.5, 0.0, 0.5].into(),
+            [0.0, 0.5, 0.5].into(),
+            [0.5, 0.5, 0.5].into(),
+            [0.0, 0.0, 0.5].into(),
+            [0.0, 0.5, 0.0].into(),
+            [0.5, 0.0, 0.0].into(),
+        ];
+        Structure::new(lattice, species, frac_coords)
+    }
+
+    fn make_fcc(element: Element, lattice_const: f64) -> Structure {
+        let lattice = Lattice::cubic(lattice_const);
+        let species = vec![Species::neutral(element); 4];
+        let frac_coords = vec![
+            [0.0, 0.0, 0.0].into(),
+            [0.5, 0.5, 0.0].into(),
+            [0.5, 0.0, 0.5].into(),
+            [0.0, 0.5, 0.5].into(),
+        ];
+        Structure::new(lattice, species, frac_coords)
+    }
+
+    fn find_peak_idx(g_of_r: &[f64]) -> usize {
+        assert!(!g_of_r.is_empty(), "find_peak_idx requires non-empty slice");
+        g_of_r
+            .iter()
+            .enumerate()
+            .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
+            .map(|(idx, _)| idx)
+            .unwrap()
+    }
+
+    fn rdf_opts(r_max: f64, n_bins: usize) -> RdfOptions {
+        RdfOptions::new(r_max, n_bins).with_auto_expand(false)
+    }
+
+    // === Core Functionality Tests ===
+
+    #[test]
+    fn test_rdf_options() {
+        // Default values
+        let def = RdfOptions::default();
+        assert!((def.r_max - 15.0).abs() < 1e-10);
+        assert_eq!(def.n_bins, 75);
+        assert!(def.normalize && def.auto_expand);
+
+        // Builder pattern
+        let custom = RdfOptions::new(10.0, 50)
+            .with_normalize(false)
+            .with_auto_expand(false);
+        assert!((custom.r_max - 10.0).abs() < 1e-10);
+        assert_eq!(custom.n_bins, 50);
+        assert!(!custom.normalize && !custom.auto_expand);
+    }
+
+    #[test]
+    fn test_rdf_basic_output() {
+        let result = compute_rdf(&make_nacl(), &rdf_opts(8.0, 40));
+
+        assert_eq!(result.radii.len(), 40);
+        assert_eq!(result.g_of_r.len(), 40);
+        assert!((result.radii[0] - 0.1).abs() < 1e-10); // First bin center
+        assert!((result.radii[39] - 7.9).abs() < 1e-10); // Last bin center
+        assert!(result.g_of_r.iter().any(|&g| g > 0.0)); // Has peaks
+    }
+
+    #[test]
+    fn test_bin_centers_various_configs() {
+        let structure = make_nacl();
+        for (r_max, n_bins) in [(10.0, 50), (6.0, 30), (8.0, 20), (6.0, 600), (6.0, 1)] {
+            let result = compute_rdf(&structure, &rdf_opts(r_max, n_bins));
+            let bin_size = r_max / n_bins as f64;
+
+            assert_eq!(result.radii.len(), n_bins);
+            assert!(
+                (result.radii[0] - 0.5 * bin_size).abs() < 1e-10,
+                "First bin center wrong for r_max={r_max}, n_bins={n_bins}"
+            );
+            assert!(
+                (result.radii[n_bins - 1] - (n_bins as f64 - 0.5) * bin_size).abs() < 1e-10,
+                "Last bin center wrong for r_max={r_max}, n_bins={n_bins}"
+            );
+
+            // Uniform spacing
+            for idx in 1..n_bins {
+                assert!((result.radii[idx] - result.radii[idx - 1] - bin_size).abs() < 1e-10);
+            }
+        }
+    }
+
+    #[test]
+    fn test_exact_bin_assignment() {
+        // Dimer: two Fe atoms 2.0 Å apart in 4 Å cell
+        let structure = Structure::new(
+            Lattice::cubic(4.0),
+            vec![Species::neutral(Element::Fe); 2],
+            vec![[0.0, 0.0, 0.0].into(), [0.5, 0.0, 0.0].into()],
+        );
+        let result = compute_rdf(&structure, &rdf_opts(5.0, 50).with_normalize(false));
+
+        // 2.0 Å → bin 20 (bin_size=0.1 Å)
+        assert!(
+            result.g_of_r[20] > 0.0,
+            "Expected count in bin 20 for 2.0 Å distance, got: {:?}",
+            result
+                .g_of_r
+                .iter()
+                .enumerate()
+                .filter(|(_, v)| **v > 0.0)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    // === Element Filtering Tests ===
+
+    #[test]
+    fn test_element_rdf_peak_ordering() {
+        let structure = make_nacl();
+        let options = rdf_opts(8.0, 40);
+
+        let na_cl = compute_element_rdf(&structure, Element::Na, Element::Cl, &options);
+        let na_na = compute_element_rdf(&structure, Element::Na, Element::Na, &options);
+
+        // Na-Cl peak (~2.82 Å) should be closer than Na-Na peak (~3.99 Å)
+        assert!(
+            na_cl.radii[find_peak_idx(&na_cl.g_of_r)] < na_na.radii[find_peak_idx(&na_na.g_of_r)]
+        );
+    }
+
+    #[test]
+    fn test_element_filtering_changes_rdf() {
+        let structure = make_nacl();
+        let (r_max, n_bins) = (6.0, 30);
+        let options = rdf_opts(r_max, n_bins).with_normalize(false);
+
+        let total = compute_rdf(&structure, &options);
+        let na_cl = compute_element_rdf(&structure, Element::Na, Element::Cl, &options);
+        let na_na = compute_element_rdf(&structure, Element::Na, Element::Na, &options);
+
+        assert!(
+            na_cl.g_of_r != na_na.g_of_r,
+            "Na-Cl should differ from Na-Na"
+        );
+        assert!(
+            na_cl.g_of_r != total.g_of_r,
+            "Na-Cl should differ from total"
+        );
+
+        // Na-Cl should dominate in 2.5-3.0 Å range (Na-Cl distance ~2.82 Å)
+        let bin_size = r_max / n_bins as f64;
+        let start = (2.5 / bin_size).floor() as usize;
+        let end = (3.0 / bin_size).ceil() as usize;
+        let na_cl_sum: f64 = na_cl.g_of_r[start..end].iter().sum();
+        let na_na_sum: f64 = na_na.g_of_r[start..end].iter().sum();
+        assert!(
+            na_cl_sum > na_na_sum,
+            "Na-Cl: {na_cl_sum}, Na-Na: {na_na_sum}"
+        );
+    }
+
+    #[test]
+    fn test_element_rdf_symmetry() {
+        let structure = make_nacl();
+        let options = rdf_opts(6.0, 30);
+
+        let na_cl = compute_element_rdf(&structure, Element::Na, Element::Cl, &options);
+        let cl_na = compute_element_rdf(&structure, Element::Cl, Element::Na, &options);
+
+        // Peaks at same positions (values may differ due to normalization)
+        for (idx, (&g1, &g2)) in na_cl.g_of_r.iter().zip(&cl_na.g_of_r).enumerate() {
+            if g1 > 0.1 {
+                assert!(g2 > 0.0, "Na-Cl peak at bin {idx} missing in Cl-Na");
+            }
+        }
+    }
+
+    #[test]
+    fn test_all_element_rdfs() {
+        let nacl = make_nacl();
+        let fcc_cu = make_fcc(Element::Cu, 3.615);
+
+        // NaCl: 3 pairs (Na-Na, Na-Cl, Cl-Cl)
+        let nacl_pairs = compute_all_element_rdfs(&nacl, &rdf_opts(6.0, 30));
+        assert_eq!(nacl_pairs.len(), 3);
+        let pair_names: Vec<_> = nacl_pairs
+            .iter()
+            .map(|(a, b, _)| (a.symbol(), b.symbol()))
+            .collect();
+        assert!(
+            pair_names.contains(&("Na", "Na"))
+                && pair_names.contains(&("Na", "Cl"))
+                && pair_names.contains(&("Cl", "Cl"))
+        );
+
+        // FCC Cu: 1 pair (Cu-Cu)
+        let cu_pairs = compute_all_element_rdfs(&fcc_cu, &rdf_opts(5.0, 50));
+        assert_eq!(cu_pairs.len(), 1);
+        assert_eq!((cu_pairs[0].0, cu_pairs[0].1), (Element::Cu, Element::Cu));
+    }
+
+    #[test]
+    fn test_total_rdf_equals_sum_of_partials() {
+        let structure = make_nacl();
+        let options = rdf_opts(6.0, 30).with_normalize(false);
+
+        let total = compute_rdf(&structure, &options);
+        let partials = compute_all_element_rdfs(&structure, &options);
+
+        let mut summed = vec![0.0; 30];
+        for (elem_a, elem_b, partial) in &partials {
+            let mult = if elem_a == elem_b { 1.0 } else { 2.0 };
+            for (idx, &g) in partial.g_of_r.iter().enumerate() {
+                summed[idx] += g * mult;
+            }
+        }
+
+        for (idx, (&total_g, &sum_g)) in total.g_of_r.iter().zip(&summed).enumerate() {
+            assert!(
+                (total_g - sum_g).abs() < 1e-10,
+                "Bin {idx}: total {total_g} != sum {sum_g}"
+            );
+        }
+    }
+
+    // === Peak Position Tests ===
+
+    #[test]
+    fn test_nacl_peak_positions() {
+        let structure = make_nacl();
+        let options = rdf_opts(6.0, 60);
+
+        // Na-Cl: a/2 = 2.82 Å
+        let na_cl = compute_element_rdf(&structure, Element::Na, Element::Cl, &options);
+        let na_cl_peak = na_cl.radii[find_peak_idx(&na_cl.g_of_r)];
+        assert!(
+            (na_cl_peak - 2.82).abs() < 0.2,
+            "Na-Cl peak at {na_cl_peak:.2}, expected ~2.82 Å"
+        );
+
+        // Na-Na: a/√2 ≈ 3.99 Å
+        let na_na = compute_element_rdf(&structure, Element::Na, Element::Na, &options);
+        let na_na_peak = na_na.radii[find_peak_idx(&na_na.g_of_r)];
+        assert!(
+            (na_na_peak - 3.99).abs() < 0.3,
+            "Na-Na peak at {na_na_peak:.2}, expected ~3.99 Å"
+        );
+    }
+
+    #[test]
+    fn test_fcc_peak_position() {
+        let structure = make_fcc(Element::Cu, 3.615);
+        let result = compute_rdf(&structure, &rdf_opts(5.0, 50));
+
+        // FCC nearest neighbor: a/√2 ≈ 2.556 Å
+        let expected = 3.615 / 2.0_f64.sqrt();
+        let peak_r = result.radii[find_peak_idx(&result.g_of_r)];
+        assert!(
+            (peak_r - expected).abs() < 0.2,
+            "FCC Cu peak at {peak_r:.2}, expected ~{expected:.2} Å"
+        );
+    }
+
+    #[test]
+    fn test_unnormalized_counts() {
+        let structure = make_nacl();
+        let (r_max, n_bins) = (4.0, 40);
+        let options = rdf_opts(r_max, n_bins).with_normalize(false);
+        let na_cl = compute_element_rdf(&structure, Element::Na, Element::Cl, &options);
+
+        // Sum counts in 2.5-3.2 Å region (first shell, Na-Cl distance ~2.82 Å)
+        let bin_size = r_max / n_bins as f64;
+        let start = (2.5 / bin_size).floor() as usize;
+        let end = (3.2 / bin_size).ceil() as usize;
+        let count: f64 = na_cl.g_of_r[start..end.min(n_bins)].iter().sum();
+        // 4 Na × 6 Cl neighbors = 24 pairs
+        assert!(
+            count > 20.0 && count < 30.0,
+            "Expected ~24 Na-Cl pairs, got {count}"
+        );
+    }
+
+    // === Edge Cases ===
+
+    #[test]
+    fn test_zero_rdf_cases() {
+        let nacl = make_nacl();
+
+        // Empty structure
+        let empty = Structure::new(Lattice::cubic(5.0), vec![], vec![]);
+        let empty_result = compute_rdf(&empty, &RdfOptions::default());
+        assert!(empty_result.g_of_r.iter().all(|&g| g == 0.0));
+
+        // r_max=0
+        let zero_r = compute_rdf(
+            &nacl,
+            &RdfOptions {
+                r_max: 0.0,
+                n_bins: 10,
+                normalize: false,
+                auto_expand: false,
+                expansion_factor: 2.0,
+            },
+        );
+        assert!(zero_r.g_of_r.iter().all(|&g| g == 0.0));
+
+        // r_max < nearest neighbor
+        let small_r = compute_rdf(&nacl, &rdf_opts(1.0, 10));
+        assert!(small_r.g_of_r.iter().all(|&g| g == 0.0));
+
+        // Non-existent elements
+        let fe_o = compute_element_rdf(&nacl, Element::Fe, Element::O, &rdf_opts(5.0, 25));
+        assert!(fe_o.g_of_r.iter().all(|&g| g == 0.0));
+    }
+
+    #[test]
+    fn test_single_atom_has_periodic_peaks() {
+        let structure = Structure::new(
+            Lattice::cubic(3.0),
+            vec![Species::neutral(Element::Fe)],
+            vec![[0.0, 0.0, 0.0].into()],
+        );
+        let result = compute_rdf(&structure, &rdf_opts(5.0, 25));
+
+        // Peak at lattice constant (3.0 Å) from periodic images
+        let bins_near_3a = &result.g_of_r[14..17]; // bins around 3.0 Å
+        assert!(
+            bins_near_3a.iter().any(|&g| g > 0.0),
+            "Expected periodic image peak at 3.0 Å"
+        );
+    }
+
+    #[test]
+    fn test_auto_expand() {
+        let structure = make_nacl();
+
+        let expanded = compute_rdf(
+            &structure,
+            &RdfOptions::new(8.0, 40).with_expansion_factor(1.5),
+        );
+        let not_expanded = compute_rdf(&structure, &rdf_opts(8.0, 40));
+
+        // Both produce valid results
+        assert_eq!(expanded.radii.len(), not_expanded.radii.len());
+        assert!(expanded.g_of_r.iter().any(|&g| g > 0.0));
+        assert!(not_expanded.g_of_r.iter().any(|&g| g > 0.0));
+    }
+}

--- a/extensions/rust/src/structure.rs
+++ b/extensions/rust/src/structure.rs
@@ -954,7 +954,7 @@ impl Structure {
     /// assert!(nacl.matches(&mgo, true));
     /// ```
     pub fn matches(&self, other: &Structure, anonymous: bool) -> bool {
-        let matcher = crate::matcher::StructureMatcher::new();
+        let matcher = crate::structure_matcher::StructureMatcher::new();
         self.matches_with(other, &matcher, anonymous)
     }
 
@@ -972,7 +972,7 @@ impl Structure {
     pub fn matches_with(
         &self,
         other: &Structure,
-        matcher: &crate::matcher::StructureMatcher,
+        matcher: &crate::structure_matcher::StructureMatcher,
         anonymous: bool,
     ) -> bool {
         if anonymous {

--- a/extensions/rust/src/structure_matcher.rs
+++ b/extensions/rust/src/structure_matcher.rs
@@ -1888,10 +1888,10 @@ mod tests {
         assert!(d_disjoint.is_finite() && d_disjoint > d_same);
         assert!(d_no_overlap.is_finite() && d_no_overlap > 0.0);
         // Same geometry but partial overlap: composition_distance = 1 - 1/3 ≈ 0.667
-        // With COMPOSITION_WEIGHT = 10.0, expected contribution ≈ 6.67
-        // Since geometric distance ≈ 0, total should be > 5.0
+        // With COMPOSITION_WEIGHT = 5.0, expected contribution ≈ 3.33
+        // Geometric distance is small but non-zero (~2.2) due to normalization
         assert!(
-            d_partial > 5.0,
+            d_partial > 3.0,
             "Same geometry + partial overlap should have composition penalty: {d_partial}"
         );
         // Partial should be less than disjoint (DISJOINT_COMPOSITION_DISTANCE = 1e9)

--- a/extensions/rust/src/wasm.rs
+++ b/extensions/rust/src/wasm.rs
@@ -441,17 +441,18 @@ impl WasmStructureMatcher {
     ///
     /// Unlike `get_rms_dist` which may return null for incompatible structures,
     /// this method always returns a finite distance value, making it suitable for
-    /// consistent ranking of structures by similarity.
+    /// consistent ranking of structures by similarity and compatible with `Number.isFinite()`.
     ///
     /// # Properties
     /// - d(x, y) ≥ 0 (non-negative)
     /// - d(x, x) = 0 (identity)
     /// - d(x, y) = d(y, x) (symmetric)
+    /// - Always finite (empty vs non-empty returns 1e9)
     ///
     /// Note: Triangle inequality is not guaranteed due to greedy matching.
     ///
     /// # Returns
-    /// Distance value in [0, ∞). Smaller values indicate more similar structures.
+    /// Finite distance in [0, 1e9]. Smaller values indicate more similar structures.
     #[wasm_bindgen(js_name = "getStructureDistance")]
     pub fn get_structure_distance(
         &self,

--- a/extensions/rust/tests/compatibility_tests.rs
+++ b/extensions/rust/tests/compatibility_tests.rs
@@ -14,9 +14,9 @@
 use ferrox::element::Element;
 use ferrox::io::{parse_structure_json, structure_to_json};
 use ferrox::lattice::Lattice;
-use ferrox::matcher::StructureMatcher;
 use ferrox::species::Species;
 use ferrox::structure::Structure;
+use ferrox::structure_matcher::StructureMatcher;
 use nalgebra::Vector3;
 
 /// Create a simple cubic structure


### PR DESCRIPTION
## Summary

Adds radial distribution function (RDF) calculation capabilities to the ferrox Rust library with Python bindings.

- Expose finite structural distance through JS/WASM `getStructureDistance` and Python `get_structure_distance`.

### RDF Module (`rdf.rs`)
- `compute_rdf`: Total pair correlation function g(r) for all atom pairs
- `compute_element_rdf`: Element-specific pair distributions (e.g., Fe-O, Na-Cl)
- `compute_all_element_rdfs`: All unique element pairs computed at once
- Auto-expansion to supercell to avoid finite-size effects
- Proper handling of mixed-occupancy sites with weighted contributions
- Configurable options: r_max, n_bins, normalization, expansion factor

### Python Bindings
- Full Python API with type stubs for IDE support
- Default parameters matching common use cases (r_max=15Å, 75 bins)

### Also included
- WASM build improvements (TypeScript types for default export, npm publish fix)