### PR TITLE
JsonTree UX: context menu, diff mode, pinning, selection, and 8 more improvements

### DIFF
--- a/src/lib/convex-hull/ConvexHull.svelte
+++ b/src/lib/convex-hull/ConvexHull.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { extract_formula_elements } from '$lib/composition/parse'
   import type { AxisConfig } from '$lib/plot'
+  import { DEFAULTS } from '$lib/settings'
   import type { Component } from 'svelte'
   import { SvelteSet } from 'svelte/reactivity'
   import ConvexHull2D from './ConvexHull2D.svelte'
@@ -28,7 +29,9 @@
     show_stable = $bindable(true),
     show_unstable = $bindable(true),
     show_hull_faces = $bindable(true),
-    hull_face_opacity = $bindable(0.3),
+    hull_face_opacity: hull_face_opacity_prop = $bindable(
+      undefined as number | undefined,
+    ),
     color_mode = $bindable(`energy`),
     color_scale = $bindable(`interpolateViridis`),
     info_pane_open = $bindable(false),
@@ -69,6 +72,15 @@
   // Detect dimensionality by counting unique elements (lightweight operation)
   const elements = $derived(extract_unique_elements(entries))
   const element_count = $derived(elements.length)
+
+  // Resolve hull face opacity: use caller's value if provided,
+  // otherwise pick the right default for the dimensionality (ternary=30%, quaternary=3%)
+  let hull_face_opacity = $derived(
+    hull_face_opacity_prop ??
+      (element_count === 4
+        ? DEFAULTS.convex_hull.quaternary.hull_face_opacity
+        : DEFAULTS.convex_hull.ternary.hull_face_opacity),
+  )
 
   // Map element count to corresponding component
   // Note: Type assertion needed because TypeScript can't infer that all components

--- a/src/lib/convex-hull/ConvexHull.svelte
+++ b/src/lib/convex-hull/ConvexHull.svelte
@@ -75,15 +75,15 @@
 
   // Resolve hull face opacity: use caller's value if provided,
   // otherwise pick the right default for the dimensionality (ternary=30%, quaternary=3%)
-  // Uses $state + $effect (not $derived) to stay writable for bind:hull_face_opacity
+  // Writable $derived handles forward sync (prop→local), back-sync $effect handles local→prop
   const default_opacity = $derived(
     element_count === 4
       ? DEFAULTS.convex_hull.quaternary.hull_face_opacity
       : DEFAULTS.convex_hull.ternary.hull_face_opacity,
   )
-  let hull_face_opacity = $state(hull_face_opacity_prop ?? default_opacity)
+  let hull_face_opacity = $derived(hull_face_opacity_prop ?? default_opacity)
   $effect(() => {
-    hull_face_opacity = hull_face_opacity_prop ?? default_opacity
+    hull_face_opacity_prop = hull_face_opacity
   })
 
   // Map element count to corresponding component

--- a/src/lib/convex-hull/ConvexHull.svelte
+++ b/src/lib/convex-hull/ConvexHull.svelte
@@ -75,12 +75,16 @@
 
   // Resolve hull face opacity: use caller's value if provided,
   // otherwise pick the right default for the dimensionality (ternary=30%, quaternary=3%)
-  let hull_face_opacity = $derived(
-    hull_face_opacity_prop ??
-      (element_count === 4
-        ? DEFAULTS.convex_hull.quaternary.hull_face_opacity
-        : DEFAULTS.convex_hull.ternary.hull_face_opacity),
+  // Uses $state + $effect (not $derived) to stay writable for bind:hull_face_opacity
+  const default_opacity = $derived(
+    element_count === 4
+      ? DEFAULTS.convex_hull.quaternary.hull_face_opacity
+      : DEFAULTS.convex_hull.ternary.hull_face_opacity,
   )
+  let hull_face_opacity = $state(hull_face_opacity_prop ?? default_opacity)
+  $effect(() => {
+    hull_face_opacity = hull_face_opacity_prop ?? default_opacity
+  })
 
   // Map element count to corresponding component
   // Note: Type assertion needed because TypeScript can't infer that all components

--- a/src/lib/layout/json-tree/JsonNode.svelte
+++ b/src/lib/layout/json-tree/JsonNode.svelte
@@ -409,17 +409,21 @@
     padding: 1px 2px;
     border-radius: 2px;
   }
