### PR TITLE
Add `exclude_from_hull` prop to convex hull components

### DIFF
--- a/src/lib/convex-hull/ConvexHull2D.svelte
+++ b/src/lib/convex-hull/ConvexHull2D.svelte
@@ -31,7 +31,6 @@
   import * as thermo from './thermodynamics'
   import type {
     ConvexHullEntry,
-    HighlightStyle,
     HoverData3D,
     PhaseData,
   } from './types'
@@ -88,7 +87,6 @@
     tooltip: custom_tooltip,
     ...rest
   }: BaseConvexHullProps<ConvexHullEntry> & {
-    highlight_style?: HighlightStyle
     x_axis?: AxisConfig
     y_axis?: AxisConfig
   } = $props()
@@ -260,8 +258,10 @@
     }
 
     // Build lower hull input: one minimum-energy point per composition x.
+    // Excluded entries don't participate in hull construction.
     const min_y_by_x = new SvelteMap<number, number>()
     for (const entry of coords_entries) {
+      if (entry.exclude_from_hull) continue
       const current_min_y = min_y_by_x.get(entry.x)
       if (current_min_y === undefined || entry.y < current_min_y) {
         min_y_by_x.set(entry.x, entry.y)
@@ -276,11 +276,14 @@
 
     const all_enriched_entries = coords_entries.map((entry) => {
       const y_hull = thermo.interpolate_hull_2d(hull_points, entry.x)
-      const e_above_hull = y_hull == null ? 0 : Math.max(0, entry.y - y_hull)
+      const raw_dist = y_hull == null ? 0 : entry.y - y_hull
+      const e_above_hull = entry.exclude_from_hull
+        ? raw_dist
+        : (Math.abs(raw_dist) < HULL_STABILITY_TOL ? 0 : Math.max(0, raw_dist))
       return {
         ...entry,
         e_above_hull,
-        is_stable: e_above_hull <= HULL_STABILITY_TOL,
+        is_stable: entry.exclude_from_hull ? false : e_above_hull <= HULL_STABILITY_TOL,
         visible: true,
       }
     })

--- a/src/lib/convex-hull/ConvexHull3D.svelte
+++ b/src/lib/convex-hull/ConvexHull3D.svelte
@@ -48,11 +48,11 @@
   import * as thermo from './thermodynamics'
   import type {
     ConvexHullEntry,
-    HighlightStyle,
     HoverData3D,
     HullFaceColorMode,
     Point3D,
   } from './types'
+  import { HULL_STABILITY_TOL } from './types'
 
   let {
     entries = [],
@@ -108,9 +108,7 @@
     children,
     tooltip,
     ...rest
-  }: BaseConvexHullProps<ConvexHullEntry> & Hull3DProps & {
-    highlight_style?: HighlightStyle
-  } = $props()
+  }: BaseConvexHullProps<ConvexHullEntry> & Hull3DProps = $props()
 
   const merged_controls = $derived({ ...default_controls, ...controls })
   const controls_config = $derived(normalize_show_controls(merged_controls.show))
@@ -231,7 +229,10 @@
   }
   const hull_faces = $derived.by((): HullTriangle[] => {
     if (coords_entries.length === 0) return []
-    const points = coords_entries.map((e) => ({ x: e.x, y: e.y, z: e.z }))
+    // Excluded entries don't participate in hull construction
+    const hull_entries = coords_entries.filter((e) => !e.exclude_from_hull)
+    if (hull_entries.length === 0) return []
+    const points = hull_entries.map((e) => ({ x: e.x, y: e.y, z: e.z }))
     try {
       return thermo.compute_lower_hull_triangles(points)
     } catch (error) {
@@ -248,8 +249,14 @@
     if (coords_entries.length === 0) return []
     if (energy_mode !== `on-the-fly`) return coords_entries
     const pts = coords_entries.map((e) => ({ x: e.x, y: e.y, z: e.z }))
-    const e_hulls = thermo.compute_e_above_hull_for_points(pts, hull_model)
-    return coords_entries.map((e, idx) => ({ ...e, e_above_hull: e_hulls[idx] }))
+    const raw_dists = thermo.compute_e_above_hull_for_points(pts, hull_model)
+    return coords_entries.map((e, idx) => {
+      const raw = raw_dists[idx]
+      const e_above_hull = e.exclude_from_hull
+        ? raw
+        : (Math.abs(raw) < HULL_STABILITY_TOL ? 0 : Math.max(0, raw))
+      return { ...e, e_above_hull }
+    })
   })
 
   // Auto threshold: show all for few entries, use default for many, interpolate between

--- a/src/lib/convex-hull/ConvexHull4D.svelte
+++ b/src/lib/convex-hull/ConvexHull4D.svelte
@@ -37,10 +37,10 @@
   import * as thermo from './thermodynamics'
   import type {
     ConvexHullEntry,
-    HighlightStyle,
     HoverData3D,
     HullFaceColorMode,
   } from './types'
+  import { HULL_STABILITY_TOL } from './types'
 
   let {
     entries = [],
@@ -97,9 +97,7 @@
     children,
     tooltip,
     ...rest
-  }: BaseConvexHullProps<ConvexHullEntry> & Hull3DProps & {
-    highlight_style?: HighlightStyle
-  } = $props()
+  }: BaseConvexHullProps<ConvexHullEntry> & Hull3DProps = $props()
 
   const merged_controls = $derived({ ...default_controls, ...controls })
   const controls_config = $derived(normalize_show_controls(merged_controls.show))
