### PR TITLE
Polish chempot diagram UX and interaction coverage

### DIFF
--- a/src/lib/chempot-diagram/ChemPotDiagram.svelte
+++ b/src/lib/chempot-diagram/ChemPotDiagram.svelte
@@ -62,7 +62,7 @@
       style:width="{width}px"
       style:height="{height}px"
     >
-      <div class="error-content">
+      <div>
         <h3>Unsupported Chemical System</h3>
         <p>
           Chemical potential diagrams require at least 2 elements. Found {n_display}
@@ -98,63 +98,63 @@
     >
       <h4>{@html get_hill_formula(hover_info.formula, false, ``)}</h4>
       {#if hover_info.view === `2d`}
-        <div class="meta-row">2D domain · Points: {hover_info.n_points}</div>
+        <p>2D domain · Points: {hover_info.n_points}</p>
         {#if tooltip_detail_level === `detailed`}
-          <div class="ranges-title">Axis ranges</div>
+          <h5>Axis ranges</h5>
           {#each hover_info.axis_ranges as axis_range (axis_range.element)}
-            <div class="range-row">
+            <p>
               {axis_range.element}: {format_num(axis_range.min_val, `.4~g`)} to
               {format_num(axis_range.max_val, `.4~g`)} eV
-            </div>
+            </p>
           {/each}
         {/if}
       {:else if is_hover_info_3d(hover_info)}
-        <div class="meta-row">
+        <p>
           {hover_info.is_elemental ? `Elemental phase` : `Compound phase`}
           {#if hover_info.is_draw_formula}
             <span> · Overlay target</span>
           {/if}
-        </div>
-        <div class="meta-row">
+        </p>
+        <p>
           Vertices: {hover_info.n_vertices} · Edges: {hover_info.n_edges} · Points:
           {hover_info.n_points}
-        </div>
-        <div class="meta-row">
+        </p>
+        <p>
           Entries: {hover_info.matching_entry_count}
           {#if hover_info.min_energy_per_atom !== null &&
           hover_info.max_energy_per_atom !== null}
             · E/atom: {format_num(hover_info.min_energy_per_atom, `.4~g`)}
             to {format_num(hover_info.max_energy_per_atom, `.4~g`)} eV
           {/if}
-        </div>
+        </p>
         {#if tooltip_detail_level === `detailed`}
-          <div class="ranges-title">Axis ranges</div>
+          <h5>Axis ranges</h5>
           {#each hover_info.axis_ranges as axis_range (axis_range.element)}
-            <div class="range-row">
+            <p>
               {axis_range.element}: {format_num(axis_range.min_val, `.4~g`)} to
               {format_num(axis_range.max_val, `.4~g`)} eV
-            </div>
+            </p>
           {/each}
-          <div class="meta-row">
+          <p>
             Centroid: ({
               hover_info.ann_loc.map((value) => format_num(value, `.3~g`)).join(
                 `, `,
               )
             })
-          </div>
+          </p>
           {#if hover_info.neighbors.length > 0}
-            <div class="ranges-title">Neighbors ({hover_info.neighbors.length})</div>
-            <div class="meta-row">
+            <h5>Neighbors ({hover_info.neighbors.length})</h5>
+            <p>
               {
                 hover_info.neighbors.map((f) => get_hill_formula(f, true, ``)).join(
                   `, `,
                 )
               }
-            </div>
+            </p>
           {/if}
           {#if hover_info.touches_limits.length > 0}
-            <div class="ranges-title">Touches bounds</div>
-            <div class="meta-row">{hover_info.touches_limits.join(`, `)}</div>
+            <h5>Touches bounds</h5>
+            <p>{hover_info.touches_limits.join(`, `)}</p>
           {/if}
         {/if}
       {/if}
@@ -174,22 +174,25 @@
     border-radius: var(--border-radius, 3pt);
     background: var(--bg-color, transparent);
   }
-  .error-content {
+  .chempot-error > div {
     text-align: center;
     padding: 2em;
     color: var(--text-color, #666);
   }
-  .error-content h3 {
+  .chempot-error h3 {
     margin: 0 0 1em;
   }
-  .error-content p {
+  .chempot-error p {
     margin: 0;
   }
   .chempot-tooltip {
     position: absolute;
     max-width: min(32rem, 92vw);
-    background: color-mix(in srgb, var(--bg-color, #fff) 94%, black 6%);
-    color: var(--text-color, #222);
+    background: var(
+      --tooltip-bg,
+      light-dark(rgba(255, 255, 255, 0.95), rgba(0, 0, 0, 0.9))
+    );
+    color: var(--tooltip-text, var(--text-color, #222));
     border: 1px solid color-mix(in srgb, currentColor 18%, transparent);
     border-radius: 6px;
     box-shadow: 0 8px 20px rgba(0, 0, 0, 0.18);
@@ -203,19 +206,16 @@
     margin: 0 0 4px;
     font-size: 13px;
   }
-  .meta-row {
+  .chempot-tooltip p {
     margin: 1px 0;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
   }
-  .ranges-title {
+  .chempot-tooltip h5 {
     margin-top: 6px;
+    margin-bottom: 0;
+    font-size: 12px;
     font-weight: 600;
-  }
-  .range-row {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
   }
 </style>

--- a/src/lib/chempot-diagram/ChemPotDiagram2D.svelte
+++ b/src/lib/chempot-diagram/ChemPotDiagram2D.svelte
@@ -1,21 +1,32 @@
 <script lang="ts">
+  import type { D3InterpolateName } from '$lib/colors'
   import { get_hill_formula } from '$lib/composition/format'
+  import {
+    count_atoms_in_composition,
+    extract_formula_elements,
+  } from '$lib/composition/parse'
   import type { PhaseData } from '$lib/convex-hull/types'
   import { export_svg_as_png, export_svg_as_svg } from '$lib/io/export'
   import { download } from '$lib/io/fetch'
   import DraggablePane from '$lib/overlays/DraggablePane.svelte'
-  import { ScatterPlot } from '$lib/plot'
+  import { ColorBar, ScatterPlot } from '$lib/plot'
   import type { DataSeries, UserContentProps } from '$lib/plot/types'
+  import { scaleSequential } from 'd3-scale'
+  import * as d3_sc from 'd3-scale-chromatic'
   import { onDestroy } from 'svelte'
+  import { SvelteMap } from 'svelte/reactivity'
   import {
     apply_element_padding,
     build_axis_ranges,
     compute_chempot_diagram,
+    formula_key_from_composition,
+    get_energy_per_atom,
+    get_min_entries_and_el_refs,
     orthonormal_2d,
     pad_domain_points,
   } from './compute'
-  import { CHEMPOT_DEFAULTS } from './types'
   import type { ChemPotDiagramConfig, ChemPotHoverInfo } from './types'
+  import { CHEMPOT_DEFAULTS } from './types'
 
   let {
     entries = [],
@@ -57,6 +68,24 @@
     default_min_limit_override ??
       (config.default_min_limit ?? CHEMPOT_DEFAULTS.default_min_limit),
   )
+  let color_mode_override = $state<
+    NonNullable<ChemPotDiagramConfig[`color_mode`]> | null
+  >(
+    null,
+  )
+  let color_scale_override = $state<D3InterpolateName | null>(null)
+  let reverse_color_scale_override = $state<boolean | null>(null)
+  const color_mode = $derived(
+    color_mode_override ?? (config.color_mode ?? CHEMPOT_DEFAULTS.color_mode),
+  )
+  const color_scale = $derived(
+    color_scale_override ?? (config.color_scale ?? CHEMPOT_DEFAULTS.color_scale),
+  )
+  const reverse_color_scale = $derived(
+    reverse_color_scale_override ??
+      (config.reverse_color_scale ?? CHEMPOT_DEFAULTS.reverse_color_scale),
+  )
+  const arity_colors = [`#3498db`, `#2ecc71`, `#e67e22`, `#9b59b6`] as const
   const show_tooltip = $derived(config.show_tooltip ?? CHEMPOT_DEFAULTS.show_tooltip)
   const effective_config = $derived({
     ...config,
@@ -71,6 +100,9 @@
     label_stable_override = null
     element_padding_override = null
     default_min_limit_override = null
+    color_mode_override = null
+    color_scale_override = null
+    reverse_color_scale_override = null
   }
 
   // === Diagram computation ===
@@ -84,7 +116,9 @@
     }
   })
 
-  const plot_elements = $derived(diagram_data?.elements.slice(0, 2) ?? [])
+  const plot_elements = $derived(
+    (diagram_data?.elements ?? config.elements ?? []).slice(0, 2),
+  )
 
   const draw_domains = $derived.by(() => {
     if (!diagram_data || plot_elements.length < 2) return {}
@@ -113,17 +147,173 @@
     }
     return result
   })
+  const domain_entries = $derived(Object.entries(draw_domains))
+  const domain_formulas = $derived(Object.keys(draw_domains))
+
+  interface FormulaEnergyStats {
+    matching_entry_count: number
+    min_energy_per_atom: number | null
+  }
+
+  const raw_el_refs = $derived(get_min_entries_and_el_refs(entries).el_refs)
+  function compute_e_form(
+    entry: PhaseData,
+    el_refs: Record<string, PhaseData>,
+  ): number {
+    const atom_count = count_atoms_in_composition(entry.composition)
+    const energy_per_atom = get_energy_per_atom(entry)
+    let ref_energy = 0
+    for (const [element, amount] of Object.entries(entry.composition)) {
+      if (amount <= 0) continue
+      const fraction = amount / atom_count
+      const ref_entry = el_refs[element]
+      if (ref_entry) ref_energy += fraction * get_energy_per_atom(ref_entry)
+    }
+    return energy_per_atom - ref_energy
+  }
+  function best_e_form_for_formula(formula: string): number | undefined {
+    let best_val: number | undefined
+    for (const entry of entries) {
+      if (formula_key_from_composition(entry.composition) !== formula) continue
+      const e_form = entry.e_form_per_atom ?? compute_e_form(entry, raw_el_refs)
+      if (best_val === undefined || e_form < best_val) best_val = e_form
+    }
+    return best_val
+  }
+  function get_interpolator(
+    interpolator_name: D3InterpolateName,
+  ): (t: number) => string {
+    const raw = (d3_sc as unknown as Record<string, (t: number) => string>)[
+      interpolator_name
+    ] ??
+      d3_sc.interpolateViridis
+    return reverse_color_scale ? (param_t: number) => raw(1 - param_t) : raw
+  }
+  function make_color_scale(
+    values: number[],
+    interpolator_name: D3InterpolateName,
+  ): ((val: number) => string) | null {
+    const finite_vals = values.filter(Number.isFinite)
+    if (finite_vals.length === 0) return null
+    let min_val = finite_vals[0], max_val_raw = finite_vals[0]
+    for (let idx = 1; idx < finite_vals.length; idx++) {
+      if (finite_vals[idx] < min_val) min_val = finite_vals[idx]
+      if (finite_vals[idx] > max_val_raw) max_val_raw = finite_vals[idx]
+    }
+    const max_val = Math.max(max_val_raw, min_val + 1e-6)
+    return scaleSequential(get_interpolator(interpolator_name)).domain([
+      min_val,
+      max_val,
+    ])
+  }
+  const entry_energy_stats_by_formula = $derived.by(
+    (): SvelteMap<string, FormulaEnergyStats> => {
+      const stats = new SvelteMap<string, FormulaEnergyStats>()
+      for (const entry of entries) {
+        const formula_key = formula_key_from_composition(entry.composition)
+        const epa = get_energy_per_atom(entry)
+        const prev_stats = stats.get(formula_key)
+        if (!prev_stats) {
+          stats.set(formula_key, {
+            matching_entry_count: 1,
+            min_energy_per_atom: epa,
+          })
+          continue
+        }
+        stats.set(formula_key, {
+          matching_entry_count: prev_stats.matching_entry_count + 1,
+          min_energy_per_atom: Math.min(prev_stats.min_energy_per_atom ?? epa, epa),
+        })
+      }
+      return stats
+    },
+  )
+  const domain_colors = $derived.by((): SvelteMap<string, string> => {
+    const colors = new SvelteMap<string, string>()
+    if (color_mode === `none`) return colors
+    if (color_mode === `arity`) {
+      for (const formula of domain_formulas) {
+        const n_elements = extract_formula_elements(formula).length
+        const color_idx = Math.min(n_elements, arity_colors.length) - 1
+        colors.set(formula, arity_colors[Math.max(0, color_idx)])
+      }
+      return colors
+    }
+    const values: number[] = []
+    const value_by_formula = new SvelteMap<string, number>()
+    for (const formula of domain_formulas) {
+      if (color_mode === `energy`) {
+        const epa = entry_energy_stats_by_formula.get(formula)?.min_energy_per_atom
+        if (epa != null) {
+          values.push(epa)
+          value_by_formula.set(formula, epa)
+        }
+      } else if (color_mode === `formation_energy`) {
+        const e_form = best_e_form_for_formula(formula)
+        if (e_form != null) {
+          values.push(e_form)
+          value_by_formula.set(formula, e_form)
+        }
+      } else if (color_mode === `entries`) {
+        const count =
+          entry_energy_stats_by_formula.get(formula)?.matching_entry_count ?? 0
+        values.push(count)
+        value_by_formula.set(formula, count)
+      }
+    }
+    const scale = make_color_scale(values, color_scale)
+    for (const formula of domain_formulas) {
+      const color_val = value_by_formula.get(formula)
+      colors.set(formula, color_val != null && scale ? scale(color_val) : `#999`)
+    }
+    return colors
+  })
+  const color_range = $derived.by(
+    (): { min: number; max: number; label: string } | null => {
+      if (color_mode === `none` || color_mode === `arity`) return null
+      const values: number[] = []
+      for (const formula of domain_formulas) {
+        if (color_mode === `energy`) {
+          const epa = entry_energy_stats_by_formula.get(formula)?.min_energy_per_atom
+          if (epa != null) values.push(epa)
+        } else if (color_mode === `formation_energy`) {
+          const e_form = best_e_form_for_formula(formula)
+          if (e_form != null) values.push(e_form)
+        } else if (color_mode === `entries`) {
+          values.push(
+            entry_energy_stats_by_formula.get(formula)?.matching_entry_count ?? 0,
+          )
+        }
+      }
+      if (values.length === 0) return null
+      let min_val = values[0], max_val = values[0]
+      for (let idx = 1; idx < values.length; idx++) {
+        if (values[idx] < min_val) min_val = values[idx]
+        if (values[idx] > max_val) max_val = values[idx]
+      }
+      const color_labels: Record<string, string> = {
+        energy: `Energy per atom (eV)`,
+        formation_energy: `Formation energy (eV/atom)`,
+        entries: `Entry count`,
+      }
+      return {
+        min: min_val,
+        max: Math.max(max_val, min_val + 1e-6),
+        label: color_labels[color_mode] ?? ``,
+      }
+    },
+  )
 
   // === Convert domains to ScatterPlot DataSeries ===
   const series = $derived<DataSeries[]>(
-    Object.entries(draw_domains).map(([formula, pts]) => ({
+    domain_entries.map(([formula, pts]) => ({
       id: formula,
       label: formula,
       x: pts.map((pt) => pt[0]),
       y: pts.map((pt) => pt[1]),
       markers: `line+points` as const,
-      line_style: { stroke: `black`, stroke_width: 3 },
-      point_style: { fill: `black`, radius: 3 },
+      line_style: { stroke: domain_colors.get(formula) ?? `black`, stroke_width: 3 },
+      point_style: { fill: domain_colors.get(formula) ?? `black`, radius: 3 },
     })),
   )
 
@@ -168,17 +358,13 @@
   })
 
   // === Hover info for external consumers ===
-  function handle_hover(
-    data: { point: { series_idx: number }; event: MouseEvent } | null,
+  let locked_hover_formula = $state<string | null>(null)
+
+  function set_hover_info(
+    formula: string,
+    pts: number[][],
+    event: MouseEvent,
   ): void {
-    if (!data) {
-      hover_info = null
-      return
-    }
-    const domain_entries = Object.entries(draw_domains)
-    const entry = domain_entries[data.point.series_idx]
-    if (!entry) return
-    const [formula, pts] = entry
     const bounds = scatter_wrapper?.getBoundingClientRect()
     hover_info = {
       formula,
@@ -187,11 +373,44 @@
       axis_ranges: build_axis_ranges(pts, plot_elements),
       pointer: bounds
         ? {
-          x: data.event.clientX - bounds.left + 4,
-          y: data.event.clientY - bounds.top + 4,
+          x: event.clientX - bounds.left + 4,
+          y: event.clientY - bounds.top + 4,
         }
         : undefined,
     }
+  }
+
+  function clear_hover_lock(): void {
+    locked_hover_formula = null
+    hover_info = null
+  }
+
+  function handle_hover(
+    data: { point: { series_idx: number }; event: MouseEvent } | null,
+  ): void {
+    if (!data) {
+      if (!locked_hover_formula) hover_info = null
+      return
+    }
+    const entry = domain_entries[data.point.series_idx]
+    if (!entry) return
+    const [formula, pts] = entry
+    if (locked_hover_formula && locked_hover_formula !== formula) return
+    set_hover_info(formula, pts, data.event)
+  }
+
+  function handle_click(
+    data: { point: { series_idx: number }; event: MouseEvent },
+  ): void {
+    const entry = domain_entries[data.point.series_idx]
+    if (!entry) return
+    const [formula, pts] = entry
+    if (locked_hover_formula === formula) {
+      clear_hover_lock()
+      return
+    }
+    locked_hover_formula = formula
+    set_hover_info(formula, pts, data.event)
   }
 
   // === Export ===
@@ -271,46 +490,54 @@
     }}
   >
     <h4>Export Image</h4>
-    <label>
-      SVG
-      <button
-        type="button"
-        onclick={() => {
-          const svg = get_svg_element()
-          if (svg) export_svg_as_svg(svg, `chempot-${plot_elements.join(`-`)}.svg`)
-        }}
-        aria-label="Download SVG"
-      >
-        ⬇
-      </button>
-    </label>
-    <label>
-      PNG
-      <button
-        type="button"
-        onclick={() => {
-          const svg = get_svg_element()
-          if (svg) export_svg_as_png(svg, `chempot-${plot_elements.join(`-`)}.png`)
-        }}
-        aria-label="Download PNG"
-      >
-        ⬇
-      </button>
-    </label>
+    <div class="export-row">
+      <label>
+        SVG
+        <button
+          type="button"
+          onclick={() => {
+            const svg = get_svg_element()
+            if (svg) {
+              export_svg_as_svg(svg, `chempot-${plot_elements.join(`-`)}.svg`)
+            }
+          }}
+          aria-label="Download SVG"
+        >
+          ⬇
+        </button>
+      </label>
+      <label>
+        PNG
+        <button
+          type="button"
+          onclick={() => {
+            const svg = get_svg_element()
+            if (svg) {
+              export_svg_as_png(svg, `chempot-${plot_elements.join(`-`)}.png`)
+            }
+          }}
+          aria-label="Download PNG"
+        >
+          ⬇
+        </button>
+      </label>
+    </div>
     <h4>Export Data</h4>
-    <label>
-      JSON
-      <button type="button" onclick={export_json_file} aria-label="Download JSON">
-        ⬇
-      </button>
-      <button
-        type="button"
-        onclick={copy_json}
-        aria-label="Copy JSON to clipboard"
-      >
-        {copy_status ? `✅` : `📋`}
-      </button>
-    </label>
+    <div class="export-row">
+      <label>
+        JSON
+        <button type="button" onclick={export_json_file} aria-label="Download JSON">
+          ⬇
+        </button>
+        <button
+          type="button"
+          onclick={copy_json}
+          aria-label="Copy JSON to clipboard"
+        >
+          {copy_status ? `✅` : `📋`}
+        </button>
+      </label>
+    </div>
   </DraggablePane>
 {/snippet}
 
@@ -364,6 +591,51 @@
       }}
     />
   </label>
+  <label>
+    <span>Color mode:</span>
+    <select
+      value={color_mode}
+      onchange={(event) => {
+        color_mode_override = event.currentTarget.value as typeof color_mode
+      }}
+    >
+      <option value="none">None</option>
+      <option value="energy">Energy/atom</option>
+      <option value="formation_energy">Formation energy</option>
+      <option value="arity">Element count</option>
+      <option value="entries">Entry count</option>
+    </select>
+  </label>
+  {#if color_mode !== `none` && color_mode !== `arity`}
+    <label>
+      <span>Color scale:</span>
+      <select
+        value={color_scale}
+        onchange={(event) => {
+          color_scale_override = event.currentTarget.value as D3InterpolateName
+        }}
+      >
+        <option value="interpolateViridis">Viridis</option>
+        <option value="interpolatePlasma">Plasma</option>
+        <option value="interpolateInferno">Inferno</option>
+        <option value="interpolateMagma">Magma</option>
+        <option value="interpolateCividis">Cividis</option>
+        <option value="interpolateTurbo">Turbo</option>
+        <option value="interpolateRdYlBu">RdYlBu</option>
+        <option value="interpolateSpectral">Spectral</option>
+      </select>
+      <span class="reverse-scale-toggle">
+        <span>Reverse:</span>
+        <input
+          type="checkbox"
+          checked={reverse_color_scale}
+          onchange={() => {
+            reverse_color_scale_override = !reverse_color_scale
+          }}
+        />
+      </span>
+    </label>
+  {/if}
   <button type="button" onclick={reset_controls}>Reset defaults</button>
 {/snippet}
 
@@ -373,7 +645,27 @@
     <p>Need at least 2 elements with elemental reference entries.</p>
   </div>
 {:else}
-  <div class="chempot-diagram-2d" bind:clientWidth={container_width}>
+  <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+  <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+  <div
+    class="chempot-diagram-2d"
+    bind:clientWidth={container_width}
+    role="application"
+    tabindex="0"
+    onkeydown={(event) => {
+      if (event.key === `Escape`) clear_hover_lock()
+    }}
+    onpointerdown={(event) => {
+      const target = event.target
+      if (!locked_hover_formula) return
+      const is_background_click = target === scatter_wrapper ||
+        (target instanceof SVGElement &&
+          target.closest(`g[data-series-id]`) === null)
+      if (is_background_click) {
+        clear_hover_lock()
+      }
+    }}
+  >
     {@render export_toggle()}
     <ScatterPlot
       bind:wrapper={scatter_wrapper}
@@ -385,8 +677,30 @@
       controls_extra={chempot_controls}
       user_content={domain_labels}
       on_point_hover={handle_hover}
+      on_point_click={handle_click}
       style="--scatter-width: 100%; --scatter-height: {render_height}px; --fullscreen-btn-offset: 68px"
     />
+    {#if color_mode !== `none` && color_mode !== `arity` && color_range}
+      <ColorBar
+        title={color_range.label}
+        range={[color_range.min, color_range.max]}
+        color_scale_fn={get_interpolator(color_scale)}
+        color_scale_domain={[0, 1]}
+        wrapper_style="position: absolute; bottom: 70px; left: 50px; width: 180px; z-index: 10;"
+        bar_style="height: 10px;"
+        title_style="margin-bottom: 3px;"
+      />
+    {/if}
+    {#if color_mode === `arity`}
+      <div class="arity-legend">
+        {#each [`Unary`, `Binary`, `Ternary`, `4+`] as label_text, color_idx (label_text)}
+          <span>
+            <span style:background={arity_colors[color_idx]}></span>
+            {label_text}
+          </span>
+        {/each}
+      </div>
+    {/if}
     {#if render_local_tooltip && show_tooltip && hover_info?.view === `2d`}
       <aside
         class="tooltip"
@@ -394,6 +708,9 @@
         style:top="{hover_info.pointer?.y ?? 4}px"
       >
         <strong>{@html get_hill_formula(hover_info.formula, false, ``)}</strong>
+        {#if locked_hover_formula === hover_info.formula}
+          <div>Pinned · Press Esc to unlock</div>
+        {/if}
       </aside>
     {/if}
   </div>
@@ -420,6 +737,21 @@
     margin: 4pt 0;
     font-size: 0.95em;
   }
+  .chempot-diagram-2d :global(.export-row) {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4pt 10pt;
+    margin: 0 0 4pt;
+  }
+  .chempot-diagram-2d :global(.export-row > label) {
+    margin: 0;
+  }
+  .chempot-diagram-2d :global(.reverse-scale-toggle) {
+    display: flex;
+    align-items: center;
+    gap: 4pt;
+    margin-left: 4pt;
+  }
   .error-state {
     display: flex;
     flex-direction: column;
@@ -436,13 +768,37 @@
   }
   .tooltip {
     position: absolute;
-    background: var(--tooltip-bg, rgba(0, 0, 0, 0.85));
-    color: var(--tooltip-text, white);
+    background: var(
+      --tooltip-bg,
+      light-dark(rgba(255, 255, 255, 0.95), rgba(0, 0, 0, 0.9))
+    );
+    color: var(--tooltip-text, var(--text-color, #fff));
     padding: 4px 8px;
     border-radius: 4px;
     font-size: 12px;
     pointer-events: none;
     white-space: nowrap;
     z-index: 10;
+  }
+  .arity-legend {
+    position: absolute;
+    bottom: 52px;
+    left: 24px;
+    display: flex;
+    gap: 10px;
+    font-size: 12px;
+    z-index: 10;
+    pointer-events: none;
+  }
+  .arity-legend > span {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+  .arity-legend > span > span {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
   }
 </style>

--- a/src/lib/chempot-diagram/ChemPotDiagram3D.svelte
+++ b/src/lib/chempot-diagram/ChemPotDiagram3D.svelte
@@ -855,15 +855,16 @@
     const pos = hull_base_geometry.getAttribute(`position`)
     const n_faces = pos.count / 3
 
-    // Domain vertex centroids in swizzled Three.js coords: data[1]→X, data[2]→Y, data[0]→Z
+    // Domain vertex centroids in render coords (swizzled + axis stretch), matching hull_base_geometry.
     const centroids = render_domains
       .filter((d) => !d.is_draw_formula && d.points_3d.length > 0)
       .map((d) => {
         let sx = 0, sy = 0, sz = 0
         for (const pt of d.points_3d) {
-          sx += pt[1]
-          sy += pt[2]
-          sz += pt[0]
+          const [x_val, y_val, z_val] = to_render_xyz(pt)
+          sx += x_val
+          sy += y_val
+          sz += z_val
         }
         const n = d.points_3d.length
         return { formula: d.formula, cx: sx / n, cy: sy / n, cz: sz / n }

--- a/src/lib/chempot-diagram/ChemPotDiagram3D.svelte
+++ b/src/lib/chempot-diagram/ChemPotDiagram3D.svelte
@@ -33,7 +33,9 @@
   import { onDestroy, onMount } from 'svelte'
   import { SvelteMap, SvelteSet } from 'svelte/reactivity'
   import * as THREE from 'three'
+  import { GLTFExporter } from 'three/examples/jsm/exporters/GLTFExporter.js'
   import { ConvexGeometry } from 'three/examples/jsm/geometries/ConvexGeometry.js'
+  import type { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
   import {
     apply_element_padding,
     build_axis_ranges,
@@ -90,7 +92,10 @@
     default_min_limit_override ??
       (config.default_min_limit ?? CHEMPOT_DEFAULTS.default_min_limit),
   )
-  const formulas_to_draw = $derived(config.formulas_to_draw ?? [])
+  let formulas_to_draw_override = $state<string[] | null>(null)
+  const formulas_to_draw = $derived(
+    formulas_to_draw_override ?? (config.formulas_to_draw ?? []),
+  )
   const draw_formula_meshes = $derived(
     draw_formula_meshes_override ??
       (config.draw_formula_meshes ?? CHEMPOT_DEFAULTS.draw_formula_meshes),
@@ -121,19 +126,22 @@
       ? config.formula_colors
       : CHEMPOT_DEFAULTS.formula_colors,
   )
-  const effective_config = $derived({
-    ...config,
-    formal_chempots,
-    label_stable,
-    element_padding,
-    default_min_limit,
-    draw_formula_meshes,
-    draw_formula_lines,
-  })
+
+  function normalize_projection_triplet(
+    maybe_triplet: string[] | undefined,
+    available_elements: string[],
+  ): string[] | null {
+    if (!maybe_triplet || maybe_triplet.length !== 3) return null
+    const deduped = Array.from(new Set(maybe_triplet))
+    if (deduped.length !== 3) return null
+    if (deduped.some((element) => !available_elements.includes(element))) return null
+    return deduped
+  }
 
   let wrapper = $state<HTMLDivElement>()
   let fullscreen = $state(false)
   let export_pane_open = $state(false)
+  let formula_picker_open = $state(false)
   let copy_status = $state(false)
   let copy_timeout_id: ReturnType<typeof setTimeout> | null = null
   let container_width = $state(0)
@@ -148,14 +156,7 @@
 
   let mounted = $state(false)
   onMount(() => mounted = true)
-  type OrbitControlsLike = {
-    object: THREE.Camera
-    target?: THREE.Vector3
-    update?: () => void
-    addEventListener: (event_name: string, callback: () => void) => void
-    removeEventListener: (event_name: string, callback: () => void) => void
-  }
-  let orbit_controls_ref = $state<OrbitControlsLike | null>(null)
+  let orbit_controls_ref = $state<OrbitControls | undefined>(undefined)
   // Backside tracking: axes/ticks/labels render on the far side from the camera
   // back[i] = backside data coordinate value for data axis i
   // Matches ScatterPlot3DScene pattern where pos tracks the opposite side from camera
@@ -184,10 +185,52 @@
   //   data[1] (plotly y, projects right) → Three.js X (projects right)
   //   data[2] (plotly z, projects up)    → Three.js Y (projects up)
   function to_vec3(pt: number[]): THREE.Vector3 {
-    return new THREE.Vector3(pt[1], pt[2], pt[0])
+    const [x_val, y_val, z_val] = to_render_xyz(pt)
+    return new THREE.Vector3(x_val, y_val, z_val)
   }
 
   // Compute diagram data (requires >= 3 elements for 3D rendering)
+  const all_entry_elements = $derived.by(() =>
+    Array.from(
+      new SvelteSet(
+        entries.flatMap((entry) =>
+          Object.entries(entry.composition)
+            .filter(([, amount]) => amount > 0)
+            .map(([element]) => element)
+        ),
+      ),
+    ).sort()
+  )
+  const has_multinary_system = $derived(all_entry_elements.length > 3)
+  let projection_elements_override = $state<string[] | null>(null)
+  const config_projection_elements = $derived(
+    normalize_projection_triplet(config.elements, all_entry_elements),
+  )
+  const projection_elements = $derived.by(() => {
+    if (all_entry_elements.length < 3) return []
+    if (!has_multinary_system) {
+      return config_projection_elements ?? all_entry_elements.slice(0, 3)
+    }
+    const override_projection = normalize_projection_triplet(
+      projection_elements_override ?? undefined,
+      all_entry_elements,
+    )
+    if (override_projection) return override_projection
+    if (config_projection_elements) return config_projection_elements
+    return all_entry_elements.slice(0, 3)
+  })
+  const effective_config = $derived({
+    ...config,
+    elements: projection_elements.length === 3
+      ? projection_elements
+      : config.elements,
+    formal_chempots,
+    label_stable,
+    element_padding,
+    default_min_limit,
+    draw_formula_meshes,
+    draw_formula_lines,
+  })
   const diagram_data = $derived.by(() => {
     if (entries.length < 3) return null
     try {
@@ -199,29 +242,60 @@
     }
   })
 
-  const plot_elements = $derived(diagram_data?.elements.slice(0, 3) ?? [])
-  const all_entry_elements = $derived.by(() =>
-    Array.from(
-      new SvelteSet(
-        entries.flatMap((entry) =>
-          Object.entries(entry.composition)
-            .filter(([, amount]) => amount > 0)
-            .map(([element]) => element)
-        ),
-      ),
-    )
-  )
+  const plot_elements = $derived(diagram_data?.elements ?? projection_elements)
   const is_projection_mode = $derived(
     plot_elements.length > 0 &&
       plot_elements.length < all_entry_elements.length &&
       plot_elements.every((element) => all_entry_elements.includes(element)),
   )
+  const projection_presets = $derived.by(() => {
+    const presets: string[][] = []
+    const seen_triplets = new SvelteSet<string>()
+    const add_triplet = (candidate: string[] | null): void => {
+      if (!candidate) return
+      const key = candidate.join(`|`)
+      if (seen_triplets.has(key)) return
+      seen_triplets.add(key)
+      presets.push(candidate)
+    }
+    add_triplet(config_projection_elements)
+    add_triplet(plot_elements.length === 3 ? plot_elements : null)
+    if (all_entry_elements.length >= 3) {
+      const n_elements = all_entry_elements.length
+      for (let first_idx = 0; first_idx < n_elements; first_idx++) {
+        for (let second_idx = first_idx + 1; second_idx < n_elements; second_idx++) {
+          for (let third_idx = second_idx + 1; third_idx < n_elements; third_idx++) {
+            add_triplet([
+              all_entry_elements[first_idx],
+              all_entry_elements[second_idx],
+              all_entry_elements[third_idx],
+            ])
+            if (presets.length >= 12) return presets
+          }
+        }
+      }
+    }
+    return presets
+  })
+  const current_projection_key = $derived(plot_elements.join(`|`))
+  let formula_filter_query = $state(``)
+  const available_formulas = $derived.by(() =>
+    Object.keys(diagram_data?.domains ?? {}).sort()
+  )
+  const filtered_formulas = $derived.by(() => {
+    const query = formula_filter_query.trim().toLowerCase()
+    if (!query) return available_formulas
+    return available_formulas.filter((formula) =>
+      formula.toLowerCase().includes(query)
+    )
+  })
 
   // Process domains for rendering
   interface DomainRenderData {
     formula: string
     points_3d: number[][]
     ann_loc: number[]
+    label_loc: number[]
     is_draw_formula: boolean
   }
 
@@ -264,14 +338,26 @@
         : pts
       if (padded.length < 2) continue
       const is_draw = formulas_to_draw.includes(formula)
+      const label_loc = padded[0].map((_, col_idx) =>
+        padded.reduce((sum, point) => sum + point[col_idx], 0) / padded.length
+      )
       if (padded.length >= 3) {
         const { ann_loc } = get_3d_domain_simplexes_and_ann_loc(padded)
-        result.push({ formula, points_3d: padded, ann_loc, is_draw_formula: is_draw })
+        result.push({
+          formula,
+          points_3d: padded,
+          ann_loc,
+          label_loc,
+          is_draw_formula: is_draw,
+        })
       } else {
-        const ann_loc = padded[0].map((_, col) =>
-          padded.reduce((s, p) => s + p[col], 0) / padded.length
-        )
-        result.push({ formula, points_3d: padded, ann_loc, is_draw_formula: is_draw })
+        result.push({
+          formula,
+          points_3d: padded,
+          ann_loc: label_loc,
+          label_loc,
+          is_draw_formula: is_draw,
+        })
       }
     }
     return result
@@ -477,25 +563,63 @@
     },
   )
 
+  // Stretch short axes to improve screen-space utilization for highly anisotropic systems.
+  // Mapping is in rendered axis order: X=data[1], Y=data[2], Z=data[0].
+  const render_axis_scale = $derived.by((): [number, number, number] => {
+    const points = render_domains.flatMap((domain) => domain.points_3d)
+    if (points.length === 0) return [1, 1, 1]
+    let min0 = Infinity, max0 = -Infinity
+    let min1 = Infinity, max1 = -Infinity
+    let min2 = Infinity, max2 = -Infinity
+    for (const point of points) {
+      if (point[0] < min0) min0 = point[0]
+      if (point[0] > max0) max0 = point[0]
+      if (point[1] < min1) min1 = point[1]
+      if (point[1] > max1) max1 = point[1]
+      if (point[2] < min2) min2 = point[2]
+      if (point[2] > max2) max2 = point[2]
+    }
+    const span_x = Math.max(max1 - min1, 1e-6) // render X from data axis 1
+    const span_y = Math.max(max2 - min2, 1e-6) // render Y from data axis 2
+    const span_z = Math.max(max0 - min0, 1e-6) // render Z from data axis 0
+    const max_span = Math.max(span_x, span_y, span_z)
+    return [
+      Math.min(Math.max(max_span / span_x, 1), 4),
+      Math.min(Math.max(max_span / span_y, 1), 4),
+      Math.min(Math.max(max_span / span_z, 1), 4),
+    ]
+  })
+
+  function to_render_xyz(point: number[]): [number, number, number] {
+    const [scale_x, scale_y, scale_z] = render_axis_scale
+    return [point[1] * scale_x, point[2] * scale_y, point[0] * scale_z]
+  }
+
   // Compute data center and extent for camera positioning (in swizzled coords)
   const { data_center, data_extent } = $derived.by(() => {
-    const pts = render_domains.flatMap((d) => d.points_3d)
-    if (pts.length === 0) {
+    const points = render_domains.flatMap((domain) => domain.points_3d)
+    if (points.length === 0) {
       return { data_center: new THREE.Vector3(0, 0, 0), data_extent: 10 }
     }
-    // Compute center (swizzled: data[1]→X, data[2]→Y, data[0]→Z)
-    let [sx, sy, sz] = [0, 0, 0]
-    for (const pt of pts) {
-      sx += pt[1]
-      sy += pt[2]
-      sz += pt[0]
+    // Compute center in rendered coordinates (swizzled + axis stretch)
+    let sum_x = 0, sum_y = 0, sum_z = 0
+    for (const point of points) {
+      const [x_val, y_val, z_val] = to_render_xyz(point)
+      sum_x += x_val
+      sum_y += y_val
+      sum_z += z_val
     }
-    const n = pts.length
-    const center = new THREE.Vector3(sx / n, sy / n, sz / n)
+    const n_points = points.length
+    const center = new THREE.Vector3(
+      sum_x / n_points,
+      sum_y / n_points,
+      sum_z / n_points,
+    )
     // Compute max distance from center
     let max_dist = 0
-    for (const pt of pts) {
-      const dist = Math.hypot(pt[1] - center.x, pt[2] - center.y, pt[0] - center.z)
+    for (const point of points) {
+      const [x_val, y_val, z_val] = to_render_xyz(point)
+      const dist = Math.hypot(x_val - center.x, y_val - center.y, z_val - center.z)
       if (dist > max_dist) max_dist = dist
     }
     return { data_center: center, data_extent: Math.max(max_dist * 1.3, 1) }
@@ -633,7 +757,7 @@
     for (const domain of render_domains) {
       if (domain.is_draw_formula) continue
       // Compute edges in swizzled (Three.js) coords since ConvexGeometry works there
-      const swizzled = domain.points_3d.map((pt) => [pt[1], pt[2], pt[0]])
+      const swizzled = domain.points_3d.map((point) => to_render_xyz(point))
       for (const [pa, pb] of get_domain_edges(swizzled)) {
         const ka = pa.map((v) => v.toFixed(4)).join(`,`)
         const kb = pb.map((v) => v.toFixed(4)).join(`,`)
@@ -970,7 +1094,7 @@
       if (!domain.is_draw_formula) continue
       const color_idx = formulas_to_draw.indexOf(domain.formula) %
         formula_colors.length
-      const swizzled = domain.points_3d.map((pt) => [pt[1], pt[2], pt[0]])
+      const swizzled = domain.points_3d.map((point) => to_render_xyz(point))
       const positions: number[] = []
       for (const [pa, pb] of get_domain_edges(swizzled)) {
         positions.push(pa[0], pa[1], pa[2], pb[0], pb[1], pb[2])
@@ -1117,7 +1241,7 @@
       if (!hover_geometry) continue
       const { geometry, n_vertices } = hover_geometry
 
-      const swizzled_points = domain.points_3d.map((pt) => [pt[1], pt[2], pt[0]])
+      const swizzled_points = domain.points_3d.map((point) => to_render_xyz(point))
       const edge_count = get_domain_edges(swizzled_points).length
       const axis_ranges = build_axis_ranges(domain.points_3d, plot_elements)
       const touches_limits = get_touches_limits(domain.points_3d, lims)
@@ -1279,7 +1403,8 @@
 
   // Swizzle a data-coord triple to Three.js coords
   function swiz(d0: number, d1: number, d2: number): [number, number, number] {
-    return [d1, d2, d0] // data[0]→Z, data[1]→X, data[2]→Y
+    const [scale_x, scale_y, scale_z] = render_axis_scale
+    return [d1 * scale_x, d2 * scale_y, d0 * scale_z] // data[0]→Z, data[1]→X, data[2]→Y
   }
 
   const axis_colors = [`#e74c3c`, `#2ecc71`, `#3498db`] as const
@@ -1566,6 +1691,52 @@
     color_mode_override = null
     color_scale_override = null
     reverse_color_scale_override = null
+    projection_elements_override = null
+    formulas_to_draw_override = null
+    formula_filter_query = ``
+  }
+
+  function set_projection_axis(axis_idx: number, element: string): void {
+    if (!all_entry_elements.includes(element)) return
+    const next_projection = [...plot_elements]
+    if (next_projection.length !== 3) return
+    const current_owner_idx = next_projection.indexOf(element)
+    if (current_owner_idx !== -1 && current_owner_idx !== axis_idx) {
+      next_projection[current_owner_idx] = next_projection[axis_idx]
+    }
+    next_projection[axis_idx] = element
+    const normalized = normalize_projection_triplet(
+      next_projection,
+      all_entry_elements,
+    )
+    if (normalized) projection_elements_override = normalized
+  }
+
+  function apply_projection_preset(preset_elements: string[]): void {
+    const normalized = normalize_projection_triplet(
+      preset_elements,
+      all_entry_elements,
+    )
+    if (normalized) projection_elements_override = normalized
+  }
+
+  function toggle_formula_selection(formula: string): void {
+    const selected_formulas = new SvelteSet(formulas_to_draw)
+    if (selected_formulas.has(formula)) selected_formulas.delete(formula)
+    else selected_formulas.add(formula)
+    formulas_to_draw_override = [...selected_formulas]
+  }
+
+  function select_surface_formulas(): void {
+    formulas_to_draw_override = render_domains
+      .filter((domain) => surface_formulas.has(domain.formula))
+      .map((domain) => domain.formula)
+  }
+
+  function select_neighbor_formulas(): void {
+    if (hover_info?.view !== `3d`) return
+    const neighbors = domain_neighbors.get(hover_info.formula) ?? []
+    formulas_to_draw_override = [hover_info.formula, ...neighbors]
   }
 
   function download_blob(blob: Blob, filename: string): void {
@@ -1578,6 +1749,26 @@
   }
 
   let png_dpi = $state(150)
+  const export_basename = $derived(`chempot-${plot_elements.join(`-`)}`)
+
+  function get_view_settings(): Record<string, unknown> {
+    const camera_position = orbit_controls_ref?.object?.position
+    const camera_target = orbit_controls_ref?.target
+    return {
+      elements: plot_elements,
+      camera_projection,
+      auto_rotate,
+      color_mode,
+      color_scale,
+      reverse_color_scale,
+      camera_position: camera_position
+        ? [camera_position.x, camera_position.y, camera_position.z]
+        : null,
+      camera_target: camera_target
+        ? [camera_target.x, camera_target.y, camera_target.z]
+        : null,
+    }
+  }
 
   function export_png_file(): void {
     if (!wrapper) return
@@ -1617,8 +1808,135 @@
 
     out.toBlob((blob) => {
       if (!blob) return
-      download_blob(blob, `chempot-${plot_elements.join(`-`)}.png`)
+      download_blob(blob, `${export_basename}.png`)
     }, `image/png`)
+  }
+
+  function xml_escape(text: string): string {
+    return text
+      .replaceAll(`&`, `&amp;`)
+      .replaceAll(`<`, `&lt;`)
+      .replaceAll(`>`, `&gt;`)
+      .replaceAll(`"`, `&quot;`)
+      .replaceAll(`'`, `&#39;`)
+  }
+
+  function export_svg_file(): void {
+    if (!wrapper) return
+    const gl_canvas = wrapper.querySelector(`canvas`)
+    if (!(gl_canvas instanceof HTMLCanvasElement)) return
+    const canvas_rect = gl_canvas.getBoundingClientRect()
+    if (canvas_rect.width === 0 || canvas_rect.height === 0) return
+    const png_data_url = gl_canvas.toDataURL(`image/png`)
+    const text_nodes: string[] = []
+    for (
+      const element of wrapper.querySelectorAll(
+        `.tick-label, .axis-label, .domain-label`,
+      )
+    ) {
+      const html_element = element as HTMLElement
+      const style = getComputedStyle(html_element)
+      if (style.display === `none` || style.visibility === `hidden`) continue
+      const el_rect = html_element.getBoundingClientRect()
+      const x = el_rect.left + el_rect.width / 2 - canvas_rect.left
+      const y = el_rect.top + el_rect.height / 2 - canvas_rect.top
+      const font_size = style.fontSize || `11px`
+      const font_family = style.fontFamily || `sans-serif`
+      const font_weight = style.fontWeight || `400`
+      const fill_color = style.color || `#333`
+      const text = xml_escape(html_element.textContent ?? ``)
+      text_nodes.push(
+        `<text x="${x.toFixed(2)}" y="${
+          y.toFixed(2)
+        }" text-anchor="middle" dominant-baseline="central" fill="${
+          xml_escape(fill_color)
+        }" font-size="${xml_escape(font_size)}" font-family="${
+          xml_escape(font_family)
+        }" font-weight="${xml_escape(font_weight)}">${text}</text>`,
+      )
+    }
+    const metadata = xml_escape(JSON.stringify(get_view_settings()))
+    const svg = [
+      `<?xml version="1.0" encoding="UTF-8"?>`,
+      `<svg xmlns="http://www.w3.org/2000/svg" width="${canvas_rect.width}" height="${canvas_rect.height}" viewBox="0 0 ${canvas_rect.width} ${canvas_rect.height}">`,
+      `<metadata>${metadata}</metadata>`,
+      `<image href="${png_data_url}" x="0" y="0" width="${canvas_rect.width}" height="${canvas_rect.height}" />`,
+      ...text_nodes,
+      `</svg>`,
+    ].join(``)
+    download_blob(
+      new Blob([svg], { type: `image/svg+xml` }),
+      `${export_basename}.svg`,
+    )
+  }
+
+  function export_view_json_file(): void {
+    const json_text = JSON.stringify(get_view_settings(), null, 2)
+    download_blob(
+      new Blob([json_text], { type: `application/json` }),
+      `${export_basename}-view.json`,
+    )
+  }
+
+  function export_glb_file(): void {
+    const gltf_exporter = new GLTFExporter()
+    const export_root = new THREE.Group()
+    if (colored_hull_geometry) {
+      export_root.add(
+        new THREE.Mesh(
+          colored_hull_geometry.clone(),
+          new THREE.MeshBasicMaterial({
+            vertexColors: true,
+            transparent: true,
+            opacity: color_mode === `none` ? 0.25 : 0.4,
+            side: THREE.DoubleSide,
+          }),
+        ),
+      )
+    }
+    export_root.add(
+      new THREE.LineSegments(
+        edge_geometry.clone(),
+        new THREE.LineBasicMaterial({ color: 0x333333 }),
+      ),
+    )
+    for (const { geometry, color } of formula_mesh_data) {
+      export_root.add(
+        new THREE.Mesh(
+          geometry.clone(),
+          new THREE.MeshBasicMaterial({
+            color: new THREE.Color(color),
+            transparent: true,
+            opacity: 0.13,
+            side: THREE.DoubleSide,
+          }),
+        ),
+      )
+    }
+    if (draw_formula_lines) {
+      for (const { geometry, color } of formula_edge_data) {
+        export_root.add(
+          new THREE.LineSegments(
+            geometry.clone(),
+            new THREE.LineBasicMaterial({ color: new THREE.Color(color) }),
+          ),
+        )
+      }
+    }
+    gltf_exporter.parse(
+      export_root,
+      (result) => {
+        if (!(result instanceof ArrayBuffer)) return
+        download_blob(
+          new Blob([result], { type: `model/gltf-binary` }),
+          `${export_basename}.glb`,
+        )
+      },
+      (err) => {
+        console.error(`Failed to export GLB:`, err)
+      },
+      { binary: true, onlyVisible: false },
+    )
   }
 
   function get_json_string(): string {
@@ -1630,6 +1948,7 @@
           points_3d: domain.points_3d,
         })),
         lims: diagram_data?.lims ?? [],
+        view: get_view_settings(),
       },
       null,
       2,
@@ -1639,7 +1958,7 @@
   function export_json_file(): void {
     download_blob(
       new Blob([get_json_string()], { type: `application/json` }),
-      `chempot-${plot_elements.join(`-`)}.json`,
+      `${export_basename}.json`,
     )
   }
 
@@ -1705,11 +2024,32 @@
     }
   }
 
-  function handle_phase_hover(domain_data: HoverMeshData, raw_event: unknown): void {
+  let locked_hover_formula = $state<string | null>(null)
+
+  function set_hover_info(domain_data: HoverMeshData, raw_event: unknown): void {
     hover_info = {
       ...domain_data.info,
       pointer: get_hover_pointer(raw_event) ?? undefined,
     }
+  }
+
+  function clear_hover_lock(): void {
+    locked_hover_formula = null
+    hover_info = null
+  }
+
+  function handle_phase_hover(domain_data: HoverMeshData, raw_event: unknown): void {
+    if (locked_hover_formula && locked_hover_formula !== domain_data.formula) return
+    set_hover_info(domain_data, raw_event)
+  }
+
+  function toggle_phase_lock(domain_data: HoverMeshData, raw_event: unknown): void {
+    if (locked_hover_formula === domain_data.formula) {
+      clear_hover_lock()
+      return
+    }
+    locked_hover_formula = domain_data.formula
+    set_hover_info(domain_data, raw_event)
   }
 
   // Color mode cycling (keyboard shortcut 'c')
@@ -1749,11 +2089,21 @@
       event.target instanceof HTMLInputElement ||
       event.target instanceof HTMLSelectElement
     ) return
-    if (event.key === `c`) cycle_color_mode()
+    if (event.key === `Escape`) clear_hover_lock()
+    else if (event.key === `c`) cycle_color_mode()
     else if (event.key === `f`) toggle_fullscreen(wrapper)
   }}
+  onpointerdown={(event) => {
+    const target = event.target
+    if (
+      locked_hover_formula &&
+      (target === wrapper || target instanceof HTMLCanvasElement)
+    ) {
+      clear_hover_lock()
+    }
+  }}
 >
-  <section class="control-buttons">
+  <section>
     <DraggablePane
       bind:show={export_pane_open}
       open_icon="Cross"
@@ -1765,34 +2115,111 @@
       }}
     >
       <h4>Export Image</h4>
-      <label>
-        PNG
-        <button type="button" onclick={export_png_file} title="PNG ({png_dpi} DPI)">
-          ⬇
-        </button>
-        &nbsp;(DPI: <input
-          type="number"
-          min={50}
-          max={500}
-          bind:value={png_dpi}
-          title="Export resolution in dots per inch"
-          style="margin: 0 0 0 2pt"
-        />)
-      </label>
+      <div class="export-row">
+        <label>
+          SVG
+          <button type="button" onclick={export_svg_file} title="SVG snapshot export">
+            ⬇
+          </button>
+        </label>
+        <label>
+          PNG
+          <button type="button" onclick={export_png_file} title="PNG ({png_dpi} DPI)">
+            ⬇
+          </button>
+          &nbsp;(DPI: <input
+            type="number"
+            min={50}
+            max={500}
+            bind:value={png_dpi}
+            title="Export resolution in dots per inch"
+            style="margin: 0 0 0 2pt"
+          />)
+        </label>
+      </div>
       <h4>Export Data</h4>
-      <label>
-        JSON
-        <button type="button" onclick={export_json_file} aria-label="Download JSON">
-          ⬇
+      <div class="export-row">
+        <label>
+          JSON
+          <button type="button" onclick={export_json_file} aria-label="Download JSON">
+            ⬇
+          </button>
+          <button
+            type="button"
+            onclick={copy_json}
+            aria-label="Copy JSON to clipboard"
+          >
+            {copy_status ? `✅` : `📋`}
+          </button>
+        </label>
+        <label>
+          View
+          <button
+            type="button"
+            onclick={export_view_json_file}
+            aria-label="Download view JSON"
+          >
+            ⬇
+          </button>
+        </label>
+        <label>
+          GLB
+          <button type="button" onclick={export_glb_file} aria-label="Download GLB">
+            ⬇
+          </button>
+        </label>
+      </div>
+    </DraggablePane>
+    <DraggablePane
+      bind:show={formula_picker_open}
+      open_icon="Cross"
+      closed_icon="Filter"
+      pane_props={{ class: `chempot-formula-pane` }}
+      toggle_props={{
+        class: `chempot-formula-toggle`,
+        title: `Formula overlays`,
+      }}
+    >
+      <h4>Formula Overlays</h4>
+      <div class="overlay-actions">
+        <button type="button" onclick={() => formulas_to_draw_override = []}>
+          Clear
         </button>
-        <button
-          type="button"
-          onclick={copy_json}
-          aria-label="Copy JSON to clipboard"
-        >
-          {copy_status ? `✅` : `📋`}
-        </button>
+        <button type="button" onclick={select_surface_formulas}>Surface</button>
+        <button type="button" onclick={select_neighbor_formulas}>Neighbors</button>
+      </div>
+      <label class="overlay-search">
+        Search:
+        <input
+          type="text"
+          placeholder="Formula filter"
+          bind:value={formula_filter_query}
+        />
       </label>
+      <div class="formula-list">
+        {#if filtered_formulas.length === 0}
+          <div class="formula-empty">No matching formulas</div>
+        {:else}
+          {#each filtered_formulas as formula, formula_idx (formula)}
+            {@const formula_overlay_idx = formulas_to_draw.indexOf(formula)}
+            <label>
+              <input
+                type="checkbox"
+                checked={formulas_to_draw.includes(formula)}
+                onchange={() => toggle_formula_selection(formula)}
+              />
+              <span
+                class="formula-color-dot"
+                style:background={formula_colors[
+                  (formula_overlay_idx >= 0 ? formula_overlay_idx : formula_idx) %
+                  formula_colors.length
+                ]}
+              ></span>
+              {get_hill_formula(formula, true, ``)}
+            </label>
+          {/each}
+        {/if}
+      </div>
     </DraggablePane>
 
     <ScatterPlot3DControls
@@ -1824,6 +2251,54 @@
         }}
         on_reset={reset_controls}
       >
+        {#if has_multinary_system && plot_elements.length === 3}
+          <div class="projection-controls">
+            <div class="pane-row">
+              <label for="chempot-proj-x">X:</label>
+              <select
+                id="chempot-proj-x"
+                value={plot_elements[0]}
+                onchange={(event) => set_projection_axis(0, event.currentTarget.value)}
+              >
+                {#each all_entry_elements as element_name (element_name)}
+                  <option value={element_name}>{element_name}</option>
+                {/each}
+              </select>
+              <label for="chempot-proj-y">Y:</label>
+              <select
+                id="chempot-proj-y"
+                value={plot_elements[1]}
+                onchange={(event) => set_projection_axis(1, event.currentTarget.value)}
+              >
+                {#each all_entry_elements as element_name (element_name)}
+                  <option value={element_name}>{element_name}</option>
+                {/each}
+              </select>
+              <label for="chempot-proj-z">Z:</label>
+              <select
+                id="chempot-proj-z"
+                value={plot_elements[2]}
+                onchange={(event) => set_projection_axis(2, event.currentTarget.value)}
+              >
+                {#each all_entry_elements as element_name (element_name)}
+                  <option value={element_name}>{element_name}</option>
+                {/each}
+              </select>
+            </div>
+            <div class="projection-presets">
+              {#each projection_presets as preset_elements (preset_elements.join(`|`))}
+                <button
+                  type="button"
+                  class:selected={preset_elements.join(`|`) === current_projection_key}
+                  onclick={() => apply_projection_preset(preset_elements)}
+                  title="Switch projection"
+                >
+                  {preset_elements.join(`-`)}
+                </button>
+              {/each}
+            </div>
+          </div>
+        {/if}
         <div class="chempot-checks">
           <label>
             <input
@@ -1945,7 +2420,6 @@
       type="button"
       onclick={() => toggle_fullscreen(wrapper)}
       title="{fullscreen ? `Exit` : `Enter`} fullscreen"
-      class="fullscreen-btn"
     >
       <Icon icon="{fullscreen ? `Exit` : ``}Fullscreen" />
     </button>
@@ -2048,8 +2522,14 @@
             geometry={domain_hover.geometry}
             onpointerenter={(event: unknown) => handle_phase_hover(domain_hover, event)}
             onpointermove={(event: unknown) => handle_phase_hover(domain_hover, event)}
+            onpointerdown={(event: unknown) => toggle_phase_lock(domain_hover, event)}
             onpointerleave={() => {
-              if (hover_info?.formula === domain_hover.formula) hover_info = null
+              if (
+                !locked_hover_formula &&
+                hover_info?.formula === domain_hover.formula
+              ) {
+                hover_info = null
+              }
             }}
           >
             <T.MeshBasicMaterial
@@ -2155,7 +2635,7 @@
             (domain.formula)
           }
             <extras.HTML
-              position={[domain.ann_loc[1], domain.ann_loc[2], domain.ann_loc[0]]}
+              position={swiz(domain.label_loc[0], domain.label_loc[1], domain.label_loc[2])}
               center
               portal={wrapper}
               zIndexRange={[1, 0]}
@@ -2184,8 +2664,8 @@
     {#if color_mode === `arity`}
       <div class="arity-legend">
         {#each [`Unary`, `Binary`, `Ternary`, `4+`] as label, idx (label)}
-          <span class="arity-item">
-            <span class="arity-dot" style:background={arity_colors[idx]}></span>
+          <span>
+            <span style:background={arity_colors[idx]}></span>
             {label}
           </span>
         {/each}
@@ -2199,36 +2679,39 @@
       style:top="{hover_info.pointer?.y ?? 4}px"
     >
       <h4>{@html get_hill_formula(hover_info.formula, false, ``)}</h4>
-      <div class="meta-row">
+      {#if locked_hover_formula === hover_info.formula}
+        <p>Pinned · Press Esc to unlock</p>
+      {/if}
+      <p>
         Vertices: {hover_info.n_vertices} · Edges: {hover_info.n_edges} · Points:
         {hover_info.n_points}
-      </div>
-      <div class="meta-row">
+      </p>
+      <p>
         Entries: {hover_info.matching_entry_count}
         {#if hover_info.min_energy_per_atom !== null &&
           hover_info.max_energy_per_atom !== null}
           · E/atom: {format_num(hover_info.min_energy_per_atom, `.4~g`)}
           to {format_num(hover_info.max_energy_per_atom, `.4~g`)} eV
         {/if}
-      </div>
+      </p>
       {#if tooltip_detail_level === `detailed`}
-        <div class="ranges-title">Axis ranges</div>
+        <h5>Axis ranges</h5>
         {#each hover_info.axis_ranges as axis_range (axis_range.element)}
-          <div class="range-row">
+          <p>
             {axis_range.element}: {format_num(axis_range.min_val, `.4~g`)} to
             {format_num(axis_range.max_val, `.4~g`)} eV
-          </div>
+          </p>
         {/each}
-        <div class="meta-row">
+        <p>
           Centroid: ({
             hover_info.ann_loc.map((value) => format_num(value, `.3~g`)).join(
               `, `,
             )
           })
-        </div>
+        </p>
         {#if hover_info.touches_limits.length > 0}
-          <div class="ranges-title">Touches bounds</div>
-          <div class="meta-row">{hover_info.touches_limits.join(`, `)}</div>
+          <h5>Touches bounds</h5>
+          <p>{hover_info.touches_limits.join(`, `)}</p>
         {/if}
       {/if}
     </aside>
@@ -2249,7 +2732,7 @@
   .chempot-diagram-3d > :global(div[style*='position: absolute'][style*='top: 0']) {
     pointer-events: none !important;
   }
-  .control-buttons {
+  .chempot-diagram-3d > section {
     position: absolute;
     top: 1ex;
     right: 1ex;
@@ -2257,8 +2740,8 @@
     gap: 8px;
     z-index: 20;
   }
-  .control-buttons > :global(button),
-  .control-buttons > :global(.pane-toggle) {
+  .chempot-diagram-3d > section > :global(button),
+  .chempot-diagram-3d > section > :global(.pane-toggle) {
     background: transparent;
     border: none;
     padding: 4px;
@@ -2269,8 +2752,8 @@
     display: flex;
     font-size: clamp(0.75em, 1.5cqmin, 1em);
   }
-  .control-buttons > :global(button:hover),
-  .control-buttons > :global(.pane-toggle:hover) {
+  .chempot-diagram-3d > section > :global(button:hover),
+  .chempot-diagram-3d > section > :global(.pane-toggle:hover) {
     background-color: color-mix(in srgb, currentColor 8%, transparent);
   }
   .chempot-diagram-3d :global(.draggable-pane label) {
@@ -2278,6 +2761,15 @@
     align-items: center;
     gap: 4pt;
     font-size: 0.9em;
+  }
+  .chempot-diagram-3d :global(.export-row) {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4pt 10pt;
+    margin: 0 0 4pt;
+  }
+  .chempot-diagram-3d :global(.export-row > label) {
+    margin: 0;
   }
   .chempot-diagram-3d :global(.chempot-checks) {
     display: flex;
@@ -2289,6 +2781,80 @@
     flex-wrap: wrap;
     gap: 1ex;
     margin: 4pt 0;
+  }
+  .chempot-diagram-3d :global(.projection-controls) {
+    margin: 0 0 6pt;
+  }
+  .chempot-diagram-3d :global(.projection-controls .pane-row) {
+    display: grid;
+    grid-template-columns:
+      auto minmax(4.5em, 1fr) auto minmax(4.5em, 1fr) auto minmax(4.5em, 1fr);
+    align-items: center;
+    gap: 3pt;
+  }
+  .chempot-diagram-3d :global(.projection-presets) {
+    margin-top: 4pt;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4pt;
+  }
+  .chempot-diagram-3d :global(.projection-presets button) {
+    border: 1px solid color-mix(in srgb, currentColor 22%, transparent);
+    border-radius: 3px;
+    padding: 1px 5px;
+    background: transparent;
+    cursor: pointer;
+    font-size: 0.85em;
+    color: var(--text-color, currentColor);
+  }
+  .chempot-diagram-3d :global(.projection-presets button.selected) {
+    background: color-mix(in srgb, currentColor 14%, transparent);
+  }
+  .chempot-diagram-3d :global(.overlay-actions) {
+    display: flex;
+    gap: 4pt;
+    margin: 0 0 4pt;
+  }
+  .chempot-diagram-3d :global(.overlay-actions button) {
+    border: 1px solid color-mix(in srgb, currentColor 22%, transparent);
+    border-radius: 3px;
+    padding: 2px 6px;
+    background: transparent;
+    cursor: pointer;
+    color: var(--text-color, currentColor);
+  }
+  .chempot-diagram-3d :global(.overlay-search) {
+    display: flex;
+    align-items: center;
+    gap: 4pt;
+    margin: 0 0 4pt;
+  }
+  .chempot-diagram-3d :global(.overlay-search input) {
+    width: 100%;
+    min-width: 10em;
+  }
+  .chempot-diagram-3d :global(.formula-list) {
+    max-height: min(42vh, 18rem);
+    overflow: auto;
+    border: 1px solid color-mix(in srgb, currentColor 14%, transparent);
+    border-radius: 4px;
+    padding: 4pt;
+  }
+  .chempot-diagram-3d :global(.formula-list label) {
+    display: flex;
+    align-items: center;
+    gap: 5pt;
+    margin: 2pt 0;
+  }
+  .chempot-diagram-3d :global(.formula-color-dot) {
+    width: 0.65em;
+    height: 0.65em;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+  .chempot-diagram-3d :global(.formula-empty) {
+    font-size: 0.9em;
+    opacity: 0.7;
   }
   .chempot-diagram-3d :global(.chempot-nums input[type='number']) {
     width: 5em;
@@ -2328,8 +2894,11 @@
   .phase-tooltip {
     position: fixed;
     max-width: min(32rem, 92vw);
-    background: color-mix(in srgb, var(--bg-color, #fff) 94%, black 6%);
-    color: var(--text-color, #222);
+    background: var(
+      --tooltip-bg,
+      light-dark(rgba(255, 255, 255, 0.95), rgba(0, 0, 0, 0.9))
+    );
+    color: var(--tooltip-text, var(--text-color, #222));
     border: 1px solid color-mix(in srgb, currentColor 18%, transparent);
     border-radius: 6px;
     box-shadow: 0 8px 20px rgba(0, 0, 0, 0.18);
@@ -2343,20 +2912,17 @@
     margin: 0 0 4px;
     font-size: 13px;
   }
-  .meta-row {
+  .phase-tooltip p {
     margin: 1px 0;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
   }
-  .ranges-title {
+  .phase-tooltip h5 {
     margin-top: 6px;
+    margin-bottom: 0;
+    font-size: 12px;
     font-weight: 600;
-  }
-  .range-row {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
   }
   .arity-legend {
     position: absolute;
@@ -2368,12 +2934,12 @@
     z-index: 10;
     pointer-events: none;
   }
-  .arity-item {
+  .arity-legend > span {
     display: flex;
     align-items: center;
     gap: 4px;
   }
-  .arity-dot {
+  .arity-legend > span > span {
     width: 10px;
     height: 10px;
     border-radius: 50%;

--- a/src/lib/chempot-diagram/ChemPotDiagram3D.svelte
+++ b/src/lib/chempot-diagram/ChemPotDiagram3D.svelte
@@ -178,6 +178,7 @@
   let x_axis = $state<AxisConfig3D>({ label: ``, range: [null, null] })
   let y_axis = $state<AxisConfig3D>({ label: ``, range: [null, null] })
   let z_axis = $state<AxisConfig3D>({ label: ``, range: [null, null] })
+  const projection_opacity = $derived(display.projection_opacity ?? 0.15)
 
   // Plotly/pymatgen uses Z-up with x-axis projecting left in isometric view.
   // Three.js uses Y-up with X projecting right. To match pymatgen's visual layout:
@@ -2563,12 +2564,12 @@
           {/each}
         {/if}
 
-        {#each projection_planes as plane (plane.key)}
+        {#each projection_planes as plane (`${plane.key}-${projection_opacity}`)}
           <T.Mesh position={plane.pos} rotation={plane.rot}>
             <T.PlaneGeometry args={plane.size} />
             <T.MeshBasicMaterial
               color={plane.color}
-              opacity={display.projection_opacity ?? 0.15}
+              opacity={projection_opacity}
               transparent
               side={THREE.DoubleSide}
               depthWrite={false}

--- a/src/routes/(demos)/chempot-diagram/+page.svelte
+++ b/src/routes/(demos)/chempot-diagram/+page.svelte
@@ -98,7 +98,9 @@
 </p>
 
 {#if loading}
-  <Spinner text="Loading phase diagram data..." style="--spinner-size: 1.5em" />
+  <div class="loading-state">
+    <Spinner text="Loading phase diagram data..." style="--spinner-size: 1.5em" />
+  </div>
 {:else if error_msg}
   <p class="error">{error_msg}</p>
 {:else}
@@ -107,6 +109,13 @@
     <p>
       For a binary system, the chemical potential diagram shows domain boundaries as line
       segments in 2D μ-space. Each line represents the stability region of a phase.
+    </p>
+    <p>
+      <strong>Features in this demo:</strong>
+      interactive hover + click-to-pin tooltips, control pane for formal potentials and
+      bounds/padding, and export options (SVG, PNG, JSON). This panel also supports the
+      full 2D color modes (none, energy/atom, formation energy, arity, entry count) with
+      color bar/legend where applicable.
     </p>
     {#if binary_entries.length > 0}
       <ChemPotDiagram2D
@@ -125,6 +134,13 @@
     <p>
       For a ternary system, stability domains are 3D polytopes. Drag to rotate the view.
     </p>
+    <p>
+      <strong>Features in this demo:</strong>
+      3D hull rendering with domain boundaries, hover + click-to-pin tooltips, camera and
+      display controls, color modes/scales, and export options (PNG, SVG snapshot, JSON,
+      view JSON, GLB). Projection switching is intentionally hidden here because this is a
+      true ternary system.
+    </p>
     {#if ternary_entries.length > 0}
       <ChemPotDiagram3D
         entries={ternary_entries}
@@ -140,6 +156,11 @@
   <section>
     <h2>Ternary System (Li-Fe-O) &mdash; 3D</h2>
     <p>Li-Fe-O ternary from pymatgen test data. Axes: x=Li, y=Fe, z=O.</p>
+    <p>
+      <strong>Features in this demo:</strong>
+      same core 3D interactions as Li-Co-O, useful as a parity/reference dataset against
+      pymatgen expectations (domain topology, labels, and energy-aware coloring).
+    </p>
     {#if li_fe_o_entries.length > 0}
       <ChemPotDiagram3D
         entries={li_fe_o_entries}
@@ -157,6 +178,12 @@
     <p>
       Full Y-Ti-O-S quaternary projected onto Ti-S-Y axes with Y<sub>2</sub>Ti<sub
       >2</sub>S<sub>2</sub>O<sub>5</sub> overlay.
+    </p>
+    <p>
+      <strong>Features in this demo:</strong>
+      multinary projection mode (4D system projected into 3D), runtime projection axis
+      switching in the 3D controls pane (X/Y/Z selectors + presets), and formula overlay
+      tooling (searchable picker, surface/neighbor quick-select actions).
     </p>
     {#if ytos_entries.length > 0}
       <ChemPotDiagram3D
@@ -177,6 +204,12 @@
     <h2>YTOS &mdash; Ti-Y-O with Y<sub>2</sub>Ti<sub>2</sub>O<sub>7</sub></h2>
     <p>
       Same quaternary data projected onto Ti-Y-O axes.
+    </p>
+    <p>
+      <strong>Features in this demo:</strong>
+      alternative projection of the same multinary dataset, showing how domain geometry
+      and visible phase relationships change with axis selection while preserving the same
+      underlying computed chemical-potential domains.
     </p>
     {#if ytos_entries.length > 0}
       <ChemPotDiagram3D
@@ -210,5 +243,11 @@
   }
   .error {
     color: red;
+  }
+  .loading-state {
+    min-height: 30vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 </style>

--- a/tests/playwright/chempot-diagram.test.ts
+++ b/tests/playwright/chempot-diagram.test.ts
@@ -3,10 +3,10 @@ import { IS_CI } from './helpers'
 
 const TEST_URL = `/chempot-diagram`
 
-async function get_section_by_heading(
+const get_section_by_heading = async (
   page: Page,
   heading_text: RegExp,
-): Promise<Locator> {
+): Promise<Locator> => {
   const section = page.locator(`section`).filter({
     has: page.getByRole(`heading`, { name: heading_text }),
   }).first()
@@ -14,11 +14,11 @@ async function get_section_by_heading(
   return section
 }
 
-async function click_until_visible_tooltip(
+const click_until_visible_tooltip = async (
   page: Page,
   target_surface: Locator,
   tooltip: Locator,
-): Promise<{ x: number; y: number }> {
+): Promise<{ x: number; y: number }> => {
   const box = await target_surface.boundingBox()
   if (!box) throw new Error(`Target surface bounding box not found`)
   for (let x_frac = 0.25; x_frac <= 0.75; x_frac += 0.08) {
@@ -36,11 +36,11 @@ async function click_until_visible_tooltip(
   throw new Error(`Failed to find clickable phase region`)
 }
 
-async function expect_download_suffix(
+const expect_download_suffix = async (
   page: Page,
   trigger_button: Locator,
   expected_suffix: string,
-): Promise<void> {
+): Promise<void> => {
   const [download] = await Promise.all([
     page.waitForEvent(`download`, { timeout: 20_000 }),
     trigger_button.click(),
@@ -48,11 +48,10 @@ async function expect_download_suffix(
   expect(download.suggestedFilename()).toMatch(new RegExp(`${expected_suffix}$`))
 }
 
-function count_checked(checkboxes: Locator): Promise<number> {
-  return checkboxes.evaluateAll((nodes) =>
+const count_checked = (checkboxes: Locator): Promise<number> =>
+  checkboxes.evaluateAll((nodes) =>
     nodes.filter((node) => (node as HTMLInputElement).checked).length
   )
-}
 
 test.describe(`ChemPot Diagram interactions`, () => {
   test.beforeEach(async ({ page }) => {

--- a/tests/playwright/chempot-diagram.test.ts
+++ b/tests/playwright/chempot-diagram.test.ts
@@ -45,7 +45,7 @@ const expect_download_suffix = async (
     page.waitForEvent(`download`, { timeout: 20_000 }),
     trigger_button.click(),
   ])
-  expect(download.suggestedFilename()).toMatch(new RegExp(`${expected_suffix}$`))
+  expect(download.suggestedFilename().endsWith(expected_suffix)).toBe(true)
 }
 
 const count_checked = (checkboxes: Locator): Promise<number> =>
@@ -227,8 +227,8 @@ test.describe(`ChemPot Diagram interactions`, () => {
     const view_export_button = export_pane.locator(`label:has-text("View") button`)
       .first()
     const glb_export_button = export_pane.locator(`label:has-text("GLB") button`).first()
-    await expect_download_suffix(page, svg_export_button, `\\.svg`)
-    await expect_download_suffix(page, view_export_button, `-view\\.json`)
-    await expect_download_suffix(page, glb_export_button, `\\.glb`)
+    await expect_download_suffix(page, svg_export_button, `.svg`)
+    await expect_download_suffix(page, view_export_button, `-view.json`)
+    await expect_download_suffix(page, glb_export_button, `.glb`)
   })
 })

--- a/tests/playwright/chempot-diagram.test.ts
+++ b/tests/playwright/chempot-diagram.test.ts
@@ -1,0 +1,235 @@
+import { expect, type Locator, type Page, test } from '@playwright/test'
+import { IS_CI } from './helpers'
+
+const TEST_URL = `/chempot-diagram`
+
+async function get_section_by_heading(
+  page: Page,
+  heading_text: RegExp,
+): Promise<Locator> {
+  const section = page.locator(`section`).filter({
+    has: page.getByRole(`heading`, { name: heading_text }),
+  }).first()
+  await expect(section).toBeVisible({ timeout: 20_000 })
+  return section
+}
+
+async function click_until_visible_tooltip(
+  page: Page,
+  target_surface: Locator,
+  tooltip: Locator,
+): Promise<{ x: number; y: number }> {
+  const box = await target_surface.boundingBox()
+  if (!box) throw new Error(`Target surface bounding box not found`)
+  for (let x_frac = 0.25; x_frac <= 0.75; x_frac += 0.08) {
+    for (let y_frac = 0.25; y_frac <= 0.75; y_frac += 0.08) {
+      const click_x = box.x + box.width * x_frac
+      const click_y = box.y + box.height * y_frac
+      // deno-lint-ignore no-await-in-loop -- probing requires sequential clicks
+      await page.mouse.click(click_x, click_y)
+      // deno-lint-ignore no-await-in-loop -- small delay for hover/pick updates
+      await page.waitForTimeout(40)
+      // deno-lint-ignore no-await-in-loop -- visibility check after each probe
+      if (await tooltip.isVisible()) return { x: click_x, y: click_y }
+    }
+  }
+  throw new Error(`Failed to find clickable phase region`)
+}
+
+async function expect_download_suffix(
+  page: Page,
+  trigger_button: Locator,
+  expected_suffix: string,
+): Promise<void> {
+  const [download] = await Promise.all([
+    page.waitForEvent(`download`, { timeout: 20_000 }),
+    trigger_button.click(),
+  ])
+  expect(download.suggestedFilename()).toMatch(new RegExp(`${expected_suffix}$`))
+}
+
+function count_checked(checkboxes: Locator): Promise<number> {
+  return checkboxes.evaluateAll((nodes) =>
+    nodes.filter((node) => (node as HTMLInputElement).checked).length
+  )
+}
+
+test.describe(`ChemPot Diagram interactions`, () => {
+  test.beforeEach(async ({ page }) => {
+    test.skip(IS_CI, `ChemPot interactions rely on WebGL-heavy rendering`)
+    await page.goto(TEST_URL, { waitUntil: `networkidle` })
+    await expect(page.getByRole(`heading`, { name: `Chemical Potential Diagram` }))
+      .toBeVisible()
+  })
+
+  test(`2D tooltip lock toggles and unlocks with Escape`, async ({ page }) => {
+    const binary_section = await get_section_by_heading(page, /Binary System \(Li-O\)/)
+    const diagram = binary_section.locator(`.chempot-diagram-2d`).first()
+    await expect(diagram).toBeVisible()
+    const svg_surface = diagram.locator(`svg[role="application"]`).first()
+    await expect(svg_surface).toBeVisible()
+    const tooltip = diagram.locator(`.tooltip`)
+
+    const hit_point = await click_until_visible_tooltip(page, svg_surface, tooltip)
+
+    await page.mouse.click(hit_point.x, hit_point.y)
+    await expect(tooltip).toContainText(`Pinned · Press Esc to unlock`)
+
+    await page.mouse.click(hit_point.x, hit_point.y)
+    await expect(tooltip).not.toContainText(`Pinned · Press Esc to unlock`)
+
+    await page.mouse.click(hit_point.x, hit_point.y)
+    await expect(tooltip).toContainText(`Pinned · Press Esc to unlock`)
+    await page.keyboard.press(`Escape`)
+    await expect(tooltip).toBeHidden()
+  })
+
+  test(`2D color controls switch between colorbar and arity legend`, async ({ page }) => {
+    const binary_section = await get_section_by_heading(page, /Binary System \(Li-O\)/)
+    const diagram = binary_section.locator(`.chempot-diagram-2d`).first()
+    await expect(diagram).toBeVisible()
+
+    await diagram.hover()
+    const controls_toggle = diagram.locator(`button.pane-toggle[title*="plot controls"]`)
+      .first()
+    await controls_toggle.click()
+    const controls_pane = diagram.locator(`.draggable-pane`).filter({
+      hasText: `Color mode:`,
+    }).first()
+    await expect(controls_pane).toBeVisible()
+
+    const color_mode_select = controls_pane.getByLabel(`Color mode:`)
+    await color_mode_select.selectOption(`energy`)
+    const colorbar = diagram.locator(`.colorbar`).first()
+    await expect(colorbar).toBeVisible()
+    await expect(colorbar).toContainText(`Energy per atom`)
+    await expect(controls_pane.getByLabel(`Color scale:`)).toBeVisible()
+
+    await color_mode_select.selectOption(`arity`)
+    const arity_legend = diagram.locator(`.arity-legend`)
+    await expect(arity_legend).toBeVisible()
+    await expect(arity_legend).toContainText(`Unary`)
+    await expect(arity_legend).toContainText(`Binary`)
+    await expect(colorbar).toBeHidden()
+    await expect(controls_pane.getByLabel(`Color scale:`)).toBeHidden()
+
+    await color_mode_select.selectOption(`entries`)
+    await expect(colorbar).toBeVisible()
+    await expect(colorbar).toContainText(`Entry count`)
+  })
+
+  test(`3D projection controls and formula picker actions work in multinary mode`, async ({ page }) => {
+    const quaternary_section = await get_section_by_heading(
+      page,
+      /YTOS Quaternary.*Ti-S-Y Projection/,
+    )
+    const diagram = quaternary_section.locator(`.chempot-diagram-3d`).first()
+    await expect(diagram).toBeVisible()
+
+    const controls_toggle = diagram.locator(
+      `button.pane-toggle[title="3D plot controls"]`,
+    ).first()
+    await controls_toggle.click()
+    const controls_pane = diagram.locator(`.draggable-pane`).filter({
+      hasText: `ChemPot`,
+    }).first()
+    await expect(controls_pane).toBeVisible()
+
+    const x_select = controls_pane.locator(`#chempot-proj-x`).first()
+    const y_select = controls_pane.locator(`#chempot-proj-y`).first()
+    const z_select = controls_pane.locator(`#chempot-proj-z`).first()
+    await expect(x_select).toBeVisible()
+    await expect(y_select).toBeVisible()
+    await expect(z_select).toBeVisible()
+
+    await x_select.selectOption(`Y`)
+    const selected_projection = await Promise.all([
+      x_select.inputValue(),
+      y_select.inputValue(),
+      z_select.inputValue(),
+    ])
+    expect(new Set(selected_projection).size).toBe(3)
+
+    const formula_toggle = diagram.locator(
+      `button.pane-toggle[title="Formula overlays"]`,
+    ).first()
+    await formula_toggle.click()
+    const formula_pane = diagram.locator(`.draggable-pane`).filter({
+      hasText: `Formula Overlays`,
+    }).first()
+    await expect(formula_pane).toBeVisible()
+
+    const checkboxes = formula_pane.locator(`input[type="checkbox"]`)
+    await expect(checkboxes.first()).toBeVisible()
+    await checkboxes.first().check()
+    await expect(checkboxes.first()).toBeChecked()
+
+    await formula_pane.getByRole(`button`, { name: `Clear` }).click()
+    await expect.poll(() => count_checked(checkboxes)).toBe(0)
+
+    await formula_pane.getByRole(`button`, { name: `Surface` }).click()
+    await expect.poll(() => count_checked(checkboxes)).toBeGreaterThan(0)
+
+    const search_input = formula_pane.getByPlaceholder(`Formula filter`)
+    await search_input.fill(`__no_matching_formula__`)
+    await expect(formula_pane.locator(`.formula-empty`)).toBeVisible()
+    await search_input.fill(``)
+    await expect(formula_pane.locator(`.formula-empty`)).toBeHidden()
+    await expect(formula_pane.locator(`input[type="checkbox"]`).first()).toBeVisible()
+
+    const preset_buttons = controls_pane.locator(`.projection-presets button`)
+    await expect
+      .poll(() => preset_buttons.count())
+      .toBeGreaterThan(1)
+    const alternate_preset = controls_pane.locator(
+      `.projection-presets button:not(.selected)`,
+    )
+      .first()
+    const preset_text = ((await alternate_preset.textContent()) ?? ``).trim()
+    expect(preset_text).toMatch(/^[A-Za-z]+-[A-Za-z]+-[A-Za-z]+$/)
+    await alternate_preset.click()
+    await expect(alternate_preset).toHaveClass(/selected/)
+    const expected_projection = preset_text.split(`-`)
+    const projection_after_click = await Promise.all([
+      x_select.inputValue(),
+      y_select.inputValue(),
+      z_select.inputValue(),
+    ])
+    expect(projection_after_click).toEqual(expected_projection)
+  })
+
+  test(`3D tooltip lock toggles and export actions download files`, async ({ page }) => {
+    const ternary_section = await get_section_by_heading(
+      page,
+      /Ternary System \(Li-Co-O\)/,
+    )
+    const diagram = ternary_section.locator(`.chempot-diagram-3d`).first()
+    await expect(diagram).toBeVisible()
+    const canvas = diagram.locator(`canvas`).first()
+    await expect(canvas).toBeVisible()
+
+    const phase_tooltip = diagram.locator(`.phase-tooltip`)
+    const hit_point = await click_until_visible_tooltip(page, canvas, phase_tooltip)
+    await page.mouse.click(hit_point.x, hit_point.y)
+    await expect(phase_tooltip).toContainText(`Pinned · Press Esc to unlock`)
+    await page.mouse.click(hit_point.x, hit_point.y)
+    await expect(phase_tooltip).not.toContainText(`Pinned · Press Esc to unlock`)
+
+    const export_toggle = diagram.locator(
+      `button.pane-toggle[title="Export chemical potential diagram"]`,
+    ).first()
+    await export_toggle.click()
+    const export_pane = diagram.locator(`.draggable-pane`).filter({
+      hasText: `Export Image`,
+    }).first()
+    await expect(export_pane).toBeVisible()
+
+    const svg_export_button = export_pane.locator(`label:has-text("SVG") button`).first()
+    const view_export_button = export_pane.locator(`label:has-text("View") button`)
+      .first()
+    const glb_export_button = export_pane.locator(`label:has-text("GLB") button`).first()
+    await expect_download_suffix(page, svg_export_button, `\\.svg`)
+    await expect_download_suffix(page, view_export_button, `-view\\.json`)
+    await expect_download_suffix(page, glb_export_button, `\\.glb`)
+  })
+})

--- a/tests/vitest/chempot-diagram/compute.test.ts
+++ b/tests/vitest/chempot-diagram/compute.test.ts
@@ -1330,6 +1330,42 @@ describe(`compute_chempot_diagram edge cases`, () => {
       for (const pt of pts) expect(pt.length).toBe(n_axes)
     }
   })
+
+  test(`non-sequential 4D projection preserves domain dimensionality`, () => {
+    const projected = compute_chempot_diagram(ytos_entries, {
+      elements: [`Y`, `Ti`, `S`],
+      default_min_limit: -25,
+      formal_chempots: true,
+    })
+    expect(projected.elements).toEqual([`Y`, `Ti`, `S`])
+    const domain_keys = Object.keys(projected.domains)
+    expect(domain_keys.length).toBeGreaterThan(0)
+    for (const pts of Object.values(projected.domains)) {
+      for (const pt of pts) {
+        expect(pt.length).toBe(3)
+        for (const coord of pt) expect(Number.isFinite(coord)).toBe(true)
+      }
+    }
+  })
+
+  test(`different projection triplets keep stable formula set overlap`, () => {
+    const proj_tsy = compute_chempot_diagram(ytos_entries, {
+      elements: [`Ti`, `S`, `Y`],
+      default_min_limit: -25,
+      formal_chempots: true,
+    })
+    const proj_tyo = compute_chempot_diagram(ytos_entries, {
+      elements: [`Ti`, `Y`, `O`],
+      default_min_limit: -25,
+      formal_chempots: true,
+    })
+    const tsy_formulas = new Set(Object.keys(proj_tsy.domains))
+    const tyo_formulas = new Set(Object.keys(proj_tyo.domains))
+    const overlap = [...tsy_formulas].filter((formula) => tyo_formulas.has(formula))
+    expect(overlap.length).toBeGreaterThan(0)
+    expect(overlap).toContain(`Ti`)
+    expect(overlap).toContain(`Y`)
+  })
 })
 
 // === Formation energy computation ===


### PR DESCRIPTION
- polish ChemPot diagram UX in 2D/3D (projection controls, tooltip/theme styling, export pane layout, and loading-state/docs updates on demo page)
- improve 3D rendering behavior for anisotropic systems by stretching short axes for better use of canvas real estate and fixing label anchor placement
- add/expand chempot test coverage with focused Playwright interaction checks and compute projection regression tests
- add reversible 2D color modes with per-domain color computation
- support pinned hover tooltips that clear on Escape or background click
- add 3D projection presets and per-formula overlays, plus SVG, GLB, PNG, and view-JSON exports