### PR TITLE
Tile volumetric data when creating supercells

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -29,6 +29,7 @@ export {
   parse_cube,
   parse_volumetric_file,
   sample_hkl_slice,
+  tile_volumetric_data,
   trilinear_interpolate,
 } from './isosurface'
 export type {

--- a/src/lib/isosurface/types.ts
+++ b/src/lib/isosurface/types.ts
@@ -1,6 +1,6 @@
 // Type definitions and utilities for isosurface visualization (charge density, molecular orbitals, etc.)
 import type { Matrix3x3, Vec3 } from '$lib/math'
-import { scale_lattice_matrix } from '$lib/structure/supercell'
+import { scale_lattice_matrix } from '$lib/math'
 import type { ParsedStructure } from '$lib/structure/parse'
 
 // Precomputed statistics for a volumetric grid (min, max, abs_max, mean)

--- a/src/lib/isosurface/types.ts
+++ b/src/lib/isosurface/types.ts
@@ -1,5 +1,6 @@
-// Type definitions for isosurface visualization (charge density, molecular orbitals, etc.)
+// Type definitions and utilities for isosurface visualization (charge density, molecular orbitals, etc.)
 import type { Matrix3x3, Vec3 } from '$lib/math'
+import { scale_lattice_matrix } from '$lib/structure/supercell'
 import type { ParsedStructure } from '$lib/structure/parse'
 
 // Precomputed statistics for a volumetric grid (min, max, abs_max, mean)
@@ -136,16 +137,19 @@ export function pad_periodic_grid(
 // 500K balances visual quality with interactive performance (<200ms marching cubes).
 const MAX_GRID_POINTS = 500_000
 
-// Downsample a 3D volumetric grid to keep total point count under MAX_GRID_POINTS.
+// Downsample a 3D volumetric grid to keep total point count under a budget.
 // Uses block averaging to preserve data fidelity while reducing grid dimensions.
 // Returns original grid/dims if already within budget.
 export function downsample_grid(
   grid: number[][][],
   dims: Vec3,
+  max_points: number = MAX_GRID_POINTS,
 ): { grid: number[][][]; dims: Vec3; factor: number } {
   const [nx, ny, nz] = dims
   const total = nx * ny * nz
-  if (total <= MAX_GRID_POINTS) return { grid, dims, factor: 1 }
+  if (total <= max_points) return { grid, dims, factor: 1 }
+  // Floor at 1 to avoid Infinity in cbrt(total/0)
+  max_points = Math.max(1, max_points)
 
   // Increase factor until the clamped output fits within budget.
   // A single cbrt step can overshoot for anisotropic grids where max(2,...)
@@ -153,15 +157,18 @@ export function downsample_grid(
   // clamp_dim: returns 1 for single-cell axes, otherwise clamps to [2, src]
   const clamp_dim = (src: number, fac: number) =>
     Math.min(src, Math.max(2, Math.ceil(src / fac)))
-  let factor = Math.ceil(Math.cbrt(total / MAX_GRID_POINTS))
+  let factor = Math.ceil(Math.cbrt(total / max_points))
   let new_nx = clamp_dim(nx, factor)
   let new_ny = clamp_dim(ny, factor)
   let new_nz = clamp_dim(nz, factor)
-  while (new_nx * new_ny * new_nz > MAX_GRID_POINTS) {
+  while (new_nx * new_ny * new_nz > max_points) {
     factor++
+    const prev_total = new_nx * new_ny * new_nz
     new_nx = clamp_dim(nx, factor)
     new_ny = clamp_dim(ny, factor)
     new_nz = clamp_dim(nz, factor)
+    // dims hit their floor (2 per axis or 1 for single-cell) — stop to avoid infinite loop
+    if (new_nx * new_ny * new_nz === prev_total) break
   }
 
   // Proportional partitioning: evenly divides [0, n) into new_n non-empty blocks.
@@ -250,4 +257,53 @@ export function generate_layers(data_range: DataRange, n_layers: number): Isosur
       negative_color: LAYER_COLORS[(idx + 1) % LAYER_COLORS.length],
     }
   })
+}
+
+// Tile (repeat) volumetric data to fill a supercell.
+// Pre-downsamples the source grid when the tiled result would exceed MAX_GRID_POINTS
+// to avoid large temporary allocations. Returns the original volume unchanged for
+// [1,1,1] scaling.
+export function tile_volumetric_data(volume: VolumetricData, scaling: Vec3): VolumetricData {
+  const [sx, sy, sz] = scaling
+  if (sx === 1 && sy === 1 && sz === 1) return volume
+
+  const total_cells = sx * sy * sz
+  let src_grid = volume.grid
+  let [nx, ny, nz] = volume.grid_dims
+
+  // Pre-downsample source grid so the tiled result stays within budget.
+  // Clamp budget to 8 (minimum downsample output = 2^3) to prevent infinite
+  // loops in downsample_grid when total_cells is very large.
+  if (nx * ny * nz * total_cells > MAX_GRID_POINTS) {
+    const budget = Math.max(8, Math.floor(MAX_GRID_POINTS / total_cells))
+    const ds = downsample_grid(src_grid, [nx, ny, nz], budget)
+    src_grid = ds.grid
+    ;[nx, ny, nz] = ds.dims
+  }
+
+  const new_nx = nx * sx
+  const new_ny = ny * sy
+  const new_nz = nz * sz
+  const new_grid: number[][][] = new Array(new_nx)
+  for (let ix = 0; ix < new_nx; ix++) {
+    const plane: number[][] = new Array(new_ny)
+    const src_x = ix % nx
+    for (let iy = 0; iy < new_ny; iy++) {
+      const row = new Array<number>(new_nz)
+      const src_y = iy % ny
+      const src_row = src_grid[src_x][src_y]
+      for (let iz = 0; iz < new_nz; iz++) {
+        row[iz] = src_row[iz % nz]
+      }
+      plane[iy] = row
+    }
+    new_grid[ix] = plane
+  }
+
+  return {
+    ...volume,
+    grid: new_grid,
+    grid_dims: [new_nx, new_ny, new_nz],
+    lattice: scale_lattice_matrix(volume.lattice, scaling),
+  }
 }

--- a/src/lib/math.ts
+++ b/src/lib/math.ts
@@ -362,6 +362,21 @@ export const transpose_3x3_matrix = (matrix: Matrix3x3): Matrix3x3 => [
   [matrix[0][2], matrix[1][2], matrix[2][2]],
 ]
 
+// Scale each row of a 3x3 matrix by the corresponding element of a Vec3.
+// Used to scale lattice vectors by supercell factors.
+export function scale_lattice_matrix(
+  orig_matrix: Matrix3x3,
+  scaling_factors: Vec3,
+): Matrix3x3 {
+  const [nx, ny, nz] = scaling_factors
+  const [a, b, c] = orig_matrix
+  return [
+    [a[0] * nx, a[1] * nx, a[2] * nx],
+    [b[0] * ny, b[1] * ny, b[2] * ny],
+    [c[0] * nz, c[1] * nz, c[2] * nz],
+  ]
+}
+
 const create_cart_to_frac_matrix = (lattice: Matrix3x3): Matrix3x3 =>
   matrix_inverse_3x3(transpose_3x3_matrix(lattice))
 

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -13,6 +13,7 @@
   import {
     auto_isosurface_settings,
     DEFAULT_ISOSURFACE_SETTINGS,
+    tile_volumetric_data,
   } from '$lib/isosurface/types'
   import { ELEM_SYMBOLS } from '$lib/labels'
   import { set_fullscreen_bg, toggle_fullscreen } from '$lib/layout'
@@ -29,7 +30,11 @@
     get_structure_vector_keys,
   } from '$lib/structure'
   import { wrap_to_unit_cell } from '$lib/structure/pbc'