@@ -202,8 +200,9 @@
     if (elements.length !== 4) return []
 
     try {
-      // Get coords with formation energies
+      // Get coords with formation energies, excluding entries that don't participate in hull
       const coords = compute_4d_coords(pd_data.entries, elements)
+        .filter((ent) => !ent.exclude_from_hull)
 
       // Convert to 4D points for hull computation using barycentric coordinates (composition fractions)
       const points_4d: Point4D[] = coords
@@ -251,12 +250,16 @@
           ? [{ idx, pt: { x, y, z, w: entry.e_form_per_atom ?? NaN } }]
           : []
       })
-      const e_hulls = thermo.compute_e_above_hull_4d(valid.map((item) => item.pt), hull_4d)
-      const hull_map = new Map(valid.map((item, hull_idx) => [item.idx, e_hulls[hull_idx]]))
-      return coords.map((entry, idx) => ({
-        ...entry,
-        e_above_hull: hull_map.get(idx),
-      }))
+      const raw_dists = thermo.compute_e_above_hull_4d(valid.map((item) => item.pt), hull_4d)
+      const hull_map = new Map(valid.map((item, hull_idx) => [item.idx, raw_dists[hull_idx]]))
+      return coords.map((entry, idx) => {
+        const raw = hull_map.get(idx)
+        if (raw === undefined) return { ...entry, e_above_hull: raw }
+        const e_above_hull = entry.exclude_from_hull
+          ? raw
+          : (Math.abs(raw) < HULL_STABILITY_TOL ? 0 : Math.max(0, raw))
+        return { ...entry, e_above_hull }
+      })
     } catch (err) {
       console.error(`Error computing quaternary coordinates:`, err)
       return []

--- a/src/lib/convex-hull/thermodynamics.ts
+++ b/src/lib/convex-hull/thermodynamics.ts
@@ -985,8 +985,7 @@ export const compute_e_above_hull_for_points = (points: Point3D[], models: HullF
   points.map((point) => {
     const z_hull = e_hull_at_xy(models, point.x, point.y)
     if (z_hull === null) return 0
-    const e_above_hull = point.z - z_hull
-    return e_above_hull > EPS ? e_above_hull : 0
+    return point.z - z_hull
   })
 
 // --- 4D Convex Hull (Quaternary Phase Diagrams) ---
@@ -1637,8 +1636,7 @@ export const compute_e_above_hull_4d = (
     // If no tetrahedron contains this point's spatial projection, it's outside the valid
     // composition domain. Return NaN to indicate invalid input.
     if (hull_w === null) return NaN
-    const distance = w - hull_w
-    return distance > EPS ? distance : 0
+    return w - hull_w
   })
 }
 

--- a/src/lib/convex-hull/types.ts
+++ b/src/lib/convex-hull/types.ts
@@ -14,6 +14,7 @@ export interface PhaseData {
   // Common computed fields
   e_above_hull?: number
   is_stable?: boolean
+  exclude_from_hull?: boolean // If true, entry is shown but not used in hull construction
   energy_per_atom?: number
   e_form_per_atom?: number // Formation energy per atom from fetch-mp-pd-data.py
   reduced_formula?: string
@@ -173,8 +174,9 @@ export const HULL_STABILITY_TOL = 1e-6
 
 // Check if entry is on the convex hull (stable or e_above_hull ≈ 0)
 export const is_on_hull = (entry: PhaseData, tol: number = HULL_STABILITY_TOL): boolean =>
-  entry.is_stable === true ||
-  (typeof entry.e_above_hull === `number` && entry.e_above_hull < tol)
+  !entry.exclude_from_hull &&
+  (entry.is_stable === true ||
+    (typeof entry.e_above_hull === `number` && entry.e_above_hull < tol))
 
 // Arity helpers (inlined from former arity.ts)
 export const get_arity = (entry: PhaseData): number =>


### PR DESCRIPTION
## Why?

Allow convex hull consumers to mark certain entries as display-only — visible on the plot but excluded from hull construction. This is needed when overlaying external/experimental data points that shouldn't influence the computed hull shape.

## How?

- Add `exclude_from_hull?: boolean` to `PhaseData` and gate `is_on_hull()` on it
- In 2D/3D/4D hull components, filter out excluded entries before hull construction
- Move `e_above_hull` clamping from `thermodynamics.ts` helpers into component callers so excluded entries retain their raw (possibly negative) hull distance
- Excluded entries are never classified as stable

- The optional `highlight_style` prop is removed from `ConvexHull2D`.