### PR TITLE
Add side-by-side layout mode to ConvexHullStats

### DIFF
--- a/extensions/rust/src/io.rs
+++ b/extensions/rust/src/io.rs
@@ -4876,7 +4876,7 @@ Fe 2.0 2.0 2.0
             // Ba should be dominant (0.88)
             assert_eq!(site.dominant_species().element, Element::Ba);
             // Total occupancy should be 0.06 + 0.88 + 0.05 + 0.01 = 1.0
-            let total: f64 = site.species.iter().map(|(_, o)| o).sum();
+            let total: f64 = site.species.iter().map(|(_, occ)| occ).sum();
             assert!(
                 (total - 1.0).abs() < 1e-10,
                 "occupancies should sum to 1.0, got {total}"

--- a/extensions/rust/src/io.rs
+++ b/extensions/rust/src/io.rs
@@ -396,9 +396,10 @@ pub fn parse_structure_json_with_merge_tol(json: &str, merge_tol: f64) -> Result
     let mut merged_occupancies: Vec<SiteOccupancy> = Vec::new();
     let mut merged_coords: Vec<Vector3<f64>> = Vec::new();
 
-    // Minimum-image distance for fractional coordinates in [0, 1)
+    // Minimum-image distance for fractional coordinates, handles wrapping
+    // so coords outside [0, 1) (e.g. -0.1 or 1.5) are compared correctly
     let periodic_dist = |a: f64, b: f64| -> f64 {
-        let diff = (a - b).abs();
+        let diff = (a - b).rem_euclid(1.0);
         diff.min(1.0 - diff)
     };
 

--- a/extensions/rust/src/io.rs
+++ b/extensions/rust/src/io.rs
@@ -396,12 +396,18 @@ pub fn parse_structure_json_with_merge_tol(json: &str, merge_tol: f64) -> Result
     let mut merged_occupancies: Vec<SiteOccupancy> = Vec::new();
     let mut merged_coords: Vec<Vector3<f64>> = Vec::new();
 
+    // Minimum-image distance for fractional coordinates in [0, 1)
+    let periodic_dist = |a: f64, b: f64| -> f64 {
+        let diff = (a - b).abs();
+        diff.min(1.0 - diff)
+    };
+
     for (occ, coord) in site_occupancies.into_iter().zip(frac_coords.into_iter()) {
-        // Check if this coordinate already exists in merged list
+        // Check if this coordinate already exists in merged list (periodic-aware)
         let existing_idx = merged_coords.iter().position(|existing| {
-            (existing.x - coord.x).abs() < merge_tol
-                && (existing.y - coord.y).abs() < merge_tol
-                && (existing.z - coord.z).abs() < merge_tol
+            periodic_dist(existing.x, coord.x) < merge_tol
+                && periodic_dist(existing.y, coord.y) < merge_tol
+                && periodic_dist(existing.z, coord.z) < merge_tol
         });
 
         if let Some(idx) = existing_idx {

--- a/extensions/rust/src/io.rs
+++ b/extensions/rust/src/io.rs
@@ -4807,11 +4807,7 @@ Fe 2.0 2.0 2.0
         // It should contain both species
         assert_eq!(structure.site_occupancies[0].species.len(), 2);
         // Total occupancy at merged site
-        let total_occ: f64 = structure.site_occupancies[0]
-            .species
-            .iter()
-            .map(|(_, occ)| occ)
-            .sum();
+        let total_occ = structure.site_occupancies[0].total_occupancy();
         assert!(
             (total_occ - 1.0).abs() < 1e-10,
             "occupancies should sum to 1.0"
@@ -4883,7 +4879,7 @@ Fe 2.0 2.0 2.0
             // Ba should be dominant (0.88)
             assert_eq!(site.dominant_species().element, Element::Ba);
             // Total occupancy should be 0.06 + 0.88 + 0.05 + 0.01 = 1.0
-            let total: f64 = site.species.iter().map(|(_, occ)| occ).sum();
+            let total = site.total_occupancy();
             assert!(
                 (total - 1.0).abs() < 1e-10,
                 "occupancies should sum to 1.0, got {total}"
@@ -4920,10 +4916,7 @@ Fe 2.0 2.0 2.0
 
         // Verify no overlapping Cartesian coordinates
         let coords = structure.cart_coords();
-        let dist = ((coords[0].x - coords[1].x).powi(2)
-            + (coords[0].y - coords[1].y).powi(2)
-            + (coords[0].z - coords[1].z).powi(2))
-        .sqrt();
+        let dist = (coords[0] - coords[1]).norm();
         assert!(
             dist > 1.0,
             "merged sites should not overlap, got dist={dist}"

--- a/extensions/rust/src/io.rs
+++ b/extensions/rust/src/io.rs
@@ -4787,17 +4787,34 @@ Fe 2.0 2.0 2.0
 
         let structure = parse_structure_json(json).unwrap();
         // K and Ba at [0,0,0] should be merged into 1 site, Fe stays separate
-        assert_eq!(structure.num_sites(), 2, "co-located K+Ba should merge into 1 site");
+        assert_eq!(
+            structure.num_sites(),
+            2,
+            "co-located K+Ba should merge into 1 site"
+        );
         // The merged site should have Ba as dominant (0.7 > 0.3)
-        assert_eq!(structure.site_occupancies[0].dominant_species().element, Element::Ba);
+        assert_eq!(
+            structure.site_occupancies[0].dominant_species().element,
+            Element::Ba
+        );
         // It should contain both species
         assert_eq!(structure.site_occupancies[0].species.len(), 2);
         // Total occupancy at merged site
-        let total_occ: f64 = structure.site_occupancies[0].species.iter().map(|(_, o)| o).sum();
-        assert!((total_occ - 1.0).abs() < 1e-10, "occupancies should sum to 1.0");
+        let total_occ: f64 = structure.site_occupancies[0]
+            .species
+            .iter()
+            .map(|(_, occ)| occ)
+            .sum();
+        assert!(
+            (total_occ - 1.0).abs() < 1e-10,
+            "occupancies should sum to 1.0"
+        );
         // Fe site should be ordered
         assert!(structure.site_occupancies[1].is_ordered());
-        assert_eq!(structure.site_occupancies[1].dominant_species().element, Element::Fe);
+        assert_eq!(
+            structure.site_occupancies[1].dominant_species().element,
+            Element::Fe
+        );
     }
 
     #[test]
@@ -4837,25 +4854,39 @@ Fe 2.0 2.0 2.0
 
         let structure = parse_structure_json(json).unwrap();
         // 4 positions with 4 species each = 16 expanded -> 4 merged + 8 F = 12 sites
-        assert_eq!(structure.num_sites(), 12,
-            "24 expanded sites should merge to 12 (4 disordered + 8 ordered F)");
+        assert_eq!(
+            structure.num_sites(),
+            12,
+            "24 expanded sites should merge to 12 (4 disordered + 8 ordered F)"
+        );
 
         // Check the merged disordered sites have 4 species each
-        let disordered_sites: Vec<_> = structure.site_occupancies.iter()
+        let disordered_sites: Vec<_> = structure
+            .site_occupancies
+            .iter()
             .filter(|so| !so.is_ordered())
             .collect();
         assert_eq!(disordered_sites.len(), 4, "should have 4 disordered sites");
         for site in &disordered_sites {
-            assert_eq!(site.species.len(), 4, "each disordered site should have 4 species");
+            assert_eq!(
+                site.species.len(),
+                4,
+                "each disordered site should have 4 species"
+            );
             // Ba should be dominant (0.88)
             assert_eq!(site.dominant_species().element, Element::Ba);
             // Total occupancy should be 0.06 + 0.88 + 0.05 + 0.01 = 1.0
             let total: f64 = site.species.iter().map(|(_, o)| o).sum();
-            assert!((total - 1.0).abs() < 1e-10, "occupancies should sum to 1.0, got {total}");
+            assert!(
+                (total - 1.0).abs() < 1e-10,
+                "occupancies should sum to 1.0, got {total}"
+            );
         }
 
         // Check F sites are ordered and unchanged
-        let ordered_sites: Vec<_> = structure.site_occupancies.iter()
+        let ordered_sites: Vec<_> = structure
+            .site_occupancies
+            .iter()
             .filter(|so| so.is_ordered())
             .collect();
         assert_eq!(ordered_sites.len(), 8, "should have 8 ordered F sites");
@@ -4886,7 +4917,10 @@ Fe 2.0 2.0 2.0
             + (coords[0].y - coords[1].y).powi(2)
             + (coords[0].z - coords[1].z).powi(2))
         .sqrt();
-        assert!(dist > 1.0, "merged sites should not overlap, got dist={dist}");
+        assert!(
+            dist > 1.0,
+            "merged sites should not overlap, got dist={dist}"
+        );
     }
 
     #[test]
@@ -4919,7 +4953,11 @@ Fe 2.0 2.0 2.0
         }"#;
 
         let structure = parse_structure_json(json).unwrap();
-        assert_eq!(structure.num_sites(), 1, "same element at same position should merge");
+        assert_eq!(
+            structure.num_sites(),
+            1,
+            "same element at same position should merge"
+        );
         // Occupancy should be summed
         assert_eq!(structure.site_occupancies[0].species.len(), 1);
         let (sp, occ) = &structure.site_occupancies[0].species[0];
@@ -4945,7 +4983,11 @@ Fe 2.0 2.0 2.0
         assert_eq!(structure.num_sites(), 3, "K+Ba merge into 1 + 2 F = 3");
 
         let state = structure_to_torch_sim_state(&structure);
-        assert_eq!(state.positions.len(), 3, "TorchSimState should have 3 atoms");
+        assert_eq!(
+            state.positions.len(),
+            3,
+            "TorchSimState should have 3 atoms"
+        );
 
         // Check no positions overlap
         for atom_idx in 0..state.positions.len() {
@@ -4964,7 +5006,10 @@ Fe 2.0 2.0 2.0
         }
 
         // Dominant species (Ba, 0.9) should be used for atomic number
-        assert_eq!(state.atomic_numbers[0], 56, "Ba should be dominant at merged site");
+        assert_eq!(
+            state.atomic_numbers[0], 56,
+            "Ba should be dominant at merged site"
+        );
     }
 
     #[test]
@@ -4979,7 +5024,11 @@ Fe 2.0 2.0 2.0
         }"#;
 
         let structure = parse_structure_json_with_merge_tol(json, 0.0).unwrap();
