### PR TITLE
Add categorical bar chart support

### DIFF
--- a/src/lib/plot/BarPlot.svelte
+++ b/src/lib/plot/BarPlot.svelte
@@ -57,6 +57,7 @@
     create_size_scale,
     generate_ticks,
     get_nice_data_range,
+    get_tick_label,
   } from '$lib/plot/scales'
   import {
     DEFAULT_GRID_STYLE,
@@ -253,22 +254,71 @@
   let indexed_ref_lines = $derived(index_ref_lines(ref_lines))
   let ref_lines_by_z = $derived(group_ref_lines_by_z(indexed_ref_lines))
 
+  // === Categorical Normalization ===
+  // Internal type with guaranteed numeric x (for downstream scale/rendering code)
+  type NumericBarSeries = Omit<BarSeries<Metadata>, `x`> & { x: readonly number[] }
+
+  let is_categorical = $derived(
+    series.some((srs) => srs.x.some((val) => typeof val === `string`)),
+  )
+
+  let category_list = $derived.by(() => {
+    if (!is_categorical) return [] as string[]
+    if (x_axis.categories?.length) return [...x_axis.categories]
+    return [...new Set(series.flatMap((srs) => srs.x.map(String)))]
+  })
+
+  let category_indices = $derived(
+    category_list.length ? category_list.map((_, idx) => idx) : null,
+  )
+
+  let internal_series = $derived.by<NumericBarSeries[]>(() => {
+    // safe: when !category_indices, all x values are numeric (is_categorical is false)
+    if (!category_indices) return series as unknown as NumericBarSeries[]
+    return series.map((srs) => {
+      const orig_map = new Map(srs.x.map((val, idx) => [String(val), idx]))
+      if (import.meta.env?.DEV && orig_map.size < srs.x.length) {
+        console.warn(
+          `BarPlot: series "${
+            srs.label ?? `?`
+          }" has duplicate x values — last occurrence wins`,
+        )
+      }
+      // Resolve original index for each category (undefined if series lacks it)
+      const orig_indices = category_list.map((cat) => orig_map.get(cat))
+      const remap = <T>(arr: readonly T[] | null | undefined, fallback: T): T[] =>
+        orig_indices.map((oi) => oi != null ? (arr?.[oi] ?? fallback) : fallback)
+      const bw_arr = Array.isArray(srs.bar_width) ? srs.bar_width : null
+      const meta_arr = Array.isArray(srs.metadata) ? srs.metadata : null
+      return {
+        ...srs,
+        x: category_indices,
+        y: remap(srs.y, 0),
+        labels: remap(srs.labels, null),
+        metadata: orig_indices.map((oi) =>
+          oi != null ? (meta_arr ? meta_arr[oi] : srs.metadata) : undefined
+        ) as Metadata[],
+        ...(bw_arr ? { bar_width: remap(bw_arr, 0.5) } : {}),
+        ...(srs.color_values ? { color_values: remap(srs.color_values, null) } : {}),
+        ...(srs.size_values ? { size_values: remap(srs.size_values, null) } : {}),
+      } as NumericBarSeries
+    })
+  })
+
   // Compute auto ranges from visible series
   let visible_series = $derived(
-    series.filter((srs: BarSeries<Metadata>) => srs?.visible ?? true),
+    internal_series.filter((srs) => srs?.visible ?? true),
   )
 
   // Separate series by y-axis
   let y1_series = $derived(
-    visible_series.filter((srs: BarSeries<Metadata>) =>
-      (srs.y_axis ?? `y1`) === `y1`
-    ),
+    visible_series.filter((srs) => (srs.y_axis ?? `y1`) === `y1`),
   )
   let y2_series = $derived(
-    visible_series.filter((srs: BarSeries<Metadata>) => srs.y_axis === `y2`),
+    visible_series.filter((srs) => srs.y_axis === `y2`),
   )
   let x2_series = $derived(
-    visible_series.filter((srs: BarSeries<Metadata>) => srs.x_axis === `x2`),
+    visible_series.filter((srs) => srs.x_axis === `x2`),
   )
 
   let auto_ranges = $derived.by(() => {
@@ -278,7 +328,7 @@
       y_limit: typeof y_range,
       scale_type: ScaleType,
     ) => {
-      let points = series_list.flatMap((srs: BarSeries<Metadata>) =>
+      let points = series_list.flatMap((srs) =>
         srs.x.map((x_val, idx) => ({ x: x_val, y: srs.y[idx] }))
       )
 
@@ -288,8 +338,8 @@
 
         // Only include visible bar series (not lines) in stacking
         series_list
-          .filter((srs: BarSeries<Metadata>) => srs.render_mode !== `line`)
-          .forEach((srs: BarSeries<Metadata>) =>
+          .filter((srs) => srs.render_mode !== `line`)
+          .forEach((srs) =>
             srs.x.forEach((x_val, idx) => {
               const y_val = srs.y[idx] ?? 0
               const totals = stacked_totals.get(x_val) ?? { pos: 0, neg: 0 }
@@ -306,8 +356,8 @@
             ...(neg < 0 ? [{ x: x_val, y: neg }] : []),
           ]),
           ...series_list
-            .filter((srs: BarSeries<Metadata>) => srs.render_mode === `line`)
-            .flatMap((srs: BarSeries<Metadata>) =>
+            .filter((srs) => srs.render_mode === `line`)
+            .flatMap((srs) =>
               srs.x.map((x_val, idx) => ({ x: x_val, y: srs.y[idx] }))
             ),
         ]
@@ -342,27 +392,29 @@
     }
 
     // Get x values split by axis for range calculation
-    const x1_x_points = visible_series
-      .filter((srs: BarSeries<Metadata>) => (srs.x_axis ?? `x1`) === `x1`)
-      .flatMap((srs: BarSeries<Metadata>) =>
-        srs.x.map((x_val) => ({ x: x_val, y: 0 }))
-      )
-    const x2_x_points = x2_series.flatMap((srs: BarSeries<Metadata>) =>
+    // For categorical data, use fixed range centered on integer indices
+    let x_auto_range: number[]
+    if (category_list.length) {
+      x_auto_range = [-0.5, category_list.length - 0.5]
+    } else {
+      const x1_x_points = visible_series
+        .filter((srs) => (srs.x_axis ?? `x1`) === `x1`)
+        .flatMap((srs) => srs.x.map((x_val) => ({ x: x_val, y: 0 })))
+      x_auto_range = x1_x_points.length
+        ? get_nice_data_range(
+          x1_x_points,
+          (pt) => pt.x,
+          x_range,
+          x_axis.scale_type ?? `linear`,
+          range_padding,
+          x_axis.format?.startsWith(`%`) || false,
+        )
+        : [0, 1]
+    }
+
+    const x2_x_points = x2_series.flatMap((srs) =>
       srs.x.map((x_val) => ({ x: x_val, y: 0 }))
     )
-
-    const x_scale_type = x_axis.scale_type ?? `linear`
-    const x_auto_range = x1_x_points.length
-      ? get_nice_data_range(
-        x1_x_points,
-        (pt) => pt.x,
-        x_range,
-        x_scale_type,
-        range_padding,
-        x_axis.format?.startsWith(`%`) || false,
-      )
-      : [0, 1]
-
     const x2_scale_type = x2_axis.scale_type ?? `linear`
     const x2_auto_range = x2_x_points.length
       ? get_nice_data_range(
@@ -544,29 +596,42 @@
   // Size scale function (using shared utility)
   let size_scale_fn = $derived(create_size_scale(size_scale, all_size_values))
 
+  // Auto-generate tick labels for categorical data (unless user provides explicit ticks)
+  // In vertical mode categories are on x-axis; in horizontal mode on y-axis
+  let cat_axis = $derived(orientation === `horizontal` ? `y` : `x`)
+  let effective_cat_ticks = $derived.by(() => {
+    if (!category_list.length) return undefined
+    // Only respect user ticks when they're a Record (custom label mapping),
+    // not a number (tick count) or array (tick positions)
+    const user_ticks = cat_axis === `x` ? x_axis.ticks : y_axis.ticks
+    if (
+      user_ticks != null && typeof user_ticks === `object` &&
+      !Array.isArray(user_ticks)
+    ) return user_ticks
+    return Object.fromEntries(
+      category_list.map((cat, idx) => [idx, cat]),
+    ) as Record<number, string>
+  })
+
   // Ticks
   let ticks = $derived({
     x: width && height
-      ? generate_ticks(
+      ? (category_indices && cat_axis === `x` ? category_indices : generate_ticks(
         ranges.current.x,
         x_axis.scale_type ?? `linear`,
         x_axis.ticks,
         scales.x,
-        {
-          default_count: 8,
-        },
-      )
+        { default_count: 8 },
+      ))
       : [],
     y: width && height
-      ? generate_ticks(
+      ? (category_indices && cat_axis === `y` ? category_indices : generate_ticks(
         ranges.current.y,
         y_axis.scale_type ?? `linear`,
         y_axis.ticks,
         scales.y,
-        {
-          default_count: 6,
-        },
-      )
+        { default_count: 6 },
+      ))
       : [],
     y2: width && height && y2_series.length > 0 && orientation === `vertical`
       ? generate_ticks(
@@ -979,10 +1044,9 @@
   let bar_points_for_placement = $derived.by(() => {
     if (!width || !height || !visible_series.length) return []
 
-    return visible_series.flatMap((srs: BarSeries<Metadata>) => {
+    return internal_series.flatMap((srs, series_idx) => {
+      if (!(srs?.visible ?? true)) return []
       const is_line = srs.render_mode === `line`
-      // Use original series index to look up stacked_offsets
-      const series_idx = series.indexOf(srs)
       const series_offsets = stacked_offsets[series_idx] ?? []
       const use_y2 = srs.y_axis === `y2`
       const y_scale = use_y2 ? scales.y2 : scales.y
@@ -1075,7 +1139,7 @@
     bar_idx: number,
     color: string,
   ): BarHandlerProps<Metadata> {
-    const srs = series[series_idx]
+    const srs = internal_series[series_idx]
     const [x, y] = [srs.x[bar_idx], srs.y[bar_idx]]
     const [orient_x, orient_y] = orientation === `horizontal` ? [y, x] : [x, y]
     const metadata = Array.isArray(srs.metadata)
@@ -1084,6 +1148,7 @@
     const label = srs.labels?.[bar_idx] ?? null
     const active_y_axis = srs.y_axis ?? `y1`
     const active_x_axis = srs.x_axis ?? `x1`
+    const category_label = category_list[x]
     const coords = {
       x,
       y,
@@ -1103,6 +1168,7 @@
       bar_idx,
       active_y_axis,
       active_x_axis,
+      category_label,
     }
   }
 
@@ -1146,9 +1212,11 @@
     if (mode !== `stacked`) return [] as number[][]
     const max_len = Math.max(
       0,
-      ...series.map((srs: BarSeries<Metadata>) => srs.y.length),
+      ...internal_series.map((srs) => srs.y.length),
     )
-    const offsets = series.map(() => Array.from({ length: max_len }, () => 0))
+    const offsets = internal_series.map(() =>
+      Array.from({ length: max_len }, () => 0)
+    )
 
     // Separate accumulators for y1 and y2 axes
     const y1_pos_acc = Array.from({ length: max_len }, () => 0)
@@ -1156,7 +1224,7 @@
     const y2_pos_acc = Array.from({ length: max_len }, () => 0)
     const y2_neg_acc = Array.from({ length: max_len }, () => 0)
 
-    series.forEach((srs: BarSeries<Metadata>, series_idx: number) => {
+    internal_series.forEach((srs, series_idx) => {
       if (!(srs?.visible ?? true) || srs.render_mode === `line`) return
 
       const use_y2 = srs.y_axis === `y2`
@@ -1176,8 +1244,8 @@
   // Calculate group positions for grouped mode (side-by-side bars)
   let group_info = $derived.by(() => {
     if (mode !== `grouped`) return { bar_series_count: 0, bar_series_indices: [] }
-    const bar_series_indices = series
-      .map((srs: BarSeries<Metadata>, idx: number) =>
+    const bar_series_indices = internal_series
+      .map((srs, idx) =>
         (srs?.visible ?? true) && srs.render_mode !== `line` ? idx : -1
       )
       .filter((idx) => idx >= 0)
@@ -1400,7 +1468,13 @@
                 ? `rotate(${rotation}, ${shift_x}, ${text_y})`
                 : undefined}
               >
-                {format_value(tick, x_axis.format)}
+                {
+                  get_tick_label(
+                    tick as number,
+                    cat_axis === `x` ? effective_cat_ticks : x_axis.ticks,
+                  ) ??
+                    format_value(tick, x_axis.format)
+                }
               </text>
             </g>
           {/if}
@@ -1469,7 +1543,10 @@
                   ? `rotate(${rotation}, ${shift_x}, ${text_y})`
                   : undefined}
                 >
-                  {format_value(tick, x2_axis.format)}
+                  {
+                    get_tick_label(tick as number, x2_axis.ticks) ??
+                    format_value(tick, x2_axis.format)
+                  }
                 </text>
               </g>
             {/if}
@@ -1536,7 +1613,13 @@
                 ? `rotate(${rotation}, ${text_x}, ${shift_y})`
                 : undefined}
               >
-                {format_value(tick, y_axis.format)}
+                {
+                  get_tick_label(
+                    tick as number,
+                    cat_axis === `y` ? effective_cat_ticks : y_axis.ticks,
+                  ) ??
+                    format_value(tick, y_axis.format)
+                }
               </text>
             </g>
           {/if}
@@ -1609,7 +1692,10 @@
                   ? `rotate(${rotation}, ${shift_x}, ${shift_y})`
                   : undefined}
                 >
-                  {format_value(tick, y2_axis.format)}
+                  {
+                    get_tick_label(tick as number, y2_axis.ticks) ??
+                    format_value(tick, y2_axis.format)
+                  }
                 </text>
               </g>
             {/if}
@@ -1673,7 +1759,7 @@
         {@render ref_lines_layer(ref_lines_by_z.below_lines)}
 
         <!-- Bars and Lines -->
-        {#each series as srs, series_idx (srs?.id ?? series_idx)}
+        {#each internal_series as srs, series_idx (srs?.id ?? series_idx)}
           {#if srs?.visible ?? true}
             {@const is_line = srs.render_mode === `line`}
             <g
@@ -2042,11 +2128,13 @@
           {/if}
           <div>
             {@html hover_info.x_axis.label || `x`}: {
+              (cat_axis === `x` ? hover_info.category_label : undefined) ??
               format_value(hover_info.orient_x, hover_info.x_axis.format || `.3~s`)
             }
           </div>
           <div>
             {@html hover_info.y_axis.label || `y`}: {
+              (cat_axis === `y` ? hover_info.category_label : undefined) ??
               format_value(hover_info.orient_y, hover_info.y_axis.format || `.3~s`)
             }
           </div>

--- a/src/lib/plot/BarPlot.svelte
+++ b/src/lib/plot/BarPlot.svelte
@@ -293,7 +293,7 @@
       return {
         ...srs,
         x: category_indices,
-        y: remap(srs.y, 0),
+        y: remap(srs.y, srs.render_mode === `line` ? NaN : 0),
         labels: remap(srs.labels, null),
         metadata: orig_indices.map((oi) =>
           oi != null ? (meta_arr ? meta_arr[oi] : srs.metadata) : undefined

--- a/src/lib/plot/types.ts
+++ b/src/lib/plot/types.ts
@@ -192,6 +192,7 @@ export interface BarHandlerProps<Metadata = Record<string, unknown>>
   active_y_axis: `y1` | `y2`
   active_x_axis: `x1` | `x2`
   color: string
+  category_label?: string // original string category (undefined when numeric x)
 }
 
 export interface HistogramHandlerProps<Metadata = Record<string, unknown>>
@@ -364,7 +365,7 @@ export type BarMode = `overlay` | `stacked` | `grouped`
 
 export interface BarSeries<Metadata = Record<string, unknown>> {
   id?: string | number // Optional stable identifier for the series (used for keying)
-  x: readonly number[]
+  x: readonly (number | string)[]
   y: readonly number[]
   label?: string
   // Group name for organizing legend items. Series with the same legend_group
@@ -454,6 +455,7 @@ export interface AxisConfig {
   // Shorthand: 'synced' | 'align' | 'none'
   // Full config: { mode: Y2SyncMode, align_value?: number }
   sync?: Y2SyncConfig | Y2SyncMode
+  categories?: readonly string[] // explicit category order/filter for categorical bar plots
 }
 
 // Result from data loader - returns complete series array

--- a/src/routes/(demos)/plot/bar-plot/+page.md
+++ b/src/routes/(demos)/plot/bar-plot/+page.md
@@ -62,10 +62,13 @@ Pass string categories directly as `x` values instead of numeric indices. Catego
   ]
 
   let x_axis = $derived({
-    label: `Semiconductor`,
+    label: orientation === `horizontal` ? `Band Gap (eV)` : `Semiconductor`,
     categories: custom_order
       ? [`Diamond`, `GaN`, `ZnO`, `GaAs`, `CdTe`, `Si`]
       : undefined,
+  })
+  let y_axis = $derived({
+    label: orientation === `horizontal` ? `Semiconductor` : `Band Gap (eV)`,
   })
 </script>
 
@@ -94,7 +97,7 @@ Pass string categories directly as `x` values instead of numeric indices. Catego
   {mode}
   {orientation}
   {x_axis}
-  y_axis={{ label: `Band Gap (eV)` }}
+  {y_axis}
   style="height: 400px"
 />
 ```

--- a/src/routes/(demos)/plot/bar-plot/+page.md
+++ b/src/routes/(demos)/plot/bar-plot/+page.md
@@ -28,6 +28,79 @@ A simple bar plot showing lattice parameters across different crystal systems. U
 />
 ```
 
+## Categorical Bar Charts
+
+Pass string categories directly as `x` values instead of numeric indices. Categories are automatically detected, positioned, and labeled on the axis. Multiple series with different categories are aligned correctly for stacking and grouping. Use `x_axis.categories` to control category order:
+
+```svelte example
+<script lang="ts">
+  import { BarPlot } from 'matterviz'
+
+  let mode = $state(`grouped`)
+  let orientation = $state(`vertical`)
+  let custom_order = $state(false)
+
+  const band_gaps = [
+    {
+      x: [`Si`, `GaAs`, `GaN`, `ZnO`, `Diamond`],
+      y: [1.12, 1.43, 3.4, 3.37, 5.47],
+      label: `Experimental`,
+      color: `#4c6ef5`,
+    },
+    {
+      x: [`Si`, `GaAs`, `GaN`, `ZnO`, `Diamond`, `CdTe`],
+      y: [0.56, 0.55, 1.87, 0.73, 4.14, 0.58],
+      label: `DFT (PBE)`,
+      color: `#ff6b6b`,
+    },
+    {
+      x: [`Si`, `GaAs`, `Diamond`],
+      y: [1.17, 1.52, 5.48],
+      label: `GW Calculation`,
+      color: `#51cf66`,
+    },
+  ]
+
+  let x_axis = $derived({
+    label: `Semiconductor`,
+    categories: custom_order
+      ? [`Diamond`, `GaN`, `ZnO`, `GaAs`, `CdTe`, `Si`]
+      : undefined,
+  })
+</script>
+
+<div
+  style="display: flex; gap: 1.5em; margin-bottom: 1em; flex-wrap: wrap; align-items: center"
+>
+  {#each [`grouped`, `stacked`, `overlay`] as m (m)}
+    <label><input type="radio" bind:group={mode} value={m} /> {m}</label>
+  {/each}
+  <label style="margin-left: 1em">
+    <input type="checkbox" bind:checked={custom_order} /> Sort by band gap
+  </label>
+  <label>
+    <input
+      type="checkbox"
+      checked={orientation === `horizontal`}
+      onchange={(
+        evt,
+      ) => (orientation = evt.currentTarget.checked ? `horizontal` : `vertical`)}
+    /> Horizontal
+  </label>
+</div>
+
+<BarPlot
+  series={band_gaps}
+  {mode}
+  {orientation}
+  {x_axis}
+  y_axis={{ label: `Band Gap (eV)` }}
+  style="height: 400px"
+/>
+```
+
+Note how series can have **different categories** -- DFT (PBE) includes CdTe while GW only covers three materials. Missing categories render as zero-height bars in stacked mode, and are simply absent in grouped mode.
+
 ## Mode Comparison: Band Gap Measurements
 
 Compare overlay, stacked, and grouped (side-by-side) modes using band gap data from different measurement techniques. Click legend items to toggle series visibility:
@@ -231,7 +304,7 @@ Horizontal bar charts work well for categorical data with long labels. This exam
   <input
     type="checkbox"
     checked={orientation === `horizontal`}
-    onchange={(evt) => (orientation = evt.target.checked ? `horizontal` : `vertical`)}
+    onchange={(evt) => (orientation = evt.currentTarget.checked ? `horizontal` : `vertical`)}
   />
   Horizontal Orientation
 </label>

--- a/src/routes/test/bar-plot/+page.svelte
+++ b/src/routes/test/bar-plot/+page.svelte
@@ -224,6 +224,39 @@
     },
   ]
 
+  // Categorical bar chart series — string x values with different categories per series
+  const categorical_series: BarSeries[] = [
+    {
+      x: [`Si`, `GaAs`, `GaN`, `ZnO`, `Diamond`],
+      y: [1.12, 1.43, 3.4, 3.37, 5.47],
+      label: `Experimental`,
+      color: `#4c6ef5`,
+    },
+    {
+      x: [`Si`, `GaAs`, `GaN`, `ZnO`, `Diamond`, `CdTe`],
+      y: [0.56, 0.55, 1.87, 0.73, 4.14, 0.58],
+      label: `DFT (PBE)`,
+      color: `#e15759`,
+    },
+    {
+      x: [`Si`, `GaAs`, `Diamond`],
+      y: [1.17, 1.52, 5.48],
+      label: `GW`,
+      color: `#59a14f`,
+    },
+  ]
+
+  const categorical_single_series: BarSeries[] = [
+    {
+      x: [`Oxygen`, `Silicon`, `Aluminum`, `Iron`],
+      y: [461000, 277200, 82300, 50000],
+      label: `Abundance`,
+      color: `#845ef7`,
+    },
+  ]
+  let cat_hover_msg = $state(`Hover over a bar`)
+  let cat_click_msg = $state(`Click on a bar`)
+
   // X2 axis demo — two series with different x scales (e.g. Celsius vs Fahrenheit)
   const x2_axis_series: BarSeries[] = [
     {
@@ -427,4 +460,78 @@
     controls_toggle_props={{ class: `bar-controls-toggle` }}
     style="height: 360px"
   />
+</section>
+
+<section id="categorical-bar">
+  <h2>Categorical Bar Charts</h2>
+  <BarPlot
+    series={categorical_series}
+    x_axis={{ label: `Material` }}
+    y_axis={{ label: `Band Gap (eV)` }}
+    mode="grouped"
+    controls_toggle_props={{ class: `bar-controls-toggle` }}
+    style="height: 360px"
+  />
+</section>
+
+<section id="categorical-stacked">
+  <h2>Categorical Stacked</h2>
+  <BarPlot
+    series={categorical_series}
+    x_axis={{ label: `Material` }}
+    y_axis={{ label: `Band Gap (eV)` }}
+    mode="stacked"
+    controls_toggle_props={{ class: `bar-controls-toggle` }}
+    style="height: 360px"
+  />
+</section>
+
+<section id="categorical-horizontal">
+  <h2>Categorical Horizontal</h2>
+  <BarPlot
+    series={categorical_series}
+    x_axis={{ label: `Material` }}
+    y_axis={{ label: `Band Gap (eV)` }}
+    mode="grouped"
+    orientation="horizontal"
+    controls_toggle_props={{ class: `bar-controls-toggle` }}
+    style="height: 360px"
+  />
+</section>
+
+<section id="categorical-custom-order">
+  <h2>Categorical Custom Order</h2>
+  <BarPlot
+    series={categorical_series}
+    x_axis={{ label: `Material`, categories: [`Diamond`, `GaN`, `Si`, `GaAs`] }}
+    y_axis={{ label: `Band Gap (eV)` }}
+    mode="grouped"
+    controls_toggle_props={{ class: `bar-controls-toggle` }}
+    style="height: 360px"
+  />
+</section>
+
+<section id="categorical-handlers">
+  <h2>Categorical With Handlers</h2>
+  <BarPlot
+    series={categorical_single_series}
+    x_axis={{ label: `Element` }}
+    y_axis={{ label: `Abundance (ppm)` }}
+    on_bar_hover={(data) => {
+      if (data) {
+        cat_hover_msg = `Hovering: ${data.category_label} (y=${data.y})`
+      } else {
+        cat_hover_msg = `Hover over a bar`
+      }
+    }}
+    on_bar_click={(data) => {
+      cat_click_msg = `Clicked: ${data.category_label} (y=${data.y})`
+    }}
+    controls_toggle_props={{ class: `bar-controls-toggle` }}
+    style="height: 360px"
+  />
+  <div class="handler-info categorical-handler-info">
+    <p>{cat_hover_msg}</p>
+    <p>{cat_click_msg}</p>
+  </div>
 </section>

--- a/tests/playwright/plot/bar-plot.test.ts
+++ b/tests/playwright/plot/bar-plot.test.ts
@@ -462,6 +462,106 @@ test.describe(`BarPlot Component Tests`, () => {
     await expect(y2_axis).toBeVisible()
   })
 
+  // CATEGORICAL BAR CHART TESTS
+
+  test(`categorical bar chart renders bars with category tick labels`, async ({ page }) => {
+    const plot = page.locator(`#categorical-bar .bar-plot`)
+    await plot.scrollIntoViewIfNeeded()
+    await expect(plot).toBeVisible()
+
+    // Bars should render
+    const bars = plot.locator(`svg path[aria-label^="bar "]`)
+    await expect(bars.first()).toBeVisible()
+
+    // X-axis should show category labels, not numeric indices
+    const x_ticks = await plot.locator(`g.x-axis .tick text`).allTextContents()
+    expect(x_ticks).toContain(`Si`)
+    expect(x_ticks).toContain(`GaAs`)
+    expect(x_ticks).toContain(`Diamond`)
+    expect(x_ticks).toContain(`CdTe`)
+    // Should NOT show numeric indices
+    expect(x_ticks).not.toContain(`0`)
+    expect(x_ticks).not.toContain(`5`)
+  })
+
+  test(`categorical stacked has correct tick count and y-range from zero-padding`, async ({ page }) => {
+    const plot = page.locator(`#categorical-stacked .bar-plot`)
+    await plot.scrollIntoViewIfNeeded()
+    await expect(plot).toBeVisible()
+    await expect(plot.locator(`svg path[aria-label^="bar "]`).first()).toBeVisible()
+
+    // Union of all categories: Si, GaAs, GaN, ZnO, Diamond, CdTe = 6 ticks
+    const x_ticks = await plot.locator(`g.x-axis .tick text`).allTextContents()
+    expect(x_ticks.length).toBe(6)
+
+    // Padding uses y=0 for missing categories — y-range should stay reasonable
+    const y_values = (await plot.locator(`g.y-axis .tick text`).allTextContents())
+      .map(Number).filter(Number.isFinite)
+    const y_max = Math.max(...y_values)
+    expect(y_max).toBeLessThan(20)
+    expect(y_max).toBeGreaterThan(0)
+  })
+
+  test(`categorical horizontal shows categories on y-axis`, async ({ page }) => {
+    const plot = page.locator(`#categorical-horizontal .bar-plot`)
+    await plot.scrollIntoViewIfNeeded()
+    await expect(plot).toBeVisible()
+
+    const bars = plot.locator(`svg path[aria-label^="bar "]`)
+    await expect(bars.first()).toBeVisible()
+
+    // In horizontal orientation, category labels should be on the y-axis
+    const y_ticks = await plot.locator(`g.y-axis .tick text`).allTextContents()
+    expect(y_ticks).toContain(`Si`)
+    expect(y_ticks).toContain(`Diamond`)
+
+    // X-axis should show numeric value ticks, not categories
+    const x_ticks = await plot.locator(`g.x-axis .tick text`).allTextContents()
+    expect(x_ticks).not.toContain(`Si`)
+    expect(x_ticks).not.toContain(`Diamond`)
+  })
+
+  test(`categorical custom order respects x_axis.categories`, async ({ page }) => {
+    const plot = page.locator(`#categorical-custom-order .bar-plot`)
+    await plot.scrollIntoViewIfNeeded()
+    await expect(plot).toBeVisible()
+
+    const x_ticks = await plot.locator(`g.x-axis .tick text`).allTextContents()
+    // Custom order: Diamond, GaN, Si, GaAs (4 categories, filtered subset)
+    expect(x_ticks.length).toBe(4)
+    expect(x_ticks[0]).toBe(`Diamond`)
+    expect(x_ticks[1]).toBe(`GaN`)
+    expect(x_ticks[2]).toBe(`Si`)
+    expect(x_ticks[3]).toBe(`GaAs`)
+  })
+
+  test(`categorical tooltip and handlers show category_label`, async ({ page }) => {
+    const section = page.locator(`#categorical-handlers`)
+    const plot = section.locator(`.bar-plot`)
+    await plot.scrollIntoViewIfNeeded()
+    await expect(plot).toBeVisible()
+
+    const bar = plot.locator(`svg path[aria-label^="bar "]`).first()
+    await bar.hover()
+
+    // Tooltip should show element name, not a number
+    const tooltip = plot.locator(`.plot-tooltip`)
+    await expect(tooltip).toBeVisible({ timeout: 5000 })
+    expect(await tooltip.textContent()).toMatch(/Oxygen|Silicon|Aluminum|Iron/)
+
+    // Handler hover message should contain the category label
+    const info = section.locator(`.categorical-handler-info`)
+    const hover_p = info.locator(`p`).first()
+    await expect(hover_p).toContainText(`Hovering:`, { timeout: 5000 })
+    expect(await hover_p.textContent()).toMatch(/Oxygen|Silicon|Aluminum|Iron/)
+
+    // Click handler should also have category label
+    await bar.click()
+    const click_p = info.locator(`p`).last()
+    await expect(click_p).toContainText(`Clicked:`)
+    expect(await click_p.textContent()).toMatch(/Oxygen|Silicon|Aluminum|Iron/)
+  })
+
   // PAN FUNCTIONALITY TESTS
 
   test(`Shift+drag pans the bar plot instead of zooming`, async ({ page }) => {

--- a/tests/vitest/plot/BarPlot.test.ts
+++ b/tests/vitest/plot/BarPlot.test.ts
@@ -256,6 +256,117 @@ describe(`BarPlot`, () => {
     )
   })
 
+  describe(`categorical bar charts`, () => {
+    const cat_series: BarSeries[] = [
+      { x: [`A`, `B`, `C`], y: [10, 20, 30], label: `S1`, color: `blue` },
+      { x: [`B`, `C`, `D`], y: [5, 15, 25], label: `S2`, color: `red` },
+    ]
+
+    // Fold all mount-and-check configs into a single parameterized test
+    test.each([
+      [`overlay mode`, { series: cat_series, mode: `overlay` as BarMode }],
+      [`stacked mode`, { series: cat_series, mode: `stacked` as BarMode }],
+      [`grouped mode`, { series: cat_series, mode: `grouped` as BarMode }],
+      [`vertical`, { series: cat_series, orientation: `vertical` as Orientation }],
+      [`horizontal`, { series: cat_series, orientation: `horizontal` as Orientation }],
+      [`explicit category order`, {
+        series: cat_series,
+        x_axis: { categories: [`D`, `C`, `B`, `A`] },
+      }],
+      [`category subset filter`, {
+        series: cat_series,
+        x_axis: { categories: [`A`, `C`] },
+      }],
+      [`empty categorical series`, {
+        series: [{ x: [] as string[], y: [], color: `blue` }],
+      }],
+      [`single category`, { series: [{ x: [`Only`], y: [42], color: `blue` }] }],
+      [`mixed bar+line`, {
+        series: [
+          { x: [`A`, `B`, `C`], y: [10, 20, 30], color: `blue` },
+          {
+            x: [`A`, `B`, `C`],
+            y: [15, 25, 35],
+            color: `red`,
+            render_mode: `line` as const,
+            markers: `line+points` as const,
+          },
+        ],
+      }],
+      [`numeric x (not categorical)`, {
+        series: [{ x: [1, 2, 3], y: [10, 20, 30], color: `blue` }],
+      }],
+    ] as [string, Partial<ComponentProps<typeof BarPlot>>][])(
+      `renders %s`,
+      async (_label, props) => {
+        mount(BarPlot, {
+          target: document.body,
+          props: { ...props, style: `width: 400px; height: 300px` },
+        })
+        await tick()
+        const plot = document.querySelector(`.bar-plot`)
+        expect(plot).toBeTruthy()
+        expect(plot?.querySelector(`svg`)).toBeTruthy()
+      },
+    )
+
+    test(`single series with 3 categories renders 3 bars`, async () => {
+      mount(BarPlot, {
+        target: document.body,
+        props: {
+          series: [{ x: [`Foo`, `Bar`, `Baz`], y: [1, 2, 3], color: `blue` }],
+          style: `width: 400px; height: 300px`,
+        },
+      })
+      await tick()
+      expect(document.querySelectorAll(`path[role="button"]`).length).toBe(3)
+    })
+
+    test(`hover provides category_label and preserves metadata`, async () => {
+      const hover_fn = vi.fn()
+      mount(BarPlot, {
+        target: document.body,
+        props: {
+          series: [{
+            x: [`X`, `Y`],
+            y: [10, 20],
+            color: `blue`,
+            metadata: [{ id: 1 }, { id: 2 }],
+            labels: [`Label X`, `Label Y`],
+          }],
+          on_bar_hover: hover_fn,
+          style: `width: 400px; height: 300px`,
+        },
+      })
+      await tick()
+      document.querySelector(`path[role="button"]`)
+        ?.dispatchEvent(new MouseEvent(`mousemove`, { bubbles: true }))
+      await tick()
+      expect(hover_fn).toHaveBeenCalled()
+      const data = hover_fn.mock.calls[0][0]
+      expect(typeof data.category_label).toBe(`string`)
+      expect(data.metadata).toBeDefined()
+    })
+
+    test(`tooltip shows category name, not numeric index`, async () => {
+      mount(BarPlot, {
+        target: document.body,
+        props: {
+          series: [{ x: [`Alpha`, `Beta`, `Gamma`], y: [10, 20, 30], color: `blue` }],
+          x_axis: { label: `Greek` },
+          style: `width: 400px; height: 300px`,
+        },
+      })
+      await tick()
+      document.querySelector(`path[role="button"]`)
+        ?.dispatchEvent(new MouseEvent(`mousemove`, { bubbles: true }))
+      await tick()
+      const tooltip_text = document.querySelector(`.plot-tooltip`)?.textContent ?? ``
+      expect(tooltip_text).toMatch(/Alpha|Beta|Gamma/)
+      expect(tooltip_text).not.toMatch(/\b0\b/)
+    })
+  })
+
   describe(`legend grouping`, () => {
     const grouped_series: BarSeries[] = [
       {

--- a/tests/vitest/plot/BarPlot.test.ts
+++ b/tests/vitest/plot/BarPlot.test.ts
@@ -339,8 +339,9 @@ describe(`BarPlot`, () => {
         },
       })
       await tick()
-      document.querySelector(`path[role="button"]`)
-        ?.dispatchEvent(new MouseEvent(`mousemove`, { bubbles: true }))
+      const bar = document.querySelector(`path[role="button"]`)
+      if (!bar) throw new Error(`bar element not found`)
+      bar.dispatchEvent(new MouseEvent(`mousemove`, { bubbles: true }))
       await tick()
       expect(hover_fn).toHaveBeenCalled()
       const data = hover_fn.mock.calls[0][0]
@@ -358,8 +359,9 @@ describe(`BarPlot`, () => {
         },
       })
       await tick()
-      document.querySelector(`path[role="button"]`)
-        ?.dispatchEvent(new MouseEvent(`mousemove`, { bubbles: true }))
+      const bar = document.querySelector(`path[role="button"]`)
+      if (!bar) throw new Error(`bar element not found`)
+      bar.dispatchEvent(new MouseEvent(`mousemove`, { bubbles: true }))
       await tick()
       const tooltip_text = document.querySelector(`.plot-tooltip`)?.textContent ?? ``
       expect(tooltip_text).toMatch(/Alpha|Beta|Gamma/)


### PR DESCRIPTION
- Accept string categories directly as `BarSeries.x` values (e.g. `x: ["Si", "GaAs", "Diamond"]`), auto-detecting categorical mode and normalizing to numeric indices internally
- Add `x_axis.categories` prop for explicit category order and filtering
- Add `category_label` to `BarHandlerProps` for tooltip/event handler access to original category strings
- Handle horizontal orientation correctly (categories on y-axis, values on x-axis)
- Import and use `get_tick_label` for all 4 axes, fixing existing gap where `Record<number, string>` ticks didn't render custom labels
- Pad series to unified category set with `y=0` for missing entries, ensuring correct stacking/grouping when series have different categories

- Duplicate category values now emit a warning.