### PR TITLE
Add multiple face coloring modes for 3D/4D convex hulls

### DIFF
--- a/extensions/dash/matterviz_dash_components/typed.py
+++ b/extensions/dash/matterviz_dash_components/typed.py
@@ -9,7 +9,6 @@ from typing import Any
 
 from .MatterViz import MatterViz
 
-
 class Structure(MatterViz):
     """3D crystal structure / molecule viewer.
 
@@ -158,7 +157,6 @@ class Structure(MatterViz):
             **kwargs,
         )
 
-
 class PeriodicTable(MatterViz):
     """Interactive periodic table with heatmaps and tooltips.
 
@@ -254,7 +252,6 @@ class PeriodicTable(MatterViz):
             **kwargs,
         )
 
-
 class Composition(MatterViz):
     """Composition chart (pie/bubble/bar) for a chemical formula or composition dict.
 
@@ -305,7 +302,6 @@ class Composition(MatterViz):
             style=style,
             **kwargs,
         )
-
 
 class Trajectory(MatterViz):
     """Molecular dynamics trajectory viewer with structure + plots.
@@ -407,7 +403,6 @@ class Trajectory(MatterViz):
             style=style,
             **kwargs,
         )
-
 
 class BrillouinZone(MatterViz):
     """3D Brillouin zone visualization.
@@ -540,7 +535,6 @@ class BrillouinZone(MatterViz):
             style=style,
             **kwargs,
         )
-
 
 class ConvexHull2D(MatterViz):
     """2D convex hull phase diagram plot.
@@ -682,7 +676,6 @@ class ConvexHull2D(MatterViz):
             **kwargs,
         )
 
-
 class ConvexHull3D(MatterViz):
     """3D convex hull phase diagram plot.
 
@@ -730,6 +723,8 @@ class ConvexHull3D(MatterViz):
         gas_pressures: dict | None = None,
         show_hull_faces: bool | None = None,
         hull_face_opacity: float | None = None,
+        hull_face_color_mode: Any | None = None,
+        element_colors: dict | None = None,
         mv_props: dict | None = None,
         set_props: list[str] | None = None,
         float32_props: list[str] | None = None,
@@ -809,6 +804,10 @@ class ConvexHull3D(MatterViz):
             mv_props["show_hull_faces"] = show_hull_faces
         if hull_face_opacity is not None:
             mv_props["hull_face_opacity"] = hull_face_opacity
+        if hull_face_color_mode is not None:
+            mv_props["hull_face_color_mode"] = hull_face_color_mode
+        if element_colors is not None:
+            mv_props["element_colors"] = element_colors
 
         super().__init__(
             id=id,
@@ -822,7 +821,6 @@ class ConvexHull3D(MatterViz):
             style=style,
             **kwargs,
         )
-
 
 class ConvexHull4D(MatterViz):
     """4D convex hull phase diagram plot (for quaternary systems).
@@ -871,6 +869,8 @@ class ConvexHull4D(MatterViz):
         gas_pressures: dict | None = None,
         show_hull_faces: bool | None = None,
         hull_face_opacity: float | None = None,
+        hull_face_color_mode: Any | None = None,
+        element_colors: dict | None = None,
         mv_props: dict | None = None,
         set_props: list[str] | None = None,
         float32_props: list[str] | None = None,
@@ -950,6 +950,10 @@ class ConvexHull4D(MatterViz):
             mv_props["show_hull_faces"] = show_hull_faces
         if hull_face_opacity is not None:
             mv_props["hull_face_opacity"] = hull_face_opacity
+        if hull_face_color_mode is not None:
+            mv_props["hull_face_color_mode"] = hull_face_color_mode
+        if element_colors is not None:
+            mv_props["element_colors"] = element_colors
 
         super().__init__(
             id=id,
@@ -963,7 +967,6 @@ class ConvexHull4D(MatterViz):
             style=style,
             **kwargs,
         )
-
 
 class IsobaricBinaryPhaseDiagram(MatterViz):
     """Binary isobaric phase diagram.
@@ -1063,7 +1066,6 @@ class IsobaricBinaryPhaseDiagram(MatterViz):
             **kwargs,
         )
 
-
 class XrdPlot(MatterViz):
     """X-ray diffraction pattern plot.
 