-  import { is_valid_supercell_input, make_supercell } from '$lib/structure/supercell'
+  import {
+    is_valid_supercell_input,
+    make_supercell,
+    parse_supercell_scaling,
+  } from '$lib/structure/supercell'
   import type { CellType, SymmetrySettings } from '$lib/symmetry'
   import * as symmetry from '$lib/symmetry'
   import { transform_cell } from '$lib/symmetry'
@@ -574,6 +579,17 @@
     !!supercell_scaling && ![``, `1x1x1`, `1`].includes(supercell_scaling),
   )
 
+  // Tile volumetric data to match supercell when active
+  let supercell_volume = $derived.by(() => {
+    const vol = volumetric_data?.[active_volume_idx]
+    if (!vol || !has_supercell) return vol
+    try {
+      return tile_volumetric_data(vol, parse_supercell_scaling(supercell_scaling))
+    } catch {
+      return vol
+    }
+  })
+
   $effect(() => {
     const base_structure = cell_transformed_structure
     if (!base_structure || !(`lattice` in base_structure) || !has_supercell) {
@@ -623,8 +639,8 @@
     }
   })
 
-  // Clear selections and site overrides when transformations change site indices
-  // (skip first run to preserve parent-provided selections)
+  // Clear selections, site overrides, and stale camera target when transformations
+  // change site indices (skip first run to preserve parent-provided selections)
   let first_run = true
   $effect(() => {
     void [supercell_scaling, show_image_atoms, structure, cell_type] // track reactively
@@ -639,6 +655,8 @@
       if (selected_sites.length > 0 || measured_sites.length > 0) clear_selection()
       // Clear site radius overrides since site indices are no longer valid
       if (site_radius_overrides?.size > 0) site_radius_overrides.clear()
+      // Clear stale camera target so orbit controls re-center on the new cell
+      scene_props.camera_target = undefined
     })
   })
 