-        assert_eq!(structure.num_sites(), 2, "merge_tol=0 should keep all sites separate");
+        assert_eq!(
+            structure.num_sites(),
+            2,
+            "merge_tol=0 should keep all sites separate"
+        );
     }
 
     #[test]
@@ -4998,7 +5047,11 @@ Fe 2.0 2.0 2.0
         }"#;
 
         let structure = parse_structure_json(json).unwrap();
-        assert_eq!(structure.num_sites(), 2, "4 co-located sites + 1 F = 2 sites");
+        assert_eq!(
+            structure.num_sites(),
+            2,
+            "4 co-located sites + 1 F = 2 sites"
+        );
         assert_eq!(
             structure.site_occupancies[0].species.len(),
             4,

--- a/extensions/rust/src/species.rs
+++ b/extensions/rust/src/species.rs
@@ -324,6 +324,25 @@ impl SiteOccupancy {
             .expect("SiteOccupancy must have at least one species")
     }
 
+    /// Merge species from another `SiteOccupancy` into this one.
+    ///
+    /// Used to combine co-located sites (expanded disorder format) back into
+    /// a single site with multiple species. If the same species already exists,
+    /// its occupancy is summed.
+    pub fn merge_from(&mut self, other: &SiteOccupancy) {
+        for (sp, occ) in &other.species {
+            if let Some(existing) = self.species.iter_mut().find(|(s, _)| s == sp) {
+                existing.1 += occ;
+            } else {
+                self.species.push((sp.clone(), *occ));
+            }
+        }
+        // Merge properties (other's properties take precedence only for new keys)
+        for (key, val) in &other.properties {
+            self.properties.entry(key.clone()).or_insert_with(|| val.clone());
+        }
+    }
+
     /// Get the total occupancy.
     pub fn total_occupancy(&self) -> f64 {
         self.species.iter().map(|(_, occ)| occ).sum()

--- a/extensions/rust/src/species.rs
+++ b/extensions/rust/src/species.rs
@@ -334,12 +334,14 @@ impl SiteOccupancy {
             if let Some(existing) = self.species.iter_mut().find(|(s, _)| s == sp) {
                 existing.1 += occ;
             } else {
-                self.species.push((sp.clone(), *occ));
+                self.species.push((*sp, *occ));
             }
         }
-        // Merge properties (other's properties take precedence only for new keys)
+        // Merge properties: keep self's values, fill in missing keys from other
         for (key, val) in &other.properties {
-            self.properties.entry(key.clone()).or_insert_with(|| val.clone());
+            self.properties
+                .entry(key.clone())
+                .or_insert_with(|| val.clone());
         }
     }
 

--- a/extensions/rust/src/species.rs
+++ b/extensions/rust/src/species.rs
@@ -331,7 +331,11 @@ impl SiteOccupancy {
     /// its occupancy is summed.
     pub fn merge_from(&mut self, other: &SiteOccupancy) {
         for (sp, occ) in &other.species {
-            if let Some(existing) = self.species.iter_mut().find(|(s, _)| s == sp) {
+            if let Some(existing) = self
+                .species
+                .iter_mut()
+                .find(|(existing_sp, _)| existing_sp == sp)
+            {
                 existing.1 += occ;
             } else {
                 self.species.push((*sp, *occ));

--- a/extensions/rust/src/structure_matcher.rs
+++ b/extensions/rust/src/structure_matcher.rs
@@ -1845,9 +1845,11 @@ mod tests {
     #[test]
     fn test_structure_distance_basic_properties() {
         // Tests: identical=0, symmetry, ranking (identical < shifted)
+        // Disable primitive_cell since moyo standardizes NaCl to canonical Wyckoff
+        // positions, erasing the rigid-body shift and producing distance=0
         let s1 = make_nacl();
         let s2 = make_nacl_shifted();
-        let matcher = StructureMatcher::new();
+        let matcher = StructureMatcher::new().with_primitive_cell(false);
 
         let d_self = matcher.get_structure_distance(&s1, &s1);
         let d12 = matcher.get_structure_distance(&s1, &s2);

--- a/extensions/rust/tests/test_cell_ops.py
+++ b/extensions/rust/tests/test_cell_ops.py
@@ -379,22 +379,24 @@ class TestBoundaryValues:
 
     def test_wrap_boundary_values(self) -> None:
         """Wrap handles boundary values correctly."""
-        # Create structure with boundary positions
+        # Use positions that are outside [0,1) but don't overlap with other sites
+        # after wrapping. Co-located sites get merged during parsing, so each
+        # site must have unique wrapped fractional coordinates.
         struct = make_structure(
             {"matrix": [[5.64, 0, 0], [0, 5.64, 0], [0, 0, 5.64]]},
             [
                 make_site("Na", [0.0, 0.0, 0.0]),
-                make_site("Na", [1.0, 1.0, 1.0]),  # Should wrap to [0,0,0]
+                make_site("Na", [1.1, 1.2, 1.3]),  # Should wrap to [0.1, 0.2, 0.3]
                 make_site("Cl", [0.5, 0.5, 0.5]),
-                make_site("Cl", [-0.5, -0.5, -0.5]),  # Should wrap to [0.5, 0.5, 0.5]
+                make_site("Cl", [-0.4, -0.3, -0.2]),  # Should wrap to [0.6, 0.7, 0.8]
             ],
         )
         wrapped = structure.wrap_to_unit_cell(struct)
         sites = wrapped["sites"]
         assert sites[0]["abc"] == pytest.approx([0, 0, 0], abs=1e-10)
-        assert sites[1]["abc"] == pytest.approx([0, 0, 0], abs=1e-10)
+        assert sites[1]["abc"] == pytest.approx([0.1, 0.2, 0.3], abs=1e-10)
         assert sites[2]["abc"] == pytest.approx([0.5, 0.5, 0.5], abs=1e-10)
-        assert sites[3]["abc"] == pytest.approx([0.5, 0.5, 0.5], abs=1e-10)
+        assert sites[3]["abc"] == pytest.approx([0.6, 0.7, 0.8], abs=1e-10)
 
     def test_minimum_image_atoms_at_same_position(self, nacl_structure: dict) -> None:
         """Minimum image distance is zero for same position."""

--- a/extensions/rust/tests/test_distortions.py
+++ b/extensions/rust/tests/test_distortions.py
@@ -541,7 +541,8 @@ class TestEdgeCases:
 
     def test_dimer_same_position_raises(self) -> None:
         """Create dimer with atoms at same position raises error."""
-        # Two atoms at exact same fractional coordinates
+        # Two atoms at exact same fractional coordinates: either merged during
+        # parsing (causing out-of-bounds) or detected as same position by create_dimer
         degenerate = make_cubic_structure(
             4.0,
             [
@@ -549,7 +550,7 @@ class TestEdgeCases:
                 make_site("Fe", [0.0, 0.0, 0.0]),  # Exact same position
             ],
         )
-        with pytest.raises(ValueError, match="same position"):
+        with pytest.raises(ValueError, match="same position|out of bounds"):
             defects.create_dimer(structure_to_json(degenerate), 0, 1, 2.0)
 
     def test_distort_bonds_highly_skewed_cell(self) -> None:

--- a/src/lib/convex-hull/ConvexHullStats.svelte
+++ b/src/lib/convex-hull/ConvexHullStats.svelte
@@ -8,18 +8,37 @@
   import HeatmapTable from '$lib/table/HeatmapTable.svelte'
   import type { HTMLAttributes } from 'svelte/elements'
   import { SvelteSet } from 'svelte/reactivity'
-  import type { ConvexHullEntry, PhaseStats } from './types'
+  import {
+    type ConvexHullEntry,
+    get_arity,
+    is_on_hull,
+    type PhaseArityField,
+    type PhaseStats,
+  } from './types'
 
-  let { phase_stats, stable_entries, unstable_entries, ...rest }:
+  let {
+    phase_stats,
+    stable_entries,
+    unstable_entries,
+    layout = `toggle`,
+    on_entry_click,
+    ...rest
+  }:
     & HTMLAttributes<HTMLDivElement>
     & {
       phase_stats: PhaseStats | null
       stable_entries: ConvexHullEntry[]
       unstable_entries: ConvexHullEntry[]
+      // 'toggle' shows stats/table with toggle buttons (default)
+      // 'side-by-side' shows both stats and table next to each other without toggle
+      layout?: `toggle` | `side-by-side`
+      // Called when a table row is clicked, with the corresponding entry
+      on_entry_click?: (entry: ConvexHullEntry) => void
     } = $props()
 
   let copied_items = new SvelteSet<string>()
   let view_mode = $state<`stats` | `table`>(`stats`)
+  let min_n_elements = $state(1)
 
   async function copy_to_clipboard(label: string, value: string, key: string) {
     try {
@@ -33,6 +52,15 @@
 
   // Shared concatenation of stable + unstable for histograms
   let all_entries = $derived([...stable_entries, ...unstable_entries])
+
+  const histogram_props = {
+    bins: 50,
+    y_axis: { label: ``, ticks: 3 },
+    show_legend: false,
+    show_controls: false,
+    padding: { t: 5, b: 22, l: 35, r: 5 },
+    style: `height: 100px; --histogram-min-height: 100px`,
+  } as const
 
   // Prepare histogram data for formation energies and hull distances
   let e_form_data = $derived.by(() => {
@@ -67,7 +95,9 @@
     const num_elements = phase_stats.chemical_system.split(`-`).length
     const max_arity = Math.max(
       num_elements,
-      phase_stats.quaternary > 0
+      phase_stats.quinary_plus > 0
+        ? 5
+        : phase_stats.quaternary > 0
         ? 4
         : phase_stats.ternary > 0
         ? 3
@@ -85,15 +115,16 @@
     ]
 
     // Only show phase types that exist or are within expected dimensionality
-    const arity_types = [
+    const arity_types: [string, PhaseArityField, number][] = [
       [`Unary`, `unary`, 1],
       [`Binary`, `binary`, 2],
       [`Ternary`, `ternary`, 3],
       [`Quaternary`, `quaternary`, 4],
-    ] as const
+      [`Quinary+`, `quinary_plus`, 5],
+    ]
     for (const [display, field, min_arity] of arity_types) {
       const count = phase_stats[field]
-      if (count > 0 || max_arity >= min_arity) {
+      if (count > 0 || (max_arity >= min_arity && min_arity <= 4)) {
         phase_items.push({
           label: `${display} phases`,
           value: `${format_num(count)} (${
@@ -106,79 +137,113 @@
 
     sections.push({ title: ``, items: phase_items })
 
-    // Stability
-    const stable_item = {
-      label: `Stable phases`,
-      value: `${format_num(phase_stats.stable)} (${
-        format_num(phase_stats.stable / phase_stats.total, `.1~%`)
-      })`,
-      key: `stable-phases`,
-    }
-    const unstable_item = {
-      label: `Unstable phases`,
-      value: `${format_num(phase_stats.unstable)} (${
-        format_num(phase_stats.unstable / phase_stats.total, `.1~%`)
-      })`,
-      key: `unstable-phases`,
-    }
-    sections.push({ title: `Stability`, items: [stable_item, unstable_item] })
-
-    // Energy Statistics
-    const energy_item = {
-      label: `Min / avg / max (eV/atom)`,
-      value: `${format_num(phase_stats.energy_range.min, `.3f`)} / ${
-        format_num(phase_stats.energy_range.avg, `.3f`)
-      } / ${format_num(phase_stats.energy_range.max, `.3f`)}`,
-      key: `formation-energy`,
-    }
     sections.push({
-      title: `E<sub>form</sub> distribution`,
-      items: [energy_item],
+      title: `Stability`,
+      items: [
+        {
+          label: `Stable phases`,
+          value: `${format_num(phase_stats.stable)} (${
+            format_num(phase_stats.stable / phase_stats.total, `.1~%`)
+          })`,
+          key: `stable-phases`,
+        },
+        {
+          label: `Unstable phases`,
+          value: `${format_num(phase_stats.unstable)} (${
+            format_num(phase_stats.unstable / phase_stats.total, `.1~%`)
+          })`,
+          key: `unstable-phases`,
+        },
+      ],
     })
 
-    // Hull Distance
-    const hull_distance_item = {
-      label: `Max / avg (eV/atom)`,
-      value: `${format_num(phase_stats.hull_distance.max, `.3f`)} / ${
-        format_num(phase_stats.hull_distance.avg, `.3f`)
-      }`,
-      key: `hull-distance`,
-    }
+    sections.push({
+      title: `E<sub>form</sub> distribution`,
+      items: [{
+        label: `Min / avg / max (eV/atom)`,
+        value: `${format_num(phase_stats.energy_range.min, `.3f`)} / ${
+          format_num(phase_stats.energy_range.avg, `.3f`)
+        } / ${format_num(phase_stats.energy_range.max, `.3f`)}`,
+        key: `formation-energy`,
+      }],
+    })
+
     sections.push({
       title: `E<sub>above hull</sub> distribution`,
-      items: [hull_distance_item],
+      items: [{
+        label: `Max / avg (eV/atom)`,
+        value: `${format_num(phase_stats.hull_distance.max, `.3f`)} / ${
+          format_num(phase_stats.hull_distance.avg, `.3f`)
+        }`,
+        key: `hull-distance`,
+      }],
     })
 
     return sections
   })
 
-  // Table view: visible entries and feature flags
+  // Table view: visible entries filtered by min element count
   let visible_entries = $derived(
-    all_entries.filter((entry) => entry.visible),
+    all_entries.filter((entry) => {
+      if (!entry.visible) return false
+      if (min_n_elements <= 1) return true
+      return get_arity(entry) >= min_n_elements
+    }),
   )
   let has_raw = $derived(
     visible_entries.some((entry) => entry.energy_per_atom !== undefined),
   )
   let has_ids = $derived(visible_entries.some((entry) => entry.entry_id))
+  let max_n_el = $derived(
+    all_entries.reduce((max, entry) => Math.max(max, get_arity(entry)), 1),
+  )
 
-  let table_data = $derived(visible_entries.map((entry) => {
-    const counts = Object.values(entry.composition)
-    const n_atoms = counts.reduce((sum, count) => sum + count, 0)
+  // Map from row object to source entry for click handler
+  let entry_by_row = new WeakMap<RowData, ConvexHullEntry>()
+
+  let table_data = $derived(visible_entries.map((entry, idx) => {
+    const n_atoms = Object.values(entry.composition).reduce(
+      (sum, count) => sum + count,
+      0,
+    )
+    const on_hull = is_on_hull(entry)
+    const formula = entry.reduced_formula ?? entry.name ??
+      get_alphabetical_formula(entry.composition, true, ``)
     const row: RowData = {
-      Formula: entry.reduced_formula ?? entry.name ??
-        get_alphabetical_formula(entry.composition, true, ``),
+      '#': idx + 1,
+      Stable: on_hull
+        ? `<span style="color: #22c55e" title="On hull">●</span>`
+        : `<span style="color: #666; opacity: 0.4" title="Above hull">●</span>`,
+      Formula: on_hull ? `<strong>${formula}</strong>` : formula,
       'E<sub>hull</sub>': entry.e_above_hull ?? null,
       'E<sub>form</sub>': entry.e_form_per_atom ?? entry.energy_per_atom ?? null,
     }
     if (has_raw) row[`E<sub>raw</sub>`] = entry.energy_per_atom
     if (has_ids) row.ID = entry.entry_id
-    row[`N<sub>el</sub>`] = counts.filter((count) => count > 0).length
+    row[`N<sub>el</sub>`] = get_arity(entry)
     row[`N<sub>at</sub>`] = n_atoms
+    entry_by_row.set(row, entry)
     return row
   }))
 
-  let table_columns = $derived.by(() => {
-    const cols: Label[] = [
+  function handle_row_click(_event: MouseEvent, row: RowData): void {
+    const entry = entry_by_row.get(row)
+    if (entry) on_entry_click?.(entry)
+  }
+
+  let table_width = $derived(layout === `side-by-side` ? `fit-content` : `100%`)
+  let table_style = $derived(
+    `width: ${table_width}${on_entry_click ? `; cursor: pointer` : ``}`,
+  )
+
+  let table_columns: Label[] = $derived(
+    [
+      { label: `#`, color_scale: null, description: `Row number` },
+      {
+        label: `Stable`,
+        color_scale: null,
+        description: `On convex hull (E above hull ≈ 0)`,
+      },
       { label: `Formula`, color_scale: null },
       {
         label: `E<sub>hull</sub>`,
@@ -194,19 +259,17 @@
         format: `.4f`,
         description: `Formation energy (eV/atom)`,
       },
-    ]
-    if (has_raw) {
-      cols.push({
-        label: `E<sub>raw</sub>`,
-        color_scale: `interpolateCool`,
-        format: `.4f`,
-        description: `Raw energy per atom (eV/atom)`,
-      })
-    }
-    if (has_ids) {
-      cols.push({ label: `ID`, color_scale: null, description: `Entry identifier` })
-    }
-    cols.push(
+      ...(has_raw
+        ? [{
+          label: `E<sub>raw</sub>`,
+          color_scale: `interpolateCool` as const,
+          format: `.4f`,
+          description: `Raw energy per atom (eV/atom)`,
+        }]
+        : []),
+      ...(has_ids
+        ? [{ label: `ID`, color_scale: null, description: `Entry identifier` }]
+        : []),
       {
         label: `N<sub>el</sub>`,
         color_scale: null,
@@ -218,102 +281,150 @@
         format: `d`,
         description: `Number of atoms in unit cell`,
       },
-    )
-    return cols
-  })
+    ] satisfies Label[],
+  )
 </script>
 
-<div {...rest} class="convex-hull-stats {rest.class ?? ``}">
-  <div class="view-toggle">
-    <button class:active={view_mode === `stats`} onclick={() => view_mode = `stats`}>
-      Stats
-    </button>
-    <button class:active={view_mode === `table`} onclick={() => view_mode = `table`}>
-      Table
-    </button>
-  </div>
-  {#if view_mode === `stats`}
-    {#each pane_data as section, sec_idx (sec_idx)}
-      {#if sec_idx > 0}<hr />{/if}
-      <section>
-        {#if section.title}
-          <h5>{@html section.title}</h5>
-        {/if}
-        {#each section.items as item (item.key ?? item.label)}
-          {@const { key, label, value } = item}
-          <div
-            class="clickable stat-item"
-            data-testid={key ? `pd-${key}` : undefined}
-            title="Click to copy: {label}: {value}"
-            onclick={() => copy_to_clipboard(item.label, String(item.value), key ?? item.label)}
-            role="button"
-            tabindex="0"
-            onkeydown={(event) => {
-              if (event.key === `Enter` || event.key === ` `) {
-                event.preventDefault()
-                copy_to_clipboard(item.label, String(item.value), key ?? item.label)
-              }
-            }}
-          >
-            <span>{@html label}:</span>
-            <span>{@html value}</span>
-            {#if key && copied_items.has(key)}
-              <Icon
-                icon="Check"
-                style="color: var(--success-color, #10b981); width: 12px; height: 12px"
-                class="copy-checkmark"
-              />
-            {/if}
-          </div>
-        {/each}
+{#snippet stats_panel()}
+  {#each pane_data as section, sec_idx (sec_idx)}
+    {#if sec_idx > 0}<hr />{/if}
+    <section>
+      {#if section.title}
+        <h5>{@html section.title}</h5>
+      {/if}
+      {#each section.items as item (item.key ?? item.label)}
+        {@const { key, label, value } = item}
+        <div
+          class="clickable stat-item"
+          data-testid={key ? `pd-${key}` : undefined}
+          title="Click to copy: {label}: {value}"
+          onclick={() => copy_to_clipboard(item.label, String(item.value), key ?? item.label)}
+          role="button"
+          tabindex="0"
+          onkeydown={(event) => {
+            if (event.key === `Enter` || event.key === ` `) {
+              event.preventDefault()
+              copy_to_clipboard(item.label, String(item.value), key ?? item.label)
+            }
+          }}
+        >
+          <span>{@html label}:</span>
+          <span>{@html value}</span>
+          {#if key && copied_items.has(key)}
+            <Icon
+              icon="Check"
+              style="color: var(--success-color, #10b981); width: 12px; height: 12px"
+              class="copy-checkmark"
+            />
+          {/if}
+        </div>
+      {/each}
 
-        {#if section.title === `E<sub>form</sub> distribution` &&
-        e_form_data[0].y.length > 0}
-          <Histogram
-            series={e_form_data}
-            bins={50}
-            x_axis={{ label: ``, format: `.2f` }}
-            y_axis={{ label: ``, ticks: 3 }}
-            show_legend={false}
-            show_controls={false}
-            padding={{ t: 5, b: 22, l: 35, r: 5 }}
-            style="height: 100px; --histogram-min-height: 100px"
-            bar={{ color: `steelblue`, opacity: 0.7 }}
-          />
-        {/if}
+      {#if section.title === `E<sub>form</sub> distribution` &&
+      e_form_data[0].y.length > 0}
+        <Histogram
+          {...histogram_props}
+          series={e_form_data}
+          x_axis={{ label: ``, format: `.2f` }}
+          bar={{ color: `steelblue`, opacity: 0.7 }}
+        />
+      {/if}
 
-        {#if section.title === `E<sub>above hull</sub> distribution` &&
-        hull_distance_data[0].y.length > 0}
-          <Histogram
-            series={hull_distance_data}
-            bins={50}
-            x_axis={{ label: ``, format: `.2f`, range: [0, null] }}
-            y_axis={{ label: ``, ticks: 3 }}
-            show_legend={false}
-            show_controls={false}
-            padding={{ t: 5, b: 22, l: 35, r: 5 }}
-            style="height: 100px; --histogram-min-height: 100px"
-            bar={{ color: `coral`, opacity: 0.7 }}
-          />
-        {/if}
-      </section>
-    {/each}
-  {:else}
-    <HeatmapTable
-      data={table_data}
-      columns={table_columns}
-      initial_sort={{ column: `E<sub>hull</sub>`, direction: `asc` }}
-      scroll_style="max-height: var(--hull-stats-max-height, 500px)"
-      style="width: 100%"
-    />
+      {#if section.title === `E<sub>above hull</sub> distribution` &&
+      hull_distance_data[0].y.length > 0}
+        <Histogram
+          {...histogram_props}
+          series={hull_distance_data}
+          x_axis={{ label: ``, format: `.2f`, range: [0, null] }}
+          bar={{ color: `coral`, opacity: 0.7 }}
+        />
+      {/if}
+    </section>
+  {/each}
+{/snippet}
+
+{#snippet table_panel()}
+  {#if max_n_el > 2}
+    <div class="nel-filter">
+      <label>
+        Min N<sub>el</sub>:
+        <select bind:value={min_n_elements}>
+          {#each Array.from({ length: max_n_el }, (_, idx) => idx + 1) as nel (nel)}
+            <option value={nel}>{nel}{nel === 1 ? ` (all)` : ``}</option>
+          {/each}
+        </select>
+      </label>
+      <span style="color: var(--text-color-muted, #666); font-size: 0.9em">{
+          visible_entries.length
+        } entries</span>
+    </div>
   {/if}
-</div>
+  <HeatmapTable
+    data={table_data}
+    columns={table_columns}
+    initial_sort={{ column: `E<sub>hull</sub>`, direction: `asc` }}
+    scroll_style={layout === `side-by-side`
+    ? `flex: 1 1 0; overflow: auto`
+    : `max-height: var(--hull-stats-max-height, 500px)`}
+    style={table_style}
+    onrowclick={on_entry_click ? handle_row_click : undefined}
+  />
+{/snippet}
+
+{#if layout === `side-by-side`}
+  <div {...rest} class="convex-hull-stats side-by-side {rest.class ?? ``}">
+    <div class="stats-pane">
+      {@render stats_panel()}
+    </div>
+    <div class="table-pane">
+      {@render table_panel()}
+    </div>
+  </div>
+{:else}
+  <div {...rest} class="convex-hull-stats {rest.class ?? ``}">
+    <div class="view-toggle">
+      <button class:active={view_mode === `stats`} onclick={() => view_mode = `stats`}>
+        Stats
+      </button>
+      <button class:active={view_mode === `table`} onclick={() => view_mode = `table`}>
+        Table
+      </button>
+    </div>
+    {#if view_mode === `stats`}
+      {@render stats_panel()}
+    {:else}
+      {@render table_panel()}
+    {/if}
+  </div>
+{/if}
 
 <style>
   .convex-hull-stats {
     background: var(--hull-stats-bg, var(--hull-bg));
     border-radius: var(--hull-border-radius, var(--border-radius, 3pt));
     padding: 1em;
+  }
+  .convex-hull-stats.side-by-side {
+    display: flex;
+    gap: 1.5em;
+    align-items: stretch;
+    width: fit-content;
+    max-width: 100%;
+    margin-inline: auto;
+  }
+  .stats-pane {
+    flex: 0 0 auto;
+    min-width: 250px;
+  }
+  .table-pane {
+    flex: 0 1 auto;
+    overflow: auto;
+    display: flex;
+    flex-direction: column;
+    :global(.table-container) {
+      flex: 1 1 0;
+      min-height: 0;
+    }
   }
   section div {
     display: flex;
@@ -374,5 +485,25 @@
   .view-toggle button.active {
     background: light-dark(rgba(0, 0, 0, 0.1), rgba(255, 255, 255, 0.15));
     font-weight: 500;
+  }
+  .nel-filter {
+    display: flex;
+    align-items: center;
+    gap: 0.75em;
+    margin-bottom: 6pt;
+    font-size: 0.85em;
+    label {
+      display: flex;
+      align-items: center;
+      gap: 0.4em;
+    }
+    select {
+      padding: 2pt 4pt;
+      border: 1px solid color-mix(in srgb, currentColor 20%, transparent);
+      border-radius: 3pt;
+      background: transparent;
+      color: inherit;
+      font-size: inherit;
+    }
   }
 </style>

--- a/src/lib/convex-hull/ConvexHullStats.svelte
+++ b/src/lib/convex-hull/ConvexHullStats.svelte
@@ -52,6 +52,15 @@
   // Shared concatenation of stable + unstable for histograms
   let all_entries = $derived([...stable_entries, ...unstable_entries])
 
+  // Static arity labels for phase breakdown display
+  const arity_types: [string, PhaseArityField, number][] = [
+    [`Unary`, `unary`, 1],
+    [`Binary`, `binary`, 2],
+    [`Ternary`, `ternary`, 3],
+    [`Quaternary`, `quaternary`, 4],
+    [`Quinary+`, `quinary_plus`, 5],
+  ]
+
   const histogram_props = {
     bins: 50,
     y_axis: { label: ``, ticks: 3 },
@@ -94,13 +103,6 @@
 
     // Determine system dimensionality from chemical_system string
     const num_elements = phase_stats.chemical_system.split(`-`).length
-    const arity_types: [string, PhaseArityField, number][] = [
-      [`Unary`, `unary`, 1],
-      [`Binary`, `binary`, 2],
-      [`Ternary`, `ternary`, 3],
-      [`Quaternary`, `quaternary`, 4],
-      [`Quinary+`, `quinary_plus`, 5],
-    ]
     // max arity from data or system dimensionality
     const max_arity = arity_types.reduce(
       (max, [, field, arity]) => phase_stats[field] > 0 ? Math.max(max, arity) : max,
@@ -194,10 +196,10 @@
       const formula = entry.reduced_formula ?? entry.name ??
         get_alphabetical_formula(entry.composition, true, ``)
       const row: RowData = {
-        '#': idx + 1,
+        '#': `<span data-sort-value="${idx + 1}">${idx + 1}</span>`,
         Stable: on_hull
-          ? `<span style="color: var(--hull-stable-color, #22c55e)" title="On hull">●</span>`
-          : `<span style="color: var(--hull-unstable-color, #666); opacity: 0.4" title="Above hull">●</span>`,
+          ? `<span data-sort-value="0" style="color: var(--hull-stable-color, #22c55e)" title="On hull">●</span>`
+          : `<span data-sort-value="1" style="color: var(--hull-unstable-color, #666); opacity: 0.4" title="Above hull">●</span>`,
         Formula: on_hull ? `<strong>${formula}</strong>` : formula,
         'E<sub>hull</sub>': entry.e_above_hull ?? null,
         'E<sub>form</sub>': entry.e_form_per_atom ?? entry.energy_per_atom ?? null,
@@ -216,8 +218,6 @@
     const entry = entry_by_row.get(row)
     if (entry) on_entry_click?.(entry)
   }
-
-  let table_width = $derived(layout === `side-by-side` ? `fit-content` : `100%`)
 
   let table_columns: Label[] = $derived(
     [
@@ -349,7 +349,7 @@
     scroll_style={layout === `side-by-side`
     ? `flex: 1 1 0; overflow: auto`
     : `max-height: var(--hull-stats-max-height, 500px)`}
-    style={`width: ${table_width}`}
+    style={`width: ${layout === `side-by-side` ? `fit-content` : `100%`}`}
     onrowclick={on_entry_click ? handle_row_click : undefined}
   />
 {/snippet}

--- a/src/lib/convex-hull/ConvexHullStats.svelte
+++ b/src/lib/convex-hull/ConvexHullStats.svelte
@@ -101,14 +101,6 @@
     const pct = (count: number) =>
       phase_stats.total > 0 ? format_num(count / phase_stats.total, `.1~%`) : `0%`
 
-    // Determine system dimensionality from chemical_system string
-    const num_elements = phase_stats.chemical_system.split(`-`).length
-    // max arity from data or system dimensionality
-    const max_arity = arity_types.reduce(
-      (max, [, field, arity]) => phase_stats[field] > 0 ? Math.max(max, arity) : max,
-      num_elements,
-    )
-
     return [
       {
         title: ``,
@@ -118,10 +110,11 @@
             value: format_num(phase_stats.total),
             key: `total-entries`,
           },
-          // Only show phase types that exist or are within system dimensionality
+          // Only show phase types that exist or are within the max_arity
+          // used when computing stats (respects zeroed-out counts)
           ...arity_types
             .filter(([, field, arity]) =>
-              phase_stats[field] > 0 || max_arity >= arity
+              phase_stats[field] > 0 || phase_stats.max_arity >= arity
             )
             .map(([display, field]) => ({
               label: `${display} phases`,

--- a/src/lib/convex-hull/thermodynamics.ts
+++ b/src/lib/convex-hull/thermodynamics.ts
@@ -475,7 +475,11 @@ export function get_convex_hull_stats(
   const unstable_count = processed_entries.length - stable_count
 
   const energies = processed_entries
-    .map((entry) => entry.e_form_per_atom ?? entry.energy_per_atom)
+    .map((entry) =>
+      entry.e_form_per_atom ??
+        entry.energy_per_atom ??
+        (typeof entry.energy === `number` ? get_energy_per_atom(entry) : undefined)
+    )
     .filter((val): val is number => typeof val === `number` && Number.isFinite(val))
 
   // Use reduce instead of Math.min/max(...arr) to avoid stack overflow on large datasets
@@ -572,6 +576,10 @@ export function process_hull_for_stats(
       if (typeof dist === `number` && Number.isFinite(dist)) {
         entry.e_above_hull = dist
         entry.is_stable = dist < HULL_STABILITY_TOL
+      } else {
+        // Clear stale hull metadata so previous values don't persist
+        entry.e_above_hull = undefined
+        entry.is_stable = undefined
       }
     }
   } catch (err) {

--- a/src/lib/convex-hull/thermodynamics.ts
+++ b/src/lib/convex-hull/thermodynamics.ts
@@ -473,7 +473,7 @@ export function get_convex_hull_stats(
   if (max_arity < 3) ternary = 0
   if (max_arity < 2) binary = 0
 
-  const stable_count = processed_entries.filter((entry) => is_on_hull(entry)).length
+  const stable_count = processed_entries.filter(is_on_hull).length
   const unstable_count = processed_entries.length - stable_count
 
   const energies = processed_entries
@@ -573,10 +573,8 @@ export function process_hull_for_stats(
       processed.entries,
     )
 
-    for (let idx = 0; idx < processed.entries.length; idx++) {
-      const entry = processed.entries[idx]
-      const id = entry.entry_id ?? JSON.stringify(entry.composition)
-      const dist = hull_distances[id]
+    for (const entry of processed.entries) {
+      const dist = hull_distances[entry.entry_id ?? JSON.stringify(entry.composition)]
       if (typeof dist === `number` && Number.isFinite(dist)) {
         entry.e_above_hull = dist
         entry.is_stable = dist < HULL_STABILITY_TOL
@@ -593,9 +591,9 @@ export function process_hull_for_stats(
 
   const hull_entries = processed.entries.map(to_hull_entry)
   return {
-    stable_entries: hull_entries.filter((entry) => is_on_hull(entry)),
+    stable_entries: hull_entries.filter(is_on_hull),
     unstable_entries: hull_entries.filter((entry) => !is_on_hull(entry)),
-    phase_stats: get_convex_hull_stats(processed.entries, hull_elements),
+    phase_stats: get_convex_hull_stats(processed.entries, hull_elements, hull_elements.length),
   }
 }
 

--- a/src/lib/convex-hull/thermodynamics.ts
+++ b/src/lib/convex-hull/thermodynamics.ts
@@ -467,6 +467,8 @@ export function get_convex_hull_stats(
     else if (arity >= 5) quinary_plus++
   }
   // Zero out counts beyond system dimensionality for cleaner display
+  // quinary_plus is intentionally not zeroed — it's a catch-all bucket that
+  // is naturally 0 for systems with fewer than 5 elements
   if (max_arity < 4) quaternary = 0
   if (max_arity < 3) ternary = 0
   if (max_arity < 2) binary = 0
@@ -514,6 +516,7 @@ export function get_convex_hull_stats(
     hull_distance,
     elements: elements.length,
     chemical_system: sort_by_electronegativity([...elements]).join(`-`),
+    max_arity,
   }
 }
 
@@ -561,8 +564,9 @@ export function process_hull_for_stats(
     }
   }
 
-  // Compute hull distances, using index-based IDs to avoid polymorph collisions
-  // when multiple entries share the same composition but have no entry_id
+  // Compute hull distances. Note: entries without entry_id are keyed by
+  // JSON.stringify(composition), so polymorphs at the same composition
+  // collide — the last-processed entry's distance wins for all of them.
   try {
     const hull_distances = calculate_e_above_hull(
       processed.entries,

--- a/src/lib/convex-hull/thermodynamics.ts
+++ b/src/lib/convex-hull/thermodynamics.ts
@@ -13,15 +13,17 @@ import {
   composition_to_barycentric_nd,
 } from './barycentric-coords'
 import type {
+  ConvexHullEntry,
   ConvexHullFace,
   ConvexHullTriangle,
   PhaseData,
+  PhaseStats,
   Plane,
   Point2D,
   Point3D,
   ProcessedPhaseData,
 } from './types'
-import { is_unary_entry } from './types'
+import { get_arity, is_on_hull, is_unary_entry } from './types'
 
 // Track warned keys to avoid log spam on large datasets with repeated invalid keys
 const warned_keys = new Set<string>()
@@ -446,62 +448,50 @@ export function calculate_e_above_hull(
 export function get_convex_hull_stats(
   processed_entries: PhaseData[],
   elements: ElementSymbol[],
-  max_arity: 3 | 4,
-): {
-  total: number
-  unary: number
-  binary: number
-  ternary: number
-  quaternary: number
-  stable: number
-  unstable: number
-  energy_range: { min: number; max: number; avg: number }
-  hull_distance: { max: number; avg: number }
-  elements: number
-  chemical_system: string
-} | null {
+  max_arity: number = 4,
+): PhaseStats | null {
   if (!processed_entries || processed_entries.length === 0) return null
+  max_arity = Math.max(1, max_arity)
 
-  const composition_counts = (max_arity === 4 ? [1, 2, 3, 4] : [1, 2, 3]).map((target) =>
-    processed_entries.filter((entry) =>
-      Object.keys(entry.composition).filter(
-        (el) => (entry.composition[el as ElementSymbol] ?? 0) > 0,
-      ).length === target
-    ).length
-  )
-  const [unary, binary, ternary, quaternaryMaybe] = composition_counts as [
-    number,
-    number,
-    number,
-    number?,
-  ]
-  const quaternary = max_arity === 4 ? (quaternaryMaybe ?? 0) : 0
+  let unary = 0
+  let binary = 0
+  let ternary = 0
+  let quaternary = 0
+  let quinary_plus = 0
+  for (const entry of processed_entries) {
+    const arity = get_arity(entry)
+    if (arity === 1) unary++
+    else if (arity === 2) binary++
+    else if (arity === 3) ternary++
+    else if (arity === 4) quaternary++
+    else if (arity >= 5) quinary_plus++
+  }
+  // Zero out counts beyond system dimensionality for cleaner display
+  if (max_arity < 4) quaternary = 0
+  if (max_arity < 3) ternary = 0
 
-  const stable_count = processed_entries.filter((e) =>
-    e.is_stable === true ||
-    (typeof e.e_above_hull === `number` && e.e_above_hull < 1e-6)
-  ).length
+  const stable_count = processed_entries.filter(is_on_hull).length
   const unstable_count = processed_entries.length - stable_count
 
   const energies = processed_entries
-    .map((e) => e.e_form_per_atom ?? e.energy_per_atom)
-    .filter((v): v is number => typeof v === `number` && Number.isFinite(v))
+    .map((entry) => entry.e_form_per_atom ?? entry.energy_per_atom)
+    .filter((val): val is number => typeof val === `number` && Number.isFinite(val))
 
   const energy_range = energies.length > 0
     ? {
       min: Math.min(...energies),
       max: Math.max(...energies),
-      avg: energies.reduce((a, b) => a + b, 0) / energies.length,
+      avg: energies.reduce((sum, val) => sum + val, 0) / energies.length,
     }
     : { min: 0, max: 0, avg: 0 }
 
   const hull_distances = processed_entries
-    .map((e) => e.e_above_hull)
-    .filter((v): v is number => typeof v === `number` && v >= 0)
+    .map((entry) => entry.e_above_hull)
+    .filter((val): val is number => typeof val === `number` && val >= 0)
   const hull_distance = hull_distances.length > 0
     ? {
       max: Math.max(...hull_distances),
-      avg: hull_distances.reduce((a, b) => a + b, 0) / hull_distances.length,
+      avg: hull_distances.reduce((sum, val) => sum + val, 0) / hull_distances.length,
     }
     : { max: 0, avg: 0 }
 
@@ -511,12 +501,76 @@ export function get_convex_hull_stats(
     binary,
     ternary,
     quaternary,
+    quinary_plus,
     stable: stable_count,
     unstable: unstable_count,
     energy_range,
     hull_distance,
     elements: elements.length,
     chemical_system: sort_by_electronegativity([...elements]).join(`-`),
+  }
+}
+
+// Result type for process_hull_for_stats
+export interface HighDimHullResult {
+  stable_entries: ConvexHullEntry[]
+  unstable_entries: ConvexHullEntry[]
+  phase_stats: PhaseStats | null
+}
+
+// Process raw hull entries for high-dimensional systems (5+ elements) where the
+// ConvexHull visual component can't render. Computes formation energies, hull distances,
+// stable/unstable classification, and phase stats. Returns null on failure.
+export function process_hull_for_stats(
+  entries: PhaseData[],
+): HighDimHullResult | null {
+  if (!entries.length) return null
+
+  const processed = process_hull_entries(entries)
+  if (!processed.entries.length) return null
+
+  // Add ConvexHullEntry-required fields (visible, is_element)
+  for (const entry of processed.entries) {
+    const hull_entry = entry as ConvexHullEntry
+    hull_entry.visible = true
+    hull_entry.is_element = get_arity(entry) === 1
+  }
+
+  // Compute formation energies
+  const el_refs = find_lowest_energy_unary_refs(processed.entries)
+  for (const entry of processed.entries) {
+    if (entry.e_form_per_atom === undefined) {
+      const e_form = compute_e_form_per_atom(entry, el_refs)
+      if (e_form !== null) entry.e_form_per_atom = e_form
+    }
+  }
+
+  // Compute hull distances
+  try {
+    const hull_distances = calculate_e_above_hull(
+      processed.entries,
+      processed.entries,
+    ) as Record<string, number>
+
+    for (const entry of processed.entries) {
+      const id = entry.entry_id ?? JSON.stringify(entry.composition)
+      const dist = hull_distances[id]
+      if (typeof dist === `number` && Number.isFinite(dist)) {
+        entry.e_above_hull = dist
+        entry.is_stable = dist < 1e-6
+      }
+    }
+  } catch (err) {
+    console.warn(`Failed to compute high-dim hull:`, err)
+    return null
+  }
+
+  return {
+    stable_entries: processed.entries.filter(is_on_hull) as ConvexHullEntry[],
+    unstable_entries: processed.entries.filter(
+      (entry) => !is_on_hull(entry) && typeof entry.e_above_hull === `number`,
+    ) as ConvexHullEntry[],
+    phase_stats: get_convex_hull_stats(processed.entries, processed.elements),
   }
 }
 

--- a/src/lib/convex-hull/thermodynamics.ts
+++ b/src/lib/convex-hull/thermodynamics.ts
@@ -473,16 +473,14 @@ export function get_convex_hull_stats(
   if (max_arity < 3) ternary = 0
   if (max_arity < 2) binary = 0
 
-  const stable_count = processed_entries.filter(is_on_hull).length
+  const stable_count = processed_entries.filter((entry) => is_on_hull(entry)).length
   const unstable_count = processed_entries.length - stable_count
 
   const energies = processed_entries
     .map((entry) =>
-      entry.e_form_per_atom ??
-        entry.energy_per_atom ??
-        (typeof entry.energy === `number` ? get_energy_per_atom(entry) : undefined)
+      entry.e_form_per_atom ?? entry.energy_per_atom ?? get_energy_per_atom(entry)
     )
-    .filter((val): val is number => typeof val === `number` && Number.isFinite(val))
+    .filter(Number.isFinite)
 
   // Use reduce instead of Math.min/max(...arr) to avoid stack overflow on large datasets
   const energy_range = energies.length > 0
@@ -591,9 +589,13 @@ export function process_hull_for_stats(
 
   const hull_entries = processed.entries.map(to_hull_entry)
   return {
-    stable_entries: hull_entries.filter(is_on_hull),
+    stable_entries: hull_entries.filter((entry) => is_on_hull(entry)),
     unstable_entries: hull_entries.filter((entry) => !is_on_hull(entry)),
-    phase_stats: get_convex_hull_stats(processed.entries, hull_elements, hull_elements.length),
+    phase_stats: get_convex_hull_stats(
+      processed.entries,
+      hull_elements,
+      hull_elements.length,
+    ),
   }
 }
 

--- a/src/lib/convex-hull/thermodynamics.ts
+++ b/src/lib/convex-hull/thermodynamics.ts
@@ -576,7 +576,7 @@ export function process_hull_for_stats(
       is_on_hull(entry)
     ) as ConvexHullEntry[],
     unstable_entries: processed.entries.filter(
-      (entry) => !is_on_hull(entry) && typeof entry.e_above_hull === `number`,
+      (entry) => !is_on_hull(entry),
     ) as ConvexHullEntry[],
     phase_stats: get_convex_hull_stats(processed.entries, processed.elements),
   }

--- a/src/lib/convex-hull/types.ts
+++ b/src/lib/convex-hull/types.ts
@@ -162,6 +162,9 @@ export interface PhaseStats {
   hull_distance: { max: number; avg: number }
   elements: number
   chemical_system: string
+  // Maximum arity used when computing stats — arity counts beyond this
+  // were zeroed. The UI uses this to decide which arity rows to display.
+  max_arity: number
 }
 
 // Numeric arity-count fields in PhaseStats (for type-safe indexing).

--- a/src/lib/convex-hull/types.ts
+++ b/src/lib/convex-hull/types.ts
@@ -172,8 +172,11 @@ export type PhaseArityField =
   | `quaternary`
   | `quinary_plus`
 
+// Tolerance for classifying a phase as on the convex hull (eV/atom)
+export const HULL_STABILITY_TOL = 1e-6
+
 // Check if entry is on the convex hull (stable or e_above_hull ≈ 0)
-export const is_on_hull = (entry: PhaseData, tol: number = 1e-6): boolean =>
+export const is_on_hull = (entry: PhaseData, tol: number = HULL_STABILITY_TOL): boolean =>
   entry.is_stable === true ||
   (typeof entry.e_above_hull === `number` && entry.e_above_hull < tol)
 

--- a/src/lib/convex-hull/types.ts
+++ b/src/lib/convex-hull/types.ts
@@ -164,13 +164,12 @@ export interface PhaseStats {
   chemical_system: string
 }
 
-// Numeric arity-count fields in PhaseStats (for type-safe indexing)
-export type PhaseArityField =
-  | `unary`
-  | `binary`
-  | `ternary`
-  | `quaternary`
-  | `quinary_plus`
+// Numeric arity-count fields in PhaseStats (for type-safe indexing).
+// Uses Extract to stay in sync with PhaseStats at compile time.
+export type PhaseArityField = Extract<
+  keyof PhaseStats,
+  `unary` | `binary` | `ternary` | `quaternary` | `quinary_plus`
+>
 
 // Tolerance for classifying a phase as on the convex hull (eV/atom)
 export const HULL_STABILITY_TOL = 1e-6

--- a/src/lib/convex-hull/types.ts
+++ b/src/lib/convex-hull/types.ts
@@ -155,6 +155,7 @@ export interface PhaseStats {
   binary: number
   ternary: number
   quaternary: number
+  quinary_plus: number
   stable: number
   unstable: number
   energy_range: { min: number; max: number; avg: number }
@@ -162,6 +163,19 @@ export interface PhaseStats {
   elements: number
   chemical_system: string
 }
+
+// Numeric arity-count fields in PhaseStats (for type-safe indexing)
+export type PhaseArityField =
+  | `unary`
+  | `binary`
+  | `ternary`
+  | `quaternary`
+  | `quinary_plus`
+
+// Check if entry is on the convex hull (stable or e_above_hull ≈ 0)
+export const is_on_hull = (entry: PhaseData, tol: number = 1e-6): boolean =>
+  entry.is_stable === true ||
+  (typeof entry.e_above_hull === `number` && entry.e_above_hull < tol)
 
 // Arity helpers (inlined from former arity.ts)
 export const get_arity = (entry: PhaseData): number =>

--- a/src/lib/table/HeatmapTable.svelte
+++ b/src/lib/table/HeatmapTable.svelte
@@ -36,6 +36,7 @@
     default_num_format = `.3`,
     show_heatmap = $bindable(true),
     heatmap_class = `heatmap`,
+    onrowclick,
     onrowdblclick,
     column_order = $bindable([]),
     export_data = false,
@@ -65,6 +66,7 @@
     default_num_format?: string
     show_heatmap?: boolean
     heatmap_class?: string
+    onrowclick?: (event: MouseEvent, row: RowData) => void
     onrowdblclick?: (event: MouseEvent, row: RowData) => void
     // Array of column IDs to control display order. IDs are derived as:
     // - Ungrouped columns: col.key ?? col.label
@@ -1002,6 +1004,7 @@
             style={row.style}
             class={row.class ?? ``}
             class:selected={row_selected}
+            onclick={onrowclick ? (event) => onrowclick(event, row) : undefined}
             ondblclick={onrowdblclick ? (event) => onrowdblclick(event, row) : undefined}
           >
             {#if show_row_select}

--- a/tests/vitest/convex-hull/ConvexHullStats.test.ts
+++ b/tests/vitest/convex-hull/ConvexHullStats.test.ts
@@ -17,6 +17,7 @@ const mock_stats = (overrides: Partial<PhaseStats> = {}): PhaseStats => ({
   chemical_system: `Li-Fe-P-O`,
   energy_range: { min: -2.5, max: 0.5, avg: -0.8 },
   hull_distance: { max: 0.4, avg: 0.12 },
+  max_arity: 4,
   ...overrides,
 })
 
@@ -130,6 +131,7 @@ describe(`ConvexHullStats`, () => {
   test.each([
     {
       system: `Li-Fe`,
+      max_arity: 2,
       ternary: 0,
       quaternary: 0,
       shown: [`Binary`],
@@ -137,6 +139,7 @@ describe(`ConvexHullStats`, () => {
     },
     {
       system: `Li-Fe-O`,
+      max_arity: 3,
       ternary: 10,
       quaternary: 0,
       shown: [`Ternary`],
@@ -144,9 +147,14 @@ describe(`ConvexHullStats`, () => {
     },
   ])(
     `conditional phase display for $system system`,
-    ({ system, ternary, quaternary, shown, hidden }) => {
+    ({ system, max_arity, ternary, quaternary, shown, hidden }) => {
       mount_stats({
-        phase_stats: mock_stats({ chemical_system: system, ternary, quaternary }),
+        phase_stats: mock_stats({
+          chemical_system: system,
+          max_arity,
+          ternary,
+          quaternary,
+        }),
       })
       const text = document.body.textContent ?? ``
       for (const type of shown) expect(text).toContain(`${type} phases`)

--- a/tests/vitest/convex-hull/ConvexHullStats.test.ts
+++ b/tests/vitest/convex-hull/ConvexHullStats.test.ts
@@ -460,15 +460,14 @@ describe(`ConvexHullStats`, () => {
   })
 
   test.each([
-    [5, true, `shown when count > 0`],
-    [0, false, `hidden when count is 0`],
-  ] as [number, boolean, string][])(
-    `Quinary+ row: %s (%s)`,
+    [5, true],
+    [0, false],
+  ] as [number, boolean][])(
+    `Quinary+ row with count=%s visible=%s`,
     (quinary_plus, should_show) => {
       mount_stats({ phase_stats: mock_stats({ quinary_plus }) })
       const text = document.body.textContent ?? ``
-      if (should_show) expect(text).toContain(`Quinary+`)
-      else expect(text).not.toContain(`Quinary+`)
+      expect(text.includes(`Quinary+`)).toBe(should_show)
     },
   )
 })

--- a/tests/vitest/convex-hull/ConvexHullStats.test.ts
+++ b/tests/vitest/convex-hull/ConvexHullStats.test.ts
@@ -10,6 +10,7 @@ const mock_stats = (overrides: Partial<PhaseStats> = {}): PhaseStats => ({
   binary: 20,
   ternary: 50,
   quaternary: 27,
+  quinary_plus: 0,
   stable: 15,
   unstable: 85,
   elements: 4,

--- a/tests/vitest/convex-hull/types.test.ts
+++ b/tests/vitest/convex-hull/types.test.ts
@@ -12,6 +12,7 @@ import {
   is_denary_entry,
   is_nonary_entry,
   is_octonary_entry,
+  is_on_hull,
   is_quaternary_entry,
   is_quinary_entry,
   is_senary_entry,
@@ -48,6 +49,43 @@ describe(`arity helpers`, () => {
         make({ A: 1, B: 1, C: 1, D: 1, E: 1, F: 1, G: 1, H: 1, I: 1, J: 1 }),
       ),
     ).toBe(true)
+  })
+})
+
+describe(`is_on_hull`, () => {
+  const make = (overrides: Partial<PhaseData>) =>
+    ({ composition: { A: 1 }, energy: -1, ...overrides }) as PhaseData
+
+  test.each([
+    [{ is_stable: true }, true, `explicitly stable`],
+    [
+      { is_stable: true, e_above_hull: 0.5 },
+      true,
+      `is_stable overrides large e_above_hull`,
+    ],
+    [{ e_above_hull: 0 }, true, `e_above_hull exactly 0`],
+    [{ e_above_hull: 1e-7 }, true, `e_above_hull within default tolerance`],
+    [{ e_above_hull: -1e-8 }, true, `negative e_above_hull (numerical noise)`],
+    [{ e_above_hull: 0.1 }, false, `e_above_hull above tolerance`],
+    [
+      { is_stable: false, e_above_hull: 0.1 },
+      false,
+      `unstable with positive e_above_hull`,
+    ],
+    [{}, false, `neither is_stable nor e_above_hull set`],
+    [{ is_stable: false }, false, `is_stable false, no e_above_hull`],
+    [{ e_above_hull: undefined }, false, `e_above_hull undefined`],
+  ] as [Partial<PhaseData>, boolean, string][])(
+    `%o → %s (%s)`,
+    (overrides, expected) => {
+      expect(is_on_hull(make(overrides))).toBe(expected)
+    },
+  )
+
+  test(`custom tolerance overrides default`, () => {
+    const entry = make({ e_above_hull: 0.05 })
+    expect(is_on_hull(entry)).toBe(false)
+    expect(is_on_hull(entry, 0.1)).toBe(true)
   })
 })
 


### PR DESCRIPTION
- Add `layout` prop to `ConvexHullStats` with `'toggle'` (default) and `'side-by-side'` modes
- In side-by-side mode, stats panel and table are shown next to each other without toggle buttons — stats take their natural fixed width, table fills remaining space
- Center the component on the page when extra width is available via `max-width: fit-content` + `margin-inline: auto`
- Extract stats and table markup into reusable Svelte 5 snippets to avoid duplication between modes
- Add clickable table rows with an external callback, a minimum-element filter, data-dependent columns/histograms, and reporting for quinary and higher systems
- Add an import option to merge co-located disordered sites