### PR TITLE
Add TorchSim state conversion + improve Rust bindings

### DIFF
--- a/extensions/rust/Cargo.toml
+++ b/extensions/rust/Cargo.toml
@@ -69,7 +69,6 @@ tracing = "0.1"
 flate2 = "1.1"  # gzip decompression for element data
 
 # File format parsing
-vasp-poscar = "0.3"
 extxyz = "0.2"
 
 [dev-dependencies]

--- a/extensions/rust/Cargo.toml
+++ b/extensions/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrox"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2024"
 rust-version = "1.93"
 authors = ["Janosh Riebesell <janosh.riebesell@gmail.com>"]

--- a/extensions/rust/license
+++ b/extensions/rust/license
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Janosh Riebesell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+The software is provided "as is", without warranty of any kind, express or
+implied, including but not limited to the warranties of merchantability,
+fitness for a particular purpose and noninfringement. In no event shall the
+authors or copyright holders be liable for any claim, damages or other
+liability, whether in an action of contract, tort or otherwise, arising from,
+out of or in connection with the software or the use or other dealings in the
+software.

--- a/extensions/rust/src/composition.rs
+++ b/extensions/rust/src/composition.rs
@@ -501,13 +501,13 @@ impl Composition {
     /// Check if two compositions are approximately equal.
     ///
     /// Uses both relative and absolute tolerances.
-    pub fn almost_equals(&self, other: &Self, rtol: f64, atol: f64) -> bool {
+    pub fn almost_equals(&self, other: &Self, rel_tol: f64, abs_tol: f64) -> bool {
         let all_species: HashSet<_> = self.species.keys().chain(other.species.keys()).collect();
 
         for sp in all_species {
             let a = self.get(*sp);
             let b = other.get(*sp);
-            let tol = atol + rtol * (a.abs() + b.abs()) / 2.0;
+            let tol = abs_tol + rel_tol * (a.abs() + b.abs()) / 2.0;
             if (a - b).abs() > tol {
                 return false;
             }

--- a/extensions/rust/src/io.rs
+++ b/extensions/rust/src/io.rs
@@ -2201,6 +2201,28 @@ pub fn torch_sim_state_to_structures(state: &TorchSimState) -> Result<Vec<Struct
         });
     }
 
+    // Validate charge and spin lengths if provided
+    if !state.charge.is_empty() && state.charge.len() != n_systems {
+        return Err(FerroxError::JsonError {
+            path: "inline".to_string(),
+            reason: format!(
+                "charge length {} doesn't match number of systems {}",
+                state.charge.len(),
+                n_systems
+            ),
+        });
+    }
+    if !state.spin.is_empty() && state.spin.len() != n_systems {
+        return Err(FerroxError::JsonError {
+            path: "inline".to_string(),
+            reason: format!(
+                "spin length {} doesn't match number of systems {}",
+                state.spin.len(),
+                n_systems
+            ),
+        });
+    }
+
     let mut structures = Vec::with_capacity(n_systems);
 
     for sys_idx in 0..n_systems {

--- a/extensions/rust/src/io.rs
+++ b/extensions/rust/src/io.rs
@@ -2180,6 +2180,17 @@ pub fn torch_sim_state_to_structures(state: &TorchSimState) -> Result<Vec<Struct
             ),
         });
     }
+    // Validate masses length if provided
+    if !state.masses.is_empty() && state.masses.len() != n_atoms {
+        return Err(FerroxError::JsonError {
+            path: "inline".to_string(),
+            reason: format!(
+                "masses length {} doesn't match positions length {}",
+                state.masses.len(),
+                n_atoms
+            ),
+        });
+    }
 
     // Determine number of systems
     let n_systems = state.cell.len();

--- a/extensions/rust/src/optimizers.rs
+++ b/extensions/rust/src/optimizers.rs
@@ -132,8 +132,8 @@ impl FireState {
     }
 
     /// Check if optimization has converged (method wrapper).
