### PR TITLE
Fix PBC distance calculation for non-orthogonal lattices

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_install_hook_types: [pre-commit, commit-msg]
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.2
+    rev: v0.15.11
     hooks:
       - id: ruff-check
         args: [--fix]
@@ -55,7 +55,7 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.36.2
+    rev: 0.37.1
     hooks:
       - id: check-jsonschema
         name: Validate element data JSON
@@ -63,7 +63,7 @@ repos:
         args: [--schemafile, src/lib/element/data.schema.json]
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.2
     hooks:
       - id: codespell
         stages: [pre-commit, commit-msg]
@@ -73,7 +73,7 @@ repos:
           - --check-filenames
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.47.0
+    rev: v0.48.0
     hooks:
       - id: markdownlint
         # MD013: line too long

--- a/package.json
+++ b/package.json
@@ -211,6 +211,7 @@
     "@types/d3-scale-chromatic": "^3.1.0",
     "@types/d3-shape": "^3.1.8",
     "@types/d3-time-format": "^4.0.3",
+    "@types/node": "^25.6.0",
     "@types/three": "^0.184.0",
     "@typescript/native-preview": "7.0.0-dev.20260422.1",
     "@vitest/coverage-v8": "4.1.4",

--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
     "@spglib/moyo-wasm": "^0.7.9",
     "@sveltejs/kit": "2.57.1",
     "@threlte/core": "^8.5.9",
-    "@threlte/extras": "^9.14.5",
+    "@threlte/extras": "^9.14.8",
     "@types/d3-hierarchy": "^3.1.7",
     "@types/js-yaml": "^4.0.9",
     "d3": "^7.9.0",
@@ -190,12 +190,12 @@
     "d3-scale": "^4.0.2",
     "d3-scale-chromatic": "^3.1.0",
     "d3-shape": "^3.2.0",
-    "dompurify": "^3.3.3",
+    "dompurify": "^3.4.1",
     "fflate": "^0.8.2",
     "h5wasm": "^0.10.1",
     "js-yaml": "^4.1.1",
     "svelte-multiselect": "^11.7.0",
-    "three": "^0.183.2"
+    "three": "^0.184.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",
@@ -211,29 +211,29 @@
     "@types/d3-scale-chromatic": "^3.1.0",
     "@types/d3-shape": "^3.1.8",
     "@types/d3-time-format": "^4.0.3",
-    "@types/three": "^0.183.1",
-    "@typescript/native-preview": "7.0.0-dev.20260410.1",
-    "@vitest/coverage-v8": "^4.1.4",
+    "@types/three": "^0.184.0",
+    "@typescript/native-preview": "7.0.0-dev.20260422.1",
+    "@vitest/coverage-v8": "^4.1.5",
     "@wooorm/starry-night": "^3.9.0",
     "d3-time-format": "^4.1.0",
-    "happy-dom": "^20.8.9",
+    "happy-dom": "^20.9.0",
     "matterviz-wasm": "^0.0.10",
     "mdsvex": "^0.12.7",
     "rehype-katex": "^7.0.1",
     "remark-math": "3.0.1",
-    "svelte": "5.55.2",
+    "svelte": "5.55.4",
     "svelte-check-rs": "0.9.7",
-    "typescript": "6.0.2",
-    "vite": "npm:@voidzero-dev/vite-plus-core@^0.1.16",
+    "typescript": "6.0.3",
+    "vite": "npm:@voidzero-dev/vite-plus-core@^0.1.19",
     "vite-plus": "latest",
-    "vitest": "npm:@voidzero-dev/vite-plus-test@^0.1.16"
+    "vitest": "npm:@voidzero-dev/vite-plus-test@^0.1.19"
   },
   "peerDependencies": {
     "svelte": "^5.0.0"
   },
   "overrides": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@^0.1.16",