@@ -1480,7 +1498,7 @@
             base_structure={cell_transformed_structure}
             {...scene_props}
             {lattice_props}
-            volumetric_data={volumetric_data?.[active_volume_idx]}
+            volumetric_data={supercell_volume}
             {isosurface_settings}
             bind:camera_is_moving
             bind:selected_sites

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -592,8 +592,10 @@
     }
   })
 
+  let supercell_timeout: ReturnType<typeof setTimeout> | undefined
   $effect(() => {
     const base_structure = cell_transformed_structure
+    clearTimeout(supercell_timeout)
     if (!base_structure || !(`lattice` in base_structure) || !has_supercell) {
       supercell_structure = base_structure
       supercell_loading = false
@@ -614,7 +616,7 @@
       if (show_loading) {
         supercell_loading = true
         // Use setTimeout to allow UI to update before heavy computation
-        setTimeout(() => {
+        supercell_timeout = setTimeout(() => {
           try {
             if (base_structure && `lattice` in base_structure) {
               supercell_structure = make_supercell(

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -579,10 +579,12 @@
     !!supercell_scaling && ![``, `1x1x1`, `1`].includes(supercell_scaling),
   )
 
-  // Tile volumetric data to match supercell when active
+  // Tile volumetric data to match supercell when active.
+  // Gate on !supercell_loading so the tiled volume and supercell structure update
+  // in the same frame (large supercells defer structure via setTimeout).
   let supercell_volume = $derived.by(() => {
     const vol = volumetric_data?.[active_volume_idx]
-    if (!vol || !has_supercell) return vol
+    if (!vol || !has_supercell || supercell_loading) return vol
     try {
       return tile_volumetric_data(vol, parse_supercell_scaling(supercell_scaling))
     } catch {

--- a/src/lib/structure/supercell.ts
+++ b/src/lib/structure/supercell.ts
@@ -1,6 +1,7 @@
 // Supercell generation utilities for Crystal
 import type { Vec3 } from '$lib/math'
 import * as math from '$lib/math'
+import { scale_lattice_matrix } from '$lib/math'
 import type { Crystal, Site } from './index'
 import { wrap_frac_coord } from './pbc'
 
@@ -64,22 +65,8 @@ export function generate_lattice_points(scaling_factors: Vec3): Vec3[] {
   return points
 }
 
-// Scale a lattice matrix by supercell factors
-// Takes original 3x3 lattice matrix and [scale_x, scale_y, scale_z] scaling factors
-// Returns new scaled lattice matrix
-export function scale_lattice_matrix(
-  orig_matrix: math.Matrix3x3,
-  scaling_factors: Vec3,
-): math.Matrix3x3 {
-  const [nx, ny, nz] = scaling_factors
-  const [a, b, c] = orig_matrix
-  // Scale each lattice vector by its corresponding factor
-  return [
-    [a[0] * nx, a[1] * nx, a[2] * nx],
-    [b[0] * ny, b[1] * ny, b[2] * ny],
-    [c[0] * nz, c[1] * nz, c[2] * nz],
-  ]
-}
+// Re-export from $lib/math for backward compatibility
+export { scale_lattice_matrix }
 
 // Create a supercell from a Crystal
 // Takes original structure, scaling factors, and whether to fold coordinates back to unit cell (default: true)

--- a/tests/vitest/isosurface/types.test.ts
+++ b/tests/vitest/isosurface/types.test.ts
@@ -337,8 +337,7 @@ describe(`downsample_grid`, () => {
     (max_points) => {
       const grid = make_grid(4, 4, 4)
       const result = downsample_grid(grid, [4, 4, 4], max_points)
-      // Minimum output is 2x2x2 = 8 (clamp_dim floors at 2)
-      expect(result.dims.every((dim) => dim >= 1)).toBe(true)
+      expect(result.dims.every((dim) => dim >= 2)).toBe(true)
       expect(result.factor).toBeGreaterThan(1)
       expect(Number.isFinite(result.factor)).toBe(true)
     },

--- a/tests/vitest/isosurface/types.test.ts
+++ b/tests/vitest/isosurface/types.test.ts
@@ -7,6 +7,8 @@ import {
   grid_data_range,
   LAYER_COLORS,
   pad_periodic_grid,
+  tile_volumetric_data,
+  type VolumetricData,
 } from '$lib/isosurface/types'
 import type { Vec3 } from '$lib/math'
 import { describe, expect, test } from 'vitest'
@@ -313,6 +315,34 @@ describe(`downsample_grid`, () => {
     expect(result.grid[0].length).toBe(rny)
     expect(result.grid[0][0].length).toBe(rnz)
   })
+
+  test(`respects custom max_points budget`, () => {
+    const grid = make_grid(50, 50, 50)
+    const result = downsample_grid(grid, [50, 50, 50], 10_000)
+    const [rnx, rny, rnz] = result.dims
+    expect(rnx * rny * rnz).toBeLessThanOrEqual(10_000)
+    expect(result.factor).toBeGreaterThan(1)
+  })
+
+  test(`returns original when total is under custom budget`, () => {
+    const dims: Vec3 = [10, 10, 10]
+    const grid = make_grid(10, 10, 10)
+    const result = downsample_grid(grid, dims, 2000)
+    expect(result.grid).toBe(grid)
+    expect(result.factor).toBe(1)
+  })
+
+  test.each([0, 1, 7])(
+    `max_points=%d below minimum output terminates without hanging`,
+    (max_points) => {
+      const grid = make_grid(4, 4, 4)
+      const result = downsample_grid(grid, [4, 4, 4], max_points)
+      // Minimum output is 2x2x2 = 8 (clamp_dim floors at 2)
+      expect(result.dims.every((dim) => dim >= 1)).toBe(true)
+      expect(result.factor).toBeGreaterThan(1)
+      expect(Number.isFinite(result.factor)).toBe(true)
+    },
+  )
 })
 
 describe(`pad_periodic_grid`, () => {
@@ -390,5 +420,159 @@ describe(`pad_periodic_grid`, () => {
     expect(result.offset[1]).toBeCloseTo(-2 / 4)
     expect(result.offset[2]).toBeCloseTo(-3 / 10)
     assert_all_cells(result.grid, (val) => expect(val).toBe(2))
+  })
+})
+
+// Helper to build a minimal VolumetricData from a grid for tile tests
+function make_volume(
+  nx: number,
+  ny: number,
+  nz: number,
+  fill: number | ((ix: number, iy: number, iz: number) => number) = 1,
+  periodic: boolean = true,
+): VolumetricData {
+  const grid = make_grid(nx, ny, nz, fill)
+  return {
+    grid,
+    grid_dims: [nx, ny, nz],
+    lattice: [
+      [3, 0, 0],
+      [0, 4, 0],
+      [0, 0, 5],
+    ],
+    origin: [0, 0, 0],
+    data_range: { min: 0, max: 1, abs_max: 1, mean: 0.5 },
+    periodic,
+    label: `test`,
+  }
+}
+
+describe(`tile_volumetric_data`, () => {
+  test(`[1,1,1] returns the same object reference`, () => {
+    const vol = make_volume(4, 4, 4)
+    expect(tile_volumetric_data(vol, [1, 1, 1])).toBe(vol)
+  })
+
+  test(`non-periodic volume is tiled, not skipped`, () => {
+    const vol = make_volume(4, 4, 4, 1, false)
+    const tiled = tile_volumetric_data(vol, [2, 2, 2])
+    expect(tiled).not.toBe(vol)
+    expect(tiled.grid_dims).toEqual([8, 8, 8])
+  })
+
+  test.each([
+    { scaling: [2, 1, 1] as Vec3, label: `2x1x1` },
+    { scaling: [1, 3, 1] as Vec3, label: `1x3x1` },
+    { scaling: [1, 1, 4] as Vec3, label: `1x1x4` },
+    { scaling: [2, 2, 2] as Vec3, label: `2x2x2` },
+    { scaling: [3, 1, 2] as Vec3, label: `3x1x2` },
+  ])(`$label: produces correct dims`, ({ scaling }) => {
+    const vol = make_volume(4, 5, 6)
+    const tiled = tile_volumetric_data(vol, scaling)
+    expect(tiled.grid_dims).toEqual([4 * scaling[0], 5 * scaling[1], 6 * scaling[2]])
+    expect(tiled.grid.length).toBe(tiled.grid_dims[0])
+    expect(tiled.grid[0].length).toBe(tiled.grid_dims[1])
+    expect(tiled.grid[0][0].length).toBe(tiled.grid_dims[2])
+  })
+
+  test(`grid values repeat via modulo at boundary wrap points`, () => {
+    const vol = make_volume(3, 4, 5, (ix, iy, iz) => ix * 100 + iy * 10 + iz)
+    const tiled = tile_volumetric_data(vol, [2, 2, 2])
+    const [nx, ny, nz] = vol.grid_dims
+    for (let ix = 0; ix < tiled.grid_dims[0]; ix++) {
+      for (let iy = 0; iy < tiled.grid_dims[1]; iy++) {
+        for (let iz = 0; iz < tiled.grid_dims[2]; iz++) {
+          expect(tiled.grid[ix][iy][iz]).toBe(vol.grid[ix % nx][iy % ny][iz % nz])
+        }
+      }
+    }
+  })
+
+  test.each([
+    {
+      scaling: [2, 3, 4] as Vec3,
+      lattice: [
+        [3, 0, 0],
+        [0, 4, 0],
+        [0, 0, 5],
+      ] as VolumetricData[`lattice`],
+      expected: [
+        [6, 0, 0],
+        [0, 12, 0],
+        [0, 0, 20],
+      ],
+      label: `orthogonal`,
+    },
+    {
+      scaling: [2, 3, 1] as Vec3,
+      lattice: [
+        [3, 1, 0],
+        [0, 4, 2],
+        [1, 0, 5],
+      ] as VolumetricData[`lattice`],
+      expected: [
+        [6, 2, 0],
+        [0, 12, 6],
+        [1, 0, 5],
+      ],
+      label: `non-orthogonal`,
+    },
+  ])(
+    `$label: lattice vectors scaled by supercell factors`,
+    ({ scaling, lattice, expected }) => {
+      const vol = make_volume(4, 4, 4)
+      vol.lattice = lattice
+      const tiled = tile_volumetric_data(vol, scaling)
+      expect(tiled.lattice).toEqual(expected)
+    },
+  )
+
+  test(`data_range, origin, periodic, label, and data_order are preserved`, () => {
+    const vol = make_volume(4, 4, 4)
+    vol.data_order = `x_fastest`
+    const tiled = tile_volumetric_data(vol, [2, 2, 2])
+    expect(tiled.data_range).toBe(vol.data_range)
+    expect(tiled.origin).toBe(vol.origin)
+    expect(tiled.periodic).toBe(vol.periodic)
+    expect(tiled.label).toBe(vol.label)
+    expect(tiled.data_order).toBe(`x_fastest`)
+  })
+
+  test(`returns a new object that does not alias source arrays`, () => {
+    const vol = make_volume(3, 3, 3, 5)
+    const tiled = tile_volumetric_data(vol, [2, 2, 2])
+    expect(tiled).not.toBe(vol)
+    expect(tiled.grid).not.toBe(vol.grid)
+    expect(tiled.lattice).not.toBe(vol.lattice)
+    // Mutating tiled grid must not affect source
+    tiled.grid[0][0][0] = -999
+    expect(vol.grid[0][0][0]).toBe(5)
+  })
+
+  test.each([
+    {
+      dims: [100, 100, 100] as Vec3,
+      scaling: [2, 2, 2] as Vec3,
+      fill: 7,
+      label: `large grid`,
+    },
+    {
+      dims: [4, 4, 4] as Vec3,
+      scaling: [80, 80, 80] as Vec3,
+      fill: 3,
+      label: `extreme supercell (budget clamp)`,
+    },
+  ])(`$label: pre-downsamples and scales lattice correctly`, ({ dims, scaling, fill }) => {
+    const vol = make_volume(dims[0], dims[1], dims[2], fill)
+    const tiled = tile_volumetric_data(vol, scaling)
+    const [tnx, tny, tnz] = tiled.grid_dims
+    // Grid shape matches dims
+    expect(tiled.grid.length).toBe(tnx)
+    expect(tiled.grid[0].length).toBe(tny)
+    expect(tiled.grid[0][0].length).toBe(tnz)
+    // Lattice diagonal scaled by supercell factors
+    for (let idx = 0; idx < 3; idx++) {
+      expect(tiled.lattice[idx][idx]).toBe(vol.lattice[idx][idx] * scaling[idx])
+    }
   })
 })

--- a/tests/vitest/structure/Structure.test.svelte.ts
+++ b/tests/vitest/structure/Structure.test.svelte.ts
@@ -916,7 +916,5 @@ describe(`Rotation target computation`, () => {
   })
 })
 
-// Camera reset on structure reload is tested via Playwright E2E
-// (tests/playwright/structure/structure.test.ts → "rotation center resets to new
-// lattice center after file drop") because it requires WebGL + OrbitControls to
-// verify the actual orbit target.
+// Camera target reset on supercell change and structure reload requires WebGL +
+// OrbitControls — tested via Playwright E2E (tests/playwright/structure/).


### PR DESCRIPTION
- When a CHGCAR or .cube file is loaded and a supercell is created, the isosurface now tiles to fill the supercell instead of staying confined to the original unit cell.
- Pre-downsamples large grids so tiled output stays within the 500K-point budget, avoiding large temporary allocations.
- Fixes orbit controls rotating around the old single-cell center after supercell change by clearing the stale `camera_target`.

- Downsampling accepts a configurable point budget.
- Pending supercell generation is canceled when inputs change, preventing stale updates.
- Volumetric tiling and lattice-scaling utilities are exported on the public API.

Closes #329