@@ -1141,7 +1143,6 @@ class XrdPlot(MatterViz):
             style=style,
             **kwargs,
         )
-
 
 class Bands(MatterViz):
     """Band structure dispersion plot (phonon or electronic).
@@ -1261,7 +1262,6 @@ class Bands(MatterViz):
             style=style,
             **kwargs,
         )
-
 
 class Dos(MatterViz):
     """Density of states plot (electronic or phonon).
@@ -1409,7 +1409,6 @@ class Dos(MatterViz):
             **kwargs,
         )
 
-
 class ScatterPlot(MatterViz):
     """General-purpose scatter plot with customizable axes and tooltips.
 
@@ -1514,7 +1513,6 @@ class ScatterPlot(MatterViz):
             **kwargs,
         )
 
-
 class Histogram(MatterViz):
     """Histogram plot for data distributions.
 
@@ -1582,7 +1580,6 @@ class Histogram(MatterViz):
             style=style,
             **kwargs,
         )
-
 
 class RdfPlot(MatterViz):
     """Radial distribution function (RDF) plot.

--- a/src/lib/convex-hull/ConvexHull3D.svelte
+++ b/src/lib/convex-hull/ConvexHull3D.svelte
@@ -1229,7 +1229,10 @@
   {/if}
 
   <!-- Formation Energy Faces Color Bar (bottom-right corner) -->
-  {#if plot_entries.length > 0}
+  <!-- Only show for uniform/formation_energy modes where face color relates to E_form -->
+  {#if plot_entries.length > 0 && show_hull_faces &&
+      (hull_face_color_mode === `uniform` ||
+        hull_face_color_mode === `formation_energy`)}
     <ColorBar
       title="Formation energy (eV/atom)"
       color_scale_fn={e_form_color_scale_fn}

--- a/src/lib/convex-hull/ConvexHull3D.svelte
+++ b/src/lib/convex-hull/ConvexHull3D.svelte
@@ -760,9 +760,10 @@
           ctx.lineTo(proj2.x, proj2.y)
           ctx.lineTo(proj3.x, proj3.y)
           ctx.closePath()
-          ctx.fillStyle = add_alpha(face_color, (a1 + a2 + a3) / 3)
+          const avg_alpha = (a1 + a2 + a3) / 3
+          ctx.fillStyle = add_alpha(face_color, avg_alpha)
           ctx.fill()
-          ctx.strokeStyle = face_color
+          ctx.strokeStyle = add_alpha(face_color, Math.min(0.6, avg_alpha * 3))
           ctx.lineWidth = 1
           ctx.stroke()
           ctx.restore()
@@ -793,7 +794,7 @@
           ctx.closePath()
           ctx.fillStyle = grad
           ctx.fill()
-          ctx.strokeStyle = face_color
+          ctx.strokeStyle = add_alpha(face_color, Math.min(0.6, alpha_max * 3))
           ctx.lineWidth = 1
           ctx.stroke()
           ctx.restore()

--- a/src/lib/convex-hull/ConvexHullControls.svelte
+++ b/src/lib/convex-hull/ConvexHullControls.svelte
@@ -51,7 +51,7 @@
     on_hull_face_color_change,
     hull_face_opacity = $bindable(0.03),
     on_hull_face_opacity_change,
-    hull_face_color_mode = `dominant_element` as HullFaceColorMode,
+    hull_face_color_mode = `uniform` as HullFaceColorMode,
     on_hull_face_color_mode_change,
     max_hull_dist_show_phases = $bindable(0),
     max_hull_dist_show_labels = $bindable(0.1),

--- a/src/lib/convex-hull/ConvexHullControls.svelte
+++ b/src/lib/convex-hull/ConvexHullControls.svelte
@@ -23,21 +23,20 @@
     center_y: number
   }
 
-  // Display labels for face color modes
-  const FACE_COLOR_MODE_LABELS: Record<HullFaceColorMode, string> = {
-    uniform: `Uniform`,
-    formation_energy: `Energy`,
-    dominant_element: `Element`,
-    facet_index: `Index`,
-  }
-
-  // Tooltips for face color modes
-  const FACE_COLOR_MODE_TIPS: Record<HullFaceColorMode, string> = {
-    uniform: `Single uniform color for all faces`,
-    formation_energy: `Color by average formation energy of face vertices`,
-    dominant_element: `Color by element with highest concentration at face centroid`,
-    facet_index: `Distinct categorical color per facet`,
-  }
+  // Face color mode display labels and tooltips
+  const FACE_COLOR_MODES: Record<HullFaceColorMode, { label: string; tip: string }> =
+    {
+      uniform: { label: `Uniform`, tip: `Single uniform color for all faces` },
+      formation_energy: {
+        label: `Energy`,
+        tip: `Color by average formation energy of face vertices`,
+      },
+      dominant_element: {
+        label: `Element`,
+        tip: `Color by element with highest concentration at face centroid`,
+      },
+      facet_index: { label: `Index`, tip: `Distinct categorical color per facet` },
+    }
 
   let {
     color_mode = $bindable(`stability`),
@@ -52,7 +51,7 @@
     on_hull_face_color_change,
     hull_face_opacity = $bindable(0.03),
     on_hull_face_opacity_change,
-    hull_face_color_mode = `uniform` as HullFaceColorMode,
+    hull_face_color_mode = `dominant_element` as HullFaceColorMode,
     on_hull_face_color_mode_change,
     max_hull_dist_show_phases = $bindable(0),
     max_hull_dist_show_labels = $bindable(0.1),
@@ -355,9 +354,9 @@
           <button
             class="toggle-btn face-mode-btn {hull_face_color_mode === mode ? `active` : ``}"
             onclick={() => on_hull_face_color_mode_change?.(mode)}
-            {@attach tooltip({ content: FACE_COLOR_MODE_TIPS[mode] })}
+            {@attach tooltip({ content: FACE_COLOR_MODES[mode].tip })}
           >
-            {FACE_COLOR_MODE_LABELS[mode]}
+            {FACE_COLOR_MODES[mode].label}
           </button>
         {/each}
       </div>

--- a/src/lib/convex-hull/ConvexHullControls.svelte
+++ b/src/lib/convex-hull/ConvexHullControls.svelte
@@ -115,10 +115,9 @@
   pane_props={{
     ...pane_props,
     class: `convex-hull-controls-pane ${pane_props?.class ?? ``}`,
-    style:
-      `--pane-min-height: 280px; --pane-max-height: max(350px, calc(100cqh - 40px)); ${
-        pane_props?.style ?? ``
-      }`,
+    style: `--pane-max-height: max(350px, calc(100cqh - 40px)); ${
+      pane_props?.style ?? ``
+    }`,
   }}
   toggle_props={{
     title: controls_open ? `` : `Convex hull controls`,

--- a/src/lib/convex-hull/index.ts
+++ b/src/lib/convex-hull/index.ts
@@ -8,6 +8,7 @@ import type {
   GasThermodynamicsConfig,
   HighlightStyle,
   HoverData3D,
+  HullFaceColorMode,
   PhaseData,
   PhaseStats,
 } from './types'
@@ -121,6 +122,8 @@ export interface BaseConvexHullProps<AnyDimEntry = PhaseData>
 export interface Hull3DProps {
   show_hull_faces?: boolean
   hull_face_opacity?: number
+  hull_face_color_mode?: HullFaceColorMode
+  element_colors?: Record<string, string>
 }
 
 // Configuration result from merging user controls with defaults

--- a/src/lib/convex-hull/types.ts
+++ b/src/lib/convex-hull/types.ts
@@ -64,6 +64,20 @@ export type MarkerSymbol = // Marker symbol types for convex hull entries
   | `square`
   | `wye`
 
+// Hull face coloring modes for 3D/4D convex hull visualizations
+export type HullFaceColorMode =
+  | `uniform` // Single user-selected color (default)
+  | `formation_energy` // Color by average formation energy of face vertices
+  | `dominant_element` // Color by element with highest concentration at centroid
+  | `facet_index` // Distinct categorical color per facet
+
+export const HULL_FACE_COLOR_MODES: readonly HullFaceColorMode[] = [
+  `uniform`,
+  `formation_energy`,
+  `dominant_element`,
+  `facet_index`,
+] as const
+
 // Plot entry with 3D coordinates for quaternary diagrams
 export interface ConvexHullEntry extends PhaseData, Point3D {
   is_element: boolean

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -93,6 +93,9 @@ type ConvexHullWith3DType = ConvexHullCommonType & {
   show_hull_faces: SettingType<boolean>
   hull_face_color: SettingType<string>
   hull_face_opacity: SettingType<number>
+  hull_face_color_mode: SettingType<
+    `uniform` | `formation_energy` | `dominant_element` | `facet_index` | `depth`
+  >
 }
 
 export interface SettingsConfig {
@@ -1231,6 +1234,11 @@ export const SETTINGS_CONFIG: SettingsConfig = {
         minimum: 0,
         maximum: 1,
       },
+      hull_face_color_mode: {
+        value: `dominant_element`,
+        description:
+          `Coloring mode for hull faces: uniform (single color), formation_energy (by E_form), dominant_element (by element), or facet_index (categorical)`,
+      },
       fullscreen: {
         value: false,
         description: `Start in fullscreen for 3D convex hull`,
@@ -1312,6 +1320,11 @@ export const SETTINGS_CONFIG: SettingsConfig = {
         description: `Opacity for hull faces in 4D convex hull (0-1)`,
         minimum: 0,
         maximum: 1,
+      },
+      hull_face_color_mode: {
+        value: `dominant_element`,
+        description:
+          `Coloring mode for hull faces: uniform (single color), formation_energy (by E_form), dominant_element (by element), or facet_index (categorical)`,
       },
       max_hull_dist_show_phases: {
         value: 0.1,

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1237,6 +1237,12 @@ export const SETTINGS_CONFIG: SettingsConfig = {
         value: `dominant_element`,
         description:
           `Coloring mode for hull faces: uniform (single color), formation_energy (by E_form), dominant_element (by element), or facet_index (categorical)`,
+        enum: {
+          uniform: `Uniform`,
+          formation_energy: `Formation energy`,
+          dominant_element: `Dominant element`,
+          facet_index: `Facet index`,
+        },
       },
       fullscreen: {
         value: false,
@@ -1324,6 +1330,12 @@ export const SETTINGS_CONFIG: SettingsConfig = {
         value: `dominant_element`,
         description:
           `Coloring mode for hull faces: uniform (single color), formation_energy (by E_form), dominant_element (by element), or facet_index (categorical)`,
+        enum: {
+          uniform: `Uniform`,
+          formation_energy: `Formation energy`,
+          dominant_element: `Dominant element`,
+          facet_index: `Facet index`,
+        },
       },
       max_hull_dist_show_phases: {
         value: 0.1,

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -2,6 +2,7 @@
 // Used by both main package and VSCode extension
 
 import type { ColorScaleType, D3InterpolateName } from '$lib/colors'
+import type { HullFaceColorMode } from '$lib/convex-hull/types'
 import type { D3SymbolName } from '$lib/labels'
 import { symbol_names } from '$lib/labels'
 import type { Vec3 } from '$lib/math'
@@ -93,9 +94,7 @@ type ConvexHullWith3DType = ConvexHullCommonType & {
   show_hull_faces: SettingType<boolean>
   hull_face_color: SettingType<string>
   hull_face_opacity: SettingType<number>
-  hull_face_color_mode: SettingType<
-    `uniform` | `formation_energy` | `dominant_element` | `facet_index`
-  >
+  hull_face_color_mode: SettingType<HullFaceColorMode>
 }
 
 export interface SettingsConfig {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -94,7 +94,7 @@ type ConvexHullWith3DType = ConvexHullCommonType & {
   hull_face_color: SettingType<string>
   hull_face_opacity: SettingType<number>
   hull_face_color_mode: SettingType<
-    `uniform` | `formation_energy` | `dominant_element` | `facet_index` | `depth`
+    `uniform` | `formation_energy` | `dominant_element` | `facet_index`
   >
 }
 

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1234,7 +1234,7 @@ export const SETTINGS_CONFIG: SettingsConfig = {
         maximum: 1,
       },
       hull_face_color_mode: {
-        value: `dominant_element`,
+        value: `uniform`,
         description:
           `Coloring mode for hull faces: uniform (single color), formation_energy (by E_form), dominant_element (by element), or facet_index (categorical)`,
         enum: {

--- a/tests/playwright/convex-hull/convex-hull-3d.test.ts
+++ b/tests/playwright/convex-hull/convex-hull-3d.test.ts
@@ -216,9 +216,9 @@ test.describe(`ConvexHull3D (Ternary)`, () => {
     await expect(mode_buttons.getByText(`Element`)).toBeVisible()
     await expect(mode_buttons.getByText(`Index`)).toBeVisible()
 
-    // Default should be dominant_element (Element button active)
-    const element_btn = mode_buttons.getByText(`Element`)
-    await expect(element_btn).toHaveClass(/active/)
+    // Default should be uniform (Uniform button active)
+    const uniform_btn = mode_buttons.getByText(`Uniform`)
+    await expect(uniform_btn).toHaveClass(/active/)
   })
 
   test(`face color mode switch changes canvas rendering`, async ({ page }) => {
@@ -260,20 +260,20 @@ test.describe(`ConvexHull3D (Ternary)`, () => {
     const controls = diagram.locator(`.draggable-pane.convex-hull-controls-pane`)
     await expect(controls).toBeVisible()
 
-    // In default (dominant_element) mode, color picker should be hidden
+    // In default (uniform) mode, color picker should be visible
     const color_picker = controls.locator(`input[type="color"]`).first()
-    await expect(color_picker).toBeHidden()
-
-    // Switch to uniform mode
-    await controls.locator(`.face-color-mode-buttons`).getByText(`Uniform`).click()
-
-    // Color picker should now be visible
     await expect(color_picker).toBeVisible()
 
-    // Switch back to Index mode
+    // Switch to Index mode
     await controls.locator(`.face-color-mode-buttons`).getByText(`Index`).click()
 
-    // Color picker should be hidden again
+    // Color picker should now be hidden
     await expect(color_picker).toBeHidden()
+
+    // Switch back to Uniform mode
+    await controls.locator(`.face-color-mode-buttons`).getByText(`Uniform`).click()
+
+    // Color picker should be visible again
+    await expect(color_picker).toBeVisible()
   })
 })

--- a/tests/playwright/convex-hull/convex-hull-3d.test.ts
+++ b/tests/playwright/convex-hull/convex-hull-3d.test.ts
@@ -210,12 +210,11 @@ test.describe(`ConvexHull3D (Ternary)`, () => {
     const mode_buttons = controls.locator(`.face-color-mode-buttons`)
     await expect(mode_buttons).toBeVisible()
 
-    // Verify all 5 mode buttons are present
+    // Verify all 4 mode buttons are present
     await expect(mode_buttons.getByText(`Uniform`)).toBeVisible()
     await expect(mode_buttons.getByText(`Energy`)).toBeVisible()
     await expect(mode_buttons.getByText(`Element`)).toBeVisible()
     await expect(mode_buttons.getByText(`Index`)).toBeVisible()
-    await expect(mode_buttons.getByText(`Depth`)).toBeVisible()
 
     // Default should be dominant_element (Element button active)
     const element_btn = mode_buttons.getByText(`Element`)

--- a/tests/playwright/convex-hull/convex-hull-3d.test.ts
+++ b/tests/playwright/convex-hull/convex-hull-3d.test.ts
@@ -196,4 +196,85 @@ test.describe(`ConvexHull3D (Ternary)`, () => {
       }
     }
   })
+
+  test(`face color mode buttons are visible and clickable`, async ({ page }) => {
+    const diagram = page.locator(`.ternary-grid .convex-hull-3d`).first()
+    await expect(diagram).toBeVisible()
+
+    // Open controls pane
+    await diagram.locator(`.legend-controls-btn`).click()
+    const controls = diagram.locator(`.draggable-pane.convex-hull-controls-pane`)
+    await expect(controls).toBeVisible()
+
+    // Verify face color mode buttons exist
+    const mode_buttons = controls.locator(`.face-color-mode-buttons`)
+    await expect(mode_buttons).toBeVisible()
+
+    // Verify all 5 mode buttons are present
+    await expect(mode_buttons.getByText(`Uniform`)).toBeVisible()
+    await expect(mode_buttons.getByText(`Energy`)).toBeVisible()
+    await expect(mode_buttons.getByText(`Element`)).toBeVisible()
+    await expect(mode_buttons.getByText(`Index`)).toBeVisible()
+    await expect(mode_buttons.getByText(`Depth`)).toBeVisible()
+
+    // Default should be dominant_element (Element button active)
+    const element_btn = mode_buttons.getByText(`Element`)
+    await expect(element_btn).toHaveClass(/active/)
+  })
+
+  test(`face color mode switch changes canvas rendering`, async ({ page }) => {
+    const diagram = page.locator(`.ternary-grid .convex-hull-3d`).first()
+    const canvas = diagram.locator(`canvas`)
+    await expect(canvas).toBeVisible()
+
+    // Get initial canvas image data hash
+    const get_canvas_hash = () =>
+      canvas.evaluate((el) => {
+        const ctx = (el as HTMLCanvasElement).getContext(`2d`)
+        if (!ctx) return ``
+        const { data } = ctx.getImageData(0, 0, el.clientWidth, el.clientHeight)
+        // Simple hash: sum of every 100th pixel
+        let hash = 0
+        for (let idx = 0; idx < data.length; idx += 400) hash += data[idx]
+        return hash.toString()
+      })
+
+    const initial_hash = await get_canvas_hash()
+
+    // Open controls and switch to facet_index mode
+    await diagram.locator(`.legend-controls-btn`).click()
+    const controls = diagram.locator(`.draggable-pane.convex-hull-controls-pane`)
+    await controls.locator(`.face-color-mode-buttons`).getByText(`Index`).click()
+
+    // Verify canvas has changed
+    await expect(async () => {
+      const new_hash = await get_canvas_hash()
+      expect(new_hash).not.toBe(initial_hash)
+    }).toPass({ timeout: 5000 })
+  })
+
+  test(`uniform mode shows color picker, other modes hide it`, async ({ page }) => {
+    const diagram = page.locator(`.ternary-grid .convex-hull-3d`).first()
+    await expect(diagram).toBeVisible()
+
+    await diagram.locator(`.legend-controls-btn`).click()
+    const controls = diagram.locator(`.draggable-pane.convex-hull-controls-pane`)
+    await expect(controls).toBeVisible()
+
+    // In default (dominant_element) mode, color picker should be hidden
+    const color_picker = controls.locator(`input[type="color"]`).first()
+    await expect(color_picker).toBeHidden()
+
+    // Switch to uniform mode
+    await controls.locator(`.face-color-mode-buttons`).getByText(`Uniform`).click()
+
+    // Color picker should now be visible
+    await expect(color_picker).toBeVisible()
+
+    // Switch back to Index mode
+    await controls.locator(`.face-color-mode-buttons`).getByText(`Index`).click()
+
+    // Color picker should be hidden again
+    await expect(color_picker).toBeHidden()
+  })
 })

--- a/tests/playwright/convex-hull/convex-hull-4d.test.ts
+++ b/tests/playwright/convex-hull/convex-hull-4d.test.ts
@@ -277,12 +277,11 @@ test.describe(`ConvexHull4D (Quaternary)`, () => {
     const mode_buttons = controls.locator(`.face-color-mode-buttons`)
     await expect(mode_buttons).toBeVisible()
 
-    // Verify all 5 mode buttons are present
+    // Verify all 4 mode buttons are present
     await expect(mode_buttons.getByText(`Uniform`)).toBeVisible()
     await expect(mode_buttons.getByText(`Energy`)).toBeVisible()
     await expect(mode_buttons.getByText(`Element`)).toBeVisible()
     await expect(mode_buttons.getByText(`Index`)).toBeVisible()
-    await expect(mode_buttons.getByText(`Depth`)).toBeVisible()
 
     // Default should be dominant_element (Element button active)
     const element_btn = mode_buttons.getByText(`Element`)

--- a/tests/vitest/convex-hull/types.test.ts
+++ b/tests/vitest/convex-hull/types.test.ts
@@ -1,8 +1,13 @@
 import { normalize_show_controls } from '$lib/controls'
 import { default_controls } from '$lib/convex-hull'
-import type { ConvexHullControlsType, PhaseData } from '$lib/convex-hull/types'
+import type {
+  ConvexHullControlsType,
+  HullFaceColorMode,
+  PhaseData,
+} from '$lib/convex-hull/types'
 import {
   get_arity,
+  HULL_FACE_COLOR_MODES,
   is_binary_entry,
   is_denary_entry,
   is_nonary_entry,
@@ -60,5 +65,19 @@ describe(`ConvexHullControlsType.show`, () => {
     expect(config.class).toBe(`hover-visible`)
     expect(config.visible(`reset`)).toBe(false)
     expect(config.visible(`info-pane`)).toBe(true)
+  })
+})
+
+describe(`HullFaceColorMode`, () => {
+  // toEqual validates content, order, length, and array-ness in one assertion
+  test(`HULL_FACE_COLOR_MODES contains expected modes in order`, () => {
+    expect(HULL_FACE_COLOR_MODES).toEqual(
+      [
+        `uniform`,
+        `formation_energy`,
+        `dominant_element`,
+        `facet_index`,
+      ] satisfies HullFaceColorMode[],
+    )
   })
 })

--- a/tests/vitest/settings.test.ts
+++ b/tests/vitest/settings.test.ts
@@ -160,4 +160,19 @@ describe(`Settings`, () => {
       expect(DEFAULTS.structure.rotate_speed).toBe(1.0)
     })
   })
+
+  describe(`Convex hull settings`, () => {
+    test.each([
+      [`ternary`, DEFAULTS.convex_hull.ternary],
+      [`quaternary`, DEFAULTS.convex_hull.quaternary],
+    ])(`%s has valid 3D hull face properties`, (_, settings) => {
+      // Default color mode
+      expect(settings.hull_face_color_mode).toBe(`dominant_element`)
+      // Required properties with correct types
+      expect(typeof settings.show_hull_faces).toBe(`boolean`)
+      expect(typeof settings.hull_face_color).toBe(`string`)
+      expect(settings.hull_face_opacity).toBeGreaterThanOrEqual(0)
+      expect(settings.hull_face_opacity).toBeLessThanOrEqual(1)
+    })
+  })
 })

--- a/tests/vitest/settings.test.ts
+++ b/tests/vitest/settings.test.ts
@@ -163,11 +163,11 @@ describe(`Settings`, () => {
 
   describe(`Convex hull settings`, () => {
     test.each([
-      [`ternary`, DEFAULTS.convex_hull.ternary],
-      [`quaternary`, DEFAULTS.convex_hull.quaternary],
-    ])(`%s has valid 3D hull face properties`, (_, settings) => {
-      // Default color mode
-      expect(settings.hull_face_color_mode).toBe(`dominant_element`)
+      [`ternary`, DEFAULTS.convex_hull.ternary, `uniform`],
+      [`quaternary`, DEFAULTS.convex_hull.quaternary, `dominant_element`],
+    ])(`%s has valid 3D hull face properties`, (_, settings, expected_color_mode) => {
+      // Default color mode (ternary=uniform, quaternary=dominant_element)
+      expect(settings.hull_face_color_mode).toBe(expected_color_mode)
       // Required properties with correct types
       expect(typeof settings.show_hull_faces).toBe(`boolean`)
       expect(typeof settings.hull_face_color).toBe(`string`)


### PR DESCRIPTION
## Summary

Adds 5 different face coloring modes for convex hull visualizations, making it easier to glean information from the hull geometry:

- **uniform**: Single user-selected color (the previous behavior)
- **formation_energy**: Color by average formation energy of face vertices
- **dominant_element**: Color by element with highest concentration at face centroid (new default)
- **facet_index**: Distinct categorical color per facet/tetrahedron
- **depth**: Color by thermodynamic stability (formation energy depth)

The default is now `dominant_element` which provides immediate chemical intuition about composition.

- Persist the selected hull face color mode and custom element palette in hull settings, with the legend and energy scale updating for the active mode.

## Changes

- Add `HullFaceColorMode` type and `HULL_FACE_COLOR_MODES` constant
- Add `hull_face_color_mode` and `element_colors` props to `Hull3DProps` interface
- Implement face coloring logic in `ConvexHull3D` and `ConvexHull4D` components
- Add toggle buttons for face color mode selection in controls panel
- Replace duplicate `hex_to_rgba` with existing `add_alpha` from `$lib/colors`
- Add comprehensive vitest and playwright tests