+  .node-content :where(button) {
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    font: inherit;
+    color: inherit;
+  }
   .collapse-toggle {
     display: inline-flex;
     align-items: center;
     justify-content: center;
     width: 1em;
     height: 1em;
-    padding: 0;
     margin: 0;
-    border: none;
-    background: none;
-    cursor: pointer;
     color: var(--jt-arrow, light-dark(#6e6e6e, #858585));
     flex-shrink: 0;
   }
@@ -441,11 +445,6 @@
   }
   .node-key {
     color: var(--jt-key, light-dark(#001080, #9cdcfe));
-    cursor: pointer;
-    background: none;
-    border: none;
-    padding: 0;
-    font: inherit;
   }
   .node-key:hover {
     text-decoration: underline;
@@ -463,12 +462,7 @@
   .preview {
     color: var(--jt-preview, light-dark(#808080, #808080));
     font-style: italic;
-    cursor: pointer;
     margin: 0 4px;
-    background: none;
-    border: none;
-    padding: 0;
-    font: inherit;
   }
   .preview:hover {
     text-decoration: underline;
@@ -524,9 +518,6 @@
   }
   .collapse-level-btn {
     opacity: 0;
-    background: none;
-    border: none;
-    cursor: pointer;
     padding: 0 2px;
     font-size: 0.85em;
     color: var(--jt-arrow, light-dark(#6e6e6e, #858585));

--- a/src/lib/layout/json-tree/JsonNode.svelte
+++ b/src/lib/layout/json-tree/JsonNode.svelte
@@ -193,7 +193,10 @@
     } else if (
       (event.key === `c` || event.key === `C`) && (event.ctrlKey || event.metaKey)
     ) {
+      // When nodes are selected, let the tree-level handler do bulk copy
+      if (ctx?.selected_paths.size) return
       event.preventDefault()
+      event.stopPropagation()
       ctx?.copy_value(path, value)
     }
   }
@@ -224,7 +227,7 @@
   data-path={path}
   role="treeitem"
   aria-expanded={expandable ? !is_collapsed : undefined}
-  aria-selected={is_focused}
+  aria-selected={is_selected}
   tabindex={is_focused ? 0 : -1}
   onclick={(event) => {
     if (event.ctrlKey || event.metaKey) {
@@ -271,10 +274,10 @@
         tabindex="-1"
         onclick={(event) => {
           event.stopPropagation()
-          if (event.shiftKey) {
+          if (event.ctrlKey || event.metaKey) {
+            ctx?.toggle_select(path, event.shiftKey)
+          } else if (event.shiftKey) {
             ctx?.copy_path(path, event)
-          } else if (event.ctrlKey || event.metaKey) {
-            ctx?.toggle_select(path, false)
           } else if (expandable && is_collapsed) {
             ctx?.toggle_collapse(path, true)
           } else {

--- a/src/lib/layout/json-tree/JsonNode.svelte
+++ b/src/lib/layout/json-tree/JsonNode.svelte
@@ -483,18 +483,27 @@
     background: var(--jt-select-bg, light-dark(#bbdefb, #0a3050));
   }
   .json-node.diff-added > .node-content {
-    background: var(--jt-diff-added, light-dark(#c8e6c9, #1b5e20));
+    background: var(
+      --jt-diff-added,
+      light-dark(rgba(76, 175, 80, 0.15), rgba(76, 175, 80, 0.2))
+    );
   }
   .json-node.diff-removed > .node-content,
   .ghost .node-content {
-    background: var(--jt-diff-removed, light-dark(#ffcdd2, #5e1b1b));
+    background: var(
+      --jt-diff-removed,
+      light-dark(rgba(244, 67, 54, 0.12), rgba(244, 67, 54, 0.18))
+    );
     text-decoration: line-through;
   }
   .json-node.diff-removed > .node-content {
     opacity: 0.7;
   }
   .json-node.diff-changed > .node-content {
-    background: var(--jt-diff-changed, light-dark(#fff9c4, #5e5200));
+    background: var(
+      --jt-diff-changed,
+      light-dark(rgba(255, 193, 7, 0.15), rgba(255, 193, 7, 0.2))
+    );
   }
   .json-node.sticky-header > .node-content {
     position: sticky;

--- a/src/lib/layout/json-tree/JsonTree.svelte
+++ b/src/lib/layout/json-tree/JsonTree.svelte
@@ -853,7 +853,9 @@
             type="button"
             onclick={() =>
             ctx_menu_action((st) =>
-              toggle_collapse_recursive(st.path, !st.is_collapsed)
+              st.is_collapsed
+                ? toggle_collapse_recursive(st.path, false)
+                : collapse_children_only(st.path)
             )}
           >
             {context_menu_state.is_collapsed ? `Expand` : `Collapse`} all children

--- a/src/lib/layout/json-tree/JsonValue.svelte
+++ b/src/lib/layout/json-tree/JsonValue.svelte
@@ -2,7 +2,7 @@
   import { getContext } from 'svelte'
   import type { JsonTreeContext, JsonValueType } from './types'
   import { JSON_TREE_CONTEXT_KEY } from './types'
-  import { format_preview, values_equal } from './utils'
+  import { format_preview, is_css_color, is_url, values_equal } from './utils'
 
   let {
     value,
@@ -48,11 +48,21 @@
     }
   })
 
+  // Auto-detect URLs in string values
+  let url_detected = $derived(value_type === `string` && is_url(value as string))
+
+  // Auto-detect CSS colors in string values
+  let color_detected = $derived(
+    value_type === `string` && is_css_color(value as string)
+      ? (value as string)
+      : null,
+  )
+
   // Handle click to copy
   async function handle_click(event: MouseEvent) {
     event.stopPropagation()
     if (ctx) {
-      await ctx.copy_value(path, value)
+      await ctx.copy_value(path, value, event)
     }
   }
 
@@ -82,6 +92,9 @@
   class="json-value {value_type}"
   class:changed={just_changed}
   onclick={handle_click}
+  oncontextmenu={(event) => {
+    ctx?.show_context_menu(event, path, value, false, false)
+  }}
   onkeydown={(event) => {
     if (event.key === `Enter` || event.key === ` `) {
       event.preventDefault()
@@ -92,7 +105,23 @@
   tabindex="-1"
   title="Click to copy"
 >
-  {display_value}
+  {#if color_detected}
+    <span class="color-swatch" style:background={color_detected}></span>
+  {/if}
+  {#if url_detected}
+    <a
+      href={encodeURI(value as string)}
+      class="url-link"
+      target="_blank"
+      rel="noopener noreferrer"
+      onclick={(event) => event.stopPropagation()}
+      title="Open URL in new tab"
+    >
+      {display_value}
+    </a>
+  {:else}
+    {display_value}
+  {/if}
   {#if is_truncated}
     <button
       type="button"
@@ -201,5 +230,21 @@
     color: var(--jt-type-annotation, light-dark(#808080, #6a6a6a));
     margin-left: 4px;
     opacity: 0.7;
+  }
+  .url-link {
+    color: var(--jt-url, light-dark(#0066cc, #4fc3f7));
+    text-decoration: none;
+  }
+  .url-link:hover {
+    text-decoration: underline;
+  }
+  .color-swatch {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+    border: 1px solid light-dark(rgba(0, 0, 0, 0.2), rgba(255, 255, 255, 0.3));
+    vertical-align: middle;
+    margin-right: 4px;
   }
 </style>

--- a/src/lib/layout/json-tree/JsonValue.svelte
+++ b/src/lib/layout/json-tree/JsonValue.svelte
@@ -48,14 +48,15 @@
     }
   })
 
+  // Trimmed string for URL/color detection (avoids using raw whitespace in href/style)
+  let trimmed_str = $derived(value_type === `string` ? (value as string).trim() : ``)
+
   // Auto-detect URLs in string values
-  let url_detected = $derived(value_type === `string` && is_url(value as string))
+  let url_detected = $derived(value_type === `string` && is_url(trimmed_str))
 
   // Auto-detect CSS colors in string values
   let color_detected = $derived(
-    value_type === `string` && is_css_color(value as string)
-      ? (value as string)
-      : null,
+    value_type === `string` && is_css_color(trimmed_str) ? trimmed_str : null,
   )
 
   // Handle click to copy
@@ -110,7 +111,7 @@
   {/if}
   {#if url_detected}
     <a
-      href={encodeURI(value as string)}
+      href={encodeURI(trimmed_str)}
       class="url-link"
       target="_blank"
       rel="noopener noreferrer"

--- a/src/lib/layout/json-tree/types.ts
+++ b/src/lib/layout/json-tree/types.ts
@@ -51,6 +51,8 @@ export interface JsonTreeProps {
   oncopy?: (path: string, value: string) => void
   // Custom filename for JSON download (default: "data-YYYY-MM-DD.json")
   download_filename?: string
+  // Optional value to diff against - highlights additions, removals, and changes
+  compare_value?: unknown
 }
 
 // Context shared with child components (state + methods)
@@ -78,11 +80,37 @@ export interface JsonTreeContext {
   collapse_all: () => void
   collapse_to_level: (level: number) => void
   set_focused: (path: string | null) => void
-  copy_value: (path: string, value: unknown) => Promise<void>
-  copy_path: (path: string) => Promise<void>
+  copy_value: (path: string, value: unknown, event?: MouseEvent) => Promise<void>
+  copy_path: (path: string, event?: MouseEvent) => Promise<void>
   register_path: (path: string) => void
   unregister_path: (path: string) => void
+  show_context_menu: (
+    event: MouseEvent,
+    path: string,
+    value: unknown,
+    expandable: boolean,
+    is_collapsed: boolean,
+  ) => void
+  pinned_paths: Set<string>
+  toggle_pin: (path: string) => void
+  selected_paths: Set<string>
+  toggle_select: (path: string, shift: boolean) => void
+  copy_selected: () => void
+  diff_map: Map<string, DiffEntry> | null
+  ghost_map: Map<string, import('./utils').GhostEntry[]>
+  collapse_children_only: (path: string) => void
 }
 
 // Context key for Svelte's setContext/getContext
 export const JSON_TREE_CONTEXT_KEY = Symbol(`json-tree-context`)
+
+// Diff status for comparing two JSON values
+export type DiffStatus = `added` | `removed` | `changed`
+
+// Single entry in a diff result (one path that differs between old and new)
+export interface DiffEntry {
+  status: DiffStatus
+  path: string
+  old_value?: unknown
+  new_value?: unknown
+}

--- a/src/lib/layout/json-tree/utils.ts
+++ b/src/lib/layout/json-tree/utils.ts
@@ -1,5 +1,5 @@
 // JSON Tree utility functions
-import type { JsonValueType } from './types'
+import type { DiffEntry, JsonValueType } from './types'
 
 // Pre-compiled regex for valid JS identifiers (used in path formatting)
 const VALID_IDENTIFIER_RE = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/
@@ -413,4 +413,244 @@ export function values_equal(val_a: unknown, val_b: unknown): boolean {
   }
 
   return false
+}
+
+// URL regex for auto-detection in string values
+const URL_RE = /^https?:\/\/\S+$/
+
+// CSS color patterns for swatch rendering
+const HEX_COLOR_RE = /^#(?:[0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i
+const FUNC_COLOR_RE = /^(?:rgba?|hsla?|oklch|oklab|lch|lab|color)\([^)]*\)$/i
+
+// Check if a string is a URL
+export function is_url(str: string): boolean {
+  return URL_RE.test(str.trim())
+}
+
+// Check if a string looks like a CSS color value
+// Rejects strings with semicolons to prevent CSS injection
+export function is_css_color(str: string): boolean {
+  const trimmed = str.trim()
+  if (trimmed.includes(`;`)) return false
+  return HEX_COLOR_RE.test(trimmed) || FUNC_COLOR_RE.test(trimmed)
+}
+
+// Estimate the serialized byte size of a value (rough approximation)
+// Uses max_depth to avoid expensive deep recursion on large trees
+export function estimate_byte_size(
+  value: unknown,
+  max_depth: number = 4,
+  current_depth: number = 0,
+): number {
+  if (current_depth >= max_depth) return 10
+  const type = get_value_type(value)
+  if (type === `null`) return 4
+  if (type === `undefined`) return 9
+  if (type === `boolean`) return value ? 4 : 5
+  if (type === `number` || type === `bigint`) return String(value).length
+  if (type === `string`) return (value as string).length + 2
+  if (type === `symbol`) return (value as symbol).toString().length
+  if (type === `function`) return 20
+  if (type === `date`) return 24
+  if (type === `regexp`) return (value as RegExp).toString().length
+  if (type === `error`) {
+    return `${(value as Error).name}: ${(value as Error).message}`.length
+  }
+  if (type === `array`) {
+    let size = 2
+    for (const item of value as unknown[]) {
+      size += estimate_byte_size(item, max_depth, current_depth + 1) + 1
+    }
+    return size
+  }
+  if (type === `object`) {
+    let size = 2
+    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+      size += key.length + 4 + estimate_byte_size(val, max_depth, current_depth + 1)
+    }
+    return size
+  }
+  if (type === `map`) {
+    let size = 2
+    for (const [, val] of value as Map<unknown, unknown>) {
+      size += estimate_byte_size(val, max_depth, current_depth + 1) + 10
+    }
+    return size
+  }
+  if (type === `set`) {
+    let size = 2
+    for (const val of value as Set<unknown>) {
+      size += estimate_byte_size(val, max_depth, current_depth + 1) + 1
+    }
+    return size
+  }
+  return String(value).length
+}
+
+// Ghost entry for removed diff children
+export interface GhostEntry {
+  key: string | number
+  value: unknown
+  path: string
+}
+
+// Pre-compute a map of parent_path -> removed children from a diff map
+// This avoids O(diff_size) iteration per expanded node
+export function build_ghost_map(
+  diff_map: Map<string, DiffEntry>,
+): Map<string, GhostEntry[]> {
+  const ghost_map = new Map<string, GhostEntry[]>()
+  for (const [diff_path, entry] of diff_map) {
+    if (entry.status !== `removed`) continue
+    const segments = parse_path(diff_path)
+    if (segments.length === 0) continue
+    const parent_path = segments.length === 1 ? `` : format_path(segments.slice(0, -1))
+    const key = segments[segments.length - 1]
+    const ghosts = ghost_map.get(parent_path) ?? []
+    ghosts.push({ key, value: entry.old_value, path: diff_path })
+    ghost_map.set(parent_path, ghosts)
+  }
+  return ghost_map
+}
+
+// Format byte size as human-readable string (e.g., "1.2 KB")
+export function format_byte_size(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+// Compute diff between old and new values, returning path -> DiffEntry map
+// Only paths that differ are included (unchanged paths are omitted)
+export function compute_diff(
+  old_val: unknown,
+  new_val: unknown,
+  current_path: string = ``,
+  result: Map<string, DiffEntry> = new Map(),
+  seen: WeakSet<object> = new WeakSet(),
+): Map<string, DiffEntry> {
+  const old_type = get_value_type(old_val)
+  const new_type = get_value_type(new_val)
+
+  // Different types = changed
+  if (old_type !== new_type) {
+    result.set(current_path, {
+      status: `changed`,
+      path: current_path,
+      old_value: old_val,
+      new_value: new_val,
+    })
+    return result
+  }
+
+  // Both primitive: compare values (with NaN === NaN special case)
+  if (is_primitive_type(old_type)) {
+    const both_nan = typeof old_val === `number` && typeof new_val === `number` &&
+      Number.isNaN(old_val) && Number.isNaN(new_val)
+    if (!both_nan && old_val !== new_val) {
+      result.set(current_path, {
+        status: `changed`,
+        path: current_path,
+        old_value: old_val,
+        new_value: new_val,
+      })
+    }
+    return result
+  }
+
+  // Non-expandable special types (date, regexp, etc): compare string forms
+  if (!is_expandable_type(old_type)) {
+    if (String(old_val) !== String(new_val)) {
+      result.set(current_path, {
+        status: `changed`,
+        path: current_path,
+        old_value: old_val,
+        new_value: new_val,
+      })
+    }
+    return result
+  }
+
+  // Prevent circular references
+  if (typeof old_val === `object` && old_val !== null) {
+    if (seen.has(old_val)) return result
+    seen.add(old_val)
+  }
+
+  // Diff two indexed lists element-by-element (shared by array, map, set)
+  function diff_indexed(old_items: unknown[], new_items: unknown[]): void {
+    const max_len = Math.max(old_items.length, new_items.length)
+    for (let idx = 0; idx < max_len; idx++) {
+      const child_path = build_path(current_path, idx)
+      if (idx >= old_items.length) {
+        result.set(child_path, {
+          status: `added`,
+          path: child_path,
+          new_value: new_items[idx],
+        })
+      } else if (idx >= new_items.length) {
+        result.set(child_path, {
+          status: `removed`,
+          path: child_path,
+          old_value: old_items[idx],
+        })
+      } else {
+        compute_diff(old_items[idx], new_items[idx], child_path, result, seen)
+      }
+    }
+  }
+
+  if (old_type === `array`) {
+    diff_indexed(old_val as unknown[], new_val as unknown[])
+    return result
+  }
+
+  // Objects: compare key sets and recurse
+  if (old_type === `object`) {
+    const old_obj = old_val as Record<string, unknown>
+    const new_obj = new_val as Record<string, unknown>
+    const all_keys = new Set([...Object.keys(old_obj), ...Object.keys(new_obj)])
+    for (const key of all_keys) {
+      const child_path = build_path(current_path, key)
+      const in_old = key in old_obj
+      const in_new = key in new_obj
+      if (!in_old) {
+        result.set(child_path, {
+          status: `added`,
+          path: child_path,
+          new_value: new_obj[key],
+        })
+      } else if (!in_new) {
+        result.set(child_path, {
+          status: `removed`,
+          path: child_path,
+          old_value: old_obj[key],
+        })
+      } else {
+        compute_diff(old_obj[key], new_obj[key], child_path, result, seen)
+      }
+    }
+    return result
+  }
+
+  // Maps: wrap entries as { key, value } to match JsonNode.get_children() rendering
+  if (old_type === `map`) {
+    diff_indexed(
+      Array.from((old_val as Map<unknown, unknown>).entries()).map(([key, val]) => ({
+        key,
+        value: val,
+      })),
+      Array.from((new_val as Map<unknown, unknown>).entries()).map(([key, val]) => ({
+        key,
+        value: val,
+      })),
+    )
+    return result
+  }
+  if (old_type === `set`) {
+    diff_indexed(Array.from(old_val as Set<unknown>), Array.from(new_val as Set<unknown>))
+    return result
+  }
+
+  return result
 }

--- a/src/lib/layout/json-tree/utils.ts
+++ b/src/lib/layout/json-tree/utils.ts
@@ -456,32 +456,30 @@ export function estimate_byte_size(
   if (type === `error`) {
     return `${(value as Error).name}: ${(value as Error).message}`.length
   }
+  // Accumulate child sizes for collection types
+  const child_depth = current_depth + 1
+  const child_size = (val: unknown, overhead: number = 1) =>
+    estimate_byte_size(val, max_depth, child_depth) + overhead
   if (type === `array`) {
     let size = 2
-    for (const item of value as unknown[]) {
-      size += estimate_byte_size(item, max_depth, current_depth + 1) + 1
-    }
+    for (const item of value as unknown[]) size += child_size(item)
     return size
   }
   if (type === `object`) {
     let size = 2
     for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
-      size += key.length + 4 + estimate_byte_size(val, max_depth, current_depth + 1)
+      size += key.length + 4 + child_size(val, 0)
     }
     return size
   }
   if (type === `map`) {
     let size = 2
-    for (const [, val] of value as Map<unknown, unknown>) {
-      size += estimate_byte_size(val, max_depth, current_depth + 1) + 10
-    }
+    for (const [, val] of value as Map<unknown, unknown>) size += child_size(val, 10)
     return size
   }
   if (type === `set`) {
     let size = 2
-    for (const val of value as Set<unknown>) {
-      size += estimate_byte_size(val, max_depth, current_depth + 1) + 1
-    }
+    for (const val of value as Set<unknown>) size += child_size(val)
     return size
   }
   return String(value).length

--- a/src/lib/table/ToggleMenu.svelte
+++ b/src/lib/table/ToggleMenu.svelte
@@ -320,6 +320,18 @@
     align-items: center;
     gap: 4px;
     margin-bottom: 4pt;
+    padding: 2pt 4pt;
+    border-radius: var(--tgl-border-radius, 3pt);
+    background: var(
+      --tgl-section-header-bg,
+      color-mix(in srgb, currentColor 5%, transparent)
+    );
+    &:hover {
+      background: var(
+        --tgl-section-header-hover-bg,
+        color-mix(in srgb, currentColor 12%, transparent)
+      );
+    }
   }
   .reset-section-btn {
     display: flex;
@@ -344,23 +356,14 @@
     gap: 4px;
     font-weight: 600;
     font-size: 0.9em;
-    padding: 2pt 4pt;
+    padding: 0;
     border: none;
-    border-radius: var(--tgl-border-radius, 3pt);
-    background: var(
-      --tgl-section-header-bg,
-      color-mix(in srgb, currentColor 5%, transparent)
-    );
+    border-radius: 0;
+    background: transparent;
     cursor: pointer;
     flex: 1;
     text-align: left;
     color: inherit;
-    &:hover {
-      background: var(
-        --tgl-section-header-hover-bg,
-        color-mix(in srgb, currentColor 12%, transparent)
-      );
-    }
   }
   .collapse-icon {
     font-size: 0.7em;

--- a/src/lib/table/ToggleMenu.svelte
+++ b/src/lib/table/ToggleMenu.svelte
@@ -167,21 +167,24 @@
 >
   <summary aria-expanded={column_panel_open}>
     Columns <Icon icon="Columns" />
+    {#if has_any_changes}
+      <button
+        class="reset-btn"
+        onclick={(event) => {
+          event.stopPropagation()
+          event.preventDefault()
+          reset_all()
+        }}
+        type="button"
+        {@attach tooltip({ content: `Reset all columns to defaults` })}
+      >
+        <Icon icon="Reset" width="12px" />
+      </button>
+    {/if}
   </summary>
 
   {#if has_sections}
     <div class="sections-container" role="group">
-      {#if has_any_changes}
-        <button
-          class="reset-all-btn"
-          onclick={reset_all}
-          type="button"
-          {@attach tooltip({ content: `Reset all columns to defaults` })}
-        >
-          <Icon icon="Reset" width="14px" />
-          Reset all
-        </button>
-      {/if}
       {#each sections as section (section.name)}
         {@const is_collapsed = section.name !== `` &&
         collapsed_sections.includes(section.name)}
@@ -199,11 +202,8 @@
               </button>
               {#if section.items.some(is_changed)}
                 <button
-                  class="reset-section-btn"
-                  onclick={(event) => {
-                    event.stopPropagation()
-                    reset_section(section.name)
-                  }}
+                  class="reset-btn"
+                  onclick={() => reset_section(section.name)}
                   type="button"
                   {@attach tooltip({ content: `Reset ${section.name} to defaults` })}
                 >
@@ -228,18 +228,6 @@
     </div>
   {:else}
     <div class="column-menu" role="group" style:grid-template-columns={grid_template}>
-      {#if has_any_changes}
-        <button
-          class="reset-all-btn"
-          onclick={reset_all}
-          type="button"
-          {@attach tooltip({ content: `Reset all columns to defaults` })}
-          style="grid-column: 1 / -1"
-        >
-          <Icon icon="Reset" width="14px" />
-          Reset all
-        </button>
-      {/if}
       {#each columns as col, idx (col.key ?? col.label ?? idx)}
         {@render toggle_item(col)}
       {/each}
@@ -297,23 +285,25 @@
     flex-direction: column;
     gap: 8px;
   }
-  .reset-all-btn {
+  .reset-btn {
     display: flex;
     align-items: center;
-    gap: 4px;
-    padding: 2pt 6pt;
-    margin-bottom: 4pt;
-    border: 1px solid color-mix(in srgb, currentColor 20%, transparent);
+    justify-content: center;
+    padding: 2pt;
+    border: none;
     border-radius: var(--tgl-border-radius, 3pt);
-    background: color-mix(in srgb, currentColor 5%, transparent);
+    background: transparent;
     cursor: pointer;
-    font-size: 0.85em;
     color: inherit;
-    opacity: 0.8;
+    opacity: 0.5;
+    flex-shrink: 0;
     &:hover {
       background: color-mix(in srgb, currentColor 12%, transparent);
       opacity: 1;
     }
+  }
+  summary .reset-btn {
+    margin-left: auto;
   }
   .section-header-row {
     display: flex;
@@ -333,23 +323,6 @@
       );
     }
   }
-  .reset-section-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 2pt;
-    border: none;
-    border-radius: var(--tgl-border-radius, 3pt);
-    background: transparent;
-    cursor: pointer;
-    color: inherit;
-    opacity: 0.5;
-    flex-shrink: 0;
-    &:hover {
-      background: color-mix(in srgb, currentColor 12%, transparent);
-      opacity: 1;
-    }
-  }
   .section-header {
     display: flex;
     align-items: center;
@@ -358,7 +331,6 @@
     font-size: 0.9em;
     padding: 0;
     border: none;
-    border-radius: 0;
     background: transparent;
     cursor: pointer;
     flex: 1;

--- a/src/routes/(demos)/layout/json-tree/+page.md
+++ b/src/routes/(demos)/layout/json-tree/+page.md
@@ -5,23 +5,7 @@ title: JsonTree
 <script lang="ts">
   import { JsonTree } from '$lib'
 
-  // Example 1: Simple config-like data
-  const config_data = {
-    name: "my-app",
-    version: "2.1.0",
-    private: true,
-    scripts: {
-      dev: "vite dev",
-      build: "vite build",
-      test: "vitest run"
-    },
-    dependencies: {
-      svelte: "^5.0.0",
-      vite: "^6.0.0"
-    }
-  }
-
-  // Example 2: API response with nested data
+  // API response with nested data
   const api_response = {
     status: "success",
     data: {
@@ -35,7 +19,7 @@ title: JsonTree
     }
   }
 
-  // Example 3: Scientific/materials data (large)
+  // Scientific/materials data (large)
   const materials_data = {
     formula: "Fe2O3",
     material_id: "mp-19770",
@@ -63,7 +47,7 @@ title: JsonTree
     }
   }
 
-  // Example 4: All data types showcase
+  // All data types showcase
   const all_types = {
     string: "Hello, World!",
     number: 42,
@@ -89,50 +73,45 @@ title: JsonTree
     special_numbers: { infinity: Infinity, neg_infinity: -Infinity, nan: NaN },
   }
 
-  // Example: Edge cases
+  // Edge cases including URL/color auto-detection
   const edge_cases = {
-    // Very long strings that wrap
-    long_paragraph: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
-    single_long_word: "supercalifragilisticexpialidocious".repeat(5),
-    // Multiline strings
+    // URLs auto-linked, CSS colors get swatches
+    urls: {
+      website: "https://github.com/janosh/matterviz",
+      api: "https://api.example.com/v2/materials?page=1&limit=100#section",
+      not_a_url: "just a regular string",
+    },
+    colors: {
+      hex: "#3b82f6",
+      rgb: "rgb(139, 92, 246)",
+      hsl: "hsl(330, 80%, 60%)",
+      oklch: "oklch(0.8 0.15 85)",
+      transparent: "rgba(0, 0, 0, 0.5)",
+      not_a_color: "blue sky",
+    },
+    // Long strings, special chars, unicode
+    long_paragraph: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
     multiline: "First line\nSecond line\nThird line with\ttab",
-    code_snippet: "function hello() {\n  console.log('world');\n  return 42;\n}",
-    // Special characters
     "key.with.dots": "dot notation won't work here",
     "key with spaces": "needs bracket notation",
     'key"with"quotes': "escaped in paths",
-    "key/with/slashes": "common in URLs",
     "émojis_🎉_work": "unicode keys supported",
-    // Unicode content
     unicode_text: "日本語テキスト • Ελληνικά • العربية",
-    emojis: "🚀 🎨 🔧 💡 ⚡ 🌈 🎯 🔥",
+    emojis: "🚀 🎨 🔧 💡 ⚡ 🌈",
     math_symbols: "∑∏∫∂∇ε δ→∞ √π ≈ ≠ ≤ ≥",
-    // Numbers edge cases
+    // Number edge cases
     huge_number: 9999999999999999999999n,
-    tiny_float: 0.000000000001,
     scientific: 6.022e23,
-    // URLs and paths
-    url: "https://example.com/api/v2/users?page=1&limit=100#section",
-    file_path: "/Users/developer/projects/my-app/src/components/Button.svelte",
-    // Base64-like data
-    base64: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ",
-    // Keys that look like numbers
-    "123": "numeric-looking string key",
-    "0": "zero as key",
-    "-1": "negative as key",
-    // Deeply nested mixed types
+    // Nested collections
     nested_collections: new Map([
       ["set_value", new Set([{ inner: [1, 2, 3] }])],
       ["map_value", new Map([["deep", { very: { deep: true } }]])]
     ]),
-    // Edge case values
     empty_string: "",
-    whitespace_only: "   \t\n   ",
     html_content: "<div class='test'><span>HTML &amp; entities</span></div>",
-    json_string: '{"escaped": "json", "inside": ["a", "string"]}',
   }
 
-  // Example 5: Large dataset for performance
+  // Large dataset for performance
   const large_dataset = {
     metadata: { generated: new Date().toISOString(), count: 100 },
     items: Array.from({ length: 100 }, (_, i) => ({
@@ -144,22 +123,20 @@ title: JsonTree
     }))
   }
 
-  // Example 6: Deeply nested structure
-  const deep_structure = {
-    level_0: {
-      level_1: {
-        level_2: {
-          level_3: {
-            level_4: {
-              level_5: {
-                deep_value: "You found me!",
-                siblings: ["a", "b", "c"]
-              }
-            }
-          }
-        }
-      }
-    }
+  // Diff mode (old vs new data)
+  const old_config = {
+    name: "my-app",
+    version: "1.0.0",
+    port: 3000,
+    features: { auth: true, logging: false, cache_ttl: 300, deprecated_flag: true },
+    plugins: ["svelte", "tailwind"],
+  }
+  const new_config = {
+    name: "my-app",
+    version: "2.0.0",
+    port: 8080,
+    features: { auth: true, logging: true, cache_ttl: 600, dark_mode: true },
+    plugins: ["svelte", "tailwind", "mdsvex"],
   }
 
   // Dynamic data for change highlighting
@@ -186,7 +163,7 @@ title: JsonTree
   }
 </script>
 
-A fully-featured JSON tree viewer with folding, search, copy, keyboard navigation, and change highlighting.
+A fully-featured JSON tree viewer with folding, search, copy, keyboard navigation, diff mode, and change highlighting.
 
 ## Quick Start
 
@@ -201,45 +178,41 @@ A fully-featured JSON tree viewer with folding, search, copy, keyboard navigatio
 
 ## Examples
 
-### Config File
-
-<JsonTree value={config_data} default_fold_level={3} />
-
 ### API Response with Search
 
-Search for "alice", "admin", or "editor" to filter results:
+Search for "alice", "admin", or "editor". Right-click any node for the context menu. Ctrl+click to select, Shift+click a key to copy its path:
 
 <JsonTree value={api_response} default_fold_level={4} />
 
-### Scientific Data (Materials)
+### Scientific Data
 
-Large nested structure with arrays of objects:
+Large nested structure. Note the **size annotations** on collapsed nodes, **sticky headers** as you scroll, and the **⊟ button** on hover to collapse children:
 
 <JsonTree value={materials_data} default_fold_level={2} auto_fold_arrays={5} />
 
 ### All Supported Data Types
 
-Every JavaScript type rendered correctly:
+Every JavaScript type rendered correctly with type annotations:
 
 <JsonTree value={all_types} default_fold_level={1} show_data_types={true} />
 
-### Edge Cases
+### Edge Cases, URLs & Colors
 
-Long strings, special characters, unicode, and nested collections:
+URLs render as clickable links. CSS color strings show inline swatches. Special characters and unicode in keys and values:
 
-<JsonTree value={edge_cases} default_fold_level={1} />
+<JsonTree value={edge_cases} default_fold_level={2} />
 
 ### Large Dataset (100 items)
 
-Performance test with auto-folding:
+Performance test with auto-folding. Use the level buttons (1, 2, 3) to control depth:
 
 <JsonTree value={large_dataset} default_fold_level={2} auto_fold_arrays={20} />
 
-### Deep Nesting with Level Controls
+### Diff Mode
 
-Use the level buttons (1, 2, 3) to control expansion depth:
+Pass `compare_value` to highlight additions (green), changes (yellow), and removals (red strikethrough):
 
-<JsonTree value={deep_structure} default_fold_level={2} />
+<JsonTree value={new_config} compare_value={old_config} default_fold_level={5} />
 
 ### Change Highlighting
 
@@ -268,48 +241,62 @@ onselect={handle_select}
 oncopy={handle_copy}
 />
 
-### Sorted Keys
+### Prop Variants
 
-Alphabetically sorted object keys:
+Sorted keys, custom root label, and headerless mode:
 
-<JsonTree value={{ zebra: 1, apple: 2, mango: 3, banana: 4, cherry: 5 }} sort_keys={true} show_header={false} />
-
-### Custom Root Label
+<JsonTree value={{ zebra: 1, apple: 2, mango: 3, banana: 4 }} sort_keys={true} show_header={false} />
 
 <JsonTree value={["red", "green", "blue"]} root_label="colors" show_header={false} />
 
-### Minimal (No Header)
-
 <JsonTree value={{ compact: true, clean: "display" }} show_header={false} />
+
+## Interactions
+
+All built-in — no props needed:
+
+- **Right-click** any node → context menu with Copy value, Copy path, Expand/Collapse children, Pin path
+- **Click a closed key** → expands it. **Click an open key** → copies value
+- **Shift+click** or **middle-click** any key → copies the path
+- **Ctrl+click** nodes to select (blue highlight), **Ctrl+Shift+click** for range select
+- **Ctrl+C** with selection → copies all selected values. **Escape** clears
+- **Hover** a key → shows `▸` expand hint or clipboard icon
+- **⊟ button** on hover → collapses children while keeping node open
+- **Pinned paths** panel appears between header and content after pinning via context menu
 
 ## Keyboard Navigation
 
-| Key         | Action                          |
-| ----------- | ------------------------------- |
-| ↓/↑         | Navigate between nodes          |
-| →           | Expand node or move to child    |
-| ←           | Collapse node or move to parent |
-| Enter/Space | Toggle collapse                 |
-| Ctrl+C      | Copy focused value              |
+| Key             | Action                                      |
+| --------------- | ------------------------------------------- |
+| ↓/↑             | Navigate between nodes                      |
+| →               | Expand node or move to child                |
+| ←               | Collapse node or move to parent             |
+| Enter/Space     | Toggle collapse (expandable) or copy (leaf) |
+| Ctrl/Cmd+C      | Copy focused value (or all selected)        |
+| Ctrl/Cmd+click  | Toggle node selection                       |
+| Shift+click key | Copy path to clipboard                      |
+| Escape          | Close context menu, then clear selection    |
 
 ## Props Reference
 
-| Prop                 | Type                    | Default     | Description                            |
-| -------------------- | ----------------------- | ----------- | -------------------------------------- |
-| `value`              | `unknown`               | required    | Data to display                        |
-| `root_label`         | `string`                | -           | Label for root node                    |
-| `default_fold_level` | `number`                | `2`         | Initial expansion depth                |
-| `auto_fold_arrays`   | `number`                | `10`        | Auto-collapse arrays larger than this  |
-| `auto_fold_objects`  | `number`                | `20`        | Auto-collapse objects larger than this |
-| `collapsed_paths`    | `Set<string>`           | `new Set()` | Bindable collapse state                |
-| `show_header`        | `boolean`               | `true`      | Show search/controls                   |
-| `show_data_types`    | `boolean`               | `false`     | Show type annotations                  |
-| `show_array_indices` | `boolean`               | `true`      | Show array indices                     |
-| `sort_keys`          | `boolean`               | `false`     | Alphabetize keys                       |
-| `max_string_length`  | `number`                | `200`       | Truncate long strings                  |
-| `highlight_changes`  | `boolean`               | `true`      | Flash on value change                  |
-| `onselect`           | `(path, value) => void` | -           | Node click callback                    |
-| `oncopy`             | `(path, value) => void` | -           | Copy callback                          |
+| Prop                 | Type                    | Default     | Description                                          |
+| -------------------- | ----------------------- | ----------- | ---------------------------------------------------- |
+| `value`              | `unknown`               | required    | Data to display                                      |
+| `root_label`         | `string`                | -           | Label for root node                                  |
+| `default_fold_level` | `number`                | `2`         | Initial expansion depth                              |
+| `auto_fold_arrays`   | `number`                | `10`        | Auto-collapse arrays larger than this                |
+| `auto_fold_objects`  | `number`                | `20`        | Auto-collapse objects larger than this               |
+| `collapsed_paths`    | `Set<string>`           | `new Set()` | Bindable collapse state                              |
+| `show_header`        | `boolean`               | `true`      | Show search/controls                                 |
+| `show_data_types`    | `boolean`               | `false`     | Show type annotations                                |
+| `show_array_indices` | `boolean`               | `true`      | Show array indices                                   |
+| `sort_keys`          | `boolean`               | `false`     | Alphabetize keys                                     |
+| `max_string_length`  | `number`                | `200`       | Truncate long strings                                |
+| `highlight_changes`  | `boolean`               | `true`      | Flash on value change                                |
+| `compare_value`      | `unknown`               | -           | Diff against this value (shows adds/removes/changes) |
+| `onselect`           | `(path, value) => void` | -           | Node click callback                                  |
+| `oncopy`             | `(path, value) => void` | -           | Copy callback                                        |
+| `download_filename`  | `string`                | auto        | Custom filename for JSON download                    |
 
 ## CSS Customization
 

--- a/tests/vitest/table/ToggleMenu.svelte.test.ts
+++ b/tests/vitest/table/ToggleMenu.svelte.test.ts
@@ -266,12 +266,12 @@ describe(`ToggleMenu`, () => {
       mount_menu(columns, { column_panel_open: true })
 
       // Initially col2 is visible=false which matches default, no changes
-      expect(document.querySelector(`.reset-all-btn`)).toBeNull()
+      expect(document.querySelector(`summary .reset-btn`)).toBeNull()
 
       // Toggle col1 off (differs from default)
       document.querySelectorAll(`label`)[0].click()
       await tick()
-      expect(document.querySelector(`.reset-all-btn`)).not.toBeNull()
+      expect(document.querySelector(`summary .reset-btn`)).not.toBeNull()
     })
 
     it(`reset all restores checkboxes to default state`, async () => {
@@ -283,14 +283,14 @@ describe(`ToggleMenu`, () => {
         document.querySelectorAll<HTMLInputElement>(`input[type="checkbox"]`)
       expect(checkboxes()[0].checked).toBe(false) // was toggled off
        // Click reset all
-      ;(document.querySelector(`.reset-all-btn`) as HTMLElement).click()
+      ;(document.querySelector(`summary .reset-btn`) as HTMLElement).click()
       await tick()
 
       // Checkboxes should be back to defaults: true, false, true
       expect(checkboxes()[0].checked).toBe(true)
       expect(checkboxes()[1].checked).toBe(false)
       expect(checkboxes()[2].checked).toBe(true)
-      expect(document.querySelector(`.reset-all-btn`)).toBeNull() // no more changes
+      expect(document.querySelector(`summary .reset-btn`)).toBeNull() // no more changes
     })
 
     it(`calls on_reset callback when reset all clicked`, async () => {
@@ -301,7 +301,7 @@ describe(`ToggleMenu`, () => {
       // Toggle col1 off then reset
       document.querySelectorAll(`label`)[0].click()
       await tick()
-      ;(document.querySelector(`.reset-all-btn`) as HTMLElement).click()
+      ;(document.querySelector(`summary .reset-btn`) as HTMLElement).click()
       await tick()
 
       expect(on_reset).toHaveBeenCalledWith()
@@ -316,14 +316,14 @@ describe(`ToggleMenu`, () => {
       mount_menu(grouped, { column_panel_open: true })
 
       // No changes yet
-      expect(document.querySelector(`.reset-section-btn`)).toBeNull()
+      expect(document.querySelector(`.section-header-row .reset-btn`)).toBeNull()
 
       // Toggle first column off
       document.querySelectorAll(`label`)[0].click()
       await tick()
 
       // Section reset button appears for G1 only
-      const section_btns = document.querySelectorAll(`.reset-section-btn`)
+      const section_btns = document.querySelectorAll(`.section-header-row .reset-btn`)
       expect(section_btns).toHaveLength(1)
     })
 
@@ -343,7 +343,7 @@ describe(`ToggleMenu`, () => {
 
       expect(checkboxes()[0].checked).toBe(false)
       expect(checkboxes()[1].checked).toBe(false) // Reset G1 section only (first reset-section-btn corresponds to G1)
-      ;(document.querySelector(`.reset-section-btn`) as HTMLElement).click()
+      ;(document.querySelector(`.section-header-row .reset-btn`) as HTMLElement).click()
       await tick()
 
       expect(checkboxes()[0].checked).toBe(true) // G1 restored


### PR DESCRIPTION
Comprehensive UX overhaul of the JsonTree component suite with 12 new features:

- **Click-to-expand keys**: clicking a closed key expands it; clicking an open key copies its value to clipboard (previously only the triangle toggled)
- **Right-click context menu**: Copy value, Copy path, Expand/Collapse all children, Pin/Unpin path
- **Hover action hints**: shows ▸ (expand) or clipboard icon on key hover to indicate what clicking will do
- **URL and color detection**: string values matching URLs render as clickable links; CSS color strings show a colored swatch
- **Sticky parent keys**: expanded nodes at depth ≤ 2 use `position: sticky` so parent context stays visible while scrolling
- **Shift+click / middle-click**: copies the path to clipboard (since regular click now copies value)
- **Inline copy feedback**: "Copied!" toast appears near the click location instead of a fixed corner position
- **Keyboard shortcut hints**: tooltips now show "Click to expand · Shift+click: copy path · Ctrl+click: select"
- **Collapse-to-level button**: ⊟ button on hover collapses all descendants but keeps the node itself expanded
- **Byte size annotation**: collapsed previews show estimated serialized size (e.g., "1.2 KB")
- **Multi-select + bulk copy**: Ctrl+click to select nodes, Ctrl+Shift+click for range, Ctrl+C to copy all, Escape to clear
- **Pin/bookmark panel**: pinned paths appear in a panel with value preview and one-click copy
- **Diff mode**: `compare_value` prop highlights added (green), removed (red strikethrough), and changed (yellow) entries with ghost nodes for removed keys

Also includes:
- Auto-select hull face opacity based on dimensionality (quaternary 3% vs ternary 30%)
- Move hover styling from ToggleMenu section button to entire header row