-    pub fn is_converged(&self, fmax: f64) -> bool {
-        is_converged(self, fmax)
+    pub fn is_converged(&self, f_max: f64) -> bool {
+        is_converged(self, f_max)
     }
 
     /// Get maximum force component (method wrapper).
@@ -154,8 +154,8 @@ pub fn max_force(state: &FireState) -> f64 {
 }
 
 /// Check if optimization has converged.
-pub fn is_converged(state: &FireState, fmax: f64) -> bool {
-    max_force(state) < fmax
+pub fn is_converged(state: &FireState, f_max: f64) -> bool {
+    max_force(state) < f_max
 }
 
 /// Perform one FIRE optimization step.
@@ -371,8 +371,8 @@ impl CellFireState {
     }
 
     /// Check if optimization has converged (method wrapper).
-    pub fn is_converged(&self, fmax: f64, smax: f64) -> bool {
-        cell_is_converged(self, fmax, smax)
+    pub fn is_converged(&self, f_max: f64, s_max: f64) -> bool {
+        cell_is_converged(self, f_max, s_max)
     }
 
     /// Get maximum force component (method wrapper).
@@ -403,8 +403,8 @@ pub fn cell_max_stress(state: &CellFireState) -> f64 {
 }
 
 /// Check if cell optimization has converged.
-pub fn cell_is_converged(state: &CellFireState, fmax: f64, smax: f64) -> bool {
-    cell_max_force(state) < fmax && cell_max_stress(state) < smax
+pub fn cell_is_converged(state: &CellFireState, f_max: f64, s_max: f64) -> bool {
+    cell_max_force(state) < f_max && cell_max_stress(state) < s_max
 }
 
 /// Perform one FIRE step with cell optimization.
@@ -700,19 +700,19 @@ mod tests {
         let config = FireConfig::default();
         let mut state = FireState::new(initial, &config);
         let k = 1.0;
-        let fmax = 0.001;
+        let f_max = 0.001;
 
         let mut steps = 0;
         for _ in 0..100 {
             state = fire_step(state, |pos| quadratic_forces(pos, &minimum, k), &config);
             steps += 1;
-            if is_converged(&state, fmax) {
+            if is_converged(&state, f_max) {
                 break;
             }
         }
 
         assert!(
-            is_converged(&state, fmax),
+            is_converged(&state, f_max),
             "Should converge when starting near minimum"
         );
         assert!(
@@ -799,12 +799,15 @@ mod tests {
         let config = FireConfig::default();
         let mut state = FireState::new(initial, &config);
         let k = 1.0;
-        let fmax = 0.001;
+        let f_max = 0.001;
 
         let forces = quadratic_forces(&state.positions, &minimum, k);
         state.last_forces = forces;
 
-        assert!(is_converged(&state, fmax), "Should be converged at minimum");
+        assert!(
+            is_converged(&state, f_max),
+            "Should be converged at minimum"
+        );
         assert!(max_force(&state) < 1e-10, "Max force should be ~0");
 
         let initial_positions = state.positions.clone();

--- a/extensions/rust/src/python/composition.rs
+++ b/extensions/rust/src/python/composition.rs
@@ -97,16 +97,16 @@ fn composition_charge(formula: &str) -> PyResult<Option<i32>> {
 
 /// Check if two compositions are almost equal.
 #[pyfunction]
-#[pyo3(signature = (formula1, formula2, rtol = 1e-6, atol = 1e-8))]
+#[pyo3(signature = (formula1, formula2, rel_tol = 1e-6, abs_tol = 1e-8))]
 fn compositions_almost_equal(
     formula1: &str,
     formula2: &str,
-    rtol: f64,
-    atol: f64,
+    rel_tol: f64,
+    abs_tol: f64,
 ) -> PyResult<bool> {
     let comp1 = parse_comp(formula1)?;
     let comp2 = parse_comp(formula2)?;
-    Ok(comp1.almost_equals(&comp2, rtol, atol))
+    Ok(comp1.almost_equals(&comp2, rel_tol, abs_tol))
 }
 
 /// Get a hash of a formula (for fast comparisons).

--- a/extensions/rust/src/python/io.rs
+++ b/extensions/rust/src/python/io.rs
@@ -152,6 +152,81 @@ fn parse_xyz_flexible(py: Python<'_>, path: &str) -> PyResult<(String, Py<PyDict
     struct_or_mol_to_pydict(py, result)
 }
 
+// === TorchSim State Conversion ===
+
+/// Convert a Structure to TorchSim SimState dict format.
+///
+/// The returned dict has the same structure as torch_sim.SimState:
+/// - positions: list of [x, y, z] for all atoms
+/// - masses: list of atomic masses in amu
+/// - cell: list of 3x3 matrices (one per system, column-major)
+/// - pbc: [bool, bool, bool] periodic boundary conditions
+/// - atomic_numbers: list of atomic numbers
+/// - system_idx: list of system indices (all 0 for single structure)
+/// - charge: list of system charges
+/// - spin: list of system spins
+#[pyfunction]
+fn to_torch_sim_state(py: Python<'_>, structure: StructureJson) -> PyResult<Py<PyDict>> {
+    let struc = parse_struct(&structure)?;
+    let state = crate::io::structure_to_torch_sim_state(&struc);
+    let json = crate::io::torch_sim_state_to_json(&state);
+    json_to_pydict(py, &json)
+}
+
+/// Convert multiple Structures to a batched TorchSim SimState dict.
+///
+/// All structures are combined into a single batched state where:
+/// - system_idx indicates which system each atom belongs to
+/// - cell contains one 3x3 matrix per system
+/// - charge/spin have one value per system
+#[pyfunction]
+fn structures_to_torch_sim_state(
+    py: Python<'_>,
+    structures: Vec<StructureJson>,
+) -> PyResult<Py<PyDict>> {
+    let structs: Vec<_> = structures
+        .iter()
+        .map(parse_struct)
+        .collect::<PyResult<_>>()?;
+    let state = crate::io::structures_to_torch_sim_state(&structs)
+        .map_err(|err| PyValueError::new_err(err.to_string()))?;
+    let json = crate::io::torch_sim_state_to_json(&state);
+    json_to_pydict(py, &json)
+}
+
+/// Parse a TorchSim SimState dict to a list of Structure dicts.
+///
+/// Converts a batched state back to individual structures.
+#[pyfunction]
+fn from_torch_sim_state(
+    py: Python<'_>,
+    state_dict: &Bound<'_, PyDict>,
+) -> PyResult<Vec<Py<PyDict>>> {
+    let json_module = py.import("json")?;
+    let json_str: String = json_module
+        .call_method1("dumps", (state_dict,))?
+        .extract()?;
+    let structures = crate::io::parse_torch_sim_state(&json_str)
+        .map_err(|err| PyValueError::new_err(format!("Error parsing TorchSim state: {err}")))?;
+
+    structures
+        .iter()
+        .map(|s| Ok(structure_to_pydict(py, s)?.unbind()))
+        .collect()
+}
+
+/// Parse a TorchSim SimState JSON string to a list of Structure dicts.
+#[pyfunction]
+fn parse_torch_sim_state_json(py: Python<'_>, json_str: &str) -> PyResult<Vec<Py<PyDict>>> {
+    let structures = crate::io::parse_torch_sim_state(json_str)
+        .map_err(|err| PyValueError::new_err(format!("Error parsing TorchSim state: {err}")))?;
+
+    structures
+        .iter()
+        .map(|s| Ok(structure_to_pydict(py, s)?.unbind()))
+        .collect()
+}
+
 // === Direct Object Conversion ===
 
 /// Convert a pymatgen Structure directly to ferrox dict format.
@@ -460,6 +535,10 @@ pub fn register(parent: &Bound<'_, PyModule>) -> PyResult<()> {
     submod.add_function(wrap_pyfunction!(parse_xyz_file, &submod)?)?;
     submod.add_function(wrap_pyfunction!(parse_ase_dict, &submod)?)?;
     submod.add_function(wrap_pyfunction!(parse_xyz_flexible, &submod)?)?;
+    submod.add_function(wrap_pyfunction!(to_torch_sim_state, &submod)?)?;
+    submod.add_function(wrap_pyfunction!(structures_to_torch_sim_state, &submod)?)?;
+    submod.add_function(wrap_pyfunction!(from_torch_sim_state, &submod)?)?;
+    submod.add_function(wrap_pyfunction!(parse_torch_sim_state_json, &submod)?)?;
     submod.add_function(wrap_pyfunction!(from_pymatgen_structure, &submod)?)?;
     submod.add_function(wrap_pyfunction!(to_pymatgen_structure, &submod)?)?;
     submod.add_function(wrap_pyfunction!(to_pymatgen_molecule, &submod)?)?;

--- a/extensions/rust/src/python/io.rs
+++ b/extensions/rust/src/python/io.rs
@@ -153,6 +153,28 @@ fn parse_xyz_flexible(py: Python<'_>, path: &str) -> PyResult<(String, Py<PyDict
     struct_or_mol_to_pydict(py, result)
 }
 
+/// Parse a structure from POSCAR content string.
+///
+/// Supports VASP 5+ format with element symbols. VASP 4 format is not supported.
+#[pyfunction]
+fn parse_poscar_str(py: Python<'_>, content: &str) -> PyResult<Py<PyDict>> {
+    let structure = crate::io::parse_poscar_str(content)
+        .map_err(|err| PyValueError::new_err(format!("{err}")))?;
+    let json = crate::io::structure_to_pymatgen_json(&structure);
+    json_to_pydict(py, &json)
+}
+
+/// Parse a structure from a POSCAR file.
+///
+/// Supports VASP 5+ format with element symbols. VASP 4 format is not supported.
+#[pyfunction]
+fn parse_poscar_file(py: Python<'_>, path: &str) -> PyResult<Py<PyDict>> {
+    let structure = crate::io::parse_poscar(Path::new(path))
+        .map_err(|err| PyValueError::new_err(format!("{err}")))?;
+    let json = crate::io::structure_to_pymatgen_json(&structure);
+    json_to_pydict(py, &json)
+}
+
 // === TorchSim State Conversion ===
 
 /// Convert a Structure to TorchSim SimState dict format.
@@ -536,6 +558,8 @@ pub fn register(parent: &Bound<'_, PyModule>) -> PyResult<()> {
     submod.add_function(wrap_pyfunction!(parse_xyz_file, &submod)?)?;
     submod.add_function(wrap_pyfunction!(parse_ase_dict, &submod)?)?;
     submod.add_function(wrap_pyfunction!(parse_xyz_flexible, &submod)?)?;
+    submod.add_function(wrap_pyfunction!(parse_poscar_str, &submod)?)?;
+    submod.add_function(wrap_pyfunction!(parse_poscar_file, &submod)?)?;
     submod.add_function(wrap_pyfunction!(to_torch_sim_state, &submod)?)?;
     submod.add_function(wrap_pyfunction!(structures_to_torch_sim_state, &submod)?)?;
     submod.add_function(wrap_pyfunction!(from_torch_sim_state, &submod)?)?;

--- a/extensions/rust/src/python/md.rs
+++ b/extensions/rust/src/python/md.rs
@@ -456,6 +456,17 @@ impl PyNPTState {
             }
         }
 
+        // Validate cell matrix for finiteness
+        for (row_idx, row) in cell.iter().enumerate() {
+            for (col_idx, &val) in row.iter().enumerate() {
+                if !val.is_finite() {
+                    return Err(PyValueError::new_err(format!(
+                        "Cell matrix element [{row_idx}][{col_idx}] must be finite, got {val}"
+                    )));
+                }
+            }
+        }
+
         let pos_vec = positions_to_vec3(&positions);
         let cell_mat = array_to_mat3(cell);
         // NPT always has a cell, so default pbc to true
@@ -589,8 +600,8 @@ impl PyFireState {
     }
 
     /// Check if optimization has converged.
-    fn is_converged(&self, fmax: f64) -> bool {
-        self.inner.is_converged(fmax)
+    fn is_converged(&self, f_max: f64) -> bool {
+        self.inner.is_converged(f_max)
     }
 
     /// Get maximum force component magnitude.
@@ -676,8 +687,8 @@ impl PyCellFireState {
     }
 
     /// Check if optimization has converged.
-    fn is_converged(&self, fmax: f64, smax: f64) -> bool {
-        self.inner.is_converged(fmax, smax)
+    fn is_converged(&self, f_max: f64, s_max: f64) -> bool {
+        self.inner.is_converged(f_max, s_max)
     }
 
     /// Get maximum force component magnitude.

--- a/extensions/rust/src/python/md.rs
+++ b/extensions/rust/src/python/md.rs
@@ -600,8 +600,13 @@ impl PyFireState {
     }
 
     /// Check if optimization has converged.
-    fn is_converged(&self, f_max: f64) -> bool {
-        self.inner.is_converged(f_max)
+    fn is_converged(&self, f_max: f64) -> PyResult<bool> {
+        if !f_max.is_finite() || f_max <= 0.0 {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "f_max must be positive and finite",
+            ));
+        }
+        Ok(self.inner.is_converged(f_max))
     }
 
     /// Get maximum force component magnitude.
@@ -687,8 +692,18 @@ impl PyCellFireState {
     }
 
     /// Check if optimization has converged.
-    fn is_converged(&self, f_max: f64, s_max: f64) -> bool {
-        self.inner.is_converged(f_max, s_max)
+    fn is_converged(&self, f_max: f64, s_max: f64) -> PyResult<bool> {
+        if !f_max.is_finite() || f_max <= 0.0 {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "f_max must be positive and finite",
+            ));
+        }
+        if !s_max.is_finite() || s_max <= 0.0 {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "s_max must be positive and finite",
+            ));
+        }
+        Ok(self.inner.is_converged(f_max, s_max))
     }
 
     /// Get maximum force component magnitude.

--- a/extensions/rust/src/python/optimizers.rs
+++ b/extensions/rust/src/python/optimizers.rs
@@ -202,13 +202,13 @@ impl PyFireState {
     }
 
     /// Check if optimization has converged.
-    fn is_converged(&self, fmax: f64) -> PyResult<bool> {
-        if !fmax.is_finite() || fmax <= 0.0 {
+    fn is_converged(&self, f_max: f64) -> PyResult<bool> {
+        if !f_max.is_finite() || f_max <= 0.0 {
             return Err(pyo3::exceptions::PyValueError::new_err(
-                "fmax must be positive and finite",
+                "f_max must be positive and finite",
             ));
         }
-        Ok(self.inner.is_converged(fmax))
+        Ok(self.inner.is_converged(f_max))
     }
 
     /// Number of atoms.
@@ -303,18 +303,18 @@ impl PyCellFireState {
     }
 
     /// Check if optimization has converged.
-    fn is_converged(&self, fmax: f64, smax: f64) -> PyResult<bool> {
-        if !fmax.is_finite() || fmax <= 0.0 {
+    fn is_converged(&self, f_max: f64, s_max: f64) -> PyResult<bool> {
+        if !f_max.is_finite() || f_max <= 0.0 {
             return Err(pyo3::exceptions::PyValueError::new_err(
-                "fmax must be positive and finite",
+                "f_max must be positive and finite",
             ));
         }
-        if !smax.is_finite() || smax <= 0.0 {
+        if !s_max.is_finite() || s_max <= 0.0 {
             return Err(pyo3::exceptions::PyValueError::new_err(
-                "smax must be positive and finite",
+                "s_max must be positive and finite",
             ));
         }
-        Ok(optimizers::cell_is_converged(&self.inner, fmax, smax))
+        Ok(optimizers::cell_is_converged(&self.inner, f_max, s_max))
     }
 
     /// Number of atoms.

--- a/extensions/rust/src/python/surfaces.rs
+++ b/extensions/rust/src/python/surfaces.rs
@@ -149,7 +149,7 @@ fn parse_site_type(site_type: &str) -> Result<surfaces::AdsorptionSiteType, Stri
         "hollow4" => Ok(surfaces::AdsorptionSiteType::Hollow4),
         "other" | "other_site" => Ok(surfaces::AdsorptionSiteType::Other),
         _ => Err(format!(
-            "Unknown site type: '{site_type}'. Valid types: atop, on_top, bridge, hollow, hollow3, hollow4, other"
+            "Unknown site type: '{site_type}'. Valid types: atop, on_top, bridge, hollow, hollow3, hollow4, other, other_site"
         )),
     }
 }

--- a/extensions/rust/src/python/surfaces.rs
+++ b/extensions/rust/src/python/surfaces.rs
@@ -147,8 +147,9 @@ fn parse_site_type(site_type: &str) -> Result<surfaces::AdsorptionSiteType, Stri
         "bridge" => Ok(surfaces::AdsorptionSiteType::Bridge),
         "hollow" | "hollow3" => Ok(surfaces::AdsorptionSiteType::Hollow3),
         "hollow4" => Ok(surfaces::AdsorptionSiteType::Hollow4),
+        "other" | "other_site" => Ok(surfaces::AdsorptionSiteType::Other),
         _ => Err(format!(
-            "Unknown site type: '{site_type}'. Valid types: atop, on_top, bridge, hollow, hollow3, hollow4"
+            "Unknown site type: '{site_type}'. Valid types: atop, on_top, bridge, hollow, hollow3, hollow4, other"
         )),
     }
 }

--- a/extensions/rust/src/structure_matcher.rs
+++ b/extensions/rust/src/structure_matcher.rs
@@ -1001,9 +1001,9 @@ mod tests {
 
     #[test]
     fn test_fit_with_scale_false() {
-        // With scale=false and tight ltol, very different volumes should not match
+        // With scale=false and tight len_tol, very different volumes should not match
         let s1 = make_simple_cubic(Element::Fe, 4.0);
-        let s2 = make_simple_cubic(Element::Fe, 6.0); // 50% larger, ratio=1.5 well outside ltol=0.2
+        let s2 = make_simple_cubic(Element::Fe, 6.0); // 50% larger, ratio=1.5 well outside len_tol=0.2
 
         let matcher = StructureMatcher::new().with_scale(false);
         assert!(

--- a/extensions/rust/src/wasm/optimizers.rs
+++ b/extensions/rust/src/wasm/optimizers.rs
@@ -98,13 +98,14 @@ impl JsFireState {
     }
 
     /// Check if optimization has converged.
-    /// Returns false for non-positive f_max thresholds.
+    ///
+    /// f_max: force convergence threshold (must be finite and positive)
     #[wasm_bindgen]
-    pub fn is_converged(&self, f_max: f64) -> bool {
+    pub fn is_converged(&self, f_max: f64) -> Result<bool, JsError> {
         if !f_max.is_finite() || f_max <= 0.0 {
-            return false;
+            return Err(JsError::new("f_max must be finite and positive"));
         }
-        self.inner.is_converged(f_max)
+        Ok(self.inner.is_converged(f_max))
     }
 
     /// Number of atoms.

--- a/extensions/rust/src/wasm/optimizers.rs
+++ b/extensions/rust/src/wasm/optimizers.rs
@@ -98,13 +98,13 @@ impl JsFireState {
     }
 
     /// Check if optimization has converged.
-    /// Returns false for non-positive fmax thresholds.
+    /// Returns false for non-positive f_max thresholds.
     #[wasm_bindgen]
-    pub fn is_converged(&self, fmax: f64) -> bool {
-        if !fmax.is_finite() || fmax <= 0.0 {
+    pub fn is_converged(&self, f_max: f64) -> bool {
+        if !f_max.is_finite() || f_max <= 0.0 {
             return false;
         }
-        self.inner.is_converged(fmax)
+        self.inner.is_converged(f_max)
     }
 
     /// Number of atoms.
@@ -213,17 +213,17 @@ impl JsCellFireState {
 
     /// Check if optimization has converged.
     ///
-    /// fmax: force convergence threshold (must be finite and positive)
-    /// smax: stress convergence threshold (must be finite and positive)
+    /// f_max: force convergence threshold (must be finite and positive)
+    /// s_max: stress convergence threshold (must be finite and positive)
     #[wasm_bindgen]
-    pub fn is_converged(&self, fmax: f64, smax: f64) -> Result<bool, JsError> {
-        if !fmax.is_finite() || fmax <= 0.0 {
-            return Err(JsError::new("fmax must be finite and positive"));
+    pub fn is_converged(&self, f_max: f64, s_max: f64) -> Result<bool, JsError> {
+        if !f_max.is_finite() || f_max <= 0.0 {
+            return Err(JsError::new("f_max must be finite and positive"));
         }
-        if !smax.is_finite() || smax <= 0.0 {
-            return Err(JsError::new("smax must be finite and positive"));
+        if !s_max.is_finite() || s_max <= 0.0 {
+            return Err(JsError::new("s_max must be finite and positive"));
         }
-        Ok(optimizers::cell_is_converged(&self.inner, fmax, smax))
+        Ok(optimizers::cell_is_converged(&self.inner, f_max, s_max))
     }
 
     /// Number of atoms.

--- a/extensions/rust/src/wasm/potentials.rs
+++ b/extensions/rust/src/wasm/potentials.rs
@@ -220,6 +220,7 @@ pub fn compute_harmonic_bonds(
             return Err("bonds array length must be divisible by 4".to_string());
         }
         let mut bond_vec: Vec<potentials::HarmonicBond> = Vec::with_capacity(bonds.len() / 4);
+        let n_atoms_f64 = n_atoms as f64;
         for (bond_idx, chunk) in bonds.chunks(4).enumerate() {
             let idx_i = chunk[0];
             let idx_j = chunk[1];
@@ -231,19 +232,20 @@ pub fn compute_harmonic_bonds(
                 return Err(format!("bond {bond_idx}: atom index j={idx_j} is invalid"));
             }
 
+            // Check bounds before casting to prevent overflow (use >= to avoid underflow when n_atoms == 0)
+            if idx_i >= n_atoms_f64 {
+                return Err(format!(
+                    "bond {bond_idx}: atom index i={idx_i} out of bounds (n_atoms={n_atoms})"
+                ));
+            }
+            if idx_j >= n_atoms_f64 {
+                return Err(format!(
+                    "bond {bond_idx}: atom index j={idx_j} out of bounds (n_atoms={n_atoms})"
+                ));
+            }
+
             let idx_i_usize = idx_i as usize;
             let idx_j_usize = idx_j as usize;
-
-            if idx_i_usize >= n_atoms {
-                return Err(format!(
-                    "bond {bond_idx}: atom index i={idx_i_usize} out of bounds"
-                ));
-            }
-            if idx_j_usize >= n_atoms {
-                return Err(format!(
-                    "bond {bond_idx}: atom index j={idx_j_usize} out of bounds"
-                ));
-            }
 
             if !chunk[2].is_finite() || chunk[2] < 0.0 {
                 return Err(format!(

--- a/extensions/rust/tests/test_io.py
+++ b/extensions/rust/tests/test_io.py
@@ -1,0 +1,386 @@
+"""Tests for TorchSim state conversion functions."""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+from conftest import make_cubic_structure, make_site, make_structure
+
+try:
+    from ferrox import io as ferrox_io
+except ImportError:
+    pytest.skip("ferrox not installed", allow_module_level=True)
+
+
+# === Fixtures ===
+
+
+@pytest.fixture
+def si_structure() -> dict:
+    """Si diamond structure (8 atoms)."""
+    return make_cubic_structure(
+        5.43,
+        [
+            make_site("Si", [i / 4, j / 4, k / 4])
+            for i, j, k in [
+                (0, 0, 0),
+                (1, 1, 1),
+                (2, 2, 0),
+                (3, 3, 1),
+                (2, 0, 2),
+                (3, 1, 3),
+                (0, 2, 2),
+                (1, 3, 3),
+            ]
+        ],
+    )
+
+
+@pytest.fixture
+def ar_structure() -> dict:
+    """Ar FCC structure (4 atoms)."""
+    return make_cubic_structure(
+        5.26,
+        [
+            make_site("Ar", pos)
+            for pos in [[0, 0, 0], [0.5, 0.5, 0], [0.5, 0, 0.5], [0, 0.5, 0.5]]
+        ],
+    )
+
+
+@pytest.fixture
+def fe_structure() -> dict:
+    """BCC Fe structure (2 atoms)."""
+    return make_cubic_structure(
+        2.87,
+        [make_site("Fe", [0, 0, 0]), make_site("Fe", [0.5, 0.5, 0.5])],
+    )
+
+
+# === Single Structure Conversion Tests ===
+
+
+class TestSingleStructureToState:
+    """Tests for single structure to TorchSim state conversion."""
+
+    def test_basic_conversion(self, si_structure: dict) -> None:
+        """Convert Si structure to state and verify all fields."""
+        state = ferrox_io.to_torch_sim_state(si_structure)
+
+        # Array fields have 8 atoms
+        for key in ("positions", "masses", "atomic_numbers", "system_idx"):
+            assert len(state[key]) == 8
+
+        # System fields have 1 system
+        for key in ("cell", "charge", "spin"):
+            assert len(state[key]) == 1
+
+        # Verify values
+        assert all(z == 14 for z in state["atomic_numbers"])  # Si atomic number
+        assert all(m == pytest.approx(28.0855, rel=1e-3) for m in state["masses"])
+        assert all(idx == 0 for idx in state["system_idx"])
+        assert state["pbc"] == [True, True, True]
+
+    def test_cell_values_cubic(self, si_structure: dict) -> None:
+        """Verify cell matrix values for cubic lattice."""
+        state = ferrox_io.to_torch_sim_state(si_structure)
+        cell = state["cell"][0]
+
+        # Cell is 3x3
+        assert len(cell) == 3
+        assert all(len(row) == 3 for row in cell)
+
+        # TorchSim uses column-major, diagonal should be lattice param
+        for idx in range(3):
+            assert cell[idx][idx] == pytest.approx(5.43, rel=1e-3)
+
+
+class TestMultipleStructuresToState:
+    """Tests for multiple structures to batched TorchSim state."""
+
+    def test_batched_conversion(self, si_structure: dict, fe_structure: dict) -> None:
+        """Convert multiple structures to batched state."""
+        state = ferrox_io.structures_to_torch_sim_state([si_structure, fe_structure])
+
+        # Si (8 atoms) + Fe (2 atoms) = 10 total atoms, 2 systems
+        assert len(state["positions"]) == 10
+        assert len(state["cell"]) == 2
+
+        # Verify system_idx and atomic_numbers
+        assert state["system_idx"][:8] == [0] * 8
+        assert state["system_idx"][8:] == [1] * 2
+        assert all(z == 14 for z in state["atomic_numbers"][:8])  # Si
+        assert all(z == 26 for z in state["atomic_numbers"][8:])  # Fe
+
+    def test_empty_list(self) -> None:
+        """Empty structure list returns empty state."""
+        state = ferrox_io.structures_to_torch_sim_state([])
+        for key in ("positions", "masses", "cell", "atomic_numbers", "system_idx"):
+            assert state[key] == []
+
+    def test_inconsistent_pbc_error(self) -> None:
+        """Structures with different PBC settings raise error."""
+        pbc_true = make_cubic_structure(4.0, [make_site("Fe", [0, 0, 0])])
+        pbc_false = make_cubic_structure(4.0, [make_site("Cu", [0, 0, 0])])
+        pbc_false["lattice"]["pbc"] = [False, False, False]
+
+        with pytest.raises(ValueError, match="periodic boundary conditions"):
+            ferrox_io.structures_to_torch_sim_state(
+                [json.dumps(pbc_true), json.dumps(pbc_false)]
+            )
+
+
+# === State to Structure Conversion Tests ===
+
+
+class TestStateToStructures:
+    """Tests for TorchSim state to structures conversion."""
+
+    def test_single_system_round_trip(self, si_structure: dict) -> None:
+        """Round-trip: structure -> state -> structure."""
+        state = ferrox_io.to_torch_sim_state(si_structure)
+        structures = ferrox_io.from_torch_sim_state(state)
+
+        assert len(structures) == 1
+        assert structures[0]["@class"] == "Structure"
+        assert len(structures[0]["sites"]) == 8
+
+    def test_multiple_systems_round_trip(
+        self, si_structure: dict, ar_structure: dict
+    ) -> None:
+        """Round-trip for multiple structures."""
+        state = ferrox_io.structures_to_torch_sim_state([si_structure, ar_structure])
+        structures = ferrox_io.from_torch_sim_state(state)
+
+        assert len(structures) == 2
+        assert len(structures[0]["sites"]) == 8  # Si
+        assert len(structures[1]["sites"]) == 4  # Ar
+
+    def test_positions_preserved(self, si_structure: dict) -> None:
+        """Verify positions are preserved in round-trip."""
+        original_matrix = np.array(si_structure["lattice"]["matrix"])
+        original_frac = np.array([site["abc"] for site in si_structure["sites"]])
+        original_cart = original_frac @ original_matrix
+
+        state = ferrox_io.to_torch_sim_state(si_structure)
+        result = ferrox_io.from_torch_sim_state(state)[0]
+
+        result_matrix = np.array(result["lattice"]["matrix"])
+        result_frac = np.array([site["abc"] for site in result["sites"]])
+        result_cart = result_frac @ result_matrix
+
+        np.testing.assert_allclose(original_cart, result_cart, rtol=1e-10)
+
+    def test_species_preserved(self, fe_structure: dict) -> None:
+        """Verify species are preserved in round-trip."""
+        state = ferrox_io.to_torch_sim_state(fe_structure)
+        result = ferrox_io.from_torch_sim_state(state)[0]
+
+        assert all(site["species"][0]["element"] == "Fe" for site in result["sites"])
+
+
+class TestParseTorchSimStateJson:
+    """Tests for parsing TorchSim state from JSON string."""
+
+    def test_parse_json_string(self, si_structure: dict) -> None:
+        """Parse state from JSON string."""
+        state_dict = ferrox_io.to_torch_sim_state(si_structure)
+        structures = ferrox_io.parse_torch_sim_state_json(json.dumps(state_dict))
+
+        assert len(structures) == 1
+        assert len(structures[0]["sites"]) == 8
+
+    @pytest.mark.parametrize(
+        "invalid_json",
+        [
+            "not valid json",
+            '{"positions": [[0, 0, 0]]}',  # missing required fields
+        ],
+    )
+    def test_invalid_json(self, invalid_json: str) -> None:
+        """Invalid JSON raises error."""
+        with pytest.raises(ValueError, match="Invalid TorchSim state JSON"):
+            ferrox_io.parse_torch_sim_state_json(invalid_json)
+
+
+# === Cell Matrix Convention Tests ===
+
+
+class TestCellMatrixConvention:
+    """Tests for cell matrix convention (row-major vs column-major)."""
+
+    def test_triclinic_cell_round_trip(self) -> None:
+        """Test triclinic cell preserves correct orientation."""
+        triclinic = make_structure(
+            {"matrix": [[4.0, 0.5, 0.2], [0.3, 5.0, 0.4], [0.1, 0.2, 6.0]]},
+            [make_site("Fe", [0.25, 0.25, 0.25])],
+        )
+
+        state = ferrox_io.to_torch_sim_state(triclinic)
+        result = ferrox_io.from_torch_sim_state(state)[0]
+
+        np.testing.assert_allclose(
+            triclinic["lattice"]["matrix"],
+            result["lattice"]["matrix"],
+            rtol=1e-10,
+        )
+
+    def test_cell_diagonal_values(self) -> None:
+        """Verify diagonal cell values are correct after conversion."""
+        ortho = make_structure(
+            {"matrix": [[3.0, 0, 0], [0, 4.0, 0], [0, 0, 5.0]]},
+            [make_site("H", [0, 0, 0])],
+        )
+
+        cell = ferrox_io.to_torch_sim_state(ortho)["cell"][0]
+        # TorchSim cell is column-major
+        assert cell[0][0] == pytest.approx(3.0)
+        assert cell[1][1] == pytest.approx(4.0)
+        assert cell[2][2] == pytest.approx(5.0)
+
+
+# === Edge Cases ===
+
+
+class TestEdgeCases:
+    """Tests for edge cases and error handling."""
+
+    def test_single_atom_structure(self) -> None:
+        """Single atom structure works correctly."""
+        single = make_cubic_structure(4.0, [make_site("Fe", [0, 0, 0])])
+        state = ferrox_io.to_torch_sim_state(single)
+
+        assert len(state["positions"]) == 1
+        assert state["atomic_numbers"] == [26]
+        assert state["system_idx"] == [0]
+
+    def test_large_structure(self) -> None:
+        """Large structure (3x3x3 BCC supercell = 54 atoms) converts correctly."""
+        sites = [
+            make_site(
+                "Fe", [(idx_a + offset) / 3, (idx_b + offset) / 3, (idx_c + offset) / 3]
+            )
+            for idx_a in range(3)
+            for idx_b in range(3)
+            for idx_c in range(3)
+            for offset in (0, 0.5)
+        ]
+        state = ferrox_io.to_torch_sim_state(make_cubic_structure(2.87 * 3, sites))
+
+        assert len(state["positions"]) == 54
+        assert len(state["atomic_numbers"]) == 54
+
+    def test_different_elements_batched(self) -> None:
+        """Batched state with different elements per system."""
+        structures = [
+            make_cubic_structure(a, [make_site(el, [0, 0, 0])])
+            for el, a in [("Si", 5.43), ("Fe", 2.87), ("Cu", 3.6)]
+        ]
+        state = ferrox_io.structures_to_torch_sim_state(structures)
+
+        assert state["atomic_numbers"] == [14, 26, 29]
+        assert state["system_idx"] == [0, 1, 2]
+        assert len(state["cell"]) == 3
+
+    def test_charge_preserved(self) -> None:
+        """Verify structure charge is preserved."""
+        charged = make_cubic_structure(4.0, [make_site("Fe", [0, 0, 0])])
+        charged["charge"] = 2.0
+
+        state = ferrox_io.to_torch_sim_state(json.dumps(charged))
+        assert state["charge"] == [2.0]
+
+    def test_spin_preserved(self) -> None:
+        """Spin is preserved via structure properties (like ASE atoms.info['spin'])."""
+        structure = make_cubic_structure(4.0, [make_site("Fe", [0, 0, 0])])
+        structure["properties"] = {"spin": 2.0}
+
+        state = ferrox_io.to_torch_sim_state(json.dumps(structure))
+        assert state["spin"] == [2.0]
+
+        # Round-trip preserves spin
+        result = ferrox_io.from_torch_sim_state(state)[0]
+        assert result["properties"]["spin"] == 2.0
+
+    def test_spin_defaults_to_zero(self) -> None:
+        """Spin defaults to 0.0 when not specified."""
+        structure = make_cubic_structure(4.0, [make_site("Fe", [0, 0, 0])])
+
+        state = ferrox_io.to_torch_sim_state(structure)
+        assert state["spin"] == [0.0]
+
+    def test_charge_and_spin_round_trip(self) -> None:
+        """Charge and spin are preserved in round-trip conversion."""
+        structure = make_cubic_structure(4.0, [make_site("Fe", [0, 0, 0])])
+        structure["charge"] = 1.0
+        structure["properties"] = {"spin": 1.0}
+
+        state = ferrox_io.to_torch_sim_state(json.dumps(structure))
+        assert state["charge"] == [1.0]
+        assert state["spin"] == [1.0]
+
+        result = ferrox_io.from_torch_sim_state(state)[0]
+        assert result.get("charge", 0) == pytest.approx(1.0)
+        assert result["properties"]["spin"] == 1.0
+
+    def test_multiple_systems_charge_spin(self) -> None:
+        """Batched state preserves per-system charge and spin."""
+        struct1 = make_cubic_structure(4.0, [make_site("Fe", [0, 0, 0])])
+        struct1["charge"] = 1.0
+        struct1["properties"] = {"spin": 1.0}
+
+        struct2 = make_cubic_structure(4.0, [make_site("Cu", [0, 0, 0])])
+        struct2["charge"] = -1.0
+        struct2["properties"] = {"spin": 0.0}
+
+        struct3 = make_cubic_structure(4.0, [make_site("Ni", [0, 0, 0])])
+        struct3["charge"] = 0.0
+        struct3["properties"] = {"spin": 2.0}
+
+        state = ferrox_io.structures_to_torch_sim_state(
+            [json.dumps(struct1), json.dumps(struct2), json.dumps(struct3)]
+        )
+
+        assert state["charge"] == [1.0, -1.0, 0.0]
+        assert state["spin"] == [1.0, 0.0, 2.0]
+
+    def test_site_properties_not_preserved(self) -> None:
+        """Site-level properties (magmom, selective_dynamics) are not preserved."""
+        site_with_props = {
+            "species": [{"element": "Fe", "occu": 1.0}],
+            "abc": [0, 0, 0],
+            "properties": {"magmom": 5.0, "selective_dynamics": [True, True, False]},
+        }
+        structure = make_structure(
+            {"matrix": [[4.0, 0, 0], [0, 4.0, 0], [0, 0, 4.0]]},
+            [site_with_props],
+        )
+
+        state = ferrox_io.to_torch_sim_state(structure)
+        result = ferrox_io.from_torch_sim_state(state)[0]
+
+        # TorchSim format doesn't preserve site-level properties
+        result_props = result["sites"][0].get("properties", {})
+        assert "magmom" not in result_props
+        assert "selective_dynamics" not in result_props
+
+    def test_structure_properties_partially_preserved(self) -> None:
+        """Only spin is preserved from structure properties, not energy/forces."""
+        structure = make_cubic_structure(4.0, [make_site("Fe", [0, 0, 0])])
+        structure["properties"] = {
+            "energy": -5.123,
+            "spin": 1.0,
+            "forces": [[0.1, 0.2, 0.3]],
+        }
+
+        state = ferrox_io.to_torch_sim_state(json.dumps(structure))
+        result = ferrox_io.from_torch_sim_state(state)[0]
+
+        result_props = result.get("properties", {})
+        # Spin IS preserved
+        assert result_props.get("spin") == 1.0
+        # Other properties are NOT preserved
+        assert "energy" not in result_props
+        assert "forces" not in result_props

--- a/extensions/rust/tests/test_poscar.py
+++ b/extensions/rust/tests/test_poscar.py
@@ -1,0 +1,616 @@
+"""Tests for POSCAR parsing functionality."""
+
+from __future__ import annotations
+
+import pytest
+
+try:
+    from ferrox import io as ferrox_io
+except ImportError:
+    pytest.skip("ferrox not installed", allow_module_level=True)
+
+
+# === Basic POSCAR Parsing Tests ===
+
+
+class TestBasicPoscar:
+    """Tests for basic POSCAR parsing functionality."""
+
+    def test_simple_cubic(self) -> None:
+        """Parse simple cubic structure."""
+        poscar = """Simple cubic
+1.0
+  4.0  0.0  0.0
+  0.0  4.0  0.0
+  0.0  0.0  4.0
+Fe
+1
+Direct
+  0.0  0.0  0.0
+"""
+        structure = ferrox_io.parse_poscar_str(poscar)
+        assert len(structure["sites"]) == 1
+        assert structure["sites"][0]["species"][0]["element"] == "Fe"
+        # Check lattice
+        matrix = structure["lattice"]["matrix"]
+        assert matrix[0][0] == pytest.approx(4.0)
+        assert matrix[1][1] == pytest.approx(4.0)
+        assert matrix[2][2] == pytest.approx(4.0)
+
+    def test_bcc_structure(self) -> None:
+        """Parse BCC structure with 2 atoms."""
+        poscar = """BCC Fe
+1.0
+  2.87  0.0  0.0
+  0.0  2.87  0.0
+  0.0  0.0  2.87
+Fe
+2
+Direct
+  0.0  0.0  0.0
+  0.5  0.5  0.5
+"""
+        structure = ferrox_io.parse_poscar_str(poscar)
+        assert len(structure["sites"]) == 2
+        # Check fractional coords
+        assert structure["sites"][0]["abc"][0] == pytest.approx(0.0)
+        assert structure["sites"][1]["abc"][0] == pytest.approx(0.5)
+
+    def test_fcc_structure(self) -> None:
+        """Parse FCC structure with 4 atoms."""
+        poscar = """FCC Al
+1.0
+  4.05  0.0  0.0
+  0.0  4.05  0.0
+  0.0  0.0  4.05
+Al
+4
+Direct
+  0.0  0.0  0.0
+  0.5  0.5  0.0
+  0.5  0.0  0.5
+  0.0  0.5  0.5
+"""
+        structure = ferrox_io.parse_poscar_str(poscar)
+        assert len(structure["sites"]) == 4
+        assert all(site["species"][0]["element"] == "Al" for site in structure["sites"])
+
+    def test_multi_element(self) -> None:
+        """Parse structure with multiple elements."""
+        poscar = """NaCl
+1.0
+  5.64  0.0  0.0
+  0.0  5.64  0.0
+  0.0  0.0  5.64
+Na Cl
+4 4
+Direct
+  0.0  0.0  0.0
+  0.5  0.5  0.0
+  0.5  0.0  0.5
+  0.0  0.5  0.5
+  0.5  0.0  0.0
+  0.0  0.5  0.0
+  0.0  0.0  0.5
+  0.5  0.5  0.5
+"""
+        structure = ferrox_io.parse_poscar_str(poscar)
+        assert len(structure["sites"]) == 8
+        na_count = sum(
+            1 for site in structure["sites"] if site["species"][0]["element"] == "Na"
+        )
+        cl_count = sum(
+            1 for site in structure["sites"] if site["species"][0]["element"] == "Cl"
+        )
+        assert na_count == 4
+        assert cl_count == 4
+
+
+# === Scale Factor Tests ===
+
+
+class TestScaleFactor:
+    """Tests for scale factor handling."""
+
+    def test_scale_factor_positive(self) -> None:
+        """Positive scale factor multiplies lattice vectors."""
+        poscar = """Scaled
+2.0
+  1.0  0.0  0.0
+  0.0  1.0  0.0
+  0.0  0.0  1.0
+H
+1
+Direct
+  0.0  0.0  0.0
+"""
+        structure = ferrox_io.parse_poscar_str(poscar)
+        matrix = structure["lattice"]["matrix"]
+        # Scale 2.0 * unit vectors = 2.0
+        assert matrix[0][0] == pytest.approx(2.0)
+        assert matrix[1][1] == pytest.approx(2.0)
+        assert matrix[2][2] == pytest.approx(2.0)
+
+    def test_scale_factor_fractional(self) -> None:
+        """Fractional scale factor."""
+        poscar = """Scaled
+1.1
+  10.0  0.0  0.0
+  0.0  6.0  0.0
+  0.0  0.0  4.7
+Fe
+1
+Direct
+  0.0  0.0  0.0
+"""
+        structure = ferrox_io.parse_poscar_str(poscar)
+        matrix = structure["lattice"]["matrix"]
+        assert matrix[0][0] == pytest.approx(11.0)
+        assert matrix[1][1] == pytest.approx(6.6)
+        assert matrix[2][2] == pytest.approx(5.17)
+
+    def test_negative_scale_volume(self) -> None:
+        """Negative scale factor specifies target volume."""
+        # -27.0 means target volume of 27 Å³
+        # For a 1x1x1 cube, scale should be cbrt(27) = 3.0
+        poscar = """Volume scaling
+-27.0
+  1.0  0.0  0.0
+  0.0  1.0  0.0
+  0.0  0.0  1.0
+H
+1
+Direct
+  0.0  0.0  0.0
+"""
+        structure = ferrox_io.parse_poscar_str(poscar)
+        matrix = structure["lattice"]["matrix"]
+        # cbrt(27) = 3.0
+        assert matrix[0][0] == pytest.approx(3.0)
+        assert matrix[1][1] == pytest.approx(3.0)
+        assert matrix[2][2] == pytest.approx(3.0)
+
+    def test_negative_scale_non_cubic(self) -> None:
+        """Negative scale with non-cubic cell."""
+        # -8.0 means target volume of 8 Å³
+        # For 2x2x2 box (vol=8), scale should be 1.0
+        poscar = """Volume scaling non-cubic
+-8.0
+  2.0  0.0  0.0
+  0.0  2.0  0.0
+  0.0  0.0  2.0
+H
+1
+Direct
+  0.0  0.0  0.0
+"""
+        structure = ferrox_io.parse_poscar_str(poscar)
+        matrix = structure["lattice"]["matrix"]
+        # Already has volume 8, scale should be 1.0
+        assert matrix[0][0] == pytest.approx(2.0)
+        assert matrix[1][1] == pytest.approx(2.0)
+        assert matrix[2][2] == pytest.approx(2.0)
+
+
+# === Coordinate Type Tests ===
+
+
+class TestCoordinateType:
+    """Tests for Direct vs Cartesian coordinates."""
+
+    def test_direct_coordinates(self) -> None:
+        """Parse Direct (fractional) coordinates."""
+        poscar = """Direct coords
+1.0
+  4.0  0.0  0.0
+  0.0  4.0  0.0
+  0.0  0.0  4.0
+H
+1
+Direct
+  0.5  0.5  0.5
+"""
+        structure = ferrox_io.parse_poscar_str(poscar)
+        # Fractional coords should be 0.5
+        assert structure["sites"][0]["abc"][0] == pytest.approx(0.5)
+        assert structure["sites"][0]["abc"][1] == pytest.approx(0.5)
+        assert structure["sites"][0]["abc"][2] == pytest.approx(0.5)
+
+    def test_cartesian_coordinates(self) -> None:
+        """Parse Cartesian coordinates."""
+        poscar = """Cartesian coords
+1.0
+  4.0  0.0  0.0
+  0.0  4.0  0.0
+  0.0  0.0  4.0
+H
+1
+Cartesian
+  2.0  2.0  2.0
+"""
+        structure = ferrox_io.parse_poscar_str(poscar)
+        # Cart 2.0 in 4.0 box = frac 0.5
+        assert structure["sites"][0]["abc"][0] == pytest.approx(0.5)
+        assert structure["sites"][0]["abc"][1] == pytest.approx(0.5)
+        assert structure["sites"][0]["abc"][2] == pytest.approx(0.5)
+
+    def test_cartesian_with_scale(self) -> None:
+        """Cartesian coordinates with scale factor."""
+        poscar = """Cartesian with scale
+2.0
+  2.0  0.0  0.0
+  0.0  2.0  0.0
+  0.0  0.0  2.0
+H
+1
+Cartesian
+  1.0  1.0  1.0
+"""
+        structure = ferrox_io.parse_poscar_str(poscar)
+        # Scale 2.0: lattice is 4.0x4.0x4.0
+        # Cartesian 1.0 * scale 2.0 = 2.0 in 4.0 box = frac 0.5
+        assert structure["sites"][0]["abc"][0] == pytest.approx(0.5)
+
+    @pytest.mark.parametrize(
+        "coord_type",
+        [pytest.param("direct", id="lowercase"), pytest.param("c", id="abbreviated_c")],
+    )
+    def test_coord_type_variations(self, coord_type: str) -> None:
+        """Coordinate type accepts lowercase and abbreviated forms."""
+        # Both direct (lowercase) and c (cartesian) should parse to frac 0.5
+        coord = "0.5 0.5 0.5" if coord_type == "direct" else "2.0 2.0 2.0"
+        poscar = f"test\n1.0\n4 0 0\n0 4 0\n0 0 4\nH\n1\n{coord_type}\n{coord}\n"
+        structure = ferrox_io.parse_poscar_str(poscar)
+        assert structure["sites"][0]["abc"][0] == pytest.approx(0.5)
+
+
+# === Selective Dynamics Tests ===
+
+
+class TestSelectiveDynamics:
+    """Tests for Selective dynamics handling."""
+
+    @pytest.mark.parametrize(
+        ("coord_type", "coords", "expected_frac"),
+        [
+            pytest.param(
+                "Direct", "0 0 0 T T T\n  0.5 0.5 0.5 F F F", [0.0, 0.5], id="direct"
+            ),
+            pytest.param("Cartesian", "2 2 2 T F T", [0.5], id="cartesian"),
+        ],
+    )
+    def test_selective_dynamics(
+        self, coord_type: str, coords: str, expected_frac: list[float]
+    ) -> None:
+        """Selective dynamics parses correctly with Direct and Cartesian coords."""
+        poscar = f"""Selective dynamics
+1.0
+  4.0  0.0  0.0
+  0.0  4.0  0.0
+  0.0  0.0  4.0
+Fe
+{len(expected_frac)}
+Selective dynamics
+{coord_type}
+  {coords}
+"""
+        structure = ferrox_io.parse_poscar_str(poscar)
+        assert len(structure["sites"]) == len(expected_frac)
+        for idx, expected in enumerate(expected_frac):
+            assert structure["sites"][idx]["abc"][0] == pytest.approx(expected)
+
+
+# === Element Symbol Variations ===
+
+
+class TestElementSymbols:
+    """Tests for various element symbol formats."""
+
+    def test_element_at_line_end(self) -> None:
+        """Element symbol at end of coordinate line (pymatgen style)."""
+        poscar = """Element at end
+1.0
+  4.0  0.0  0.0
+  0.0  4.0  0.0
+  0.0  0.0  4.0
+Fe O
+2 1
+Direct
+  0.0  0.0  0.0 Fe
+  0.5  0.5  0.0 Fe
+  0.5  0.5  0.5 O
+"""
+        structure = ferrox_io.parse_poscar_str(poscar)
+        assert len(structure["sites"]) == 3
+        assert structure["sites"][0]["species"][0]["element"] == "Fe"
+        assert structure["sites"][2]["species"][0]["element"] == "O"
+
+    def test_vasp6_potcar_hash(self) -> None:
+        """VASP 6.4.2+ format with POTCAR hash in symbol."""
+        poscar = """VASP 6.4.2 format
+1.0
+  4.0  0.0  0.0
+  0.0  4.0  0.0
+  0.0  0.0  4.0
+Mg_pv/f474ac0d Si/79d9987ad87
+1 1
+Direct
+  0.0  0.0  0.0
+  0.5  0.5  0.5
+"""
+        structure = ferrox_io.parse_poscar_str(poscar)
+        assert len(structure["sites"]) == 2
+        assert structure["sites"][0]["species"][0]["element"] == "Mg"
+        assert structure["sites"][1]["species"][0]["element"] == "Si"
+
+    def test_elements_starting_with_s_c_d(self) -> None:
+        """Elements starting with S, C, D must not be confused with coordinate type lines."""
+        # S (Sulfur), C (Carbon), Dy (Dysprosium) start with letters used for
+        # coordinate types (Selective/Cartesian/Direct) - parser must handle this
+        poscar = """S C Dy test
+1.0
+  5.0  0.0  0.0
+  0.0  5.0  0.0
+  0.0  0.0  5.0
+S C Dy
+1 1 1
+Direct
+  0.0  0.0  0.0
+  0.3  0.3  0.3
+  0.6  0.6  0.6
+"""
+        structure = ferrox_io.parse_poscar_str(poscar)
+        assert len(structure["sites"]) == 3
+        elements = [site["species"][0]["element"] for site in structure["sites"]]
+        assert elements == ["S", "C", "Dy"]
+
+    def test_element_with_underscore(self) -> None:
+        """Element with underscore variant (Fe_pv, etc.)."""
+        poscar = """Element variant
+1.0
+  4.0  0.0  0.0
+  0.0  4.0  0.0
+  0.0  0.0  4.0
+Fe_pv O_s
+2 1
+Direct
+  0.0  0.0  0.0
+  0.5  0.5  0.0
+  0.5  0.5  0.5
+"""
+        structure = ferrox_io.parse_poscar_str(poscar)
+        assert structure["sites"][0]["species"][0]["element"] == "Fe"
+        assert structure["sites"][2]["species"][0]["element"] == "O"
+
+
+# === Multi-line Symbol/Count Tests ===
+
+
+class TestMultilineSymbols:
+    """Tests for multi-line element symbols and counts."""
+
+    def test_many_elements_multiline(self) -> None:
+        """Many elements requiring multi-line symbols/counts."""
+        poscar = """Multi-element
+1.0
+  10.0  0.0  0.0
+  0.0  10.0  0.0
+  0.0  0.0  10.0
+Fe Cr Ni
+1 1 1
+Direct
+  0.0  0.0  0.0
+  0.3  0.3  0.3
+  0.6  0.6  0.6
+"""
+        structure = ferrox_io.parse_poscar_str(poscar)
+        assert len(structure["sites"]) == 3
+        elements = [site["species"][0]["element"] for site in structure["sites"]]
+        assert elements == ["Fe", "Cr", "Ni"]
+
+
+# === Lattice Vector Tests ===
+
+
+class TestLatticeVectors:
+    """Tests for various lattice configurations."""
+
+    def test_triclinic_lattice(self) -> None:
+        """Parse triclinic (fully general) lattice."""
+        poscar = """Triclinic
+1.0
+  4.0  0.5  0.2
+  0.3  5.0  0.4
+  0.1  0.2  6.0
+H
+1
+Direct
+  0.25  0.25  0.25
+"""
+        structure = ferrox_io.parse_poscar_str(poscar)
+        matrix = structure["lattice"]["matrix"]
+        assert matrix[0][0] == pytest.approx(4.0)
+        assert matrix[0][1] == pytest.approx(0.5)
+        assert matrix[1][2] == pytest.approx(0.4)
+        assert matrix[2][2] == pytest.approx(6.0)
+
+    def test_hexagonal_lattice(self) -> None:
+        """Parse hexagonal lattice."""
+        import math
+
+        a = 3.0
+        c = 5.0
+        poscar = f"""Hexagonal
+1.0
+  {a}  0.0  0.0
+  {-a / 2}  {a * math.sqrt(3) / 2}  0.0
+  0.0  0.0  {c}
+Zn
+2
+Direct
+  0.333333  0.666667  0.25
+  0.666667  0.333333  0.75
+"""
+        structure = ferrox_io.parse_poscar_str(poscar)
+        assert len(structure["sites"]) == 2
+        matrix = structure["lattice"]["matrix"]
+        assert matrix[0][0] == pytest.approx(3.0)
+
+
+# === Error Handling Tests ===
+
+
+class TestErrorHandling:
+    """Tests for error handling."""
+
+    @pytest.mark.parametrize(
+        ("poscar", "match"),
+        [
+            pytest.param(
+                "VASP 4\n1.0\n4 0 0\n0 4 0\n0 0 4\n2\nDirect\n0 0 0\n0.5 0.5 0.5\n",
+                "VASP 4 format",
+                id="vasp4_format",
+            ),
+            pytest.param(
+                "Bad element\n1.0\n4 0 0\n0 4 0\n0 0 4\nZz\n1\nDirect\n0 0 0\n",
+                "Unknown element",
+                id="invalid_element",
+            ),
+            pytest.param(
+                "Missing\n1.0\n4 0 0\n0 4 0\n0 0 4\nFe\n3\nDirect\n0 0 0\n0.5 0.5 0.5\n",
+                "Expected 3 coordinates",
+                id="missing_coords",
+            ),
+            pytest.param(
+                "Bad scale\nabc\n4 0 0\n0 4 0\n0 0 4\nFe\n1\nDirect\n0 0 0\n",
+                "Invalid scale factor",
+                id="invalid_scale",
+            ),
+            pytest.param(
+                "Mismatch\n1.0\n4 0 0\n0 4 0\n0 0 4\nFe Ni Cu\n1 2\nDirect\n0 0 0\n",
+                "doesn't match",
+                id="mismatched_counts",
+            ),
+            pytest.param(
+                "Short\n1.0\n4 0 0\n",
+                "at least 8 lines",
+                id="too_few_lines",
+            ),
+        ],
+    )
+    def test_invalid_poscar(self, poscar: str, match: str) -> None:
+        """Invalid POSCAR content raises appropriate error."""
+        with pytest.raises(ValueError, match=match):
+            ferrox_io.parse_poscar_str(poscar)
+
+
+# === Real-world POSCAR Tests ===
+
+
+class TestRealWorldPoscar:
+    """Tests with real-world POSCAR examples."""
+
+    def test_fe4p4o16_pymatgen(self) -> None:
+        """Fe4P4O16 structure from pymatgen tests (negative volume scale)."""
+        poscar = """Fe4P4O16
+-300.65685512
+    10.4117668700     0.0000000000     0.0000000000
+     0.0000000000     6.0671718800     0.0000000000
+     0.0000000000     0.0000000000     4.7594895400
+Fe P O
+4 4 16
+direct
+     0.2187282200     0.7500000000     0.4748671100
+     0.2812717800     0.2500000000     0.9748671100
+     0.7187282200     0.7500000000     0.0251328900
+     0.7812717800     0.2500000000     0.5251328900
+     0.0946130900     0.2500000000     0.4182432700
+     0.4053869100     0.7500000000     0.9182432700
+     0.5946130900     0.2500000000     0.0817567300
+     0.9053869100     0.7500000000     0.5817567300
+     0.0433723100     0.7500000000     0.7071376700
+     0.0966424400     0.2500000000     0.7413203500
+     0.1657097400     0.0460723300     0.2853839400
+     0.1657097400     0.4539276700     0.2853839400
+     0.3342902600     0.5460723300     0.7853839400
+     0.3342902600     0.9539276700     0.7853839400
+     0.4033575600     0.7500000000     0.2413203500
+     0.4566276900     0.2500000000     0.2071376700
+     0.5433723100     0.7500000000     0.7928623300
+     0.5966424400     0.2500000000     0.7586796500
+     0.6657097400     0.0460723300     0.2146160600
+     0.6657097400     0.4539276700     0.2146160600
+     0.8342902600     0.5460723300     0.7146160600
+     0.8342902600     0.9539276700     0.7146160600
+     0.9033575600     0.7500000000     0.2586796500
+     0.9566276900     0.2500000000     0.2928623300
+"""
+        structure = ferrox_io.parse_poscar_str(poscar)
+        assert len(structure["sites"]) == 24
+        # Count elements
+        elements = [site["species"][0]["element"] for site in structure["sites"]]
+        assert elements.count("Fe") == 4
+        assert elements.count("P") == 4
+        assert elements.count("O") == 16
+
+    def test_silicon_diamond(self) -> None:
+        """Silicon diamond structure."""
+        poscar = """Si diamond
+5.43
+  0.0  0.5  0.5
+  0.5  0.0  0.5
+  0.5  0.5  0.0
+Si
+2
+Direct
+  0.0   0.0   0.0
+  0.25  0.25  0.25
+"""
+        structure = ferrox_io.parse_poscar_str(poscar)
+        assert len(structure["sites"]) == 2
+        # Lattice should be scaled by 5.43
+        matrix = structure["lattice"]["matrix"]
+        assert matrix[0][1] == pytest.approx(5.43 * 0.5)
+
+    def test_h2_bcc(self) -> None:
+        """Simple H2 BCC test case."""
+        poscar = """H2
+1.0
+   1.0000000000000000    0.0000000000000000    0.0000000000000000
+   0.0000000000000000    1.0000000000000000    0.0000000000000000
+   0.0000000000000000    0.0000000000000000    1.0000000000000000
+H
+2
+direct
+   0.0000000000000000    0.0000000000000000    0.0000000000000000 H
+   0.5000000000000000    0.5000000000000000    0.5000000000000000 H
+"""
+        structure = ferrox_io.parse_poscar_str(poscar)
+        assert len(structure["sites"]) == 2
+        assert structure["sites"][0]["abc"][0] == pytest.approx(0.0)
+        assert structure["sites"][1]["abc"][0] == pytest.approx(0.5)
+
+
+# === Whitespace Handling Tests ===
+
+
+class TestWhitespace:
+    """Tests for various whitespace patterns."""
+
+    @pytest.mark.parametrize(
+        "poscar",
+        [
+            pytest.param(
+                "  Spaces\n  1.0\n    4 0 0\n    0 4 0\n    0 0 4\n  Fe\n  1\n  Direct\n    0 0 0\n",
+                id="extra_spaces",
+            ),
+            pytest.param(
+                "Tabs\n1.0\n\t4\t0\t0\n\t0\t4\t0\n\t0\t0\t4\nFe\n1\nDirect\n\t0\t0\t0\n",
+                id="tabs",
+            ),
+        ],
+    )
+    def test_whitespace_variations(self, poscar: str) -> None:
+        """Parser handles various whitespace patterns."""
+        structure = ferrox_io.parse_poscar_str(poscar)
+        assert len(structure["sites"]) == 1

--- a/extensions/rust/wasm/package.json
+++ b/extensions/rust/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matterviz-wasm",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "WASM bindings for ferrox structure matching library",
   "type": "module",
   "main": "index.js",

--- a/src/lib/convex-hull/TemperatureSlider.svelte
+++ b/src/lib/convex-hull/TemperatureSlider.svelte
@@ -32,7 +32,6 @@
   }
 
   function handle_slider_end(event: Event): void {
-    if (preview_index === null) return // Already processed or no drag occurred
     const new_temp =
       available_temperatures[+(event.currentTarget as HTMLInputElement).value]
     if (new_temp !== undefined) temperature = new_temp

--- a/src/lib/convex-hull/TemperatureSlider.svelte
+++ b/src/lib/convex-hull/TemperatureSlider.svelte
@@ -97,6 +97,7 @@
       onchange={handle_slider_change}
       onmouseup={handle_slider_end}
       ontouchend={handle_slider_end}
+      ontouchcancel={handle_slider_end}
       aria-label="Temperature (Kelvin)"
     />
   </div>

--- a/src/lib/convex-hull/TemperatureSlider.svelte
+++ b/src/lib/convex-hull/TemperatureSlider.svelte
@@ -10,9 +10,8 @@
   } = $props()
 
   // Local preview state for smooth slider interaction without causing full re-renders
-  let is_dragging = $state(false)
   let preview_index = $state<number | null>(null)
-  let last_update_time = $state(0)
+  let last_update_time = 0
   const THROTTLE_MS = 100
 
   const temp_index = $derived(
@@ -32,27 +31,12 @@
     }
   }
 
-  function handle_slider_change(event: Event): void {
-    const new_temp =
-      available_temperatures[+(event.currentTarget as HTMLInputElement).value]
-    if (new_temp !== undefined) temperature = new_temp
-    preview_index = null
-    is_dragging = false
-  }
-
-  // Explicit end handlers for touch devices where onchange fires unreliably
   function handle_slider_end(event: Event): void {
-    if (!is_dragging) return
+    if (preview_index === null) return // Already processed or no drag occurred
     const new_temp =
       available_temperatures[+(event.currentTarget as HTMLInputElement).value]
     if (new_temp !== undefined) temperature = new_temp
     preview_index = null
-    is_dragging = false
-  }
-
-  function handle_slider_start(): void {
-    is_dragging = true
-    last_update_time = 0 // Reset throttle for fresh drag
   }
 
   function set_closest_temp(value: number): void {
@@ -65,7 +49,6 @@
 
 <div
   class="temperature-slider"
-  class:is-dragging={is_dragging}
   {@attach tooltip({ content: `Temperature for G(T) free energies` })}
 >
   <label class="temp-label">
@@ -90,13 +73,10 @@
         min="0"
         max={available_temperatures.length - 1}
         value={display_index}
-        onmousedown={handle_slider_start}
-        ontouchstart={handle_slider_start}
         oninput={handle_slider_input}
-        onchange={handle_slider_change}
+        onchange={handle_slider_end}
         onmouseup={handle_slider_end}
         ontouchend={handle_slider_end}
-        ontouchcancel={handle_slider_end}
         aria-label="Temperature (Kelvin)"
       />
     </div>

--- a/src/lib/convex-hull/TemperatureSlider.svelte
+++ b/src/lib/convex-hull/TemperatureSlider.svelte
@@ -12,7 +12,7 @@
   // Local preview state for smooth slider interaction without causing full re-renders
   let is_dragging = $state(false)
   let preview_index = $state<number | null>(null)
-  let last_update_time = 0
+  let last_update_time = $state(0)
   const THROTTLE_MS = 100
 
   const temp_index = $derived(

--- a/src/lib/convex-hull/TemperatureSlider.svelte
+++ b/src/lib/convex-hull/TemperatureSlider.svelte
@@ -80,27 +80,27 @@
     />
     <span>K</span>
   </label>
-  <div class="slider-wrapper">
-    {#if available_temperatures.length > 0}
+  {#if available_temperatures.length > 0}
+    <div class="slider-wrapper">
       <span class="temp-range">
         {available_temperatures[0]}–{available_temperatures.at(-1)} K
       </span>
-    {/if}
-    <input
-      type="range"
-      min="0"
-      max={available_temperatures.length - 1}
-      value={display_index}
-      onmousedown={handle_slider_start}
-      ontouchstart={handle_slider_start}
-      oninput={handle_slider_input}
-      onchange={handle_slider_change}
-      onmouseup={handle_slider_end}
-      ontouchend={handle_slider_end}
-      ontouchcancel={handle_slider_end}
-      aria-label="Temperature (Kelvin)"
-    />
-  </div>
+      <input
+        type="range"
+        min="0"
+        max={available_temperatures.length - 1}
+        value={display_index}
+        onmousedown={handle_slider_start}
+        ontouchstart={handle_slider_start}
+        oninput={handle_slider_input}
+        onchange={handle_slider_change}
+        onmouseup={handle_slider_end}
+        ontouchend={handle_slider_end}
+        ontouchcancel={handle_slider_end}
+        aria-label="Temperature (Kelvin)"
+      />
+    </div>
+  {/if}
 </div>
 
 <style>

--- a/src/routes/(demos)/convex-hull/+page.svelte
+++ b/src/routes/(demos)/convex-hull/+page.svelte
@@ -190,7 +190,7 @@
   })
 
   // Binary Li-Fe system with temperature-dependent G(T)
-  const temp_binary_entries = [
+  const temp_binary_entries = ([
     { composition: { Li: 1 }, energy: 0, entropy_coef: 0.5 },
     { composition: { Fe: 1 }, energy: 0, entropy_coef: 0.8 },
     { composition: { Li: 0.5, Fe: 0.5 }, energy: -0.3, entropy_coef: 1.2 },
@@ -200,72 +200,163 @@
     { composition: { Li: 0.75, Fe: 0.25 }, energy: -0.12, entropy_coef: 0.6 },
     { composition: { Li: 0.4, Fe: 0.6 }, energy: -0.1, entropy_coef: 2.0 },
     { composition: { Li: 0.6, Fe: 0.4 }, energy: -0.08, entropy_coef: 1.1 },
-  ].map(with_temp_data)
+  ] as BaseEntry[]).map(with_temp_data)
 
   // Ternary Li-Fe-O system with temperature-dependent G(T)
-  const temp_ternary_entries = [
+  // Shows phase transitions: ordered oxides stable at low T, disordered at high T
+  const temp_ternary_entries = ([
+    // Pure elements
     { composition: { Li: 1 }, energy: 0, entropy_coef: 0.4 },
     { composition: { Fe: 1 }, energy: 0, entropy_coef: 0.6 },
     { composition: { O: 1 }, energy: 0, entropy_coef: 0.5 },
-    { composition: { Li: 0.5, Fe: 0.5 }, energy: -0.35, entropy_coef: 1.3 },
-    { composition: { Fe: 0.5, O: 0.5 }, energy: -0.28, entropy_coef: 1.6 },
-    { composition: { Li: 0.5, O: 0.5 }, energy: -0.32, entropy_coef: 1.1 },
+    // Binary phases with competing polymorphs
+    { composition: { Li: 0.5, Fe: 0.5 }, energy: -0.42, entropy_coef: 0.9 }, // ordered
+    { composition: { Li: 0.5, Fe: 0.5 }, energy: -0.28, entropy_coef: 3.5 }, // disordered
+    { composition: { Fe: 0.5, O: 0.5 }, energy: -0.55, entropy_coef: 1.0 }, // FeO wustite
+    { composition: { Fe: 0.4, O: 0.6 }, energy: -0.62, entropy_coef: 1.2 }, // Fe2O3
+    { composition: { Li: 0.5, O: 0.5 }, energy: -0.58, entropy_coef: 0.8 }, // Li2O ordered
+    { composition: { Li: 0.67, O: 0.33 }, energy: -0.48, entropy_coef: 1.4 }, // Li2O variant
+    // Ternary - LiFeO2 polymorphs (key demo: order-disorder transition)
     {
       composition: { Li: 0.33, Fe: 0.33, O: 0.34 },
-      energy: -0.45,
-      entropy_coef: 1.8,
-    },
-    { composition: { Li: 0.5, Fe: 0.25, O: 0.25 }, energy: -0.38, entropy_coef: 1.4 },
-    { composition: { Li: 0.25, Fe: 0.5, O: 0.25 }, energy: -0.36, entropy_coef: 1.5 },
-    { composition: { Li: 0.25, Fe: 0.25, O: 0.5 }, energy: -0.34, entropy_coef: 1.2 },
-    { composition: { Li: 0.4, Fe: 0.4, O: 0.2 }, energy: -0.2, entropy_coef: 2.2 },
-    { composition: { Li: 0.2, Fe: 0.4, O: 0.4 }, energy: -0.18, entropy_coef: 2.0 },
-  ].map(with_temp_data)
+      energy: -0.72,
+      entropy_coef: 1.0,
+    }, // α-LiFeO2
+    {
+      composition: { Li: 0.33, Fe: 0.33, O: 0.34 },
+      energy: -0.58,
+      entropy_coef: 4.0,
+    }, // β-LiFeO2
+    {
+      composition: { Li: 0.33, Fe: 0.33, O: 0.34 },
+      energy: -0.42,
+      entropy_coef: 5.5,
+    }, // γ-LiFeO2
+    // Other ternary compositions
+    { composition: { Li: 0.5, Fe: 0.25, O: 0.25 }, energy: -0.52, entropy_coef: 1.6 },
+    { composition: { Li: 0.25, Fe: 0.5, O: 0.25 }, energy: -0.48, entropy_coef: 2.0 },
+    { composition: { Li: 0.25, Fe: 0.25, O: 0.5 }, energy: -0.65, entropy_coef: 1.2 }, // oxide-rich
+    { composition: { Li: 0.4, Fe: 0.4, O: 0.2 }, energy: -0.35, entropy_coef: 3.2 }, // low-O
+    { composition: { Li: 0.2, Fe: 0.4, O: 0.4 }, energy: -0.58, entropy_coef: 1.8 },
+    { composition: { Li: 0.4, Fe: 0.2, O: 0.4 }, energy: -0.62, entropy_coef: 1.5 },
+    { composition: { Li: 0.2, Fe: 0.2, O: 0.6 }, energy: -0.55, entropy_coef: 2.2 },
+    // High-entropy phases (become stable at high T)
+    { composition: { Li: 0.35, Fe: 0.35, O: 0.3 }, energy: -0.32, entropy_coef: 4.8 },
+    { composition: { Li: 0.3, Fe: 0.3, O: 0.4 }, energy: -0.38, entropy_coef: 4.2 },
+  ] as BaseEntry[]).map(with_temp_data)
 
   // Quaternary Li-Fe-Ni-O system with temperature-dependent G(T)
-  const temp_quaternary_entries = [
+  // Designed to show dramatic stability changes with temperature:
+  // - Low T: ordered phases with low entropy are stable
+  // - High T: disordered/high-entropy phases become stable
+  const temp_quaternary_entries = ([
+    // Pure elements (reference states)
     { composition: { Li: 1 }, energy: 0, entropy_coef: 0.3 },
     { composition: { Fe: 1 }, energy: 0, entropy_coef: 0.5 },
     { composition: { Ni: 1 }, energy: 0, entropy_coef: 0.4 },
     { composition: { O: 1 }, energy: 0, entropy_coef: 0.6 },
-    { composition: { Li: 0.5, Fe: 0.5 }, energy: -0.3, entropy_coef: 1.2 },
-    { composition: { Ni: 0.5, O: 0.5 }, energy: -0.28, entropy_coef: 1.4 },
+    // Binary phases - competing low-T vs high-T stability
+    { composition: { Li: 0.5, Fe: 0.5 }, energy: -0.45, entropy_coef: 0.8 }, // ordered LiFe
+    { composition: { Li: 0.5, Fe: 0.5 }, energy: -0.32, entropy_coef: 2.8 }, // disordered LiFe
+    { composition: { Li: 0.5, Ni: 0.5 }, energy: -0.38, entropy_coef: 1.0 }, // LiNi
+    { composition: { Fe: 0.5, Ni: 0.5 }, energy: -0.25, entropy_coef: 3.2 }, // FeNi alloy
+    { composition: { Ni: 0.5, O: 0.5 }, energy: -0.52, entropy_coef: 0.9 }, // NiO ordered
+    { composition: { Fe: 0.5, O: 0.5 }, energy: -0.48, entropy_coef: 1.1 }, // FeO
+    { composition: { Li: 0.5, O: 0.5 }, energy: -0.55, entropy_coef: 0.7 }, // Li2O (stable)
+    { composition: { Li: 0.67, O: 0.33 }, energy: -0.42, entropy_coef: 1.5 }, // Li2O variant
+    // Ternary phases - more complex T-dependence
     {
       composition: { Li: 0.33, Fe: 0.33, Ni: 0.34 },
-      energy: -0.4,
-      entropy_coef: 1.6,
-    },
+      energy: -0.58,
+      entropy_coef: 1.2,
+    }, // ordered
+    {
+      composition: { Li: 0.33, Fe: 0.33, Ni: 0.34 },
+      energy: -0.38,
+      entropy_coef: 4.5,
+    }, // disordered
     {
       composition: { Fe: 0.33, Ni: 0.33, O: 0.34 },
-      energy: -0.38,
-      entropy_coef: 1.7,
-    },
+      energy: -0.62,
+      entropy_coef: 1.4,
+    }, // spinel-like
+    {
+      composition: { Li: 0.33, Fe: 0.33, O: 0.34 },
+      energy: -0.65,
+      entropy_coef: 1.0,
+    }, // LiFeO2
+    {
+      composition: { Li: 0.33, Ni: 0.33, O: 0.34 },
+      energy: -0.68,
+      entropy_coef: 0.9,
+    }, // LiNiO2
+    { composition: { Li: 0.4, Fe: 0.2, O: 0.4 }, energy: -0.58, entropy_coef: 1.3 },
+    { composition: { Li: 0.2, Fe: 0.4, O: 0.4 }, energy: -0.54, entropy_coef: 1.6 },
+    { composition: { Fe: 0.4, Ni: 0.2, O: 0.4 }, energy: -0.56, entropy_coef: 1.8 },
+    { composition: { Fe: 0.2, Ni: 0.4, O: 0.4 }, energy: -0.52, entropy_coef: 2.0 },
+    // Quaternary phases - dramatic crossovers
     {
       composition: { Li: 0.25, Fe: 0.25, Ni: 0.25, O: 0.25 },
-      energy: -0.5,
-      entropy_coef: 2.0,
-    },
+      energy: -0.72,
+      entropy_coef: 1.5,
+    }, // ordered
+    {
+      composition: { Li: 0.25, Fe: 0.25, Ni: 0.25, O: 0.25 },
+      energy: -0.48,
+      entropy_coef: 5.5,
+    }, // HEO
     {
       composition: { Li: 0.4, Fe: 0.2, Ni: 0.2, O: 0.2 },
-      energy: -0.42,
-      entropy_coef: 1.8,
+      energy: -0.65,
+      entropy_coef: 2.2,
     },
     {
       composition: { Li: 0.2, Fe: 0.4, Ni: 0.2, O: 0.2 },
-      energy: -0.4,
-      entropy_coef: 1.9,
+      energy: -0.58,
+      entropy_coef: 2.8,
     },
     {
-      composition: { Li: 0.3, Fe: 0.3, Ni: 0.3, O: 0.1 },
-      energy: -0.25,
+      composition: { Li: 0.2, Fe: 0.2, Ni: 0.4, O: 0.2 },
+      energy: -0.55,
+      entropy_coef: 3.0,
+    },
+    {
+      composition: { Li: 0.2, Fe: 0.2, Ni: 0.2, O: 0.4 },
+      energy: -0.62,
       entropy_coef: 2.5,
     },
     {
+      composition: { Li: 0.3, Fe: 0.3, Ni: 0.3, O: 0.1 },
+      energy: -0.42,
+      entropy_coef: 4.2,
+    }, // low-O
+    {
       composition: { Li: 0.1, Fe: 0.3, Ni: 0.3, O: 0.3 },
-      energy: -0.22,
-      entropy_coef: 2.3,
+      energy: -0.52,
+      entropy_coef: 3.8,
+    }, // low-Li
+    {
+      composition: { Li: 0.35, Fe: 0.35, Ni: 0.15, O: 0.15 },
+      energy: -0.48,
+      entropy_coef: 3.5,
     },
-  ].map(with_temp_data)
+    {
+      composition: { Li: 0.15, Fe: 0.15, Ni: 0.35, O: 0.35 },
+      energy: -0.58,
+      entropy_coef: 2.8,
+    },
+    // High-entropy phases that become stable at very high T
+    {
+      composition: { Li: 0.22, Fe: 0.28, Ni: 0.28, O: 0.22 },
+      energy: -0.35,
+      entropy_coef: 6.0,
+    },
+    {
+      composition: { Li: 0.28, Fe: 0.22, Ni: 0.22, O: 0.28 },
+      energy: -0.38,
+      entropy_coef: 5.8,
+    },
+  ] as BaseEntry[]).map(with_temp_data)
 
   // Gas pressure demo: configurable gas atmosphere control
   let selected_demo_gas = $state<GasSpecies>(`O2`)

--- a/src/routes/(demos)/convex-hull/+page.svelte
+++ b/src/routes/(demos)/convex-hull/+page.svelte
@@ -273,12 +273,12 @@
   // Bindable gas pressures for the demo
   let gas_demo_pressures = $state<Partial<Record<GasSpecies, number>>>({})
 
-  // Gas demo helper: linear G(T) = E - S*(T - 300K) for smooth T-dependence
-  // entropy values in meV/K (typical range 0.05-0.15 meV/K for solids)
+  // Gas demo helper: linear G(T) = E - S*(T - 300K)*0.001 for smooth T-dependence
+  // Demo entropy values 30-80 (unitless scaling factor, not physical meV/K)
   const make_gas_phase = (
     comp: Comp,
     energy: number,
-    entropy: number, // meV/K
+    entropy: number, // unitless scaling factor
   ): PhaseData => ({
     composition: comp,
     energy,

--- a/src/routes/(demos)/convex-hull/+page.svelte
+++ b/src/routes/(demos)/convex-hull/+page.svelte
@@ -273,44 +273,42 @@
   // Bindable gas pressures for the demo
   let gas_demo_pressures = $state<Partial<Record<GasSpecies, number>>>({})
 
-  // Gas demo helper: explicit energy/entropy for physically smooth T-dependence
+  // Gas demo helper: linear G(T) = E - S*(T - 300K) for smooth T-dependence
+  // entropy values in meV/K (typical range 0.05-0.15 meV/K for solids)
   const make_gas_phase = (
     comp: Comp,
     energy: number,
-    entropy_coef: number,
+    entropy: number, // meV/K
   ): PhaseData => ({
     composition: comp,
     energy,
     temperatures,
-    free_energies: temperatures.map(
-      (T) => energy + entropy_coef * T * 0.0001 - 0.00005 * T * Math.log(T),
-    ),
+    free_energies: temperatures.map((T) => energy - entropy * (T - 300) * 0.001),
   })
 
-  // Gas demo: Fe-O binary with realistic iron oxide energies
-  // Values approximate DFT formation energies for Fe-O system
+  // Gas demo: Fe-O binary - entropy increases with O content (oxides have higher S)
   const gas_demo_fe_o_entries: PhaseData[] = [
-    make_gas_phase({ Fe: 1 }, 0, 0.6), // Fe metal
-    make_gas_phase({ O: 1 }, 0, 0.5), // O2 reference
-    make_gas_phase({ Fe: 0.75, O: 0.25 }, -0.45, 0.9), // Fe-rich
-    make_gas_phase({ Fe: 0.67, O: 0.33 }, -0.85, 1.2), // FeO (wüstite)
-    make_gas_phase({ Fe: 0.6, O: 0.4 }, -0.95, 1.3), // Fe3O4-like
-    make_gas_phase({ Fe: 0.5, O: 0.5 }, -0.78, 1.4), // intermediate
-    make_gas_phase({ Fe: 0.43, O: 0.57 }, -1.05, 1.5), // Fe2O3 (hematite)
-    make_gas_phase({ Fe: 0.33, O: 0.67 }, -0.68, 1.6), // O-rich
+    make_gas_phase({ Fe: 1 }, 0, 30), // Fe metal, low entropy
+    make_gas_phase({ O: 1 }, 0, 50), // O2 reference
+    make_gas_phase({ Fe: 0.75, O: 0.25 }, -0.4, 45), // Fe-rich
+    make_gas_phase({ Fe: 0.67, O: 0.33 }, -0.75, 55), // FeO (wüstite)
+    make_gas_phase({ Fe: 0.6, O: 0.4 }, -0.85, 60), // Fe3O4-like
+    make_gas_phase({ Fe: 0.5, O: 0.5 }, -0.7, 65), // intermediate
+    make_gas_phase({ Fe: 0.43, O: 0.57 }, -0.95, 70), // Fe2O3 (hematite)
+    make_gas_phase({ Fe: 0.33, O: 0.67 }, -0.55, 80), // O-rich
   ]
 
-  // Gas demo: Fe-Ni-O ternary with smooth energies
+  // Gas demo: Fe-Ni-O ternary with consistent entropy trend
   const gas_demo_ternary_entries: PhaseData[] = [
-    make_gas_phase({ Fe: 1 }, 0, 0.6),
-    make_gas_phase({ Ni: 1 }, 0, 0.5),
-    make_gas_phase({ O: 1 }, 0, 0.5),
-    make_gas_phase({ Fe: 0.5, Ni: 0.5 }, -0.15, 1.0), // FeNi alloy
-    make_gas_phase({ Fe: 0.5, O: 0.5 }, -0.9, 1.3), // FeO
-    make_gas_phase({ Ni: 0.5, O: 0.5 }, -0.85, 1.2), // NiO
-    make_gas_phase({ Fe: 0.33, Ni: 0.33, O: 0.34 }, -0.72, 1.5), // spinel
-    make_gas_phase({ Fe: 0.4, Ni: 0.2, O: 0.4 }, -0.82, 1.4),
-    make_gas_phase({ Fe: 0.2, Ni: 0.4, O: 0.4 }, -0.78, 1.3),
+    make_gas_phase({ Fe: 1 }, 0, 30),
+    make_gas_phase({ Ni: 1 }, 0, 32),
+    make_gas_phase({ O: 1 }, 0, 50),
+    make_gas_phase({ Fe: 0.5, Ni: 0.5 }, -0.12, 40), // FeNi alloy
+    make_gas_phase({ Fe: 0.5, O: 0.5 }, -0.8, 60), // FeO
+    make_gas_phase({ Ni: 0.5, O: 0.5 }, -0.75, 58), // NiO
+    make_gas_phase({ Fe: 0.33, Ni: 0.33, O: 0.34 }, -0.65, 55), // spinel
+    make_gas_phase({ Fe: 0.4, Ni: 0.2, O: 0.4 }, -0.72, 58),
+    make_gas_phase({ Fe: 0.2, Ni: 0.4, O: 0.4 }, -0.68, 56),
   ]
 </script>
 

--- a/src/routes/(demos)/convex-hull/+page.svelte
+++ b/src/routes/(demos)/convex-hull/+page.svelte
@@ -273,24 +273,44 @@
   // Bindable gas pressures for the demo
   let gas_demo_pressures = $state<Partial<Record<GasSpecies, number>>>({})
 
-  // Gas demo: Fe-O binary with iron oxides
-  const gas_demo_fe_o_entries: PhaseData[] = [
-    make_phase({ Fe: 1 }, 1100),
-    make_phase({ O: 1 }, 1101),
-    ...[0.33, 0.4, 0.5, 0.6, 0.67, 0.75].map((x, idx) =>
-      make_phase({ Fe: x, O: 1 - x }, 1110 + idx)
+  // Gas demo helper: explicit energy/entropy for physically smooth T-dependence
+  const make_gas_phase = (
+    comp: Comp,
+    energy: number,
+    entropy_coef: number,
+  ): PhaseData => ({
+    composition: comp,
+    energy,
+    temperatures,
+    free_energies: temperatures.map(
+      (T) => energy + entropy_coef * T * 0.0001 - 0.00005 * T * Math.log(T),
     ),
+  })
+
+  // Gas demo: Fe-O binary with realistic iron oxide energies
+  // Values approximate DFT formation energies for Fe-O system
+  const gas_demo_fe_o_entries: PhaseData[] = [
+    make_gas_phase({ Fe: 1 }, 0, 0.6), // Fe metal
+    make_gas_phase({ O: 1 }, 0, 0.5), // O2 reference
+    make_gas_phase({ Fe: 0.75, O: 0.25 }, -0.45, 0.9), // Fe-rich
+    make_gas_phase({ Fe: 0.67, O: 0.33 }, -0.85, 1.2), // FeO (wüstite)
+    make_gas_phase({ Fe: 0.6, O: 0.4 }, -0.95, 1.3), // Fe3O4-like
+    make_gas_phase({ Fe: 0.5, O: 0.5 }, -0.78, 1.4), // intermediate
+    make_gas_phase({ Fe: 0.43, O: 0.57 }, -1.05, 1.5), // Fe2O3 (hematite)
+    make_gas_phase({ Fe: 0.33, O: 0.67 }, -0.68, 1.6), // O-rich
   ]
 
-  // Gas demo: Fe-Ni-O ternary
+  // Gas demo: Fe-Ni-O ternary with smooth energies
   const gas_demo_ternary_entries: PhaseData[] = [
-    ...[`Fe`, `Ni`, `O`].map((el, idx) => make_phase({ [el]: 1 }, 1200 + idx)),
-    ...[[`Fe`, `Ni`], [`Fe`, `O`], [`Ni`, `O`]].map(([a, b], idx) =>
-      make_phase({ [a]: 0.5, [b]: 0.5 }, 1210 + idx)
-    ),
-    make_phase({ Fe: 0.33, Ni: 0.33, O: 0.34 }, 1220),
-    make_phase({ Fe: 0.4, Ni: 0.2, O: 0.4 }, 1221),
-    make_phase({ Fe: 0.2, Ni: 0.4, O: 0.4 }, 1222),
+    make_gas_phase({ Fe: 1 }, 0, 0.6),
+    make_gas_phase({ Ni: 1 }, 0, 0.5),
+    make_gas_phase({ O: 1 }, 0, 0.5),
+    make_gas_phase({ Fe: 0.5, Ni: 0.5 }, -0.15, 1.0), // FeNi alloy
+    make_gas_phase({ Fe: 0.5, O: 0.5 }, -0.9, 1.3), // FeO
+    make_gas_phase({ Ni: 0.5, O: 0.5 }, -0.85, 1.2), // NiO
+    make_gas_phase({ Fe: 0.33, Ni: 0.33, O: 0.34 }, -0.72, 1.5), // spinel
+    make_gas_phase({ Fe: 0.4, Ni: 0.2, O: 0.4 }, -0.82, 1.4),
+    make_gas_phase({ Fe: 0.2, Ni: 0.4, O: 0.4 }, -0.78, 1.3),
   ]
 </script>
 

--- a/tests/playwright/convex-hull/temperature-slider.test.ts
+++ b/tests/playwright/convex-hull/temperature-slider.test.ts
@@ -47,7 +47,7 @@ test.describe(`Temperature-Dependent Free Energies`, () => {
       const initial_temp = await temp_input.inputValue()
 
       // Move slider to a different position
-      await range_input.fill(`2`) // Index 2 = 900K (temperatures: [300, 600, 900, 1200, 1500])
+      await range_input.fill(`6`) // Index 6 = 900K (temperatures: 300-1500K in 100K steps)
 
       // Temperature should update
       await expect(temp_input).toHaveValue(`900`)
@@ -83,7 +83,7 @@ test.describe(`Temperature-Dependent Free Energies`, () => {
       const initial_temp = await temp_input.inputValue()
 
       // Change temperature to a different value
-      await range_input.fill(`4`) // Index 4 = 1500K
+      await range_input.fill(`12`) // Index 12 = 1500K (max)
 
       // Verify temperature changed
       await expect(temp_input).toHaveValue(`1500`)
@@ -109,7 +109,7 @@ test.describe(`Temperature-Dependent Free Energies`, () => {
       // Verify slider has correct range
       const range_input = temp_slider.locator(`input[type="range"]`)
       await expect(range_input).toHaveAttribute(`min`, `0`)
-      await expect(range_input).toHaveAttribute(`max`, `4`) // 5 temperatures: 0-4
+      await expect(range_input).toHaveAttribute(`max`, `12`) // 13 temperatures: 0-12
     })
 
     test(`canvas redraws when temperature changes`, async ({ page }) => {
@@ -124,7 +124,7 @@ test.describe(`Temperature-Dependent Free Energies`, () => {
       const range_input = temp_slider.locator(`input[type="range"]`)
 
       // Change temperature
-      await range_input.fill(`3`) // Index 3 = 1200K
+      await range_input.fill(`9`) // Index 9 = 1200K
 
       // Wait for redraw and verify canvas still renders
       await expect(canvas).toBeVisible()
@@ -170,14 +170,14 @@ test.describe(`Temperature-Dependent Free Energies`, () => {
       const temp_input = temp_slider.locator(`.temp-label input[type="number"]`)
       const range_input = temp_slider.locator(`input[type="range"]`)
 
-      // Test first and last temperature values (sequential testing required)
+      // Test first, middle, and last temperature values (sequential testing required)
       await range_input.fill(`0`)
       await expect(temp_input).toHaveValue(`300`)
 
-      await range_input.fill(`2`)
+      await range_input.fill(`6`)
       await expect(temp_input).toHaveValue(`900`)
 
-      await range_input.fill(`4`)
+      await range_input.fill(`12`)
       await expect(temp_input).toHaveValue(`1500`)
     })
   })
@@ -203,9 +203,9 @@ test.describe(`Temperature Slider - Accessibility`, () => {
     await expect(diagram).toBeVisible()
 
     const range_input = diagram.locator(`.temperature-slider input[type="range"]`)
-    // 5 temperatures [300, 600, 900, 1200, 1500] → indices 0-4
+    // 13 temperatures [300, 400, ..., 1500] → indices 0-12
     await expect(range_input).toHaveAttribute(`min`, `0`)
-    await expect(range_input).toHaveAttribute(`max`, `4`)
+    await expect(range_input).toHaveAttribute(`max`, `12`)
   })
 
   for (const dim of [`3d`, `4d`]) {


### PR DESCRIPTION
## Summary

- Add TorchSim SimState conversion functions for interoperability with torch-sim
- Rename abbreviated parameters to proper snake_case throughout the Rust codebase
- Add input validation for tolerance and matrix parameters

### Snake_case naming fixes
- `fmax`/`smax` → `f_max`/`s_max` (optimizers)
- `nimages` → `n_images` (structure interpolation)
- `ltol`/`atol` → `len_tol`/`ang_tol` (lattice mapping)
- `rtol`/`atol` → `rel_tol`/`abs_tol` (composition comparison)

### Input validation improvements
- StructureMatcher tolerance parameters
- NPT cell matrix finiteness check
- `interpolate()` `n_images >= 1` validation

### Binding additions
- Expose POSCAR parsing in Python and WASM

### Bug fixes
- Fix bounds check in `compute_harmonic_bonds` to prevent underflow when `n_atoms=0`
- Add "other" site type to `parse_site_type` in surfaces

## TorchSim State Conversion

New functions for converting between ferrox Structures and TorchSim's batched SimState format:

**Python bindings:**
- `io.to_torch_sim_state(structure)` - Convert single structure to SimState dict
- `io.structures_to_torch_sim_state([structures])` - Convert multiple structures to batched state
- `io.from_torch_sim_state(state_dict)` - Convert SimState back to structures
- `io.parse_torch_sim_state_json(json_str)` - Parse SimState from JSON string

**Features:**
- Preserves charge and spin (via structure.properties["spin"])
- Handles cell matrix transposition (row-major ↔ column-major)
- Validates array lengths and PBC consistency
- Supports batched states with system_idx