-    "vitest": "npm:@voidzero-dev/vite-plus-test@^0.1.16"
+    "vite": "npm:@voidzero-dev/vite-plus-core@^0.1.19",
+    "vitest": "npm:@voidzero-dev/vite-plus-test@^0.1.19"
   },
   "engines": {
     "node": ">=24"

--- a/package.json
+++ b/package.json
@@ -213,7 +213,7 @@
     "@types/d3-time-format": "^4.0.3",
     "@types/three": "^0.184.0",
     "@typescript/native-preview": "7.0.0-dev.20260422.1",
-    "@vitest/coverage-v8": "^4.1.5",
+    "@vitest/coverage-v8": "4.1.4",
     "@wooorm/starry-night": "^3.9.0",
     "d3-time-format": "^4.1.0",
     "happy-dom": "^20.9.0",

--- a/src/lib/colors/index.ts
+++ b/src/lib/colors/index.ts
@@ -84,7 +84,7 @@ export const is_color = (val: unknown): val is string => {
   // Check for hex colors, rgb/rgba, hsl/hsla, color(), var(), and named colors
   // Exclude incomplete function prefixes like 'rgb', 'hsl', 'var', 'color'
   return /^(#[0-9a-f]{3,8}|rgba?\([^)]+\)|hsla?\([^)]+\)|color\([^)]+\)|var\([^)]+\)|(?!rgb$|hsl$|var$|color$)[a-z]+)$/i.test(
-    val.toString().trim(),
+    val.trim(),
   )
 }
 

--- a/src/lib/isosurface/parse.ts
+++ b/src/lib/isosurface/parse.ts
@@ -502,7 +502,7 @@ export function parse_cube(
     cube_cart_to_frac = math.create_cart_to_frac(lattice)
   } catch {
     // Non-periodic system (molecule), use identity
-    cube_cart_to_frac = (v: Vec3): Vec3 => [...v]
+    cube_cart_to_frac = (v: Vec3): Vec3 => [v[0], v[1], v[2]]
   }
 
   for (let atom_idx = 0; atom_idx < n_atoms; atom_idx++) {

--- a/src/lib/isosurface/parse.ts
+++ b/src/lib/isosurface/parse.ts
@@ -5,14 +5,12 @@ import { ELEM_SYMBOLS } from '$lib/labels'
 import type { Matrix3x3, Vec3 } from '$lib/math'
 import * as math from '$lib/math'
 import type { Site } from '$lib/structure'
+import { wrap_to_unit_cell } from '$lib/structure/pbc'
 import type { ParsedStructure } from '$lib/structure/parse'
 import type { DataRange, VolumetricData, VolumetricFileData } from './types'
 
 // Bohr radius in Angstroms (for Gaussian .cube unit conversion)
 const BOHR_TO_ANGSTROM = 0.529177249
-
-// Wrap a value to [0, 1) range for fractional coordinates
-const wrap_frac = (val: number): number => val - Math.floor(val)
 
 // === Fast number parsing utilities ===
 
@@ -282,8 +280,14 @@ export function parse_chgcar(content: string): VolumetricFileData | null {
   pos = cur.next
 
   // Parse atomic positions
-  const lattice_transposed = math.transpose_3x3_matrix(lattice)
-  const lattice_inv = math.matrix_inverse_3x3(lattice_transposed)
+  let cart_to_frac: (v: Vec3) => Vec3
+  let frac_to_cart: (v: Vec3) => Vec3
+  try {
+    ;({ cart_to_frac, frac_to_cart } = math.create_lattice_converters(lattice))
+  } catch {
+    console.error(`CHGCAR: lattice matrix is singular; cannot convert coordinates`)
+    return null
+  }
   const sites: Site[] = []
   let atom_idx = 0
 
@@ -307,12 +311,12 @@ export function parse_chgcar(content: string): VolumetricFileData | null {
       let xyz: Vec3
 
       if (is_direct) {
-        abc = [wrap_frac(coords[0]), wrap_frac(coords[1]), wrap_frac(coords[2])]
-        xyz = math.mat3x3_vec3_multiply(lattice_transposed, abc)
+        abc = wrap_to_unit_cell(coords)
+        xyz = frac_to_cart(abc)
       } else {
         xyz = math.scale(coords, scale_factor)
-        const raw = math.mat3x3_vec3_multiply(lattice_inv, xyz)
-        abc = [wrap_frac(raw[0]), wrap_frac(raw[1]), wrap_frac(raw[2])]
+        const raw = cart_to_frac(xyz)
+        abc = wrap_to_unit_cell(raw)
       }
 
       sites.push({
@@ -493,18 +497,12 @@ export function parse_cube(
 
   // Parse atomic positions
   const sites: Site[] = []
-  const lattice_transposed = math.transpose_3x3_matrix(lattice)
-
-  let lattice_inv: Matrix3x3
+  let cube_cart_to_frac: (v: Vec3) => Vec3
   try {
-    lattice_inv = math.matrix_inverse_3x3(lattice_transposed)
+    cube_cart_to_frac = math.create_cart_to_frac(lattice)
   } catch {
     // Non-periodic system (molecule), use identity
-    lattice_inv = [
-      [1, 0, 0],
-      [0, 1, 0],
-      [0, 0, 1],
-    ]
+    cube_cart_to_frac = (v: Vec3): Vec3 => [...v]
   }
 
   for (let atom_idx = 0; atom_idx < n_atoms; atom_idx++) {
@@ -529,7 +527,7 @@ export function parse_cube(
     // Convert Cartesian to fractional, accounting for origin offset.
     // Store lattice-frame xyz (shifted) so abc and xyz stay consistent.
     const xyz = math.subtract(raw_xyz, origin)
-    const abc = math.mat3x3_vec3_multiply(lattice_inv, xyz)
+    const abc = cube_cart_to_frac(xyz)
 
     const element = atomic_number_to_symbol(atom_line[0])
     sites.push({

--- a/src/lib/isosurface/slice.ts
+++ b/src/lib/isosurface/slice.ts
@@ -107,9 +107,7 @@ export function sample_hkl_slice(
   // In-plane basis vectors
   const [u_vec, v_vec] = math.compute_in_plane_basis(unit_normal)
 
-  // Compute lattice inverse for Cartesian → fractional conversion.
-  // lattice rows are vectors [a, b, c], so cart = lattice^T * frac → frac = inv(lattice^T) * cart
-  const lattice_inv = math.matrix_inverse_3x3(math.transpose_3x3_matrix(lattice))
+  const cart_to_frac = math.create_cart_to_frac(lattice)
 
   // Project all 8 unit cell corners onto the (u, v) plane to find sampling bounds.
   // Corners are at fractional coords (0 or 1) for each axis.
@@ -165,11 +163,7 @@ export function sample_hkl_slice(
       const py = d_cartesian * unit_normal[1] + u_val * u_vec[1] + v_val * v_vec[1]
       const pz = d_cartesian * unit_normal[2] + u_val * u_vec[2] + v_val * v_vec[2]
 
-      // Convert to fractional coordinates: frac = lattice_inv * p
-      const fx = lattice_inv[0][0] * px + lattice_inv[0][1] * py + lattice_inv[0][2] * pz
-      const fy = lattice_inv[1][0] * px + lattice_inv[1][1] * py + lattice_inv[1][2] * pz
-      const fz = lattice_inv[2][0] * px + lattice_inv[2][1] * py + lattice_inv[2][2] * pz
-
+      const [fx, fy, fz] = cart_to_frac([px, py, pz])
       const val = trilinear_interpolate(grid, fx, fy, fz, periodic)
       data[row * width + col] = val
       if (val < data_min) data_min = val

--- a/src/lib/math.ts
+++ b/src/lib/math.ts
@@ -75,29 +75,78 @@ export const euclidean_dist = (vec1: NdVector, vec2: NdVector): number => {
   return Math.hypot(...vec1.map((x, idx) => x - vec2[idx]))
 }
 
+const vec3_norm_sq = (vec: Vec3): number => vec[0] ** 2 + vec[1] ** 2 + vec[2] ** 2
+
+// Exact minimum-image displacement for row-vector lattices.
+// Rounded fractional wrapping is only approximate for highly skewed cells, so
+// we use it as a starting guess and then search the small set of shifts that
+// can still beat that Cartesian radius.
+export function min_image_displacement(
+  from: Vec3,
+  to: Vec3,
+  lattice_matrix: Matrix3x3,
+  converters?: LatticeConverters,
+  pbc: Pbc = [true, true, true],
+): Vec3 {
+  const { cart_to_frac, frac_to_cart, reciprocal_axis_norms } =
+    converters ?? create_lattice_converters(lattice_matrix)
+  const frac_from = cart_to_frac(from)
+  const frac_to = cart_to_frac(to)
+  const frac_diff: Vec3 = [
+    frac_to[0] - frac_from[0],
+    frac_to[1] - frac_from[1],
+    frac_to[2] - frac_from[2],
+  ]
+  const wrapped_frac_diff: Vec3 = [
+    pbc[0] ? frac_diff[0] - Math.round(frac_diff[0]) : frac_diff[0],
+    pbc[1] ? frac_diff[1] - Math.round(frac_diff[1]) : frac_diff[1],
+    pbc[2] ? frac_diff[2] - Math.round(frac_diff[2]) : frac_diff[2],
+  ]
+
+  let best_displacement = frac_to_cart(wrapped_frac_diff)
+  let best_dist_sq = vec3_norm_sq(best_displacement)
+  const search_radius = Math.sqrt(best_dist_sq) + EPS
+  const candidate_shift_ranges = ([0, 1, 2] as const).map((axis_idx) => {
+    if (!pbc[axis_idx]) return [0, 0] as const
+    const axis_bound = reciprocal_axis_norms[axis_idx] * search_radius
+    return [
+      Math.ceil(-frac_diff[axis_idx] - axis_bound),
+      Math.floor(-frac_diff[axis_idx] + axis_bound),
+    ] as const
+  })
+  const [[i_min, i_max], [j_min, j_max], [k_min, k_max]] = candidate_shift_ranges
+
+  // Only test integer shifts that reciprocal-space bounds say could still win.
+  for (let ii = i_min; ii <= i_max; ii++) {
+    for (let jj = j_min; jj <= j_max; jj++) {
+      for (let kk = k_min; kk <= k_max; kk++) {
+        const candidate_frac_diff: Vec3 = [
+          frac_diff[0] + ii,
+          frac_diff[1] + jj,
+          frac_diff[2] + kk,
+        ]
+        const candidate_displacement = frac_to_cart(candidate_frac_diff)
+        const candidate_dist_sq = vec3_norm_sq(candidate_displacement)
+        if (candidate_dist_sq < best_dist_sq) {
+          best_dist_sq = candidate_dist_sq
+          best_displacement = candidate_displacement
+        }
+      }
+    }
+  }
+
+  return best_displacement
+}
+
 // Calculate the minimum distance between two points considering periodic boundary conditions.
 export function pbc_dist(
-  pos1: Vec3, // First position vector (Cartesian coordinates)
-  pos2: Vec3, // Second position vector (Cartesian coordinates)
-  lattice_matrix: Matrix3x3, // 3x3 lattice matrix where each row is a lattice vector
-  lattice_inv?: Matrix3x3, // Optional pre-computed inverse matrix for optimization (since lattice is usually constant and repeatedly inverting matrix is expensive)
+  pos1: Vec3,
+  pos2: Vec3,
+  lattice_matrix: Matrix3x3,
+  converters?: LatticeConverters,
   pbc: Pbc = [true, true, true],
 ): number {
-  const inv_matrix = lattice_inv ?? matrix_inverse_3x3(lattice_matrix)
-
-  // Convert Cartesian coordinates to fractional coordinates
-  const [fx1, fy1, fz1] = mat3x3_vec3_multiply(inv_matrix, pos1)
-  const [fx2, fy2, fz2] = mat3x3_vec3_multiply(inv_matrix, pos2)
-
-  // Apply minimum image convention only for periodic axes
-  const wrapped_frac_diff = [fx1 - fx2, fy1 - fy2, fz1 - fz2].map((diff, idx) =>
-    pbc[idx] ? diff - Math.round(diff) : diff,
-  ) as Vec3
-
-  // Convert back to Cartesian coordinates
-  const cart_diff = mat3x3_vec3_multiply(lattice_matrix, wrapped_frac_diff)
-
-  return Math.hypot(...cart_diff)
+  return Math.hypot(...min_image_displacement(pos1, pos2, lattice_matrix, converters, pbc))
 }
 
 export function matrix_inverse_3x3(matrix: Matrix3x3): Matrix3x3 {
@@ -301,16 +350,36 @@ export const transpose_3x3_matrix = (matrix: Matrix3x3): Matrix3x3 => [
   [matrix[0][2], matrix[1][2], matrix[2][2]],
 ]
 
+const create_cart_to_frac_matrix = (lattice: Matrix3x3): Matrix3x3 =>
+  matrix_inverse_3x3(transpose_3x3_matrix(lattice))
+
 // Curried fractional→Cartesian converter (caches transposed matrix)
 export const create_frac_to_cart = (lattice: Matrix3x3) => {
   const transposed = transpose_3x3_matrix(lattice)
-  return (frac: Vec3) => mat3x3_vec3_multiply(transposed, frac)
+  return (frac: Vec3): Vec3 => mat3x3_vec3_multiply(transposed, frac)
 }
 
 // Curried Cartesian→fractional converter (caches inverse transpose)
 export const create_cart_to_frac = (lattice: Matrix3x3) => {
-  const inv_transposed = matrix_inverse_3x3(transpose_3x3_matrix(lattice))
-  return (cart: Vec3) => mat3x3_vec3_multiply(inv_transposed, cart)
+  const cart_to_frac_mat = create_cart_to_frac_matrix(lattice)
+  return (cart: Vec3): Vec3 => mat3x3_vec3_multiply(cart_to_frac_mat, cart)
+}
+
+// Paired converters for a lattice — the safe way to do cart↔frac conversion.
+// Encapsulates the transpose convention so callers never touch raw matrices.
+export type LatticeConverters = {
+  cart_to_frac: (v: Vec3) => Vec3
+  frac_to_cart: (v: Vec3) => Vec3
+  reciprocal_axis_norms: Vec3
+}
+
+export const create_lattice_converters = (lattice: Matrix3x3): LatticeConverters => {
+  const cart_to_frac_mat = create_cart_to_frac_matrix(lattice)
+  return {
+    cart_to_frac: (cart: Vec3): Vec3 => mat3x3_vec3_multiply(cart_to_frac_mat, cart),
+    frac_to_cart: create_frac_to_cart(lattice),
+    reciprocal_axis_norms: cart_to_frac_mat.map((row) => Math.hypot(...row)) as Vec3,
+  }
 }
 
 // Convert unit cell parameters to lattice matrix (crystallographic convention)

--- a/src/lib/math.ts
+++ b/src/lib/math.ts
@@ -32,6 +32,7 @@ export const LOG_EPS = 1e-9
 export const EPS = 1e-10
 export const RAD_TO_DEG = 180 / Math.PI
 export const DEG_TO_RAD = Math.PI / 180
+const MAX_MIN_IMAGE_CANDIDATES = 100_000
 
 export const to_degrees = (radians: number): number => radians * RAD_TO_DEG
 export const to_radians = (degrees: number): number => degrees * DEG_TO_RAD
@@ -114,6 +115,17 @@ export function min_image_displacement(
       Math.floor(-frac_diff[axis_idx] + axis_bound),
     ] as const
   })
+  let candidate_count = 1
+  for (const [shift_min, shift_max] of candidate_shift_ranges) {
+    candidate_count *= shift_max - shift_min + 1
+    if (candidate_count > MAX_MIN_IMAGE_CANDIDATES) {
+      throw new Error(
+        `Minimum-image search would test >${MAX_MIN_IMAGE_CANDIDATES} candidates ` +
+          `for lattice ${JSON.stringify(lattice_matrix)}; reciprocal norms=` +
+          `${JSON.stringify(reciprocal_axis_norms)} ranges=${JSON.stringify(candidate_shift_ranges)}`,
+      )
+    }
+  }
   const [[i_min, i_max], [j_min, j_max], [k_min, k_max]] = candidate_shift_ranges
 
   // Only test integer shifts that reciprocal-space bounds say could still win.

--- a/src/lib/plot/layout.ts
+++ b/src/lib/plot/layout.ts
@@ -7,8 +7,8 @@ export const LABEL_GAP_DEFAULT = 30
 
 // Filter undefined values from padding to prevent overriding defaults when spreading
 // Guards against undefined/null padding inputs (common for optional props)
-export const filter_padding = <T extends Partial<Sides>>(
-  padding: T | undefined | null,
+export const filter_padding = (
+  padding: Partial<Sides> | undefined | null,
   defaults: Required<Sides>,
 ): Required<Sides> =>
   ({

--- a/src/lib/rdf/calc-rdf.ts
+++ b/src/lib/rdf/calc-rdf.ts
@@ -1,5 +1,10 @@
 import type { Matrix3x3, Vec3 } from '$lib/math'
-import { calc_lattice_params, euclidean_dist, matrix_inverse_3x3, pbc_dist } from '$lib/math'
+import {
+  calc_lattice_params,
+  create_lattice_converters,
+  euclidean_dist,
+  pbc_dist,
+} from '$lib/math'
 import type { Crystal, Pbc } from '$lib/structure'
 import { make_supercell } from '$lib/structure/supercell'
 import type { RdfOptions, RdfPattern } from './index'
@@ -71,14 +76,14 @@ export function calculate_rdf(structure: Crystal, options: RdfOptions = {}): Rdf
 
   // Calculate distances and bin them with occupancy weighting
   const use_pbc = pbc.some((flag) => flag)
-  const lattice_inv = use_pbc ? matrix_inverse_3x3(lattice) : undefined
+  const converters = use_pbc ? create_lattice_converters(lattice) : undefined
 
   for (const center of centers) {
     for (const neighbor of neighbors) {
       if (center === neighbor) continue
 
       const dist = use_pbc
-        ? pbc_dist(center.xyz as Vec3, neighbor.xyz as Vec3, lattice, lattice_inv, pbc)
+        ? pbc_dist(center.xyz as Vec3, neighbor.xyz as Vec3, lattice, converters, pbc)
         : euclidean_dist(center.xyz, neighbor.xyz)
 
       if (dist > 0 && dist < cutoff) {

--- a/src/lib/structure/atom-properties.ts
+++ b/src/lib/structure/atom-properties.ts
@@ -6,6 +6,7 @@ import * as math from '$lib/math'
 import type { AtomColorMode } from '$lib/settings'
 import type { AnyStructure, Site } from '$lib/structure'
 import type { BondingStrategy } from '$lib/structure/bonding'
+import { wrap_to_unit_cell } from '$lib/structure/pbc'
 import type { MoyoDataset } from '@spglib/moyo-wasm'
 import { rgb } from 'd3-color'
 import * as d3_sc from 'd3-scale-chromatic'
@@ -44,7 +45,7 @@ const get_interpolator = (scale: string) => {
 const to_hex = (interp_fn: (t: number) => string, t: number) => rgb(interp_fn(t)).formatHex()
 const build_image_site = (
   site: Site,
-  lattice_T: math.Matrix3x3,
+  frac_to_cart: (v: math.Vec3) => math.Vec3,
   offset: readonly [number, number, number],
   orig_idx: number,
 ): Site => {
@@ -56,7 +57,7 @@ const build_image_site = (
   return {
     ...site,
     abc: img_abc,
-    xyz: math.mat3x3_vec3_multiply(lattice_T, img_abc),
+    xyz: frac_to_cart(img_abc),
     properties: { ...site.properties, orig_site_idx: orig_idx },
   }
 }
@@ -150,14 +151,14 @@ function expand_structure_for_pbc(structure: AnyStructure): AnyStructure {
   }
 
   const { sites, lattice } = structure
-  const lattice_T = math.transpose_3x3_matrix(lattice.matrix)
+  const frac_to_cart = math.create_frac_to_cart(lattice.matrix)
   const pbc = lattice.pbc ?? [true, true, true]
   const all_offsets = get_all_offsets(pbc)
 
   // Small structures: expand all atoms
   if (sites.length < 20 || !pbc.some((periodic) => periodic)) {
     const image_sites = sites.flatMap((site, orig_idx) =>
-      all_offsets.map((offset) => build_image_site(site, lattice_T, offset, orig_idx)),
+      all_offsets.map((offset) => build_image_site(site, frac_to_cart, offset, orig_idx)),
     )
     return { ...structure, sites: [...sites, ...image_sites] }
   }
@@ -166,7 +167,7 @@ function expand_structure_for_pbc(structure: AnyStructure): AnyStructure {
   const cutoff: math.Vec3 = [5.0 / lattice.a, 5.0 / lattice.b, 5.0 / lattice.c]
 
   const image_sites = sites.flatMap((site, orig_idx) => {
-    const norm = site.abc.map((coord) => coord - Math.floor(coord)) as math.Vec3
+    const norm = wrap_to_unit_cell(site.abc)
 
     return all_offsets
       .filter(
@@ -175,7 +176,7 @@ function expand_structure_for_pbc(structure: AnyStructure): AnyStructure {
           (dy === 0 || (dy === -1 ? norm[1] <= cutoff[1] : norm[1] >= 1 - cutoff[1])) &&
           (dz === 0 || (dz === -1 ? norm[2] <= cutoff[2] : norm[2] >= 1 - cutoff[2])),
       )
-      .map((offset) => build_image_site(site, lattice_T, offset, orig_idx))
+      .map((offset) => build_image_site(site, frac_to_cart, offset, orig_idx))
   })
 
   return { ...structure, sites: [...sites, ...image_sites] }

--- a/src/lib/structure/measure.ts
+++ b/src/lib/structure/measure.ts
@@ -1,7 +1,7 @@
 // functions for measuring distances and angles between structure sites
 
-import type { Matrix3x3, Vec3 } from '$lib/math'
-import { mat3x3_vec3_multiply, matrix_inverse_3x3, subtract, transpose_3x3_matrix } from '$lib/math'
+import type { LatticeConverters, Matrix3x3, Vec3 } from '$lib/math'
+import { min_image_displacement, subtract } from '$lib/math'
 
 export type AngleMode = `degrees` | `radians`
 
@@ -13,62 +13,14 @@ export function displacement_pbc(
   from: Vec3,
   to: Vec3,
   lattice_matrix: Matrix3x3 | null | undefined,
-  lattice_inv?: Matrix3x3,
+  converters?: LatticeConverters,
 ): Vec3 {
-  // For non-periodic structures, return direct displacement
   if (!lattice_matrix) return subtract(to, from)
-
-  const lattice_T = transpose_3x3_matrix(lattice_matrix)
-  const inv_mat = lattice_inv ?? matrix_inverse_3x3(lattice_T)
-  const frac_from = mat3x3_vec3_multiply(inv_mat, from)
-  const frac_to = mat3x3_vec3_multiply(inv_mat, to)
-
-  // Wrap fractional coordinates to [0,1) for easier boundary checking
-  const frac_from_wrapped: Vec3 = [
-    frac_from[0] - Math.floor(frac_from[0]),
-    frac_from[1] - Math.floor(frac_from[1]),
-    frac_from[2] - Math.floor(frac_from[2]),
-  ]
-  const frac_to_wrapped: Vec3 = [
-    frac_to[0] - Math.floor(frac_to[0]),
-    frac_to[1] - Math.floor(frac_to[1]),
-    frac_to[2] - Math.floor(frac_to[2]),
-  ]
-
-  // Find minimum image by testing all nearby lattice translations
-  let min_dist_sq = Infinity
-  let best_displacement: Vec3 = [0, 0, 0]
-
-  // Test lattice images in a 3x3x3 neighborhood (sufficient for minimum image)
-  for (let ii = -1; ii <= 1; ii++) {
-    for (let jj = -1; jj <= 1; jj++) {
-      for (let kk = -1; kk <= 1; kk++) {
-        // Fractional displacement with lattice translation
-        const frac_diff: Vec3 = [
-          frac_to_wrapped[0] - frac_from_wrapped[0] + ii,
-          frac_to_wrapped[1] - frac_from_wrapped[1] + jj,
-          frac_to_wrapped[2] - frac_from_wrapped[2] + kk,
-        ]
-
-        // Convert to cartesian
-        const cart_diff = mat3x3_vec3_multiply(lattice_T, frac_diff)
-        const dist_sq = cart_diff[0] ** 2 + cart_diff[1] ** 2 + cart_diff[2] ** 2
-
-        // Keep the shortest displacement
-        if (dist_sq < min_dist_sq) {
-          min_dist_sq = dist_sq
-          best_displacement = cart_diff
-        }
-      }
-    }
-  }
-
-  return best_displacement
+  return min_image_displacement(from, to, lattice_matrix, converters)
 }
 
 export function distance_pbc(a: Vec3, b: Vec3, lattice_matrix: Matrix3x3): number {
-  const inv_mat = matrix_inverse_3x3(transpose_3x3_matrix(lattice_matrix))
-  const [dx, dy, dz] = displacement_pbc(a, b, lattice_matrix, inv_mat)
+  const [dx, dy, dz] = displacement_pbc(a, b, lattice_matrix)
   return Math.hypot(dx, dy, dz)
 }
 

--- a/src/lib/structure/measure.ts
+++ b/src/lib/structure/measure.ts
@@ -1,7 +1,7 @@
 // functions for measuring distances and angles between structure sites
 
 import type { Matrix3x3, Vec3 } from '$lib/math'
-import { mat3x3_vec3_multiply, matrix_inverse_3x3, subtract } from '$lib/math'
+import { mat3x3_vec3_multiply, matrix_inverse_3x3, subtract, transpose_3x3_matrix } from '$lib/math'
 
 export type AngleMode = `degrees` | `radians`
 
@@ -18,7 +18,8 @@ export function displacement_pbc(
   // For non-periodic structures, return direct displacement
   if (!lattice_matrix) return subtract(to, from)
 
-  const inv_mat = lattice_inv ?? matrix_inverse_3x3(lattice_matrix)
+  const lattice_T = transpose_3x3_matrix(lattice_matrix)
+  const inv_mat = lattice_inv ?? matrix_inverse_3x3(lattice_T)
   const frac_from = mat3x3_vec3_multiply(inv_mat, from)
   const frac_to = mat3x3_vec3_multiply(inv_mat, to)
 
@@ -50,7 +51,7 @@ export function displacement_pbc(
         ]
 
         // Convert to cartesian
-        const cart_diff = mat3x3_vec3_multiply(lattice_matrix, frac_diff)
+        const cart_diff = mat3x3_vec3_multiply(lattice_T, frac_diff)
         const dist_sq = cart_diff[0] ** 2 + cart_diff[1] ** 2 + cart_diff[2] ** 2
 
         // Keep the shortest displacement
@@ -66,7 +67,7 @@ export function displacement_pbc(
 }
 
 export function distance_pbc(a: Vec3, b: Vec3, lattice_matrix: Matrix3x3): number {
-  const inv_mat = matrix_inverse_3x3(lattice_matrix)
+  const inv_mat = matrix_inverse_3x3(transpose_3x3_matrix(lattice_matrix))
   const [dx, dy, dz] = displacement_pbc(a, b, lattice_matrix, inv_mat)
   return Math.hypot(dx, dy, dz)
 }

--- a/src/lib/structure/parse.ts
+++ b/src/lib/structure/parse.ts
@@ -113,6 +113,22 @@ function validate_element_symbol(symbol: string, index: number): ElementSymbol {
   return fallback as ElementSymbol
 }
 
+const try_create_cart_to_frac = (
+  lattice_matrix: math.Matrix3x3,
+): ((v: Vec3) => Vec3) | null => {
+  try {
+    return math.create_cart_to_frac(lattice_matrix)
+  } catch {
+    return null
+  }
+}
+
+const approximate_cart_to_frac = (xyz: Vec3, axis_lengths: Vec3): Vec3 => [
+  Math.abs(axis_lengths[0]) > math.EPS ? xyz[0] / axis_lengths[0] : 0,
+  Math.abs(axis_lengths[1]) > math.EPS ? xyz[1] / axis_lengths[1] : 0,
+  Math.abs(axis_lengths[2]) > math.EPS ? xyz[2] / axis_lengths[2] : 0,
+]
+
 // Parse VASP POSCAR file format
 export function parse_poscar(content: string): ParsedStructure | null {
   try {
@@ -245,6 +261,14 @@ export function parse_poscar(content: string): ParsedStructure | null {
       }
 
       // Parse atomic positions
+      const poscar_axis_lengths = scaled_lattice.map((lattice_vec) =>
+        Math.hypot(...lattice_vec),
+      ) as Vec3
+      const poscar_frac_to_cart = math.create_frac_to_cart(scaled_lattice)
+      const poscar_cart_to_frac = try_create_cart_to_frac(scaled_lattice)
+      if (!is_direct && !poscar_cart_to_frac) {
+        console.warn(`POSCAR: singular lattice, using axis-length fallback for cart→frac`)
+      }
       const sites: Site[] = []
       let atom_index = 0
 
@@ -275,35 +299,16 @@ export function parse_poscar(content: string): ParsedStructure | null {
 
           if (is_direct) {
             // Store fractional coordinates, wrapping to [0, 1) range
-            abc = [x - Math.floor(x), y - Math.floor(y), z - Math.floor(z)]
-            // Convert fractional to Cartesian coordinates
-            const lattice_transposed = math.transpose_3x3_matrix(scaled_lattice)
-            xyz = math.mat3x3_vec3_multiply(lattice_transposed, abc)
+            abc = wrap_to_unit_cell([x, y, z])
+            xyz = poscar_frac_to_cart(abc)
           } else {
             // Already Cartesian, scale if needed
             xyz = math.scale([x, y, z], scale_factor)
-            // Calculate fractional coordinates using proper matrix inversion
-            // Note: Our lattice matrix is stored as row vectors, but for coordinate conversion
-            // we need column vectors, so we transpose before inversion
-            let raw_abc: Vec3
-            try {
-              const lattice_transposed = math.transpose_3x3_matrix(scaled_lattice)
-              const lattice_inv = math.matrix_inverse_3x3(lattice_transposed)
-              raw_abc = math.mat3x3_vec3_multiply(lattice_inv, xyz)
-            } catch {
-              // Fallback to simplified method if matrix is singular
-              raw_abc = [
-                xyz[0] / scaled_lattice[0][0],
-                xyz[1] / scaled_lattice[1][1],
-                xyz[2] / scaled_lattice[2][2],
-              ]
-            }
+            const raw_abc = poscar_cart_to_frac
+              ? poscar_cart_to_frac(xyz)
+              : approximate_cart_to_frac(xyz, poscar_axis_lengths)
             // Wrap fractional coordinates to [0, 1) range
-            abc = [
-              raw_abc[0] - Math.floor(raw_abc[0]),
-              raw_abc[1] - Math.floor(raw_abc[1]),
-              raw_abc[2] - Math.floor(raw_abc[2]),
-            ]
+            abc = wrap_to_unit_cell(raw_abc)
           }
 
           const site: Site = {
@@ -400,6 +405,13 @@ export function parse_xyz(content: string): ParsedStructure | null {
     }
 
     // Parse atomic coordinates (starting from line 3)
+    const xyz_axis_lengths = lattice ? ([lattice.a, lattice.b, lattice.c] as Vec3) : null
+    let xyz_frac_to_cart: ((v: Vec3) => Vec3) | null = null
+    let xyz_cart_to_frac: ((v: Vec3) => Vec3) | null = null
+    if (lattice) {
+      xyz_frac_to_cart = math.create_frac_to_cart(lattice.matrix)
+      xyz_cart_to_frac = try_create_cart_to_frac(lattice.matrix)
+    }
     const sites: Site[] = []
 
     for (let atom_idx = 0; atom_idx < num_atoms; atom_idx++) {
@@ -427,30 +439,16 @@ export function parse_xyz(content: string): ParsedStructure | null {
 
       // Calculate fractional coordinates if lattice is available
       let abc: Vec3 = [0, 0, 0]
-      if (lattice) {
-        // Calculate fractional coordinates using proper matrix inversion
-        // Note: Our lattice matrix is stored as row vectors, but for coordinate conversion
-        // we need column vectors, so we transpose before inversion
-        try {
-          const lattice_transposed = math.transpose_3x3_matrix(lattice.matrix)
-          const lattice_inv = math.matrix_inverse_3x3(lattice_transposed)
-          abc = math.mat3x3_vec3_multiply(lattice_inv, xyz)
-        } catch {
-          // Fallback to simplified method if matrix is singular
-          abc = [xyz[0] / lattice.a, xyz[1] / lattice.b, xyz[2] / lattice.c]
-        }
+      if (lattice && xyz_frac_to_cart && xyz_axis_lengths) {
+        abc = xyz_cart_to_frac
+          ? xyz_cart_to_frac(xyz)
+          : approximate_cart_to_frac(xyz, xyz_axis_lengths)
 
         // Ensure fractional coordinates are wrapped into [0, 1) for consistency
-        abc = [
-          abc[0] - Math.floor(abc[0]),
-          abc[1] - Math.floor(abc[1]),
-          abc[2] - Math.floor(abc[2]),
-        ]
+        abc = wrap_to_unit_cell(abc)
 
         // Keep rendered atoms inside primary unit cell by recomputing xyz
-        // from the wrapped fractional coordinates using transpose(lattice)
-        const lattice_transposed = math.transpose_3x3_matrix(lattice.matrix)
-        const wrapped_xyz = math.mat3x3_vec3_multiply(lattice_transposed, abc)
+        const wrapped_xyz = xyz_frac_to_cart(abc)
         xyz[0] = wrapped_xyz[0]
         xyz[1] = wrapped_xyz[1]
         xyz[2] = wrapped_xyz[2]
@@ -559,7 +557,7 @@ const apply_symmetry_ops = (
   const equivalent_atoms: CifAtom[] = []
   const seen = new Set<string>()
   const wrap = (coords: Vec3): Vec3 =>
-    wrap_fractional_coords ? (coords.map((val) => val - Math.floor(val)) as Vec3) : coords
+    wrap_fractional_coords ? wrap_to_unit_cell(coords) : coords
   // Use 6 decimal places for deduplication to handle floating point imprecision
   // from compound symmetry operations like x-y, -x+y which can produce small errors
   const key = (coords: Vec3): string =>
@@ -869,17 +867,11 @@ export function parse_cif(
     const [alpha, beta, gamma] = angles
     const lattice_matrix = math.cell_to_lattice_matrix(a, b, c, alpha, beta, gamma)
     const lattice_params = math.calc_lattice_params(lattice_matrix)
-    const lattice_transposed = math.transpose_3x3_matrix(lattice_matrix)
-    let lattice_inv_transposed: math.Matrix3x3 | null = null
-    try {
-      lattice_inv_transposed = math.matrix_inverse_3x3(lattice_transposed)
-    } catch {
-      lattice_inv_transposed = null
-    }
+    const frac_to_cart = math.create_frac_to_cart(lattice_matrix)
+    const cart_to_frac = try_create_cart_to_frac(lattice_matrix)
 
     // Create sites with coordinate conversion and symmetry operations
-    const wrap_vec3 = (v: Vec3): Vec3 =>
-      wrap_fractional_coords ? (v.map((coord) => coord - Math.floor(coord)) as Vec3) : v
+    const wrap_vec3 = (v: Vec3): Vec3 => (wrap_fractional_coords ? wrap_to_unit_cell(v) : v)
 
     // Apply symmetry operations to generate all equivalent positions
     const all_sites: Site[] = []
@@ -967,11 +959,11 @@ export function parse_cif(
         }
       } else {
         const xyz_base: Vec3 = [atom.coords[0], atom.coords[1], atom.coords[2]]
-        let atom_abc: Vec3
-        if (lattice_inv_transposed) {
-          const raw = math.mat3x3_vec3_multiply(lattice_inv_transposed, xyz_base)
-          atom_abc = wrap_vec3(raw as Vec3)
-        } else atom_abc = wrap_vec3([xyz_base[0] / a, xyz_base[1] / b, xyz_base[2] / c])
+        const atom_abc = wrap_vec3(
+          cart_to_frac
+            ? cart_to_frac(xyz_base)
+            : approximate_cart_to_frac(xyz_base, [a, b, c]),
+        )
         fractional_atom = { ...atom, coords: atom_abc, coords_type: `fract` }
       }
 
@@ -993,7 +985,7 @@ export function parse_cif(
           const key = site_key(element, abc, equiv_atom.id)
           if (seen_site_keys.has(key)) continue
           seen_site_keys.add(key)
-          const xyz = math.mat3x3_vec3_multiply(lattice_transposed, abc)
+          const xyz = frac_to_cart(abc)
           all_sites.push({
             species: [{ element, occu: equiv_atom.occupancy, oxidation_state: 0 }],
             abc,
@@ -1020,12 +1012,12 @@ function convert_phonopy_cell(cell: PhonopyCell): ParsedStructure {
   const lattice_matrix = cell.lattice as math.Matrix3x3
 
   // Process each atomic site
+  const phonopy_frac_to_cart = math.create_frac_to_cart(lattice_matrix)
   for (const point of cell.points) {
     const element = validate_element_symbol(point.symbol, sites.length)
     const abc: Vec3 = [point.coordinates[0], point.coordinates[1], point.coordinates[2]]
 
-    // Convert fractional to Cartesian coordinates
-    const xyz = math.mat3x3_vec3_multiply(math.transpose_3x3_matrix(lattice_matrix), abc)
+    const xyz = phonopy_frac_to_cart(abc)
 
     const properties = {
       mass: point.mass,
@@ -1413,6 +1405,12 @@ export function parse_optimade_from_raw(raw: unknown): ParsedStructure | null {
     const lattice_matrix = attrs.lattice_vectors as math.Matrix3x3 | undefined
 
     // Parse atomic sites
+    const optimade_cart_to_frac = lattice_matrix
+      ? try_create_cart_to_frac(lattice_matrix)
+      : null
+    if (lattice_matrix && !optimade_cart_to_frac) {
+      console.warn(`Failed to create coordinate converter for OPTIMADE structure`)
+    }
     const sites: Site[] = []
     for (let idx = 0; idx < positions.length; idx++) {
       const pos = positions[idx]
@@ -1427,17 +1425,7 @@ export function parse_optimade_from_raw(raw: unknown): ParsedStructure | null {
       const xyz: Vec3 = [pos[0], pos[1], pos[2]]
 
       // Calculate fractional coordinates if lattice is available
-      let abc: Vec3 = [0, 0, 0]
-      if (lattice_matrix) {
-        try {
-          const lattice_transposed = math.transpose_3x3_matrix(lattice_matrix)
-          const lattice_inv = math.matrix_inverse_3x3(lattice_transposed)
-          abc = math.mat3x3_vec3_multiply(lattice_inv, xyz)
-        } catch {
-          // Fallback if matrix inversion fails
-          console.warn(`Failed to calculate fractional coordinates for OPTIMADE structure`)
-        }
-      }
+      const abc: Vec3 = optimade_cart_to_frac ? optimade_cart_to_frac(xyz) : [0, 0, 0]
 
       const site: Site = {
         species: [{ element, occu: 1, oxidation_state: 0 }],
@@ -1540,6 +1528,7 @@ export function optimade_to_crystal(optimade_structure: OptimadeStructure): Crys
 
     // Build species lookup for site properties (mass, concentration, etc.)
     const species_map = new Map(species?.map((spec) => [spec.name, spec]))
+    const crystal_cart_to_frac = try_create_cart_to_frac(lattice_matrix)
 
     const sites = cartesian_site_positions.map((pos, idx) => {
       const element_symbol = species_at_sites[idx]
@@ -1547,14 +1536,7 @@ export function optimade_to_crystal(optimade_structure: OptimadeStructure): Crys
       const element = validate_element_symbol(element_symbol, idx)
 
       const xyz: Vec3 = [pos[0], pos[1], pos[2]]
-      let abc: Vec3
-      try {
-        const lattice_transposed = math.transpose_3x3_matrix(lattice_matrix)
-        const inv_matrix = math.matrix_inverse_3x3(lattice_transposed)
-        abc = math.mat3x3_vec3_multiply(inv_matrix, xyz)
-      } catch {
-        abc = [0, 0, 0]
-      }
+      const abc: Vec3 = crystal_cart_to_frac ? crystal_cart_to_frac(xyz) : [0, 0, 0]
 
       // Extract mass/concentration from species data
       const spec = species_map.get(element_symbol)

--- a/src/lib/structure/parse.ts
+++ b/src/lib/structure/parse.ts
@@ -1403,13 +1403,26 @@ export function parse_optimade_from_raw(raw: unknown): ParsedStructure | null {
 
     // Optimade stores lattice vectors as rows, so use as is
     const lattice_matrix = attrs.lattice_vectors as math.Matrix3x3 | undefined
+    const optimade_lattice_params = lattice_matrix
+      ? math.calc_lattice_params(lattice_matrix)
+      : null
 
     // Parse atomic sites
-    const optimade_cart_to_frac = lattice_matrix
+    const optimade_exact_cart_to_frac = lattice_matrix
       ? try_create_cart_to_frac(lattice_matrix)
       : null
-    if (lattice_matrix && !optimade_cart_to_frac) {
-      console.warn(`Failed to create coordinate converter for OPTIMADE structure`)
+    const optimade_cart_to_frac =
+      lattice_matrix && optimade_lattice_params
+        ? (optimade_exact_cart_to_frac ??
+          ((xyz: Vec3): Vec3 =>
+            approximate_cart_to_frac(xyz, [
+              optimade_lattice_params.a,
+              optimade_lattice_params.b,
+              optimade_lattice_params.c,
+            ])))
+        : null
+    if (lattice_matrix && !optimade_exact_cart_to_frac) {
+      console.warn(`Failed to create exact coordinate converter for OPTIMADE structure`)
     }
     const sites: Site[] = []
     for (let idx = 0; idx < positions.length; idx++) {
@@ -1445,9 +1458,8 @@ export function parse_optimade_from_raw(raw: unknown): ParsedStructure | null {
 
     // Create structure object
     let lattice: ParsedStructure[`lattice`] | undefined
-    if (lattice_matrix) {
-      const lattice_params = math.calc_lattice_params(lattice_matrix)
-      lattice = { matrix: lattice_matrix, ...lattice_params }
+    if (lattice_matrix && optimade_lattice_params) {
+      lattice = { matrix: lattice_matrix, ...optimade_lattice_params }
     }
 
     const structure_result: ParsedStructure = {
@@ -1528,7 +1540,10 @@ export function optimade_to_crystal(optimade_structure: OptimadeStructure): Crys
 
     // Build species lookup for site properties (mass, concentration, etc.)
     const species_map = new Map(species?.map((spec) => [spec.name, spec]))
-    const crystal_cart_to_frac = try_create_cart_to_frac(lattice_matrix)
+    const crystal_cart_to_frac =
+      try_create_cart_to_frac(lattice_matrix) ??
+      ((xyz: Vec3): Vec3 =>
+        approximate_cart_to_frac(xyz, [lattice_params.a, lattice_params.b, lattice_params.c]))
 
     const sites = cartesian_site_positions.map((pos, idx) => {
       const element_symbol = species_at_sites[idx]

--- a/src/lib/structure/pbc.ts
+++ b/src/lib/structure/pbc.ts
@@ -5,12 +5,20 @@ import type { ParsedStructure } from './parse'
 
 export type Pbc = readonly [boolean, boolean, boolean]
 
+// Wrap a single fractional coordinate to [0, 1), clamping near-1 values to 0
+// and rounding to 15 digits to suppress floating-point noise.
+export const wrap_frac_coord = (coord: number): number => {
+  const wrapped = coord - Math.floor(coord)
+  if (wrapped >= 1 - 1e-10) return 0
+  return Number(wrapped.toFixed(15))
+}
+
 // Wrap fractional coordinates to [0, 1) range for periodicity.
-export const wrap_to_unit_cell = (frac: Vec3): Vec3 =>
-  frac.map((coord) => {
-    const wrapped = ((coord % 1) + 1) % 1
-    return wrapped >= 1 - 1e-10 ? 0 : wrapped // clamp near-1 to 0 for float precision
-  }) as Vec3
+export const wrap_to_unit_cell = (frac: Vec3): Vec3 => [
+  wrap_frac_coord(frac[0]),
+  wrap_frac_coord(frac[1]),
+  wrap_frac_coord(frac[2]),
+]
 
 export function find_image_atoms(
   structure: ParsedStructure,

--- a/src/lib/structure/supercell.ts
+++ b/src/lib/structure/supercell.ts
@@ -2,12 +2,7 @@
 import type { Vec3 } from '$lib/math'
 import * as math from '$lib/math'
 import type { Crystal, Site } from './index'
-
-// Wrap fractional coordinates to [0, 1) range, clamping near-1 values to 0
-const wrap_frac = (coord: number): number => {
-  const wrapped = ((coord % 1) + 1) % 1
-  return wrapped >= 1 - 1e-10 ? 0 : wrapped
-}
+import { wrap_frac_coord } from './pbc'
 
 type SupercellType = Crystal & {
   supercell_scaling?: Vec3
@@ -149,9 +144,9 @@ export function make_supercell(
           let new_c = (site.abc[2] + kk) / sz
 
           if (to_unit_cell) {
-            new_a = wrap_frac(new_a)
-            new_b = wrap_frac(new_b)
-            new_c = wrap_frac(new_c)
+            new_a = wrap_frac_coord(new_a)
+            new_b = wrap_frac_coord(new_b)
+            new_c = wrap_frac_coord(new_c)
           }
 
           new_sites[write_idx++] = {

--- a/src/lib/symmetry/cell-transform.ts
+++ b/src/lib/symmetry/cell-transform.ts
@@ -30,7 +30,7 @@ export function moyo_cell_to_structure(
 
   // Calculate lattice parameters from matrix
   const lattice_params = math.calc_lattice_params(lattice_matrix)
-  const lattice_T = math.transpose_3x3_matrix(lattice_matrix)
+  const frac_to_cart = math.create_frac_to_cart(lattice_matrix)
 
   // Build sites from positions and atomic numbers
   const sites: Site[] = cell.positions.map((abc, idx) => {
@@ -43,8 +43,7 @@ export function moyo_cell_to_structure(
     // Wrap fractional coordinates to [0, 1) range (moyo-wasm may return outside)
     const wrapped_abc = wrap_to_unit_cell(abc as Vec3)
 
-    // Convert fractional to Cartesian: xyz = lattice_T · abc
-    const xyz = math.mat3x3_vec3_multiply(lattice_T, wrapped_abc)
+    const xyz = frac_to_cart(wrapped_abc)
 
     // Oxidation state is set to 0 (unknown) because moyo-wasm only provides atomic numbers.
     // transformed cell may have different/reordered sites, making it non-trivial to

--- a/src/lib/symmetry/index.ts
+++ b/src/lib/symmetry/index.ts
@@ -81,11 +81,11 @@ function get_site_atomic_number(site: Crystal[`sites`][number], site_idx: number
   })
 
   if (selected_element === undefined) {
-    throw new Error(`Unknown element at site ${site_idx}: ${String(selected_element)}`)
+    throw new Error(`Unknown element at site ${site_idx}: ${selected_element}`)
   }
   const atomic_number = SYMBOL_TO_ATOMIC_NUMBER[selected_element]
   if (atomic_number === undefined) {
-    throw new Error(`Unknown element at site ${site_idx}: ${String(selected_element)}`)
+    throw new Error(`Unknown element at site ${site_idx}: ${selected_element}`)
   }
   return atomic_number
 }
@@ -219,7 +219,7 @@ export function wyckoff_positions_from_moyo(sym_data: SymmetryDataset | null): W
   for (let idx = 0; idx < numbers.length; idx++) {
     // Use wyckoff letter if available, otherwise mark as non-symmetric
     const full = idx < wyckoffs.length ? wyckoffs[idx] : null
-    const letter = (full?.match(/[a-z]+$/)?.[0] ?? full ?? ``).toString()
+    const letter = full?.match(/[a-z]+$/)?.[0] ?? full ?? ``
     const atomic_num = numbers[idx]
     const elem = ATOMIC_NUMBER_TO_SYMBOL[atomic_num] ?? `?`
     const position = positions[idx]

--- a/src/lib/trajectory/helpers.ts
+++ b/src/lib/trajectory/helpers.ts
@@ -46,19 +46,6 @@ export const convert_atomic_numbers = (numbers: number[]): ElementSymbol[] =>
     return symbol
   })
 
-// Cache inverse matrices by original matrix reference for performance
-// IMPORTANT: This cache assumes lattice matrices are immutable. Mutating a cached
-// matrix in place yields incorrect inverses. Always create new matrix instances
-// if modifications are needed.
-const matrix_cache = new WeakMap<math.Matrix3x3, math.Matrix3x3>()
-export const get_inverse_matrix = (matrix: math.Matrix3x3): math.Matrix3x3 => {
-  const cached = matrix_cache.get(matrix)
-  if (cached) return cached
-  const inverse = math.matrix_inverse_3x3(matrix)
-  matrix_cache.set(matrix, inverse)
-  return inverse
-}
-
 export const create_structure = (
   positions: number[][],
   elements: ElementSymbol[],

--- a/src/lib/trajectory/helpers.ts
+++ b/src/lib/trajectory/helpers.ts
@@ -71,7 +71,7 @@ export const create_structure = (
       `create_structure requires matching positions and elements lengths, got positions=${positions.length}, elements=${elements.length}`,
     )
   }
-  const inv_matrix = lattice_matrix ? get_inverse_matrix(lattice_matrix) : null
+  const cart_to_frac = lattice_matrix ? math.create_cart_to_frac(lattice_matrix) : null
 
   const is_valid_vec3 = (coords: unknown): coords is Vec3 =>
     Array.isArray(coords) &&
@@ -84,7 +84,7 @@ export const create_structure = (
     }
 
     const xyz = pos
-    const abc = inv_matrix ? math.mat3x3_vec3_multiply(inv_matrix, xyz) : ([0, 0, 0] as Vec3)
+    const abc = cart_to_frac ? cart_to_frac(xyz as Vec3) : ([0, 0, 0] as Vec3)
 
     const force = force_data?.[idx]
     const properties = is_valid_vec3(force) ? { force } : {}

--- a/src/site/isosurfaces/generate_examples.py
+++ b/src/site/isosurfaces/generate_examples.py
@@ -146,7 +146,9 @@ def write_chgcar(
     lines.append("")
 
     nx, ny, nz = grid_dims
-    all_blocks = [(density_fn, None)]
+    all_blocks: list[
+        tuple[Callable[[float, float, float, float, float, float], float], str | None]
+    ] = [(density_fn, None)]
     if extra_blocks:
         all_blocks.extend(extra_blocks)
 

--- a/tests/vitest/chempot-diagram/compute.test.ts
+++ b/tests/vitest/chempot-diagram/compute.test.ts
@@ -40,14 +40,14 @@ import { describe, expect, test } from 'vitest'
 
 const test_dir = dirname(fileURLToPath(import.meta.url))
 
-function load_gzip_json<T>(filename: string): T {
+function load_gzip_json(filename: string): PhaseData[] {
   const compressed_bytes = readFileSync(`${test_dir}/${filename}`)
   const decompressed_text = gunzipSync(compressed_bytes).toString(`utf8`)
-  return JSON.parse(decompressed_text) as T
+  return JSON.parse(decompressed_text) as PhaseData[]
 }
 
-const entries = load_gzip_json<PhaseData[]>(`pd_entries_test.json.gz`)
-const ytos_entries = load_gzip_json<PhaseData[]>(`ytos_entries.json.gz`)
+const entries = load_gzip_json(`pd_entries_test.json.gz`)
+const ytos_entries = load_gzip_json(`ytos_entries.json.gz`)
 
 // Filter to Fe-O binary subsystem
 const fe_o_elements = new Set([`Fe`, `O`])

--- a/tests/vitest/chempot-diagram/performance.test.ts
+++ b/tests/vitest/chempot-diagram/performance.test.ts
@@ -19,10 +19,10 @@ const min_speedup_ratio = Number(
   process.env.CHEMPOT_MIN_SPEEDUP_RATIO ?? (process.env.CI ? 1.5 : 2),
 )
 
-function load_gzip_json<T>(filename: string): T {
+function load_gzip_json(filename: string): PhaseData[] {
   const compressed_bytes = readFileSync(`${test_dir}/${filename}`)
   const decompressed_text = gunzipSync(compressed_bytes).toString(`utf8`)
-  return JSON.parse(decompressed_text) as T
+  return JSON.parse(decompressed_text) as PhaseData[]
 }
 
 function median(values: number[]): number {
@@ -61,8 +61,8 @@ function hash_points(points_3d: number[][]): string {
   return points_3d.map((point) => point.map((value) => value.toFixed(4)).join(`,`)).join(`;`)
 }
 
-const pd_entries = load_gzip_json<PhaseData[]>(`pd_entries_test.json.gz`)
-const ytos_entries = load_gzip_json<PhaseData[]>(`ytos_entries.json.gz`)
+const pd_entries = load_gzip_json(`pd_entries_test.json.gz`)
+const ytos_entries = load_gzip_json(`ytos_entries.json.gz`)
 
 const dataset_cases: { name: string; entries: PhaseData[]; default_min_limit: number }[] = [
   { name: `li_fe_o`, entries: pd_entries, default_min_limit: -25 },

--- a/tests/vitest/io/index.test.ts
+++ b/tests/vitest/io/index.test.ts
@@ -202,12 +202,12 @@ describe(`load_from_url`, () => {
   })
 
   test.each([
-    [`GZIP magic bytes`, [0x1f, 0x8b], `ArrayBuffer`],
-    [`HDF5 magic bytes`, [0x89, 0x48, 0x44, 0x46], `ArrayBuffer`],
+    [`GZIP magic bytes`, [0x1f, 0x8b], `ArrayBuffer`, undefined],
+    [`HDF5 magic bytes`, [0x89, 0x48, 0x44, 0x46], `ArrayBuffer`, undefined],
     [`unknown format`, [0x12, 0x34, 0x56, 0x78], `string`, `unknown format content`],
-  ])(
+  ] as const)(
     `magic bytes detection: %s`,
-    async (_, magic_bytes, expected_type, expected_content = undefined) => {
+    async (_, magic_bytes, expected_type, expected_content) => {
       const header = new Uint8Array([
         ...magic_bytes,
         ...new Array(16 - magic_bytes.length).fill(0),

--- a/tests/vitest/isosurface/parse.test.ts
+++ b/tests/vitest/isosurface/parse.test.ts
@@ -212,6 +212,16 @@ describe(`parse_chgcar`, () => {
     expect(parse_chgcar(content as string)).toBeNull()
   })
 
+  test(`returns null for singular CHGCAR lattice instead of throwing`, () => {
+    const content = make_chgcar({
+      lattice: [`5.0  0.0  0.0`, `0.0  0.0  0.0`, `0.0  0.0  5.0`],
+      coord_mode: `Cartesian`,
+      positions: [`0.0  0.0  0.0`, `1.0  0.0  1.0`],
+    })
+
+    expect(parse_chgcar(content)).toBeNull()
+  })
+
   test(`computes data_range with correct min, max, abs_max, and mean`, () => {
     const result = parse_chgcar(make_chgcar())
     const range = result?.volumes[0].data_range

--- a/tests/vitest/math.test.ts
+++ b/tests/vitest/math.test.ts
@@ -490,76 +490,13 @@ test.each([
 })
 
 describe(`pbc_dist`, () => {
-  test(`basic functionality with comprehensive scenarios`, () => {
-    const cubic_lattice: math.Matrix3x3 = [
-      [10, 0, 0],
-      [0, 10, 0],
-      [0, 0, 10],
-    ]
-
-    // Opposite corners via PBC
-    expect(math.pbc_dist([1, 1, 1], [9, 9, 9], cubic_lattice)).toBeCloseTo(Math.sqrt(12), 3)
-    expect(math.euclidean_dist([1, 1, 1], [9, 9, 9])).toBeCloseTo(13.856, 3)
-
-    // Extreme PBC case
-    expect(math.pbc_dist([0.5, 0.5, 0.5], [9.7, 9.7, 9.7], cubic_lattice)).toBeCloseTo(
-      1.386,
-      3,
-    )
-
-    // Close points
-    const close_direct = math.euclidean_dist([2, 2, 2], [3, 3, 3])
-    const close_pbc = math.pbc_dist([2, 2, 2], [3, 3, 3], cubic_lattice)
-    expect(close_pbc).toBeCloseTo(close_direct, 5)
-    expect(close_pbc).toBeCloseTo(1.732, 3)
-
-    // 1D PBC
-    expect(math.pbc_dist([0.5, 5, 5], [9.7, 5, 5], cubic_lattice)).toBeCloseTo(0.8, 5)
-
-    // Hexagonal lattice
+  test(`hexagonal lattice PBC wrapping`, () => {
     const hex_lattice: math.Matrix3x3 = [
       [4, 0, 0],
       [2, 3.464, 0],
       [0, 0, 8],
     ]
-    expect(math.euclidean_dist([0.2, 0.2, 1], [3.8, 3.264, 7])).toBeCloseTo(7.639, 3)
-    expect(math.pbc_dist([0.2, 0.2, 1], [3.8, 3.264, 7], hex_lattice)).toBeCloseTo(2.3, 3)
-
-    // Additional comprehensive scenarios
-    const cubic_lattice_2: math.Matrix3x3 = [
-      [6.256930122878799, 0.0, 0.0],
-      [0.0, 6.256930122878799, 0.0],
-      [0.0, 0.0, 6.256930122878799],
-    ]
-
-    // Atoms at optimal separation - PBC should match direct distance
-    const center1: Vec3 = [0.0, 0.0, 0.0]
-    const center2: Vec3 = [3.1284650614394, 3.1284650614393996, 3.1284650614394]
-    const center_direct = math.euclidean_dist(center1, center2)
-    const center_pbc = math.pbc_dist(center1, center2, cubic_lattice_2)
-    expect(center_pbc).toBeCloseTo(center_direct, 3)
-    expect(center_pbc).toBeCloseTo(5.419, 3)
-
-    // Corner atoms - PBC improvement
-    const corner1: Vec3 = [0.1, 0.1, 0.1]
-    const corner2: Vec3 = [6.156930122878799, 6.156930122878799, 6.156930122878799]
-    const corner_direct = math.euclidean_dist(corner1, corner2)
-    const corner_pbc = math.pbc_dist(corner1, corner2, cubic_lattice_2)
-    expect(corner_pbc).toBeCloseTo(0.346, 3)
-    expect(corner_direct).toBeCloseTo(10.491, 3)
-
-    // Long cell scenario - extreme aspect ratio
-    const long_cell: math.Matrix3x3 = [
-      [20.0, 0.0, 0.0],
-      [0.0, 5.0, 0.0],
-      [0.0, 0.0, 5.0],
-    ]
-    const long1: Vec3 = [1.0, 2.5, 2.5]
-    const long2: Vec3 = [19.0, 2.5, 2.5]
-    const long_pbc = math.pbc_dist(long1, long2, long_cell)
-    const long_direct = math.euclidean_dist(long1, long2)
-    expect(long_pbc).toBeCloseTo(2.0, 3)
-    expect(long_direct).toBeCloseTo(18.0, 3)
+    expect(math.pbc_dist([0.2, 0.2, 1], [3.8, 3.264, 7], hex_lattice)).toBeCloseTo(2.592, 3)
   })
 
   test.each([
@@ -639,7 +576,7 @@ describe(`pbc_dist`, () => {
       ] as math.Matrix3x3,
       pos1: [0.2, 0.2, 0.2] as Vec3,
       pos2: [7.3, 4.9, 3.9] as Vec3,
-      expected_pbc: 3.308,
+      expected_pbc: 1.564,
       expected_direct: 9.284,
     },
     {
@@ -701,207 +638,100 @@ describe(`pbc_dist`, () => {
     },
   )
 
-  test(`symmetry equivalence`, () => {
-    const sym_lattice: math.Matrix3x3 = [
-      [6.0, 0.0, 0.0],
-      [0.0, 6.0, 0.0],
-      [0.0, 0.0, 6.0],
-    ]
-    const equiv_cases = [
-      { pos1: [0.1, 3.0, 3.0], pos2: [5.9, 3.0, 3.0] },
-      { pos1: [3.0, 0.1, 3.0], pos2: [3.0, 5.9, 3.0] },
-      { pos1: [3.0, 3.0, 0.1], pos2: [3.0, 3.0, 5.9] },
-    ]
-
-    const equiv_distances = equiv_cases.map(({ pos1, pos2 }) =>
-      math.pbc_dist(pos1 as Vec3, pos2 as Vec3, sym_lattice),
-    )
-
-    // All should be equal (0.2 Å)
-    for (let idx = 1; idx < equiv_distances.length; idx++) {
-      expect(equiv_distances[idx]).toBeCloseTo(equiv_distances[0], 5)
-    }
-    expect(equiv_distances[0]).toBeCloseTo(0.2, 3)
-  })
-
-  test.each([
-    { pos1: [0.5, 0.5, 0.5], pos2: [7.7, 11.7, 5.7], desc: `corner to corner` },
-    { pos1: [1.0, 2.0, 3.0], pos2: [6.0, 10.0, 4.0], desc: `mid-cell positions` },
-    { pos1: [0.1, 0.1, 0.1], pos2: [7.9, 11.9, 5.9], desc: `near boundaries` },
-    { pos1: [4.0, 6.0, 3.0], pos2: [4.1, 6.1, 3.1], desc: `close positions` },
-  ])(`optimized path consistency: $desc`, ({ pos1, pos2 }) => {
-    const lattice: math.Matrix3x3 = [
-      [8.0, 0.0, 0.0],
-      [0.0, 12.0, 0.0],
-      [0.0, 0.0, 6.0],
-    ]
-
-    const lattice_inv: math.Matrix3x3 = [
-      [1 / 8.0, 0.0, 0.0],
-      [0.0, 1 / 12.0, 0.0],
-      [0.0, 0.0, 1 / 6.0],
-    ]
-
-    const standard = math.pbc_dist(pos1 as Vec3, pos2 as Vec3, lattice)
-    const optimized = math.pbc_dist(pos1 as Vec3, pos2 as Vec3, lattice, lattice_inv)
-
-    expect(optimized).toBeCloseTo(standard, 10)
-    expect(optimized).toBeGreaterThanOrEqual(0)
-    expect(isFinite(optimized)).toBe(true)
-  })
-
+  // Pre-built converters must match standard pbc_dist across lattice types and positions
   test.each([
     {
-      pos1: [0.0, 0.0, 0.0],
-      pos2: [0.5, 0.5, 0.5],
-      desc: `exactly 0.5 fractional`,
-    },
-    { pos1: [0.0, 0.0, 0.0], pos2: [1.0, 0.0, 0.0], desc: `exactly at boundary` },
-    {
-      pos1: [0.1, 0.1, 0.1],
-      pos2: [0.9, 0.9, 0.9],
-      desc: `close to 0.5 fractional`,
-    },
-    { pos1: [0.0, 0.0, 0.0], pos2: [0.0, 0.0, 0.0], desc: `identical positions` },
-    {
-      pos1: [0.0000001, 0.0, 0.0],
-      pos2: [0.0000002, 0.0, 0.0],
-      desc: `tiny distance`,
+      lattice: [
+        [8, 0, 0],
+        [0, 12, 0],
+        [0, 0, 6],
+      ] as math.Matrix3x3,
+      pos1: [0.5, 0.5, 0.5] as Vec3,
+      pos2: [7.7, 11.7, 5.7] as Vec3,
+      desc: `orthorhombic corner-to-corner`,
     },
     {
-      pos1: [0.9999999, 0.0, 0.0],
-      pos2: [0.0000001, 0.0, 0.0],
-      desc: `across boundary`,
+      lattice: [
+        [8, 0, 0],
+        [0, 12, 0],
+        [0, 0, 6],
+      ] as math.Matrix3x3,
+      pos1: [0.1, 0.1, 0.1] as Vec3,
+      pos2: [7.9, 11.9, 5.9] as Vec3,
+      desc: `orthorhombic near boundaries`,
     },
-  ])(`optimization boundary conditions: $desc`, ({ pos1, pos2 }) => {
-    const unit_lattice: math.Matrix3x3 = [
-      [1.0, 0.0, 0.0],
-      [0.0, 1.0, 0.0],
-      [0.0, 0.0, 1.0],
-    ]
+    {
+      lattice: [
+        [1, 0, 0],
+        [0, 1, 0],
+        [0, 0, 1],
+      ] as math.Matrix3x3,
+      pos1: [0, 0, 0] as Vec3,
+      pos2: [1, 0, 0] as Vec3,
+      desc: `unit lattice at boundary`,
+    },
+    {
+      lattice: [
+        [1, 0, 0],
+        [0, 1, 0],
+        [0, 0, 1],
+      ] as math.Matrix3x3,
+      pos1: [0.9999999, 0, 0] as Vec3,
+      pos2: [0.0000001, 0, 0] as Vec3,
+      desc: `unit lattice across boundary`,
+    },
+    {
+      lattice: [
+        [100, 0, 0],
+        [0, 200, 0],
+        [0, 0, 50],
+      ] as math.Matrix3x3,
+      pos1: [1, 1, 1] as Vec3,
+      pos2: [99, 199, 49] as Vec3,
+      desc: `large lattice wrap-around`,
+    },
+    {
+      lattice: [
+        [5, 0, 0],
+        [2.5, 4.33, 0],
+        [1, 1, 4],
+      ] as math.Matrix3x3,
+      pos1: [0.2, 0.2, 0.2] as Vec3,
+      pos2: [4.8, 4.1, 3.8] as Vec3,
+      desc: `triclinic`,
+    },
+  ])(`pre-built converters match standard: $desc`, ({ lattice, pos1, pos2 }) => {
+    const converters = math.create_lattice_converters(lattice)
+    const standard = math.pbc_dist(pos1, pos2, lattice)
+    const with_converters = math.pbc_dist(pos1, pos2, lattice, converters)
 
-    const unit_lattice_inv: math.Matrix3x3 = [
-      [1.0, 0.0, 0.0],
-      [0.0, 1.0, 0.0],
-      [0.0, 0.0, 1.0],
-    ]
-
-    const standard = math.pbc_dist(pos1 as Vec3, pos2 as Vec3, unit_lattice)
-    const optimized = math.pbc_dist(pos1 as Vec3, pos2 as Vec3, unit_lattice, unit_lattice_inv)
-
-    const precision = pos1[0] < 0.001 ? 8 : 12
-    expect(optimized).toBeCloseTo(standard, precision)
-    expect(optimized).toBeGreaterThanOrEqual(0)
-    expect(isFinite(optimized)).toBe(true)
+    expect(with_converters).toBeCloseTo(standard, 10)
+    expect(with_converters).toBeGreaterThanOrEqual(0)
+    expect(isFinite(with_converters)).toBe(true)
   })
 
-  test(`optimization advanced scenarios`, () => {
-    // Test with triclinic lattice determinism
-    const triclinic_lattice: math.Matrix3x3 = [
-      [5.0, 0.0, 0.0],
-      [2.5, 4.33, 0.0],
-      [1.0, 1.0, 4.0],
+  // Math.round wrapping at 0.5 fractional boundary — unit lattice
+  test.each([
+    { pos2: [0.5, 0.5, 0.5], expected: Math.sqrt(0.75), desc: `exactly 0.5` },
+    {
+      pos2: [0.499999, 0.499999, 0.499999],
+      expected: Math.sqrt(0.75),
+      desc: `just below 0.5`,
+    },
+    {
+      pos2: [0.500001, 0.500001, 0.500001],
+      expected: Math.sqrt(0.75),
+      desc: `just above 0.5`,
+    },
+    { pos2: [0.999999, 0.999999, 0.999999], expected: 0.000001732, desc: `near boundary` },
+    { pos2: [0.000001, 0.000001, 0.000001], expected: 0.000001732, desc: `near origin` },
+  ])(`minimal-image wrapping: $desc`, ({ pos2, expected }) => {
+    const unit: math.Matrix3x3 = [
+      [1, 0, 0],
+      [0, 1, 0],
+      [0, 0, 1],
     ]
-
-    const tri_pos1: Vec3 = [0.2, 0.2, 0.2]
-    const tri_pos2: Vec3 = [4.8, 4.1, 3.8]
-
-    const tri_standard = math.pbc_dist(tri_pos1, tri_pos2, triclinic_lattice)
-    const tri_standard_repeat = math.pbc_dist(tri_pos1, tri_pos2, triclinic_lattice)
-    expect(tri_standard_repeat).toBeCloseTo(tri_standard, 10)
-
-    // Test large lattice wrap-around behavior
-    const large_lattice: math.Matrix3x3 = [
-      [100.0, 0.0, 0.0],
-      [0.0, 200.0, 0.0],
-      [0.0, 0.0, 50.0],
-    ]
-
-    const large_lattice_inv: math.Matrix3x3 = [
-      [0.01, 0.0, 0.0],
-      [0.0, 0.005, 0.0],
-      [0.0, 0.0, 0.02],
-    ]
-
-    const wrap_around_case = { pos1: [1.0, 1.0, 1.0], pos2: [99.0, 199.0, 49.0] }
-    const center_case = { pos1: [50.0, 100.0, 25.0], pos2: [51.0, 101.0, 26.0] }
-
-    for (const { pos1, pos2 } of [wrap_around_case, center_case]) {
-      const standard = math.pbc_dist(pos1 as Vec3, pos2 as Vec3, large_lattice)
-      const optimized = math.pbc_dist(
-        pos1 as Vec3,
-        pos2 as Vec3,
-        large_lattice,
-        large_lattice_inv,
-      )
-
-      expect(optimized).toBeCloseTo(standard, 10)
-
-      // Verify the distances are reasonable and finite
-      expect(standard).toBeGreaterThanOrEqual(0)
-      expect(optimized).toBeGreaterThanOrEqual(0)
-      expect(isFinite(standard)).toBe(true)
-      expect(isFinite(optimized)).toBe(true)
-
-      // For wrap-around case, PBC should be shorter than direct distance
-      if (pos1[0] === 1.0 && pos2[0] === 99.0) {
-        const direct = math.euclidean_dist(pos1 as Vec3, pos2 as Vec3)
-        expect(standard).toBeLessThan(direct)
-        expect(optimized).toBeLessThan(direct)
-      }
-    }
-  })
-
-  test(`simplified minimal-image wrapping edge cases`, () => {
-    // Test the new Math.round-based wrapping logic
-    const unit_lattice: math.Matrix3x3 = [
-      [1.0, 0.0, 0.0],
-      [0.0, 1.0, 0.0],
-      [0.0, 0.0, 1.0],
-    ]
-
-    // Test exactly at 0.5 fractional coordinates (edge case for Math.round)
-    const edge_cases = [
-      { pos1: [0.0, 0.0, 0.0], pos2: [0.5, 0.5, 0.5], expected: Math.sqrt(0.75) },
-      {
-        pos1: [0.0, 0.0, 0.0],
-        pos2: [0.499999, 0.499999, 0.499999],
-        expected: Math.sqrt(0.75),
-        desc: `just below 0.5`,
-      },
-      {
-        pos1: [0.0, 0.0, 0.0],
-        pos2: [0.500001, 0.500001, 0.500001],
-        expected: Math.sqrt(0.75),
-        desc: `just above 0.5`,
-      },
-    ]
-
-    for (const { pos1, pos2, expected } of edge_cases) {
-      const result = math.pbc_dist(pos1 as Vec3, pos2 as Vec3, unit_lattice)
-      expect(result).toBeCloseTo(expected, 5)
-    }
-
-    // Test boundary conditions where Math.round behavior is critical
-    const boundary_cases = [
-      {
-        pos1: [0.0, 0.0, 0.0],
-        pos2: [0.999999, 0.999999, 0.999999],
-        expected: 0.000001732, // sqrt(3 * 0.000001^2) ≈ 0.000001732
-        desc: `near unit cell boundary`,
-      },
-      {
-        pos1: [0.0, 0.0, 0.0],
-        pos2: [0.000001, 0.000001, 0.000001],
-        expected: 0.000001732, // sqrt(3 * 0.000001^2) ≈ 0.000001732
-        desc: `near origin`,
-      },
-    ]
-
-    for (const { pos1, pos2, expected } of boundary_cases) {
-      const result = math.pbc_dist(pos1 as Vec3, pos2 as Vec3, unit_lattice)
-      expect(result).toBeCloseTo(expected, 4)
-    }
+    expect(math.pbc_dist([0, 0, 0] as Vec3, pos2 as Vec3, unit)).toBeCloseTo(expected, 4)
   })
 
   test(`axis-specific PBC flags (mixed boundary conditions)`, () => {
@@ -996,6 +826,9 @@ describe(`pbc_dist`, () => {
     // These should be equal (x-wrapping shouldn't affect z-separation)
     expect(dist_z_sep_x_pbc).toBeCloseTo(dist_z_sep_no_pbc, 5)
   })
+
+  // Non-orthogonal lattice tests live in measure.test.ts where they exercise
+  // displacement_pbc with additional invariants (antisymmetry, half-lattice guard, etc.)
 })
 
 describe(`tensor conversion utilities`, () => {

--- a/tests/vitest/math.test.ts
+++ b/tests/vitest/math.test.ts
@@ -712,6 +712,7 @@ describe(`pbc_dist`, () => {
 
   // Math.round wrapping at 0.5 fractional boundary — unit lattice
   test.each([
+    // sqrt(0.75) is the same for the +0.5 and -0.5 tie-break because the cubic norm is symmetric.
     { pos2: [0.5, 0.5, 0.5], expected: Math.sqrt(0.75), desc: `exactly 0.5` },
     {
       pos2: [0.499999, 0.499999, 0.499999],
@@ -732,6 +733,18 @@ describe(`pbc_dist`, () => {
       [0, 0, 1],
     ]
     expect(math.pbc_dist([0, 0, 0] as Vec3, pos2 as Vec3, unit)).toBeCloseTo(expected, 4)
+  })
+
+  test(`guards against explosive minimum-image enumeration for ill-conditioned lattices`, () => {
+    const ill_conditioned_lattice: math.Matrix3x3 = [
+      [1, 0, 0],
+      [0.999999, 0.000001, 0],
+      [0, 0, 1],
+    ]
+
+    expect(() =>
+      math.pbc_dist([0, 0, 0] as Vec3, [0.49, 0.49, 0.49] as Vec3, ill_conditioned_lattice),
+    ).toThrow(/Minimum-image search would test/)
   })
 
   test(`axis-specific PBC flags (mixed boundary conditions)`, () => {

--- a/tests/vitest/rdf/calc-rdf.test.ts
+++ b/tests/vitest/rdf/calc-rdf.test.ts
@@ -1,3 +1,4 @@
+import * as math from '$lib/math'
 import type { Matrix3x3 } from '$lib/math'
 import { calculate_all_pair_rdfs, calculate_rdf } from '$lib/rdf'
 import type { Pbc } from '$lib/structure'
@@ -253,12 +254,19 @@ describe(`calculate_rdf`, () => {
     const cutoff = 2
     const n_bins = 20
     const result = calculate_rdf(structure, { cutoff, n_bins, auto_expand: false })
+    const expected_dist = math.pbc_dist(
+      structure.sites[0].xyz as math.Vec3,
+      structure.sites[1].xyz as math.Vec3,
+      lattice,
+    )
+    const bin_width = cutoff / n_bins
+    const expected_bin = Math.floor(expected_dist / bin_width)
     const nonzero_bins = result.g_r
       .map((value, idx) => ({ value, idx }))
       .filter(({ value }) => value > 0)
 
     expect(nonzero_bins).toHaveLength(1)
-    expect(nonzero_bins[0]?.idx).toBe(10)
+    expect(nonzero_bins[0]?.idx).toBe(expected_bin)
   })
 
   test.each([

--- a/tests/vitest/rdf/calc-rdf.test.ts
+++ b/tests/vitest/rdf/calc-rdf.test.ts
@@ -3,7 +3,7 @@ import { calculate_all_pair_rdfs, calculate_rdf } from '$lib/rdf'
 import type { Pbc } from '$lib/structure'
 import { structure_map } from '$site/structures'
 import { describe, expect, test } from 'vitest'
-import { create_test_structure } from '../setup'
+import { create_test_structure, make_crystal } from '../setup'
 
 // Use actual structure files from the project
 const lu_al_structure = structure_map.get(`mp-1234`) // Lu-Al structure (binary compound)
@@ -234,6 +234,31 @@ describe(`calculate_rdf`, () => {
     const result2 = calculate_rdf(lu_al_structure, { cutoff: 5, n_bins: 50 })
     expect(result1.r).toEqual(result2.r)
     expect(result1.g_r).toEqual(result2.g_r)
+  })
+
+  test(`RDF regression: skewed triclinic nearest image lands in correct bin`, () => {
+    const lattice: Matrix3x3 = [
+      [1.9705932249259481, -3.955757771584847, 1.6595752827868262],
+      [-2.0392732691684845, 3.498999611184008, -1.7465434512400368],
+      [3.716215074235551, 3.996782696347811, 1.0904649182023587],
+    ]
+    const structure = make_crystal(
+      lattice,
+      [
+        { element: `Si`, xyz: [3.395535765213964, 4.297261971797731, 0.837260400991752] },
+        { element: `Si`, xyz: [1.6425399077772327, -1.0582437501479167, 0.9390064337754569] },
+      ],
+      { pbc: [true, true, true] },
+    )
+    const cutoff = 2
+    const n_bins = 20
+    const result = calculate_rdf(structure, { cutoff, n_bins, auto_expand: false })
+    const nonzero_bins = result.g_r
+      .map((value, idx) => ({ value, idx }))
+      .filter(({ value }) => value > 0)
+
+    expect(nonzero_bins).toHaveLength(1)
+    expect(nonzero_bins[0]?.idx).toBe(10)
   })
 
   test.each([

--- a/tests/vitest/setup.ts
+++ b/tests/vitest/setup.ts
@@ -58,15 +58,29 @@ beforeEach(() => {
   })
 })
 
-export function doc_query<T extends HTMLElement>(selector: string): T {
-  const node = document.querySelector(selector) satisfies T | null
+type Element_ctor<T extends Element> = abstract new (...args: never[]) => T
+
+function query_required<T extends Element>(
+  selector: string,
+  element_ctor?: Element_ctor<T>,
+): T {
+  const node = document.querySelector(selector)
   if (!node) throw new Error(`No element found for selector: ${selector}`)
-  return node
+  if (element_ctor && !(node instanceof element_ctor)) {
+    throw new Error(`Element found for selector ${selector} has the wrong type`)
+  }
+  return node as T
 }
-export function svg_query<T extends SVGElement>(selector: string): T {
-  const node = document.querySelector(selector) satisfies T | null
-  if (!node) throw new Error(`No element found for selector: ${selector}`)
-  return node
+
+export function doc_query<T extends HTMLElement>(
+  selector: string,
+  element_ctor?: Element_ctor<T>,
+): T {
+  return query_required(selector, element_ctor)
+}
+
+export function svg_query(selector: string): SVGElement {
+  return query_required(selector)
 }
 
 // Test data factory for creating mock structures

--- a/tests/vitest/setup.ts
+++ b/tests/vitest/setup.ts
@@ -140,8 +140,9 @@ export function create_test_structure(
   // Mode 1: Fractional coordinates (original behavior)
   if (frac_coords) {
     const elements = elements_or_sites as ElementSymbol[]
+    const frac_to_cart = math.create_frac_to_cart(lattice_matrix)
     sites = frac_coords.map((frac_coord, idx) => ({
-      xyz: math.mat3x3_vec3_multiply(lattice_matrix, frac_coord),
+      xyz: frac_to_cart(frac_coord),
       abc: frac_coord,
       species: [{ element: elements[idx], occu: 1, oxidation_state: 0 }],
       label: elements[idx],
@@ -153,17 +154,14 @@ export function create_test_structure(
       species: { element: string; occu: number; oxidation_state: number }[]
       xyz: number[]
     }[]
+    const cart_to_frac = math.create_cart_to_frac(lattice_matrix)
     sites = sites_data.map((site, idx) => ({
       species: site.species.map((sp) => ({
         ...sp,
         element: sp.element as ElementSymbol,
       })),
       xyz: site.xyz as Vec3,
-      // Calculate fractional coordinates: abc = inverse(lattice_matrix) · xyz
-      abc: math.mat3x3_vec3_multiply(
-        math.matrix_inverse_3x3(lattice_matrix),
-        site.xyz as Vec3,
-      ),
+      abc: cart_to_frac(site.xyz as Vec3),
       label: `${site.species[0].element}${idx}`,
       properties: {},
     }))

--- a/tests/vitest/structure/measure.test.ts
+++ b/tests/vitest/structure/measure.test.ts
@@ -198,80 +198,124 @@ describe(`measure: angles`, () => {
     expect(angle_between_vectors([1, 0, 0], [-1, eps, 0])).toBeCloseTo(180, 6)
   })
 
-  test(`PBC distance regression: opposing corners of cubic cell`, () => {
-    // Test the new bug: opposing corners should have PBC distance 0
-    const cubic_lattice: Matrix3x3 = [
-      [5, 0, 0],
-      [0, 5, 0],
-      [0, 0, 5],
+  // Non-orthogonal lattices where L ≠ L^T — catches missing transpose bugs.
+  // Includes a cubic lattice to verify basic opposing-corners-are-equivalent behavior.
+  const non_ortho_lattices = [
+    {
+      name: `cubic`,
+      lattice: [
+        [5, 0, 0],
+        [0, 5, 0],
+        [0, 0, 5],
+      ] as Matrix3x3,
+    },
+    {
+      name: `monoclinic`,
+      lattice: [
+        [2, 1, 0],
+        [0, 2, 0],
+        [0, 0, 2],
+      ] as Matrix3x3,
+    },
+    {
+      name: `hexagonal`,
+      lattice: [
+        [4, 0, 0],
+        [2, 3.464, 0],
+        [0, 0, 8],
+      ] as Matrix3x3,
+    },
+    {
+      name: `triclinic`,
+      lattice: [
+        [5, 0, 0],
+        [2.5, 4.33, 0],
+        [1, 1, 4],
+      ] as Matrix3x3,
+    },
+    {
+      name: `fully skewed`,
+      lattice: [
+        [3, 0.5, 0.3],
+        [0.7, 4, 0.2],
+        [0.4, 0.6, 5],
+      ] as Matrix3x3,
+    },
+  ]
+
+  test.each(non_ortho_lattices)(
+    `lattice vector equivalence ($name): dist to any lattice translate is 0`,
+    ({ lattice }) => {
+      const origin: Vec3 = [0, 0, 0]
+      // Each row is a lattice vector — displacement by any single vector is the same site
+      for (const vec of lattice) {
+        expect(distance_pbc(origin, vec as Vec3, lattice)).toBeCloseTo(0, 10)
+      }
+      // Sum of all three lattice vectors is also an equivalent site
+      const all_sum: Vec3 = [
+        lattice[0][0] + lattice[1][0] + lattice[2][0],
+        lattice[0][1] + lattice[1][1] + lattice[2][1],
+        lattice[0][2] + lattice[1][2] + lattice[2][2],
+      ]
+      expect(distance_pbc(origin, all_sum, lattice)).toBeCloseTo(0, 10)
+
+      // Half a lattice vector is NOT an equivalent site — guard against always-zero bugs
+      const half_a: Vec3 = [lattice[0][0] / 2, lattice[0][1] / 2, lattice[0][2] / 2]
+      const half_dist = distance_pbc(origin, half_a, lattice)
+      expect(half_dist).toBeGreaterThan(0.1)
+      expect(Math.hypot(...displacement_pbc(origin, half_a, lattice))).toBeCloseTo(
+        half_dist,
+        10,
+      )
+    },
+  )
+
+  test.each(non_ortho_lattices)(
+    `displacement antisymmetry ($name): disp(a,b) = -disp(b,a)`,
+    ({ lattice }) => {
+      const pos1: Vec3 = [0.3, 0.7, 1.2]
+      const pos2: Vec3 = [2.1, 1.5, 0.8]
+      const d_ab = displacement_pbc(pos1, pos2, lattice)
+      const d_ba = displacement_pbc(pos2, pos1, lattice)
+      for (let idx = 0; idx < 3; idx++) {
+        expect(d_ab[idx]).toBeCloseTo(-d_ba[idx], 10)
+      }
+    },
+  )
+
+  test.each(non_ortho_lattices)(`PBC ≤ direct distance ($name)`, ({ lattice }) => {
+    const pairs: [Vec3, Vec3][] = [
+      [
+        [0, 0, 0],
+        [1.5, 1.5, 1.5],
+      ],
+      [
+        [0.1, 0.2, 0.3],
+        [3.7, 2.9, 3.1],
+      ],
     ]
-
-    // Atoms at opposing corners of the unit cell
-    const corner1: Vec3 = [0, 0, 0]
-    const corner2: Vec3 = [5, 5, 5] // This is the same as [0,0,0] under PBC
-
-    const pbc_dist = distance_pbc(corner1, corner2, cubic_lattice)
-    const direct_dist = Math.hypot(5, 5, 5)
-
-    // PBC distance should be 0 (same site), direct should be non-zero
-    expect(pbc_dist).toBeCloseTo(0, 10)
-    expect(direct_dist).toBeGreaterThan(8)
-
-    // Additional test cases
-    expect(distance_pbc([0, 0, 0], [5, 0, 0], cubic_lattice)).toBeCloseTo(0, 10)
-    expect(distance_pbc([0, 0, 0], [0, 5, 0], cubic_lattice)).toBeCloseTo(0, 10)
-    expect(distance_pbc([0, 0, 0], [0, 0, 5], cubic_lattice)).toBeCloseTo(0, 10)
-  })
-
-  test(`PBC distance with non-orthogonal lattice: distance to equivalent site is zero`, () => {
-    // Lattice with off-diagonal element — transpose ≠ original, so this test
-    // fails with the old code (missing transpose) and passes with the fix.
-    const lattice: Matrix3x3 = [
-      [2, 1, 0],
-      [0, 2, 0],
-      [0, 0, 2],
-    ]
-    const origin: Vec3 = [0, 0, 0]
-    // [2, 1, 0] is exactly the first lattice vector → same site under PBC
-    const same_site: Vec3 = [2, 1, 0]
-
-    // Old code returns 1.0 (wrong); fixed code returns 0.0
-    expect(distance_pbc(origin, same_site, lattice)).toBeCloseTo(0, 10)
-    const disp = displacement_pbc(origin, same_site, lattice)
-    expect(Math.hypot(...disp)).toBeCloseTo(0, 10)
-  })
-
-  test(`PBC distance invariant: PBC ≤ direct distance`, () => {
-    // Test various lattice types to ensure PBC never violates minimum image
-    const test_cases = [
-      {
-        name: `cubic`,
-        lattice: [
-          [3, 0, 0],
-          [0, 3, 0],
-          [0, 0, 3],
-        ] satisfies Matrix3x3,
-        pos1: [0, 0, 0] as Vec3,
-        pos2: [1.5, 1.5, 1.5] as Vec3,
-      },
-      {
-        name: `triclinic (original bug case)`,
-        lattice: [
-          [6.038698, 0, 0],
-          [0, 6.038698, 0],
-          [3.019349, 3.019349, 4.167943],
-        ] satisfies Matrix3x3,
-        pos1: [0, 0, 0] as Vec3,
-        pos2: [3.019349, 3.019349, 0] as Vec3,
-      },
-    ]
-
-    for (const { lattice, pos1, pos2 } of test_cases) {
-      const direct_dist = Math.hypot(pos2[0] - pos1[0], pos2[1] - pos1[1], pos2[2] - pos1[2])
-      const pbc_dist = distance_pbc(pos1, pos2, lattice)
-
-      // The fundamental PBC invariant: PBC distance ≤ direct distance
-      expect(pbc_dist).toBeLessThanOrEqual(direct_dist + 1e-10)
+    for (const [pos1, pos2] of pairs) {
+      const direct = Math.hypot(pos2[0] - pos1[0], pos2[1] - pos1[1], pos2[2] - pos1[2])
+      expect(distance_pbc(pos1, pos2, lattice)).toBeLessThanOrEqual(direct + 1e-10)
     }
+  })
+
+  test(`skewed triclinic regression: displacement finds non-local minimum image`, () => {
+    const lattice: Matrix3x3 = [
+      [1.9705932249259481, -3.955757771584847, 1.6595752827868262],
+      [-2.0392732691684845, 3.498999611184008, -1.7465434512400368],
+      [3.716215074235551, 3.996782696347811, 1.0904649182023587],
+    ]
+    const pos1: Vec3 = [3.395535765213964, 4.297261971797731, 0.837260400991752]
+    const pos2: Vec3 = [1.6425399077772327, -1.0582437501479167, 0.9390064337754569]
+    const expected_disp: Vec3 = [-0.3507742293398103, 0.31324394398281463, -0.9022051740668167]
+
+    const disp = displacement_pbc(pos1, pos2, lattice)
+    disp.forEach((val, idx) => expect(val).toBeCloseTo(expected_disp[idx], 12))
+    expect(distance_pbc(pos1, pos2, lattice)).toBeCloseTo(Math.hypot(...expected_disp), 12)
+    expect(distance_pbc(pos1, pos2, lattice)).toBeCloseTo(
+      distance_pbc(pos2, pos1, lattice),
+      12,
+    )
   })
 })

--- a/tests/vitest/structure/measure.test.ts
+++ b/tests/vitest/structure/measure.test.ts
@@ -223,6 +223,24 @@ describe(`measure: angles`, () => {
     expect(distance_pbc([0, 0, 0], [0, 0, 5], cubic_lattice)).toBeCloseTo(0, 10)
   })
 
+  test(`PBC distance with non-orthogonal lattice: distance to equivalent site is zero`, () => {
+    // Lattice with off-diagonal element — transpose ≠ original, so this test
+    // fails with the old code (missing transpose) and passes with the fix.
+    const lattice: Matrix3x3 = [
+      [2, 1, 0],
+      [0, 2, 0],
+      [0, 0, 2],
+    ]
+    const origin: Vec3 = [0, 0, 0]
+    // [2, 1, 0] is exactly the first lattice vector → same site under PBC
+    const same_site: Vec3 = [2, 1, 0]
+
+    // Old code returns 1.0 (wrong); fixed code returns 0.0
+    expect(distance_pbc(origin, same_site, lattice)).toBeCloseTo(0, 10)
+    const disp = displacement_pbc(origin, same_site, lattice)
+    expect(Math.hypot(...disp)).toBeCloseTo(0, 10)
+  })
+
   test(`PBC distance invariant: PBC ≤ direct distance`, () => {
     // Test various lattice types to ensure PBC never violates minimum image
     const test_cases = [

--- a/tests/vitest/structure/parse.test.ts
+++ b/tests/vitest/structure/parse.test.ts
@@ -151,6 +151,23 @@ describe(`POSCAR Parser`, () => {
     }
   })
 
+  it(`keeps singular Cartesian POSCAR fractional coordinates finite`, () => {
+    const result = parse_poscar(
+      `Test
+1.0
+5.0 0.0 0.0
+0.0 0.0 0.0
+0.0 0.0 5.0
+H
+1
+Cartesian
+1.0 1.0 1.0`,
+    )
+    if (!result) throw `Failed to parse singular Cartesian POSCAR`
+    expect_abc_in_unit_cell(result.sites[0])
+    expect(result.sites[0].abc.every(Number.isFinite)).toBe(true)
+  })
+
   it(`should keep all fractional coordinates within unit cell for aviary-CuF3K-triolith.poscar`, () => {
     const result = parse_poscar(aviary_CuF3K_triolith)
     if (!result) throw `Failed to parse aviary-CuF3K-triolith.poscar`
@@ -425,6 +442,15 @@ describe(`XYZ Parser`, () => {
     expect(Number.isFinite(result.sites[0].abc[0])).toBe(true)
     expect(Number.isFinite(result.sites[0].abc[1])).toBe(true)
     expect(Number.isFinite(result.sites[0].abc[2])).toBe(true)
+  })
+
+  it(`keeps singular Cartesian XYZ fractional coordinates finite`, () => {
+    const result = parse_xyz(`1
+Lattice="5 0 0 0 0 0 0 0 5"
+H 1 1 1`)
+    if (!result) throw `Failed to parse singular Cartesian XYZ`
+    expect_abc_in_unit_cell(result.sites[0])
+    expect(result.sites[0].abc.every(Number.isFinite)).toBe(true)
   })
 
   it(`parses quickly for small XYZ`, () => {

--- a/tests/vitest/structure/parse.test.ts
+++ b/tests/vitest/structure/parse.test.ts
@@ -2358,6 +2358,16 @@ describe(`OPTIMADE JSON parser`, () => {
       expected_abc: [[0.0, 0.0, 0.0]],
     },
     {
+      name: `dependent lattice vectors fall back to axis lengths`,
+      lattice_vectors: [
+        [5.0, 0.0, 0.0],
+        [5.0, 0.0, 0.0],
+        [0.0, 0.0, 7.0],
+      ],
+      positions: [[2.5, 0.0, 3.5]],
+      expected_abc: [[0.5, 0.0, 0.5]],
+    },
+    {
       name: `non-orthogonal lattice matrix`,
       lattice_vectors: [
         [5.0, 0.0, 0.0],
@@ -2739,6 +2749,23 @@ describe(`OPTIMADE to Pymatgen Conversion`, () => {
         },
       },
       expected_abc: [[0.0, 0.0, 0.0]],
+    },
+    {
+      name: `dependent lattice vectors fall back to axis lengths`,
+      optimade_structure: {
+        id: `test`,
+        type: `structures` as const,
+        attributes: {
+          lattice_vectors: [
+            [5.0, 0.0, 0.0],
+            [5.0, 0.0, 0.0],
+            [0.0, 0.0, 7.0],
+          ],
+          cartesian_site_positions: [[2.5, 0.0, 3.5]],
+          species_at_sites: [`Fe`],
+        },
+      },
+      expected_abc: [[0.5, 0.0, 0.5]],
     },
     {
       name: `non-orthogonal lattice matrix`,

--- a/tests/vitest/structure/pbc.test.ts
+++ b/tests/vitest/structure/pbc.test.ts
@@ -1,6 +1,6 @@
 import type { Matrix3x3, Vec3 } from '$lib/math'
 import * as math from '$lib/math'
-import { euclidean_dist, mat3x3_vec3_multiply } from '$lib/math'
+import { create_frac_to_cart, euclidean_dist } from '$lib/math'
 import type { Crystal } from '$lib/structure'
 import { find_image_atoms, get_pbc_image_sites, wrap_to_unit_cell } from '$lib/structure'
 import { parse_structure_file } from '$lib/structure/parse'
@@ -24,18 +24,11 @@ function assert_xyz_matches_lattice(
   xyz: Vec3,
   digits: number = 10,
 ) {
-  const expected_rows = math.add(
-    math.scale(lattice_matrix[0], frac[0]),
-    math.scale(lattice_matrix[1], frac[1]),
-    math.scale(lattice_matrix[2], frac[2]),
-  )
-  const expected_mul = mat3x3_vec3_multiply(lattice_matrix, frac)
-  const matches_either = [0, 1, 2].every(
-    (dim) =>
-      Math.abs(xyz[dim] - expected_rows[dim]) < 10 ** -digits ||
-      Math.abs(xyz[dim] - expected_mul[dim]) < 10 ** -digits,
-  )
-  expect(matches_either).toBe(true)
+  const frac_to_cart = create_frac_to_cart(lattice_matrix)
+  const expected = frac_to_cart(frac)
+  for (let dim = 0; dim < 3; dim++) {
+    expect(xyz[dim]).toBeCloseTo(expected[dim], digits)
+  }
 }
 
 function assert_integer_translation(
@@ -236,6 +229,60 @@ test(`triclinic lattice image xyz must match lattice * abc`, () => {
   }
 })
 
+// Non-orthogonal lattices where L ≠ L^T — using cubic lattices here can't
+// distinguish L*frac from L^T*frac, so these catch wrong-convention bugs.
+const non_ortho_lattices = [
+  {
+    name: `monoclinic`,
+    lattice: [
+      [5, 0, 0],
+      [0, 6, 0],
+      [2, 0, 7],
+    ] as Matrix3x3,
+  },
+  {
+    name: `hexagonal`,
+    lattice: [
+      [4, 0, 0],
+      [2, 3.464, 0],
+      [0, 0, 8],
+    ] as Matrix3x3,
+  },
+  {
+    name: `triclinic`,
+    lattice: [
+      [5, 0, 0],
+      [2.5, 4.33, 0],
+      [1, 1, 4],
+    ] as Matrix3x3,
+  },
+]
+
+test.each(non_ortho_lattices)(
+  `non-ortho image generation stays lattice-consistent ($name)`,
+  ({ lattice }) => {
+    const structure = make_crystal(lattice, [
+      [`Na`, [0.0, 0.0, 0.0]],
+      [`Cl`, [0.01, 0.5, 0.5]],
+    ])
+    const images = find_image_atoms(structure)
+    expect(images.length).toBeGreaterThan(0)
+
+    for (const [orig_idx, img_xyz, img_abc] of images) {
+      assert_xyz_matches_lattice(lattice, img_abc, img_xyz)
+      assert_integer_translation(structure.sites[orig_idx].abc, img_abc)
+    }
+
+    const with_images = get_pbc_image_sites(structure)
+    const image_sites = with_images.sites.slice(structure.sites.length)
+    expect(image_sites.length).toBeGreaterThan(0)
+
+    for (const site of image_sites) {
+      assert_xyz_matches_lattice(lattice, site.abc, site.xyz)
+    }
+  },
+)
+
 test.each([
   {
     tolerance: 0.02,
@@ -272,11 +319,8 @@ test(`upper boundary at abc=1.0 images wrap near 0 via epsilon`, () => {
   expect(img_abc[1]).toBeCloseTo(0.5, 12)
   expect(img_abc[2]).toBeCloseTo(0.5, 12)
 
-  // xyz must be consistent with lattice * abc
-  const expected_xyz = mat3x3_vec3_multiply(structure.lattice.matrix, img_abc)
-  for (let dim = 0; dim < 3; dim++) {
-    expect(img_xyz[dim]).toBeCloseTo(expected_xyz[dim], 10)
-  }
+  // xyz must be consistent with L^T * abc
+  assert_xyz_matches_lattice(structure.lattice.matrix, img_abc, img_xyz)
 })
 
 test(`find_image_atoms finds correct images for trajectory-like cell`, async () => {
@@ -420,22 +464,6 @@ test.each([
   },
 )
 
-// Test that image atoms have correct fractional coordinates
-test(`image atoms should have fractional coordinates related by lattice translations`, () => {
-  // Use mp-1 structure which should generate image atoms
-  const structure = mp_1_struct
-  const image_atoms = find_image_atoms(structure)
-
-  expect(image_atoms.length).toBeGreaterThan(0) // Should have some image atoms
-
-  // Check each image atom
-  for (const [orig_idx, image_xyz, image_abc] of image_atoms) {
-    const orig_abc = structure.sites[orig_idx].abc
-    assert_integer_translation(orig_abc, image_abc, 0.001)
-    assert_xyz_matches_lattice(structure.lattice.matrix, image_abc, image_xyz, 10)
-  }
-})
-
 // Test edge detection accuracy
 test(`edge detection should be precise for atoms at boundaries`, () => {
   // Create a test structure with atoms exactly at edges
@@ -492,12 +520,6 @@ test.each([
     description: `strict tolerance with very close atom`,
   },
   {
-    tolerance: 0.01,
-    abc_coords: [0.02, 0.0, 0.0], // Too far from edge with strict tolerance
-    expected_count: 3, // TODO: Algorithm bug - should be 0 but currently creates 3 images
-    description: `strict tolerance with distant atom`,
-  },
-  {
     tolerance: 0.05,
     abc_coords: [0.02, 0.0, 0.0], // Should create images with default tolerance
     expected_count: 1,
@@ -527,105 +549,6 @@ test.each([
     }
   },
 )
-
-// Test that all image atoms are positioned correctly within or just outside unit cell
-test(`all image atoms should be positioned at unit cell boundaries`, () => {
-  // Test multiple structures
-  for (const structure of [mp_1_struct, mp_2_struct]) {
-    const image_atoms = find_image_atoms(structure)
-
-    // Check each image atom position
-    for (const [orig_idx, image_xyz] of image_atoms) {
-      const lattice_matrix = structure.lattice.matrix
-
-      // Convert to fractional coordinates
-      const inv_mat = math.matrix_inverse_3x3(lattice_matrix)
-      const image_abc: Vec3 = mat3x3_vec3_multiply(inv_mat, image_xyz)
-
-      // Image atoms should be at positions that are related to the original
-      // by integer translations. This means their fractional coordinates
-      // should differ from the original by integers.
-      const orig_abc = structure.sites[orig_idx].abc
-
-      assert_integer_translation(orig_abc, image_abc, 0.001)
-    }
-  }
-})
-
-// Test that image atoms have fractional coordinates inside expected cell boundaries
-test(`image atoms should have fractional coordinates at cell boundaries`, () => {
-  // Create a simple cubic structure with atoms at exact boundaries
-  const test_structure = make_crystal(4, [
-    [`C`, [0.0, 0.0, 0.0]], // Corner
-    [`C`, [1.0, 1.0, 1.0]], // Opposite corner
-  ])
-
-  const image_atoms = find_image_atoms(test_structure)
-  expect(image_atoms.length).toBeGreaterThan(0)
-
-  // Check that all image atoms have fractional coordinates that are
-  // related to originals by integer translations
-  for (const [orig_idx, image_xyz, image_abc] of image_atoms) {
-    const orig_abc = test_structure.sites[orig_idx].abc
-
-    // Image fractional coordinates are now directly provided
-    // Each fractional coordinate should differ by an integer
-    assert_integer_translation(orig_abc, image_abc, 1e-8)
-    const expected_xyz: Vec3 = math.scale(image_abc, 4.0) as Vec3
-    for (let dim = 0; dim < 3; dim++) {
-      expect(image_xyz[dim]).toBeCloseTo(expected_xyz[dim], 10)
-    }
-  }
-})
-
-// Test comprehensive validation of image atom properties
-test(`comprehensive image atom validation`, () => {
-  const structure = mp_1_struct
-  const image_atoms = find_image_atoms(structure)
-
-  expect(image_atoms.length).toBeGreaterThan(0)
-
-  validate_image_tuples(structure, image_atoms, { min_dist: 0.01, tol: 1e-6 })
-})
-
-// Test that no duplicate image atoms are created
-test(`image atom generation should not create duplicates`, () => {
-  const structure = mp_1_struct
-  const image_atoms = find_image_atoms(structure)
-
-  // Check for duplicate image positions (within tolerance)
-  const unique_positions = new Set<string>()
-  let duplicates_found = 0
-
-  for (const [_, image_xyz, __] of image_atoms) {
-    // Create a string representation of the position with reasonable precision
-    const pos_key = image_xyz.map((coord) => coord.toFixed(6)).join(`,`)
-
-    // Count duplicates but don't fail immediately - the algorithm may legitimately create some
-    if (unique_positions.has(pos_key)) {
-      duplicates_found++
-    }
-    unique_positions.add(pos_key)
-  }
-
-  // Allow a small number of duplicates due to algorithm complexity, but not excessive
-  expect(duplicates_found).toBeLessThanOrEqual(
-    Math.max(3, Math.floor(image_atoms.length * 0.2)),
-  ) // Max 20% duplicates or 3, whichever is higher
-
-  // Alternative check: ensure all pairwise distances are reasonable
-  for (let idx = 0; idx < image_atoms.length; idx++) {
-    for (let j = idx + 1; j < image_atoms.length; j++) {
-      const pos1 = image_atoms[idx][1] // xyz coordinates
-      const pos2 = image_atoms[j][1] // xyz coordinates
-      const distance = euclidean_dist(pos1, pos2)
-
-      // No two image atoms should be at exactly the same position
-      // Fail test if image atoms are too close (likely duplicates suggesting a bug in the detection logic)
-      expect(distance).toBeGreaterThan(1e-6)
-    }
-  }
-})
 
 // Test image atom generation with various crystal systems
 test.each([
@@ -731,12 +654,7 @@ test(`image atoms preserve fractional coordinates correctly`, () => {
     }
 
     // Verify consistency between abc and xyz coordinates in the image site
-    const lattice_matrix = test_structure.lattice.matrix
-    const computed_xyz = mat3x3_vec3_multiply(lattice_matrix, image_site.abc)
-
-    for (let dim = 0; dim < 3; dim++) {
-      expect(image_site.xyz[dim]).toBeCloseTo(computed_xyz[dim], 10)
-    }
+    assert_xyz_matches_lattice(test_structure.lattice.matrix, image_site.abc, image_site.xyz)
 
     // Verify the image abc coordinates are related to original by integer translations
     const orig_abc = test_structure.sites[orig_idx].abc
@@ -814,19 +732,7 @@ test(`mp-1204603 image sites are valid integer translations`, () => {
 
   const lattice_matrix = structure.lattice.matrix
   for (const site of image_sites) {
-    // Verify xyz matches lattice * abc
-    const expected_rows = math.add(
-      math.scale(lattice_matrix[0], site.abc[0]),
-      math.scale(lattice_matrix[1], site.abc[1]),
-      math.scale(lattice_matrix[2], site.abc[2]),
-    )
-    const expected_mul = mat3x3_vec3_multiply(lattice_matrix, site.abc)
-    const matches_either = [0, 1, 2].every(
-      (dim) =>
-        Math.abs(site.xyz[dim] - expected_rows[dim]) < 1e-9 ||
-        Math.abs(site.xyz[dim] - expected_mul[dim]) < 1e-9,
-    )
-    expect(matches_either).toBe(true)
+    assert_xyz_matches_lattice(lattice_matrix, site.abc, site.xyz, 9)
   }
 })
 

--- a/tests/vitest/trajectory/helpers.test.ts
+++ b/tests/vitest/trajectory/helpers.test.ts
@@ -4,6 +4,7 @@ import {
   read_ndarray_from_view,
 } from '$lib/trajectory/helpers'
 import type { ElementSymbol } from '$lib/element'
+import type { Matrix3x3 } from '$lib/math'
 import { describe, expect, it } from 'vitest'
 
 describe(`trajectory helpers`, () => {
@@ -41,6 +42,18 @@ describe(`trajectory helpers`, () => {
     expect(structure.sites[1]?.xyz).toEqual([1, 1, 1])
     expect(structure.sites[0]?.species[0]?.element).toBe(`H`)
     expect(structure.sites[1]?.species[0]?.element).toBe(`He`)
+  })
+
+  it(`computes fractional coordinates correctly for non-orthogonal lattices`, () => {
+    const lattice: Matrix3x3 = [
+      [2, 1, 0],
+      [0, 2, 0],
+      [0, 0, 2],
+    ]
+    const structure = create_structure([[2, 1, 0]], [`H`], lattice)
+
+    expect(`lattice` in structure).toBe(true)
+    expect(structure.sites[0]?.abc).toEqual([1, 0, 0])
   })
 
   it.each([

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,11 +5,9 @@
     "module": "esnext",
     "target": "esnext",
     "moduleResolution": "bundler",
-
     // To have warnings/errors of the Svelte compiler at the correct position,
     // enable source maps by default.
     "sourceMap": true,
-
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "skipLibCheck": true

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -145,7 +145,7 @@ export default defineConfig({
           if (is_build) return { code: json_str, moduleType: `json` }
           return `export default ${json_str}`
         } catch (error) {
-          this.error(`Failed to decompress ${id}: ${error}`)
+          return this.error(`Failed to decompress ${id}: ${error}`)
         }
       },
     },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -208,6 +208,11 @@ export default defineConfig({
     port: 3000,
   },
 
+  build: {
+    // Default cssTarget is chrome111 which doesn't support light-dark(),
+    cssTarget: `esnext`, // causing LightningCSS to polyfill it with broken space toggles
+  },
+
   resolve: {
     conditions: process.env.VITEST ? [`browser`] : undefined,
   },


### PR DESCRIPTION
Hi @janosh, thanks for maintaining this amazing package, it is super helpful for my studies! I have been using it a lot in the last week without any issues. Today I used it for a non-orthogonal lattice with PBC. The `.traj` files where not displayed as expected while the individual snapshots as `.xyz` files were displayed as expected.

## Problem
For non-orthogonal lattices, the lattice matrix has off-diagonal elements, so `L^{-1} \neq L^T^{-1}`. The old code used `L^{-1}`, producing wrong fractional coordinates and therefore wrong PBC distances. Orthogonal lattices were unaffected since their transpose equals themselves.

## Fix
- Transpose lattice matrix before inversion when converting cartesian to fractional coordinates in `displacement_pbc` and `distance_pbc`
- Reuse existing `math.create_cart_to_frac` helper in trajectory helpers, which already had the correct convention implemented
- Add test that fails with the old code and passes with the fix

- Singular or degenerate lattices are handled without throwing, returning `null` for impossible conversions and finite wrapped coordinates where valid.