### PR TITLE
Bond editing: add/delete modes, undo snapshots, set order

### DIFF
--- a/extensions/dash/component_manifest.toml
+++ b/extensions/dash/component_manifest.toml
@@ -14,6 +14,10 @@ doc = "3D crystal structure / molecule viewer."
 # This wrapper defaults set_props/float32_props accordingly.
 set_props = ["hidden_elements", "hidden_prop_vals"]
 
+[components.Structure.extra_props]
+bond_edit_mode = "'add' | 'delete'"
+bond_edit_order = "1 | 1.5 | 2 | 3 | 'aromatic'"
+
 [components.PeriodicTable]
 key = "periodic-table/PeriodicTable"
 doc = "Interactive periodic table with heatmaps and tooltips."

--- a/extensions/dash/matterviz_dash_components/typed.py
+++ b/extensions/dash/matterviz_dash_components/typed.py
@@ -14,7 +14,7 @@ class Structure(MatterViz):
 
     Component key: ``structure/Structure``
 
-    Events: on_file_drop
+    Events: on_bonds_change, on_camera_move, on_camera_reset, on_error, on_file_drop, on_file_load, on_fullscreen_change
 
     Unsupported snippets: top_right_controls
     """
@@ -25,8 +25,7 @@ class Structure(MatterViz):
         active_volume_idx: int | None = None,
         allow_file_drop: bool | None = None,
         atom_color_config: dict | None = None,
-        bond_edit_mode: Any | None = None,
-        bond_edit_order: Any | None = None,
+        bonds: list | None = None,
         cell_type: Any | None = None,
         data_url: str | None = None,
         displayed_structure: Any | None = None,
@@ -48,11 +47,6 @@ class Structure(MatterViz):
         loading: bool | None = None,
         measure_mode: Any | None = None,
         measured_sites: list[int] | None = None,
-        on_camera_move: Any | None = None,
-        on_camera_reset: Any | None = None,
-        on_error: Any | None = None,
-        on_file_load: Any | None = None,
-        on_fullscreen_change: Any | None = None,
         performance_mode: Any | None = None,
         png_dpi: float | None = None,
         reset_text: str | None = None,
@@ -66,6 +60,8 @@ class Structure(MatterViz):
         symmetry_settings: dict | None = None,
         volumetric_data: list | None = None,
         width: float | None = None,
+        bond_edit_mode: Any | None = None,
+        bond_edit_order: Any | None = None,
         mv_props: dict | None = None,
         set_props: list[str] | None = None,
         float32_props: list[str] | None = None,
@@ -83,10 +79,8 @@ class Structure(MatterViz):
             mv_props["allow_file_drop"] = allow_file_drop
         if atom_color_config is not None:
             mv_props["atom_color_config"] = atom_color_config
-        if bond_edit_mode is not None:
-            mv_props["bond_edit_mode"] = bond_edit_mode
-        if bond_edit_order is not None:
-            mv_props["bond_edit_order"] = bond_edit_order
+        if bonds is not None:
+            mv_props["bonds"] = bonds
         if cell_type is not None:
             mv_props["cell_type"] = cell_type
         if data_url is not None:
@@ -129,16 +123,6 @@ class Structure(MatterViz):
             mv_props["measure_mode"] = measure_mode
         if measured_sites is not None:
             mv_props["measured_sites"] = measured_sites
-        if on_camera_move is not None:
-            mv_props["on_camera_move"] = on_camera_move
-        if on_camera_reset is not None:
-            mv_props["on_camera_reset"] = on_camera_reset
-        if on_error is not None:
-            mv_props["on_error"] = on_error
-        if on_file_load is not None:
-            mv_props["on_file_load"] = on_file_load
-        if on_fullscreen_change is not None:
-            mv_props["on_fullscreen_change"] = on_fullscreen_change
         if performance_mode is not None:
             mv_props["performance_mode"] = performance_mode
         if png_dpi is not None:
@@ -165,6 +149,10 @@ class Structure(MatterViz):
             mv_props["volumetric_data"] = volumetric_data
         if width is not None:
             mv_props["width"] = width
+        if bond_edit_mode is not None:
+            mv_props["bond_edit_mode"] = bond_edit_mode
+        if bond_edit_order is not None:
+            mv_props["bond_edit_order"] = bond_edit_order
         if set_props is None:
             set_props = ["hidden_elements", "hidden_prop_vals"]
 

--- a/extensions/dash/matterviz_dash_components/typed.py
+++ b/extensions/dash/matterviz_dash_components/typed.py
@@ -25,6 +25,8 @@ class Structure(MatterViz):
         active_volume_idx: int | None = None,
         allow_file_drop: bool | None = None,
         atom_color_config: dict | None = None,
+        bond_edit_mode: Any | None = None,
+        bond_edit_order: Any | None = None,
         cell_type: Any | None = None,
         data_url: str | None = None,
         displayed_structure: Any | None = None,
@@ -81,6 +83,10 @@ class Structure(MatterViz):
             mv_props["allow_file_drop"] = allow_file_drop
         if atom_color_config is not None:
             mv_props["atom_color_config"] = atom_color_config
+        if bond_edit_mode is not None:
+            mv_props["bond_edit_mode"] = bond_edit_mode
+        if bond_edit_order is not None:
+            mv_props["bond_edit_order"] = bond_edit_order
         if cell_type is not None:
             mv_props["cell_type"] = cell_type
         if data_url is not None:

--- a/extensions/dash/scripts/sync_typed_wrappers.py
+++ b/extensions/dash/scripts/sync_typed_wrappers.py
@@ -436,7 +436,11 @@ def parse_external_type(
 
 def _detect_prop_kind(ts_type: str, aliases: dict[str, str] | None = None) -> str:
     """Determine prop kind based on TypeScript type signature."""
-    resolved = aliases.get(ts_type, ts_type) if aliases else ts_type
+    resolved = ts_type
+    seen_aliases: set[str] = set()
+    while aliases and resolved in aliases and resolved not in seen_aliases:
+        seen_aliases.add(resolved)
+        resolved = aliases[resolved]
     if "=>" in resolved:
         return "callback"
     if "Snippet" in resolved:

--- a/extensions/dash/scripts/sync_typed_wrappers.py
+++ b/extensions/dash/scripts/sync_typed_wrappers.py
@@ -427,13 +427,14 @@ def parse_external_type(
     return {}
 
 
-def _detect_prop_kind(ts_type: str) -> str:
+def _detect_prop_kind(ts_type: str, aliases: dict[str, str] | None = None) -> str:
     """Determine prop kind based on TypeScript type signature."""
-    if "=>" in ts_type:
+    resolved = aliases.get(ts_type, ts_type) if aliases else ts_type
+    if "=>" in resolved:
         return "callback"
-    if "Snippet" in ts_type:
+    if "Snippet" in resolved:
         return "snippet"
-    if "HTMLElement" in ts_type or "HTMLDivElement" in ts_type:
+    if "HTMLElement" in resolved or "HTMLDivElement" in resolved:
         return "dom"
     return "value"
 
@@ -461,7 +462,7 @@ def parse_svelte_dts(
     dom_props: list[str] = []
 
     for js_name, (ts_type, required) in sorted(js_props.items()):
-        kind = _detect_prop_kind(ts_type)
+        kind = _detect_prop_kind(ts_type, aliases)
         if kind == "callback":
             callback_props.append(js_name)
         elif kind == "snippet":

--- a/extensions/dash/scripts/sync_typed_wrappers.py
+++ b/extensions/dash/scripts/sync_typed_wrappers.py
@@ -397,34 +397,41 @@ def _parse_interface_props(
     return _parse_object_literal(src[brace_start:idx])
 
 
-def parse_external_type(
+def _parse_external_type_with_aliases(
     dist_dir: str, include_spec: str
-) -> dict[str, tuple[str, bool]]:
-    """Parse a type/interface from an external .d.ts file.
+) -> tuple[dict[str, tuple[str, bool]], dict[str, str]]:
+    """Parse an external type/interface and return same-file aliases.
 
     include_spec format: "path/to/file.d.ts:TypeName"
     """
     if ":" not in include_spec:
-        return {}
+        return {}, {}
 
     file_path, type_name = include_spec.rsplit(":", 1)
     dts_path = f"{dist_dir}/{file_path}"
     if not os.path.isfile(dts_path):
         print(f"Warning: External type file not found: {dts_path}")
-        return {}
+        return {}, {}
 
     with open(dts_path, encoding="utf-8") as fh:
         src = fh.read()
 
+    aliases = _extract_type_aliases(src)
     # Try interface first, then type alias
     if props := _parse_interface_props(src, type_name):
-        return props
+        return props, aliases
 
-    aliases = _extract_type_aliases(src)
     if type_name in aliases:
-        return _collect_props(aliases[type_name], aliases, dist_dir, src=src)
+        return _collect_props(aliases[type_name], aliases, dist_dir, src=src), aliases
 
-    return {}
+    return {}, aliases
+
+
+def parse_external_type(
+    dist_dir: str, include_spec: str
+) -> dict[str, tuple[str, bool]]:
+    """Parse a type/interface from an external .d.ts file."""
+    return _parse_external_type_with_aliases(dist_dir, include_spec)[0]
 
 
 def _detect_prop_kind(ts_type: str, aliases: dict[str, str] | None = None) -> str:
@@ -485,13 +492,14 @@ def parse_svelte_dts_with_includes(
     existing = {p.js_name for p in props}
 
     for include_spec in include_from:
-        for js_name, (ts_type, required) in parse_external_type(
+        include_props, aliases = _parse_external_type_with_aliases(
             dist_dir, include_spec
-        ).items():
+        )
+        for js_name, (ts_type, required) in include_props.items():
             if js_name in existing:
                 continue
 
-            kind = _detect_prop_kind(ts_type)
+            kind = _detect_prop_kind(ts_type, aliases)
             if kind == "callback":
                 callback_props.append(js_name)
             elif kind == "snippet":

--- a/extensions/dash/tests/test_wrappers.py
+++ b/extensions/dash/tests/test_wrappers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import matterviz_dash_components as mvc
 import pytest
 from matterviz_dash_components import MatterViz
+from scripts.sync_typed_wrappers import _detect_prop_kind
 
 # Note: We don't import typed wrappers (Structure, PeriodicTable, Trajectory) directly
 # in tests because they have @_explicitize_args decorator conflicts. Instead, we test
@@ -48,6 +49,12 @@ class TestMatterVizBase:
             event_props=["on_file_load", "on_error"],
         )
         assert comp.event_props == ["on_file_load", "on_error"]
+        assert (
+            _detect_prop_kind(
+                "EventHandler", {"EventHandler": "(data: StructureHandlerData) => void"}
+            )
+            == "callback"
+        )
 
 
 class TestComponentInstantiation:

--- a/extensions/dash/tests/test_wrappers.py
+++ b/extensions/dash/tests/test_wrappers.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import matterviz_dash_components as mvc
 import pytest
 from matterviz_dash_components import MatterViz
-from scripts.sync_typed_wrappers import _detect_prop_kind
+from scripts.sync_typed_wrappers import (
+    _detect_prop_kind,
+    parse_svelte_dts_with_includes,
+)
 
 # Note: We don't import typed wrappers (Structure, PeriodicTable, Trajectory) directly
 # in tests because they have @_explicitize_args decorator conflicts. Instead, we test
@@ -55,6 +60,35 @@ class TestMatterVizBase:
             )
             == "callback"
         )
+
+    def test_include_aliases_detect_event_props(self, tmp_path: Path) -> None:
+        """External include aliases classify callback props."""
+        dist_dir = tmp_path / "dist"
+        dist_dir.mkdir()
+        component_dts = dist_dir / "Component.svelte.d.ts"
+        component_dts.write_text(
+            "type $$ComponentProps = {}; declare const Component: "
+            'import("svelte").Component<$$ComponentProps>;',
+            encoding="utf-8",
+        )
+        include_dts = dist_dir / "included.d.ts"
+        include_dts.write_text(
+            "type EventHandler = (data: StructureHandlerData) => void;\n"
+            "interface IncludedProps { onReady?: EventHandler; value?: string; }\n",
+            encoding="utf-8",
+        )
+
+        props, callback_props, snippet_props, dom_props = (
+            parse_svelte_dts_with_includes(
+                str(component_dts), str(dist_dir), ["included.d.ts:IncludedProps"]
+            )
+        )
+
+        prop_kinds = {prop.js_name: prop.kind for prop in props}
+        assert prop_kinds == {"onReady": "callback", "value": "value"}
+        assert callback_props == ["onReady"]
+        assert snippet_props == []
+        assert dom_props == []
 
 
 class TestComponentInstantiation:

--- a/extensions/dash/tests/test_wrappers.py
+++ b/extensions/dash/tests/test_wrappers.py
@@ -56,7 +56,11 @@ class TestMatterVizBase:
         assert comp.event_props == ["on_file_load", "on_error"]
         assert (
             _detect_prop_kind(
-                "EventHandler", {"EventHandler": "(data: StructureHandlerData) => void"}
+                "OnReady",
+                {
+                    "OnReady": "EventHandler",
+                    "EventHandler": "(data: StructureHandlerData) => void",
+                },
             )
             == "callback"
         )
@@ -74,7 +78,8 @@ class TestMatterVizBase:
         include_dts = dist_dir / "included.d.ts"
         include_dts.write_text(
             "type EventHandler = (data: StructureHandlerData) => void;\n"
-            "interface IncludedProps { onReady?: EventHandler; value?: string; }\n",
+            "type OnReady = EventHandler;\n"
+            "interface IncludedProps { onReady?: OnReady; value?: string; }\n",
             encoding="utf-8",
         )
 

--- a/extensions/vscode/src/node-io.ts
+++ b/extensions/vscode/src/node-io.ts
@@ -55,5 +55,5 @@ export const stream_file_to_buffer = async (
 
   on_progress?.({ bytes_read: uint8array.length, total_size, progress: 1.0 }) // Report completion
 
-  return uint8array.buffer as ArrayBuffer
+  return uint8array.slice().buffer
 }

--- a/extensions/vscode/src/node-io.ts
+++ b/extensions/vscode/src/node-io.ts
@@ -55,5 +55,11 @@ export const stream_file_to_buffer = async (
 
   on_progress?.({ bytes_read: uint8array.length, total_size, progress: 1.0 }) // Report completion
 
-  return uint8array.slice().buffer
+  // Keep the return type a true ArrayBuffer. This intentionally excludes
+  // SharedArrayBuffer-backed views, which fall back to slice().buffer.
+  return uint8array.buffer instanceof ArrayBuffer &&
+    uint8array.byteOffset === 0 &&
+    uint8array.byteLength === uint8array.buffer.byteLength
+    ? uint8array.buffer
+    : uint8array.slice().buffer
 }

--- a/extensions/vscode/src/webview/main.ts
+++ b/extensions/vscode/src/webview/main.ts
@@ -2,14 +2,17 @@
 import '$lib/app.css'
 import { COMPRESSION_EXTENSIONS_REGEX } from '$lib/constants'
 import ConvexHull from '$lib/convex-hull/ConvexHull.svelte'
+import type { PhaseData } from '$lib/convex-hull/types'
 import FermiSurface from '$lib/fermi-surface/FermiSurface.svelte'
 import { parse_fermi_file } from '$lib/fermi-surface/parse'
 import { is_fermi_surface_data } from '$lib/fermi-surface/types'
 import { decompress_data, detect_compression_format } from '$lib/io/decompress'
 import { parse_volumetric_file } from '$lib/isosurface/parse'
+import type { VolumetricData } from '$lib/isosurface/types'
 import IsobaricBinaryPhaseDiagram from '$lib/phase-diagram/IsobaricBinaryPhaseDiagram.svelte'
+import type { PhaseDiagramData } from '$lib/phase-diagram/types'
 import { type DefaultSettings, merge } from '$lib/settings'
-import type { Crystal } from '$lib/structure'
+import type { AnyStructure } from '$lib/structure'
 import { parse_structure_file } from '$lib/structure/parse'
 import Structure from '$lib/structure/Structure.svelte'
 import { ensure_moyo_wasm_ready } from '$lib/symmetry'
@@ -259,7 +262,7 @@ export function base64_to_array_buffer(base64: string): ArrayBuffer {
   for (let idx = 0; idx < binary.length; idx++) {
     bytes[idx] = binary.charCodeAt(idx)
   }
-  return bytes.buffer as ArrayBuffer
+  return bytes.buffer
 }
 
 // Type for parsed trajectory response from large file requests
@@ -558,7 +561,7 @@ const create_display = (
     log_message = `Fermi surface rendered: ${filename}`
   } else if (result.type === `isosurface`) {
     // VolumetricFileData has structure + volumes; render via Structure with volumetric_data
-    const vol_file = result.data as { structure: unknown; volumes: unknown[] }
+    const vol_file = result.data as { structure: AnyStructure; volumes: VolumetricData[] }
     app = mount(Structure, {
       target: container,
       props: {
@@ -570,15 +573,16 @@ const create_display = (
     })
     log_message = `Volumetric data rendered: ${filename}`
   } else if (result.type === `convex_hull`) {
+    const entries = result.data as PhaseData[]
     app = mount(ConvexHull, {
       target: container,
-      props: { entries: result.data as unknown[], ...common_props },
+      props: { entries, ...common_props },
     })
-    log_message = `Convex hull rendered: ${filename} (${(result.data as unknown[]).length} entries)`
+    log_message = `Convex hull rendered: ${filename} (${entries.length} entries)`
   } else if (result.type === `phase_diagram`) {
     app = mount(IsobaricBinaryPhaseDiagram, {
       target: container,
-      props: { data: result.data, ...common_props },
+      props: { data: result.data as PhaseDiagramData, ...common_props },
     })
     log_message = `Phase diagram rendered: ${filename}`
   } else if (result.type === `json_browser`) {
@@ -589,17 +593,16 @@ const create_display = (
     log_message = `JSON browser opened: ${filename}`
   } else {
     // Default: structure
+    const structure = result.data as AnyStructure
     app = mount(Structure, {
       target: container,
       props: {
-        structure: result.data,
+        structure,
         ...structure_props(defaults),
         ...common_props,
       },
     })
-    log_message = `Structure rendered: ${filename} (${
-      (result.data as Crystal).sites?.length ?? 0
-    } sites)`
+    log_message = `Structure rendered: ${filename} (${structure.sites?.length ?? 0} sites)`
   }
 
   vscode_api?.postMessage({ command: `info`, text: log_message })

--- a/extensions/vscode/tests/node-io.test.ts
+++ b/extensions/vscode/tests/node-io.test.ts
@@ -16,6 +16,16 @@ const mock_vscode = vi.hoisted(() => ({
 vi.mock(`vscode`, () => mock_vscode)
 
 describe(`stream_file_to_buffer`, () => {
+  test(`returns the underlying buffer without copying for full-span file bytes`, async () => {
+    const file_bytes = new Uint8Array([1, 2, 3])
+    mock_vscode.workspace.fs.stat.mockResolvedValue({ size: file_bytes.byteLength })
+    mock_vscode.workspace.fs.readFile.mockResolvedValue(file_bytes)
+
+    const result = await stream_file_to_buffer(`/tmp/full-span.bin`)
+
+    expect(result).toBe(file_bytes.buffer)
+  })
+
   test(`returns exact bytes when VS Code returns an ArrayBuffer view`, async () => {
     const parent_buffer = new Uint8Array([0, 1, 2, 3, 4, 5])
     const file_bytes = parent_buffer.subarray(2, 5)

--- a/extensions/vscode/tests/node-io.test.ts
+++ b/extensions/vscode/tests/node-io.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test, vi } from 'vitest'
+import { stream_file_to_buffer } from '../src/node-io'
+
+const mock_vscode = vi.hoisted(() => ({
+  Uri: {
+    file: vi.fn((file_path: string) => ({ fsPath: file_path })),
+  },
+  workspace: {
+    fs: {
+      stat: vi.fn(),
+      readFile: vi.fn(),
+    },
+  },
+}))
+
+vi.mock(`vscode`, () => mock_vscode)
+
+describe(`stream_file_to_buffer`, () => {
+  test(`returns exact bytes when VS Code returns an ArrayBuffer view`, async () => {
+    const parent_buffer = new Uint8Array([0, 1, 2, 3, 4, 5])
+    const file_bytes = parent_buffer.subarray(2, 5)
+    mock_vscode.workspace.fs.stat.mockResolvedValue({ size: file_bytes.byteLength })
+    mock_vscode.workspace.fs.readFile.mockResolvedValue(file_bytes)
+
+    const result = await stream_file_to_buffer(`/tmp/view-backed.bin`)
+
+    expect(Array.from(new Uint8Array(result))).toEqual([2, 3, 4])
+  })
+})

--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
     "@types/node": "^25.9.0",
     "@types/three": "^0.184.1",
     "@typescript/native-preview": "7.0.0-dev.20260519.1",
-    "@vitest/coverage-v8": "4.1.5",
+    "@vitest/coverage-v8": "4.1.6",
     "@wooorm/starry-night": "^3.9.0",
     "happy-dom": "^20.9.0",
     "mdsvex": "^0.12.7",

--- a/package.json
+++ b/package.json
@@ -162,10 +162,10 @@
     "prepublishOnly": "npm run package:dist"
   },
   "dependencies": {
-    "@spglib/moyo-wasm": "^0.9.0",
-    "@sveltejs/kit": "2.60.1",
-    "@threlte/core": "^8.5.14",
-    "@threlte/extras": "^9.19.0",
+    "@spglib/moyo-wasm": "^0.10.0",
+    "@sveltejs/kit": "2.61.1",
+    "@threlte/core": "^8.5.15",
+    "@threlte/extras": "^9.20.0",
     "d3-array": "^3.2.4",
     "d3-color": "^3.1.0",
     "d3-format": "^3.1.2",
@@ -198,28 +198,28 @@
     "@types/d3-shape": "^3.1.8",
     "@types/d3-time-format": "^4.0.3",
     "@types/js-yaml": "^4.0.9",
-    "@types/node": "^25.9.0",
+    "@types/node": "^25.9.1",
     "@types/three": "^0.184.1",
-    "@typescript/native-preview": "7.0.0-dev.20260519.1",
-    "@vitest/coverage-v8": "4.1.6",
+    "@typescript/native-preview": "7.0.0-dev.20260524.1",
+    "@vitest/coverage-v8": "4.1.7",
     "@wooorm/starry-night": "^3.9.0",
     "happy-dom": "^20.9.0",
     "mdsvex": "^0.12.7",
     "rehype-katex": "^7.0.1",
     "remark-math": "3.0.1",
-    "svelte": "5.55.8",
-    "svelte-check-rs": "0.9.13",
+    "svelte": "5.55.9",
+    "svelte-check-rs": "0.9.14",
     "typescript": "6.0.3",
-    "vite": "npm:@voidzero-dev/vite-plus-core@^0.1.21",
+    "vite": "npm:@voidzero-dev/vite-plus-core@^0.1.22",
     "vite-plus": "latest",
-    "vitest": "npm:@voidzero-dev/vite-plus-test@^0.1.21"
+    "vitest": "npm:@voidzero-dev/vite-plus-test@^0.1.22"
   },
   "peerDependencies": {
     "svelte": "^5.0.0"
   },
   "overrides": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@^0.1.21",
-    "vitest": "npm:@voidzero-dev/vite-plus-test@^0.1.21"
+    "vite": "npm:@voidzero-dev/vite-plus-core@^0.1.22",
+    "vitest": "npm:@voidzero-dev/vite-plus-test@^0.1.22"
   },
   "engines": {
     "node": ">=24"

--- a/package.json
+++ b/package.json
@@ -210,16 +210,12 @@
     "svelte": "5.55.9",
     "svelte-check-rs": "0.9.14",
     "typescript": "6.0.3",
-    "vite": "npm:@voidzero-dev/vite-plus-core@^0.1.22",
+    "vite": "^8.0.14",
     "vite-plus": "latest",
-    "vitest": "npm:@voidzero-dev/vite-plus-test@^0.1.22"
+    "vitest": "4.1.7"
   },
   "peerDependencies": {
     "svelte": "^5.0.0"
-  },
-  "overrides": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@^0.1.22",
-    "vitest": "npm:@voidzero-dev/vite-plus-test@^0.1.22"
   },
   "engines": {
     "node": ">=24"

--- a/src/lib/structure/CanvasTooltip.svelte
+++ b/src/lib/structure/CanvasTooltip.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
+  import { HTML } from '@threlte/extras'
+  import type { Snippet } from 'svelte'
+  import type { HTMLAttributes } from 'svelte/elements'
   import type { Vec3 } from '$lib/math'
-    import { HTML } from '@threlte/extras'
-    import type { Snippet } from 'svelte'
-    import type { HTMLAttributes } from 'svelte/elements'
 
-    let { position, children, ...rest }: HTMLAttributes<HTMLDivElement> & {
-      position: Vec3
-      children: Snippet<[{ position: Vec3 }]>
-    } = $props()
+  let { position, children, ...rest }: HTMLAttributes<HTMLDivElement> & {
+    position: Vec3
+    children: Snippet<[{ position: Vec3 }]>
+  } = $props()
 </script>
 
 <HTML {position} pointerEvents="none">
@@ -22,9 +22,9 @@
     box-sizing: border-box;
     text-align: var(--canvas-tooltip-text-align, left);
     border-radius: var(--canvas-tooltip-border-radius, var(--border-radius, 3pt));
-    background: var(--canvas-tooltip-bg, var(--code-bg));
+    background: var(--canvas-tooltip-bg, light-dark(rgba(226, 232, 240, 0.96), rgba(15, 23, 42, 0.96)));
     padding: var(--canvas-tooltip-padding, 1pt 5pt);
-    color: var(--canvas-tooltip-text-color);
+    color: var(--canvas-tooltip-text-color, light-dark(#0f172a, #f8fafc));
     font-family: var(--canvas-tooltip-font-family);
     font-size: var(--canvas-tooltip-font-size, clamp(8pt, 3cqmin, 18pt));
     line-height: var(--canvas-tooltip-line-height);

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -1146,11 +1146,13 @@
       const plain = !event.ctrlKey && !event.metaKey && !event.altKey
       if (event.ctrlKey || event.metaKey) {
         if (key === `z` && !event.shiftKey) {
+          if (bond_undo_stack.length === 0) return
           event.preventDefault()
           undo_bond_edit()
           show_toast(`Undo bond edit (${bond_undo_stack.length} left)`)
           return
         } else if (key === `y` || (key === `z` && event.shiftKey)) {
+          if (bond_redo_stack.length === 0) return
           event.preventDefault()
           redo_bond_edit()
           show_toast(`Redo bond edit (${bond_redo_stack.length} left)`)
@@ -1642,10 +1644,10 @@
               </button>
               <button
                 type="button"
-                aria-label="Redo (Cmd/Ctrl+Y)"
+                aria-label="Redo (Cmd/Ctrl+Y or Cmd+Shift+Z)"
                 disabled={redo_stack.length === 0}
                 onclick={redo}
-                title="Redo (Cmd/Ctrl+Y)"
+                title="Redo (Cmd/Ctrl+Y or Cmd+Shift+Z)"
                 class="undo-redo-btn"
               >
                 <Icon icon="Redo" />
@@ -1658,6 +1660,16 @@
 
           {#if measure_mode === `edit-bonds`}
             <div class="bond-edit-toolbar" aria-label="Bond editing controls">
+              {#if bond_edit_mode === `add`}
+                <label>
+                  <span>Order</span>
+                  <select bind:value={bond_edit_order}>
+                    {#each BOND_ORDER_OPTIONS as { order, label } (label)}
+                      <option value={order}>{label}</option>
+                    {/each}
+                  </select>
+                </label>
+              {/if}
               <div class="bond-edit-mode-toggle">
                 {#each [
                   { mode: `add`, label: `Add`, title: `Add: click two atoms` },
@@ -1674,14 +1686,6 @@
                   </button>
                 {/each}
               </div>
-              <label class:disabled={bond_edit_mode === `delete`}>
-                <span>Order</span>
-                <select bind:value={bond_edit_order} disabled={bond_edit_mode === `delete`}>
-                  {#each BOND_ORDER_OPTIONS as { order, label } (label)}
-                    <option value={order}>{label}</option>
-                  {/each}
-                </select>
-              </label>
             </div>
             <div class="undo-redo-container">
               <button
@@ -1699,10 +1703,10 @@
               </button>
               <button
                 type="button"
-                aria-label="Redo bond edit (Cmd/Ctrl+Y)"
+                aria-label="Redo bond edit (Cmd/Ctrl+Y or Cmd+Shift+Z)"
                 disabled={bond_redo_stack.length === 0}
                 onclick={redo_bond_edit}
-                title="Redo bond edit (Cmd/Ctrl+Y)"
+                title="Redo bond edit (Cmd/Ctrl+Y or Cmd+Shift+Z)"
                 class="undo-redo-btn"
               >
                 <Icon icon="Redo" />
@@ -2137,6 +2141,7 @@
   }
   .bond-edit-mode-toggle {
     display: flex;
+    gap: 0.35em;
   }
   .bond-edit-mode-toggle button {
     min-width: 3.5em;
@@ -2145,13 +2150,13 @@
     background: var(--accent-color, #007acc);
     color: white;
   }
+  .bond-edit-mode-toggle button.selected:hover {
+    background-color: color-mix(in srgb, var(--accent-color, #007acc) 70%, black);
+  }
   .bond-edit-toolbar label {
     display: flex;
     align-items: center;
     gap: 0.25em;
-  }
-  .bond-edit-toolbar label.disabled {
-    opacity: 0.55;
   }
   .bond-edit-toolbar select {
     font: inherit;

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -558,7 +558,9 @@
     const raw_signature = bond_signature(current_source_bonds())
     if (raw_signature !== last_emitted_bond_signature) return raw_signature
     return bond_history_context?.source_bond_signature ??
-      bond_signature(bond_edit_snapshot?.bonds)
+      (bond_edit_snapshot
+        ? bond_signature(bond_edit_snapshot.bonds)
+        : raw_signature)
   }
 
   const current_bond_edit_context = (): BondEditContext => ({

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -651,6 +651,10 @@
   let add_atom_mode = $state(false)
   let add_element = $state<ElementSymbol>(`C` as ElementSymbol)
   let canvas_cursor = $state(`default`)
+  let show_measure_selection_limit = $derived(
+    (measure_mode === `distance` || measure_mode === `angle`) &&
+      (measured_sites?.length ?? 0) >= MAX_SELECTED_SITES,
+  )
   let change_element_mode = $state(false)
   let change_element_value = $state(``)
   // Ephemeral toast message for edit operations
@@ -1554,7 +1558,7 @@
               aria-expanded={measure_menu_open}
               style="transform: scale(1.2)"
             >
-              {#if (measured_sites?.length ?? 0) >= MAX_SELECTED_SITES}
+              {#if show_measure_selection_limit}
                 <span class="selection-limit-text">
                   {measured_sites.length}/{MAX_SELECTED_SITES}
                 </span>

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -20,7 +20,6 @@
   import type { Vec3 } from '$lib/math'
   import { create_cart_to_frac, create_frac_to_cart } from '$lib/math'
   import { DEFAULTS } from '$lib/settings'
-  import { sanitize_html } from '$lib/sanitize'
   import { colors } from '$lib/state.svelte'
   import type {
     AnyStructure,
@@ -69,7 +68,7 @@
   // Type alias for event handlers to reduce verbosity
   type EventHandler = (data: StructureHandlerData) => void
   type BondEditContext = {
-    structure_signature: string
+    structure_identity: AnyStructure | undefined
     source_bond_signature: string
     cell_type: CellType
     supercell_scaling: string
@@ -472,7 +471,7 @@
   let bond_undo_stack = $state<BondEditHistorySnapshot[]>([])
   let bond_redo_stack = $state<BondEditHistorySnapshot[]>([])
   let bond_history_context = $state<BondEditContext>()
-  let last_bond_structure_signature = $state(get_structure_signature(structure))
+  let last_bond_structure_identity = $state(structure)
   let last_emitted_bond_signature = $state<string>()
   let bond_edit_snapshot = $state<BondEditSnapshot>()
   let has_bond_edits = $derived(
@@ -552,10 +551,6 @@
   const bond_signature = (edit_bonds: StructureBond[] | undefined): string =>
     edit_bonds === undefined ? `undefined` : JSON.stringify(edit_bonds)
 
-  function get_structure_signature(next_structure: AnyStructure | undefined): string {
-    return next_structure === undefined ? `undefined` : JSON.stringify(next_structure)
-  }
-
   const current_source_bonds = (): StructureBond[] | undefined =>
     bonds ?? structure?.properties?.bonds
 
@@ -567,7 +562,7 @@
   }
 
   const current_bond_edit_context = (): BondEditContext => ({
-    structure_signature: get_structure_signature(structure),
+    structure_identity: structure,
     source_bond_signature: current_source_bond_signature(),
     cell_type,
     supercell_scaling,
@@ -578,7 +573,7 @@
     previous: BondEditContext,
     current: BondEditContext,
   ): boolean =>
-    previous.structure_signature !== current.structure_signature ||
+    previous.structure_identity !== current.structure_identity ||
     previous.source_bond_signature !== current.source_bond_signature ||
     previous.cell_type !== current.cell_type ||
     previous.supercell_scaling !== current.supercell_scaling ||
@@ -587,20 +582,20 @@
   const resolve_bond_edit_reset_bonds = (
     snapshot: BondEditSnapshot,
   ): StructureBond[] | undefined =>
-    snapshot.context.structure_signature === get_structure_signature(structure)
+    snapshot.context.structure_identity === structure
       ? snapshot.bonds
       : structure?.properties?.bonds
 
   $effect(() => {
-    const next_structure_signature = get_structure_signature(structure)
+    const next_structure_identity = structure
     untrack(() => {
       if (
-        last_bond_structure_signature !== next_structure_signature &&
+        last_bond_structure_identity !== next_structure_identity &&
         bond_signature(bonds) === last_emitted_bond_signature
       ) {
         emit_bonds(structure?.properties?.bonds)
       }
-      last_bond_structure_signature = next_structure_signature
+      last_bond_structure_identity = next_structure_identity
     })
   })
 
@@ -1622,7 +1617,7 @@
                     }}
                   >
                     <Icon {icon} style="transform: scale({scale})" />
-                    <span>{@html sanitize_html(label)}</span>
+                    <span>{label}</span>
                   </button>
                 {/each}
               </div>
@@ -1634,10 +1629,10 @@
             <div class="undo-redo-container">
               <button
                 type="button"
-                aria-label="Undo (Ctrl+Z)"
+                aria-label="Undo (Cmd/Ctrl+Z)"
                 disabled={undo_stack.length === 0}
                 onclick={undo}
-                title="Undo (Ctrl+Z)"
+                title="Undo (Cmd/Ctrl+Z)"
                 class="undo-redo-btn"
               >
                 <Icon icon="Undo" />
@@ -1647,10 +1642,10 @@
               </button>
               <button
                 type="button"
-                aria-label="Redo (Ctrl+Y)"
+                aria-label="Redo (Cmd/Ctrl+Y)"
                 disabled={redo_stack.length === 0}
                 onclick={redo}
-                title="Redo (Ctrl+Y)"
+                title="Redo (Cmd/Ctrl+Y)"
                 class="undo-redo-btn"
               >
                 <Icon icon="Redo" />
@@ -1691,10 +1686,10 @@
             <div class="undo-redo-container">
               <button
                 type="button"
-                aria-label="Undo bond edit (Ctrl+Z)"
+                aria-label="Undo bond edit (Cmd/Ctrl+Z)"
                 disabled={bond_undo_stack.length === 0}
                 onclick={undo_bond_edit}
-                title="Undo bond edit (Ctrl+Z)"
+                title="Undo bond edit (Cmd/Ctrl+Z)"
                 class="undo-redo-btn"
               >
                 <Icon icon="Undo" />
@@ -1704,10 +1699,10 @@
               </button>
               <button
                 type="button"
-                aria-label="Redo bond edit (Ctrl+Y)"
+                aria-label="Redo bond edit (Cmd/Ctrl+Y)"
                 disabled={bond_redo_stack.length === 0}
                 onclick={redo_bond_edit}
-                title="Redo bond edit (Ctrl+Y)"
+                title="Redo bond edit (Cmd/Ctrl+Y)"
                 class="undo-redo-btn"
               >
                 <Icon icon="Redo" />

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -651,9 +651,19 @@
   let add_atom_mode = $state(false)
   let add_element = $state<ElementSymbol>(`C` as ElementSymbol)
   let canvas_cursor = $state(`default`)
+  let is_measure_selection_mode = $derived(
+    measure_mode === `distance` || measure_mode === `angle`,
+  )
   let show_measure_selection_limit = $derived(
-    (measure_mode === `distance` || measure_mode === `angle`) &&
-      (measured_sites?.length ?? 0) >= MAX_SELECTED_SITES,
+    is_measure_selection_mode && measured_sites.length >= MAX_SELECTED_SITES,
+  )
+  let show_selection_reset = $derived(
+    has_bond_edits ||
+      (is_measure_selection_mode && measured_sites.length > 0) ||
+      (measure_mode === `edit-atoms` && selected_sites.length > 0),
+  )
+  let atom_legend_selected_sites = $derived(
+    measure_mode === `edit-atoms` ? selected_sites : [],
   )
   let change_element_mode = $state(false)
   let change_element_value = $state(``)
@@ -1577,7 +1587,7 @@
                 style="margin-left: -2px"
               />
             </button>
-            {#if (measured_sites?.length ?? 0) > 0 || has_bond_edits}
+            {#if show_selection_reset}
               <button
                 type="button"
                 aria-label="Reset selection and bond edits"
@@ -1827,7 +1837,7 @@
       bind:element_mapping
       bind:element_radius_overrides
       bind:site_radius_overrides
-      {selected_sites}
+      selected_sites={atom_legend_selected_sites}
       structure={displayed_structure}
       {sym_data}
     >

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -2151,9 +2151,12 @@
     gap: 0.4em;
     font-size: 0.8em;
   }
-  .bond-edit-mode-toggle {
+  .bond-edit-mode-toggle,
+  .bond-edit-toolbar label {
     display: flex;
     align-items: center;
+  }
+  .bond-edit-mode-toggle {
     gap: 0.35em;
   }
   .bond-edit-mode-toggle button,
@@ -2174,8 +2177,6 @@
     background-color: color-mix(in srgb, var(--accent-color, #007acc) 70%, black);
   }
   .bond-edit-toolbar label {
-    display: flex;
-    align-items: center;
     gap: 0.25em;
   }
   .bond-edit-toolbar select {

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -2136,7 +2136,7 @@
     gap: 0.4em;
     background: color-mix(in srgb, var(--page-bg, Canvas) 85%, currentColor);
     border-radius: var(--border-radius, 3pt);
-    padding: 0.15em 0.25em;
+    padding: 0.15em 0.35em 0.15em 0.5em;
     font-size: 0.8em;
   }
   .bond-edit-mode-toggle {

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -1676,7 +1676,7 @@
             <div class="bond-edit-toolbar" aria-label="Bond editing controls">
               {#if bond_edit_mode === `add`}
                 <label>
-                  <span>Order</span>
+                  <span>Bond order</span>
                   <select bind:value={bond_edit_order}>
                     {#each BOND_ORDER_OPTIONS as { order, label } (label)}
                       <option value={order}>{label}</option>
@@ -2145,20 +2145,26 @@
     justify-content: center;
   }
   .bond-edit-toolbar {
+    --bond-edit-control-height: 1.8em;
     display: flex;
     align-items: center;
     gap: 0.4em;
-    background: color-mix(in srgb, var(--page-bg, Canvas) 85%, currentColor);
-    border-radius: var(--border-radius, 3pt);
-    padding: 0.15em 0.35em 0.15em 0.5em;
     font-size: 0.8em;
   }
   .bond-edit-mode-toggle {
     display: flex;
+    align-items: center;
     gap: 0.35em;
+  }
+  .bond-edit-mode-toggle button,
+  .bond-edit-toolbar label,
+  .bond-edit-toolbar select {
+    height: var(--bond-edit-control-height);
+    line-height: 1;
   }
   .bond-edit-mode-toggle button {
     min-width: 3.5em;
+    font: inherit;
   }
   .bond-edit-mode-toggle button.selected {
     background: var(--accent-color, #007acc);
@@ -2173,8 +2179,8 @@
     gap: 0.25em;
   }
   .bond-edit-toolbar select {
-    font: inherit;
     max-width: 8em;
+    font: inherit;
   }
   .history-count {
     position: absolute;

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -24,6 +24,8 @@
   import { colors } from '$lib/state.svelte'
   import type {
     AnyStructure,
+    BondEditMode,
+    BondOrder,
     Crystal,
     MeasureMode,
     StructureBond,
@@ -55,7 +57,7 @@
   import { get_property_colors } from './atom-properties'
   import AtomLegend from './AtomLegend.svelte'
   import CellSelect from './CellSelect.svelte'
-  import { merge_bond_edits } from './bonding'
+  import { BOND_ORDER_OPTIONS, merge_bond_edits } from './bonding'
   import type { StructureHandlerData } from './index'
   import { MAX_SELECTED_SITES } from './measure'
   import { normalize_fractional_coords, parse_any_structure } from './parse'
@@ -67,7 +69,8 @@
   // Type alias for event handlers to reduce verbosity
   type EventHandler = (data: StructureHandlerData) => void
   type BondEditContext = {
-    structure?: AnyStructure
+    structure_signature: string
+    source_bond_signature: string
     cell_type: CellType
     supercell_scaling: string
     show_image_atoms: boolean
@@ -75,6 +78,13 @@
   type BondEditSnapshot = {
     bonds: StructureBond[] | undefined
     context: BondEditContext
+  }
+  type BondEditHistorySnapshot = {
+    added_bonds: StructureBond[]
+    removed_bonds: StructureBond[]
+    bond_order_overrides: StructureBond[]
+    bond_edit_mode: BondEditMode
+    bond_edit_order: BondOrder
   }
 
   // Local reactive state for scene and lattice props. Deeply reactive so nested mutations propagate.
@@ -103,6 +113,8 @@
     info_pane_open = $bindable(false),
     enable_measure_mode = $bindable(true),
     measure_mode = $bindable<MeasureMode>(`distance`),
+    bond_edit_mode = $bindable<BondEditMode>(`add`),
+    bond_edit_order = $bindable<BondOrder>(1),
     background_color = $bindable(),
     background_opacity = $bindable(0.1),
     show_controls,
@@ -206,6 +218,8 @@
       enable_info_pane?: boolean
       enable_measure_mode?: boolean
       measure_mode?: MeasureMode
+      bond_edit_mode?: BondEditMode
+      bond_edit_order?: BondOrder
       info_pane_open?: boolean
       fullscreen_toggle?: Snippet<[{ fullscreen: boolean }]> | boolean
       bottom_left?: Snippet<[{ structure?: AnyStructure }]>
@@ -455,6 +469,10 @@
   let added_bonds = $state<StructureBond[]>([])
   let removed_bonds = $state<StructureBond[]>([])
   let bond_order_overrides = $state<StructureBond[]>([])
+  let bond_undo_stack = $state<BondEditHistorySnapshot[]>([])
+  let bond_redo_stack = $state<BondEditHistorySnapshot[]>([])
+  let bond_history_context = $state<BondEditContext>()
+  let last_bond_structure_signature = $state(get_structure_signature(structure))
   let last_emitted_bond_signature = $state<string>()
   let bond_edit_snapshot = $state<BondEditSnapshot>()
   let has_bond_edits = $derived(
@@ -462,25 +480,95 @@
       bond_order_overrides.length > 0,
   )
 
+  const clone_bonds = (edit_bonds: StructureBond[]): StructureBond[] =>
+    edit_bonds.map((bond) => ({
+      ...bond,
+      cell_shift: bond.cell_shift && ([...bond.cell_shift] as Vec3),
+    }))
+
+  const snapshot_bond_edits = (): BondEditHistorySnapshot => ({
+    added_bonds: clone_bonds(added_bonds),
+    removed_bonds: clone_bonds(removed_bonds),
+    bond_order_overrides: clone_bonds(bond_order_overrides),
+    bond_edit_mode,
+    bond_edit_order,
+  })
+
+  function restore_bond_edit_snapshot(snapshot: BondEditHistorySnapshot) {
+    added_bonds = clone_bonds(snapshot.added_bonds)
+    removed_bonds = clone_bonds(snapshot.removed_bonds)
+    bond_order_overrides = clone_bonds(snapshot.bond_order_overrides)
+    bond_edit_mode = snapshot.bond_edit_mode
+    bond_edit_order = snapshot.bond_edit_order
+    clear_selection()
+  }
+
+  function clear_bond_history() {
+    bond_undo_stack = []
+    bond_redo_stack = []
+    bond_history_context = undefined
+  }
+
+  function push_bond_undo() {
+    if (bond_undo_stack.length >= MAX_HISTORY) {
+      bond_undo_stack.splice(0, bond_undo_stack.length - MAX_HISTORY + 1)
+    }
+    bond_history_context ??= current_bond_edit_context()
+    bond_undo_stack.push(snapshot_bond_edits())
+    bond_redo_stack = []
+  }
+
+  function undo_bond_edit() {
+    if (bond_undo_stack.length === 0) return
+    const restored = bond_undo_stack.pop()
+    if (!restored) return
+    bond_redo_stack.push(snapshot_bond_edits())
+    restore_bond_edit_snapshot(restored)
+  }
+
+  function redo_bond_edit() {
+    if (bond_redo_stack.length === 0) return
+    const restored = bond_redo_stack.pop()
+    if (!restored) return
+    bond_undo_stack.push(snapshot_bond_edits())
+    restore_bond_edit_snapshot(restored)
+  }
+
   function clear_bond_edits() {
     added_bonds = []
     removed_bonds = []
     bond_order_overrides = []
+    clear_bond_history()
   }
 
   function emit_bonds(next_bonds: StructureBond[] | undefined) {
-    const signature = next_bonds === undefined ? `undefined` : JSON.stringify(next_bonds)
+    const signature = bond_signature(next_bonds)
     if (signature === last_emitted_bond_signature) return
     last_emitted_bond_signature = signature
     bonds = next_bonds
     on_bonds_change?.(next_bonds)
   }
 
+  const bond_signature = (edit_bonds: StructureBond[] | undefined): string =>
+    edit_bonds === undefined ? `undefined` : JSON.stringify(edit_bonds)
+
+  function get_structure_signature(next_structure: AnyStructure | undefined): string {
+    return next_structure === undefined ? `undefined` : JSON.stringify(next_structure)
+  }
+
   const current_source_bonds = (): StructureBond[] | undefined =>
     bonds ?? structure?.properties?.bonds
 
+  const current_source_bond_signature = (): string => {
+    const raw_signature = bond_signature(current_source_bonds())
+    if (raw_signature !== last_emitted_bond_signature) return raw_signature
+    return bond_history_context?.source_bond_signature ??
+      bond_signature(bond_edit_snapshot?.bonds)
+  }
+
   const current_bond_edit_context = (): BondEditContext => ({
-    structure,
+    structure_signature: get_structure_signature(structure),
+    source_bond_signature: current_source_bond_signature(),
     cell_type,
     supercell_scaling,
     show_image_atoms,
@@ -490,7 +578,8 @@
     previous: BondEditContext,
     current: BondEditContext,
   ): boolean =>
-    previous.structure !== current.structure ||
+    previous.structure_signature !== current.structure_signature ||
+    previous.source_bond_signature !== current.source_bond_signature ||
     previous.cell_type !== current.cell_type ||
     previous.supercell_scaling !== current.supercell_scaling ||
     previous.show_image_atoms !== current.show_image_atoms
@@ -498,7 +587,30 @@
   const resolve_bond_edit_reset_bonds = (
     snapshot: BondEditSnapshot,
   ): StructureBond[] | undefined =>
-    snapshot.context.structure === structure ? snapshot.bonds : structure?.properties?.bonds
+    snapshot.context.structure_signature === get_structure_signature(structure)
+      ? snapshot.bonds
+      : structure?.properties?.bonds
+
+  $effect(() => {
+    const next_structure_signature = get_structure_signature(structure)
+    untrack(() => {
+      if (
+        last_bond_structure_signature !== next_structure_signature &&
+        bond_signature(bonds) === last_emitted_bond_signature
+      ) {
+        emit_bonds(structure?.properties?.bonds)
+      }
+      last_bond_structure_signature = next_structure_signature
+    })
+  })
+
+  $effect(() => {
+    const history_context = bond_history_context
+    if (history_context === undefined) return
+    if (bond_edit_context_changed(history_context, current_bond_edit_context())) {
+      untrack(clear_bond_history)
+    }
+  })
 
   $effect(() => {
     const snapshot = bond_edit_snapshot
@@ -624,6 +736,16 @@
     }
     untrack(() => {
       if (selected_sites.length > 0 || measured_sites.length > 0) clear_selection()
+      if (measure_mode === `edit-bonds`) bond_edit_mode = `add`
+    })
+  })
+
+  $effect(() => {
+    void bond_edit_mode
+    untrack(() => {
+      if (measure_mode === `edit-bonds` && (selected_sites.length > 0 || measured_sites.length > 0)) {
+        clear_selection()
+      }
     })
   })
 
@@ -633,6 +755,7 @@
     untrack(() => {
       // Clear bond edits from edit-bonds mode to avoid stale state
       if (has_bond_edits) clear_bond_edits()
+      else clear_bond_history()
       if (cell_type !== `original` && cell_transformed_structure && structure) {
         // Bake the transformed cell: push original to undo, replace structure
         is_internal_edit = true
@@ -1008,8 +1131,11 @@
   function handle_keydown(event: KeyboardEvent) {
     // Don't handle shortcuts if user is typing in an input field
     const target = event.target as HTMLElement
-    const is_input_focused = target.tagName === `INPUT` ||
-      target.tagName === `TEXTAREA`
+    const is_input_focused =
+      target.tagName === `INPUT` ||
+      target.tagName === `TEXTAREA` ||
+      target.tagName === `SELECT` ||
+      target.isContentEditable
 
     // Allow Escape to cancel add-atom mode even when the element input is focused
     if (event.key === `Escape` && measure_mode === `edit-atoms` && add_atom_mode) {
@@ -1019,6 +1145,39 @@
     }
 
     if (is_input_focused) return
+
+    if (measure_mode === `edit-bonds`) {
+      const key = event.key.toLowerCase()
+      const plain = !event.ctrlKey && !event.metaKey && !event.altKey
+      if (event.ctrlKey || event.metaKey) {
+        if (key === `z` && !event.shiftKey) {
+          event.preventDefault()
+          undo_bond_edit()
+          show_toast(`Undo bond edit (${bond_undo_stack.length} left)`)
+          return
+        } else if (key === `y` || (key === `z` && event.shiftKey)) {
+          event.preventDefault()
+          redo_bond_edit()
+          show_toast(`Redo bond edit (${bond_redo_stack.length} left)`)
+          return
+        }
+      }
+      if (key === `a` && plain) {
+        event.preventDefault()
+        bond_edit_mode = `add`
+        return
+      }
+      if (key === `d` && plain) {
+        event.preventDefault()
+        bond_edit_mode = `delete`
+        return
+      }
+      if (event.key === `Escape` && selected_sites.length > 0) {
+        event.preventDefault()
+        clear_selection()
+        return
+      }
+    }
 
     // Edit-atoms mode shortcuts (including undo/redo)
     if (measure_mode === `edit-atoms`) {
@@ -1502,6 +1661,63 @@
             </div>
           {/if}
 
+          {#if measure_mode === `edit-bonds`}
+            <div class="bond-edit-toolbar" aria-label="Bond editing controls">
+              <div class="bond-edit-mode-toggle">
+                {#each [
+                  { mode: `add`, label: `Add`, title: `Add: click two atoms` },
+                  { mode: `delete`, label: `Delete`, title: `Delete: click a bond` },
+                ] as const as { mode, label, title } (mode)}
+                  <button
+                    type="button"
+                    class:selected={bond_edit_mode === mode}
+                    aria-pressed={bond_edit_mode === mode}
+                    title="{title} ({label[0]})"
+                    onclick={() => (bond_edit_mode = mode)}
+                  >
+                    {label}
+                  </button>
+                {/each}
+              </div>
+              <label class:disabled={bond_edit_mode === `delete`}>
+                <span>Order</span>
+                <select bind:value={bond_edit_order} disabled={bond_edit_mode === `delete`}>
+                  {#each BOND_ORDER_OPTIONS as { order, label } (label)}
+                    <option value={order}>{label}</option>
+                  {/each}
+                </select>
+              </label>
+            </div>
+            <div class="undo-redo-container">
+              <button
+                type="button"
+                aria-label="Undo bond edit (Ctrl+Z)"
+                disabled={bond_undo_stack.length === 0}
+                onclick={undo_bond_edit}
+                title="Undo bond edit (Ctrl+Z)"
+                class="undo-redo-btn"
+              >
+                <Icon icon="Undo" />
+                {#if bond_undo_stack.length > 0}
+                  <span class="history-count">{bond_undo_stack.length}</span>
+                {/if}
+              </button>
+              <button
+                type="button"
+                aria-label="Redo bond edit (Ctrl+Y)"
+                disabled={bond_redo_stack.length === 0}
+                onclick={redo_bond_edit}
+                title="Redo bond edit (Ctrl+Y)"
+                class="undo-redo-btn"
+              >
+                <Icon icon="Redo" />
+                {#if bond_redo_stack.length > 0}
+                  <span class="history-count">{bond_redo_stack.length}</span>
+                {/if}
+              </button>
+            </div>
+          {/if}
+
           <!-- Add-atom element input (shown when add_atom_mode is active) -->
           {#if measure_mode === `edit-atoms` && add_atom_mode}
             <div class="add-atom-input">
@@ -1653,6 +1869,8 @@
             bind:removed_bonds
             bind:bond_order_overrides
             {bond_edits_enabled}
+            bind:bond_edit_mode
+            {bond_edit_order}
             {measure_mode}
             {width}
             {height}
@@ -1660,6 +1878,7 @@
             {sym_data}
             on_sites_moved={handle_sites_moved}
             on_operation_start={push_undo}
+            on_bond_edit_start={push_bond_undo}
             on_add_atom={handle_add_atom}
             bind:add_atom_mode
             bind:add_element
@@ -1676,20 +1895,6 @@
 
     {#if toast_msg}
       <div class="edit-toast">{toast_msg}</div>
-    {/if}
-
-    {#if measure_mode === `edit-bonds` && has_bond_edits}
-      <div class="bond-edit-status">
-        {#if added_bonds.length > 0}
-          <span class="added">+{added_bonds.length} added</span>
-        {/if}
-        {#if removed_bonds.length > 0}
-          <span class="removed">-{removed_bonds.length} removed</span>
-        {/if}
-        {#if bond_order_overrides.length > 0}
-          <span class="changed">{bond_order_overrides.length} ordered</span>
-        {/if}
-      </div>
     {/if}
 
     {#if symmetry_error}
@@ -1906,34 +2111,6 @@
       opacity: 0;
     }
   }
-  .bond-edit-status {
-    position: absolute;
-    bottom: 1rem;
-    left: 50%;
-    transform: translateX(-50%);
-    background: color-mix(in srgb, var(--page-bg, Canvas) 85%, currentColor);
-    color: var(--text-color, currentColor);
-    padding: 0.5rem 1rem;
-    border-radius: var(--border-radius, 3pt);
-    font-size: 0.85rem;
-    display: flex;
-    gap: 0.75rem;
-    z-index: 100;
-    pointer-events: none;
-    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.15);
-  }
-  .bond-edit-status .added {
-    color: #4caf50;
-    font-weight: bold;
-  }
-  .bond-edit-status .removed {
-    color: #f44336;
-    font-weight: bold;
-  }
-  .bond-edit-status .changed {
-    color: var(--accent-color, #007acc);
-    font-weight: bold;
-  }
   /* CellSelect: position at left of legend, show on hover */
   .structure :global(.cell-select) {
     order: -1; /* Move to left side of AtomLegend flex container */
@@ -1953,6 +2130,37 @@
     display: flex;
     align-items: center;
     justify-content: center;
+  }
+  .bond-edit-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 0.4em;
+    background: color-mix(in srgb, var(--page-bg, Canvas) 85%, currentColor);
+    border-radius: var(--border-radius, 3pt);
+    padding: 0.15em 0.25em;
+    font-size: 0.8em;
+  }
+  .bond-edit-mode-toggle {
+    display: flex;
+  }
+  .bond-edit-mode-toggle button {
+    min-width: 3.5em;
+  }
+  .bond-edit-mode-toggle button.selected {
+    background: var(--accent-color, #007acc);
+    color: white;
+  }
+  .bond-edit-toolbar label {
+    display: flex;
+    align-items: center;
+    gap: 0.25em;
+  }
+  .bond-edit-toolbar label.disabled {
+    opacity: 0.55;
+  }
+  .bond-edit-toolbar select {
+    font: inherit;
+    max-width: 8em;
   }
   .history-count {
     position: absolute;

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -445,6 +445,20 @@
   const matches_bond_key = (bond: BondKeyTarget, key: string): boolean =>
     bond_key_for(bond) === key
 
+  const find_added_bond_by_rendered_key = (key: string): StructureBond | undefined =>
+    added_bonds.find((bond) => rendered_bond_key_for(bond) === key)
+
+  function resolve_bond_edit_target(
+    site_idx_1: number,
+    site_idx_2: number,
+    cell_shift?: Vec3,
+  ): BondKeyTarget {
+    const rendered_target = { site_idx_1, site_idx_2, cell_shift }
+    const rendered_key = rendered_bond_key_for(rendered_target)
+    return find_added_bond_by_rendered_key(rendered_key) ??
+      canonical_bond_target(rendered_target)
+  }
+
   function is_image_bond_site(site_idx: number): boolean {
     return structure?.sites?.[site_idx]?.properties?.orig_site_idx != null
   }
@@ -468,7 +482,8 @@
     cell_shift?: Vec3,
   ): BondOrder | undefined {
     const key = get_bond_key(site_idx_1, site_idx_2, cell_shift)
-    return bond_order_overrides.find((bond) => matches_bond_key(bond, key))?.order ??
+    return find_added_bond_by_rendered_key(key)?.order ??
+      bond_order_overrides.find((bond) => matches_bond_key(bond, key))?.order ??
       added_bonds.find((bond) => matches_bond_key(bond, key))?.order ??
       filtered_bond_pairs.find((bond) => matches_bond_key(bond, key))?.bond_order
   }
@@ -498,18 +513,31 @@
     mesh.raycast = skip_raycast
   }
 
-  function get_bond_endpoint_site_idx(site_idx: number, position: Vec3): number {
+  function site_world_position(parent: Object3D, site: Site): Vector3 {
+    const position = new Vector3(...site.xyz)
+    return parent.localToWorld(position)
+  }
+
+  function get_bond_endpoint_site_idx(
+    site_idx: number,
+    world_position: Vector3,
+    parent: Object3D,
+  ): number {
     if (!structure?.sites) return site_idx
     const site = structure.sites[site_idx]
     if (!site) return site_idx
-    if (math.euclidean_dist(site.xyz, position) <= BOND_ENDPOINT_SITE_MATCH_TOLERANCE) {
+
+    const matches_world_position = (candidate_site: Site): boolean =>
+      site_world_position(parent, candidate_site).distanceTo(world_position) <=
+      BOND_ENDPOINT_SITE_MATCH_TOLERANCE
+
+    if (matches_world_position(site)) {
       return site_idx
     }
 
     const image_site_idx = structure.sites.findIndex((candidate_site) =>
       candidate_site.properties?.orig_site_idx === site_idx &&
-      math.euclidean_dist(candidate_site.xyz, position) <=
-        BOND_ENDPOINT_SITE_MATCH_TOLERANCE
+      matches_world_position(candidate_site)
     )
     return image_site_idx === -1 ? site_idx : image_site_idx
   }
@@ -522,22 +550,22 @@
     const parent = event.object?.parent
     if (!parent) return null
 
-    const pos_1 = new Vector3(...bond.pos_1)
-    const pos_2 = new Vector3(...bond.pos_2)
-    parent.localToWorld(pos_1)
-    parent.localToWorld(pos_2)
+    const world_pos_1 = new Vector3(...bond.pos_1)
+    const world_pos_2 = new Vector3(...bond.pos_2)
+    parent.localToWorld(world_pos_1)
+    parent.localToWorld(world_pos_2)
 
-    const bond_vec = pos_2.sub(pos_1)
+    const bond_vec = world_pos_2.clone().sub(world_pos_1)
     const length_sq = bond_vec.lengthSq()
     if (length_sq <= math.EPS) return null
 
-    const hit_vec = event.point.clone().sub(pos_1)
+    const hit_vec = event.point.clone().sub(world_pos_1)
     const t = hit_vec.dot(bond_vec) / length_sq
     if (t <= BOND_ENDPOINT_HIT_FRACTION) {
-      return get_bond_endpoint_site_idx(bond.site_idx_1, bond.pos_1)
+      return get_bond_endpoint_site_idx(bond.site_idx_1, world_pos_1, parent)
     }
     if (t >= 1 - BOND_ENDPOINT_HIT_FRACTION) {
-      return get_bond_endpoint_site_idx(bond.site_idx_2, bond.pos_2)
+      return get_bond_endpoint_site_idx(bond.site_idx_2, world_pos_2, parent)
     }
     return null
   }
@@ -558,11 +586,10 @@
 
   function open_bond_context_menu(bond: BondPair, event?: BondContextMenuEvent) {
     if (!can_edit_bond(bond)) return
-    const target = canonical_bond_target(bond)
     bond_context_target = {
-      site_idx_1: target.site_idx_1,
-      site_idx_2: target.site_idx_2,
-      cell_shift: target.cell_shift,
+      site_idx_1: bond.site_idx_1,
+      site_idx_2: bond.site_idx_2,
+      cell_shift: bond.cell_shift,
       position: get_bond_context_menu_position(bond, event),
     }
     bond_context_menu = bond_context_target
@@ -584,34 +611,48 @@
   }
 
   const find_visible_bond = (
-    site_idx_1: number,
-    site_idx_2: number,
-    cell_shift?: Vec3,
+    target: BondKeyTarget,
+    canonical_target: BondKeyTarget = target,
   ): BondPair | undefined => {
-    const key = get_bond_key(site_idx_1, site_idx_2, cell_shift)
-    return filtered_bond_pairs.find((bond) => matches_bond_key(bond, key))
+    const rendered_key = rendered_bond_key_for(target)
+    const canonical_key = bond_key_for(canonical_target)
+    return filtered_bond_pairs.find((bond) => rendered_bond_key_for(bond) === rendered_key) ??
+      filtered_bond_pairs.find((bond) => bond_key_for(bond) === canonical_key)
   }
 
-  function open_bond_order_menu_for_pair(
-    site_idx_1: number,
-    site_idx_2: number,
-    cell_shift?: Vec3,
+  function open_bond_order_menu_for_target(
+    target: BondKeyTarget,
+    canonical_target: BondKeyTarget = target,
   ) {
-    const bond = find_visible_bond(site_idx_1, site_idx_2, cell_shift)
+    const bond = find_visible_bond(target, canonical_target)
     if (bond) open_bond_context_menu(bond)
   }
 
   function add_or_restore_pair(site_idx_1: number, site_idx_2: number) {
-    const target: BondKeyTarget = { site_idx_1, site_idx_2 }
-    if (!can_edit_bond(target)) return
-    const result = add_or_restore_bond(
-      current_bond_edit_state(),
-      target,
+    const rendered_target = { site_idx_1, site_idx_2 }
+    if (!can_edit_bond(rendered_target)) return
+    const edit_state = current_bond_edit_state()
+    const canonical_target = canonical_bond_target(rendered_target)
+    const canonical_result = add_or_restore_bond(
+      edit_state,
+      canonical_target,
       editable_perceived_bond_pairs,
       bond_edit_order,
     )
+    const use_rendered_target =
+      canonical_result.action === `added` &&
+      rendered_bond_key_for(canonical_target) !== rendered_bond_key_for(rendered_target)
+    const target = use_rendered_target ? rendered_target : canonical_target
+    const result = use_rendered_target
+      ? add_or_restore_bond(
+          edit_state,
+          rendered_target,
+          editable_perceived_bond_pairs,
+          bond_edit_order,
+        )
+      : canonical_result
     if (result.action === `already-visible`) {
-      open_bond_order_menu_for_pair(target.site_idx_1, target.site_idx_2, target.cell_shift)
+      open_bond_order_menu_for_target(rendered_target, target)
       return
     }
     apply_bond_edit_result(result, false)
@@ -623,7 +664,7 @@
     order: BondOrder,
     cell_shift?: Vec3,
   ) {
-    const target = canonical_bond_target({ site_idx_1, site_idx_2, cell_shift })
+    const target = resolve_bond_edit_target(site_idx_1, site_idx_2, cell_shift)
     if (!can_edit_bond(target)) return
     apply_bond_edit_result(
       apply_set_bond_order(
@@ -642,7 +683,7 @@
   }
 
   function remove_bond(site_idx_1: number, site_idx_2: number, cell_shift?: Vec3) {
-    const target = canonical_bond_target({ site_idx_1, site_idx_2, cell_shift })
+    const target = resolve_bond_edit_target(site_idx_1, site_idx_2, cell_shift)
     if (!can_edit_bond(target)) return
     apply_bond_edit_result(
       apply_delete_bond(

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -482,6 +482,7 @@
   const BOND_ENDPOINT_HIT_FRACTION = 0.3
   const BOND_ENDPOINT_SITE_MATCH_TOLERANCE = 1e-6
   const EDITABLE_ATOM_HIT_RADIUS_SCALE = 1.15
+  const skip_raycast = (): void => undefined
 
   function apply_bond_transform(mesh: Mesh, bond: BondPair): void {
     mesh.matrix.fromArray(bond.transform_matrix)
@@ -490,7 +491,11 @@
 
   function apply_non_raycastable_bond_hit_transform(mesh: Mesh, bond: BondPair): void {
     apply_bond_transform(mesh, bond)
-    mesh.raycast = () => undefined
+    disable_raycast(mesh)
+  }
+
+  function disable_raycast(mesh: Mesh): void {
+    mesh.raycast = skip_raycast
   }
 
   function get_bond_endpoint_site_idx(site_idx: number, position: Vec3): number {
@@ -596,10 +601,8 @@
     if (bond) open_bond_context_menu(bond)
   }
 
-  function add_or_restore_pair(site_idx_1: number, site_idx_2: number, cell_shift?: Vec3) {
-    if (is_image_bond_site(site_idx_1) && is_image_bond_site(site_idx_2)) return
-
-    const target = canonical_bond_target({ site_idx_1, site_idx_2, cell_shift })
+  function add_or_restore_pair(site_idx_1: number, site_idx_2: number) {
+    const target: BondKeyTarget = { site_idx_1, site_idx_2 }
     if (!can_edit_bond(target)) return
     const result = add_or_restore_bond(
       current_bond_edit_state(),
@@ -676,6 +679,11 @@
       last_edit_bonds_pointerdown_site_idx = null
       clear_edit_bonds_pointerdown_site_timeout = null
     }, 250)
+  }
+
+  function select_edit_bonds_site(site_idx: number, event: Event): void {
+    toggle_selection(site_idx, event)
+    remember_edit_bonds_pointerdown_site(site_idx)
   }
 
   function skip_duplicate_edit_bonds_click(site_idx: number) {
@@ -1508,8 +1516,7 @@
                   ) {
                     return
                   }
-                  toggle_selection(atom.site_idx, event)
-                  remember_edit_bonds_pointerdown_site(atom.site_idx)
+                  select_edit_bonds_site(atom.site_idx, event)
                 }}
                 onclick={(event: MouseEvent) => {
                   if (edit_mode_image) return
@@ -1546,8 +1553,7 @@
               ) {
                 return
               }
-              toggle_selection(atom.site_idx, event)
-              remember_edit_bonds_pointerdown_site(atom.site_idx)
+              select_edit_bonds_site(atom.site_idx, event)
             }}
             onclick={(event: MouseEvent) => {
               if (partial_edit_image) return
@@ -1678,8 +1684,7 @@
               } else {
                 const endpoint_site_idx = get_bond_endpoint_hit_site_idx(bond, event)
                 if (endpoint_site_idx != null) {
-                  toggle_selection(endpoint_site_idx, event)
-                  remember_edit_bonds_pointerdown_site(endpoint_site_idx)
+                  select_edit_bonds_site(endpoint_site_idx, event)
                 }
               }
             }}
@@ -1730,7 +1735,7 @@
             scale={atom_hit.radius * EDITABLE_ATOM_HIT_RADIUS_SCALE}
             {...atom_hover_props(atom_hit.site_idx)}
             onpointerdown={(event: PointerEvent) => {
-              toggle_selection(atom_hit.site_idx, event)
+              select_edit_bonds_site(atom_hit.site_idx, event)
             }}
           >
             <T.SphereGeometry args={[0.5, 12, 12]} />
@@ -1843,12 +1848,7 @@
           <T.Mesh
             position={xyz}
             scale={1.2 * highlight_radius}
-            {...atom_hover_props(site_idx)}
-            onclick={(event: MouseEvent) => {
-              if (site_idx != null) {
-                toggle_selection(site_idx, event)
-              }
-            }}
+            oncreate={disable_raycast}
           >
             <T.SphereGeometry args={[0.5, 22, 22]} />
             <T.MeshStandardMaterial
@@ -1864,9 +1864,10 @@
         {/if}
       {/each}
 
-      <!-- selection order labels (1, 2, 3, ...) for distance/angle measurements -->
+      <!-- selection order labels (1, 2, 3, ...) for measurements and bond editing -->
       {#if structure?.sites && (measured_sites?.length ?? 0) > 0 &&
-        (measure_mode === `distance` || measure_mode === `angle`)}
+        (measure_mode === `distance` || measure_mode === `angle` ||
+          measure_mode === `edit-bonds`)}
         {#each measured_sites as site_index, loop_idx (site_index)}
           {@const site = structure.sites[site_index]}
           {#if site}

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -54,11 +54,12 @@
   import { SvelteMap, SvelteSet } from 'svelte/reactivity'
   import { type Camera, Color, type Mesh, type Scene } from 'three'
   import Bond from './Bond.svelte'
-  import type { BondEditResult, BondingStrategy } from './bonding'
+  import type { BondEditResult, BondingStrategy, BondKeyTarget } from './bonding'
   import {
     add_or_restore_bond,
     BONDING_STRATEGIES,
     BOND_ORDER_OPTIONS,
+    canonicalize_bond_target,
     delete_bond as apply_delete_bond,
     get_bond_key,
     get_bond_render_matrices,
@@ -91,7 +92,6 @@
     cell_shift?: Vec3
     position: Vec3
   }
-  type BondKeyTarget = Pick<StructureBond, `site_idx_1` | `site_idx_2` | `cell_shift`>
 
   let pulse_time = $state(0)
   let pulse_opacity = $derived(0.15 + 0.25 * Math.sin(pulse_time * 5))
@@ -379,7 +379,14 @@
     bond_context_target = null
   }
 
-  const bond_key_for = (bond: BondKeyTarget): string =>
+  const canonical_bond_target = (bond: BondKeyTarget): BondKeyTarget =>
+    canonicalize_bond_target(bond, structure?.sites)
+
+  const bond_key_for = (bond: BondKeyTarget): string => {
+    const target = canonical_bond_target(bond)
+    return get_bond_key(target.site_idx_1, target.site_idx_2, target.cell_shift)
+  }
+  const rendered_bond_key_for = (bond: BondKeyTarget): string =>
     get_bond_key(bond.site_idx_1, bond.site_idx_2, bond.cell_shift)
 
   const matches_bond_key = (bond: BondKeyTarget, key: string): boolean =>
@@ -389,10 +396,12 @@
     return structure?.sites?.[site_idx]?.properties?.orig_site_idx == null
   }
 
-  const can_edit_bond = (bond: BondKeyTarget): boolean =>
-    bond_edits_enabled &&
-    is_editable_bond_site(bond.site_idx_1) &&
-    is_editable_bond_site(bond.site_idx_2)
+  const can_edit_bond = (bond: BondKeyTarget): boolean => {
+    const target = canonical_bond_target(bond)
+    return bond_edits_enabled &&
+      is_editable_bond_site(target.site_idx_1) &&
+      is_editable_bond_site(target.site_idx_2)
+  }
 
   const format_bond_order = (order: BondOrder | undefined): string =>
     order === undefined ? `1` : `${order}`
@@ -414,14 +423,20 @@
     (pos_1[2] + pos_2[2]) / 2,
   ]
 
+  function apply_bond_transform(mesh: Mesh, bond: BondPair) {
+    mesh.matrix.fromArray(bond.transform_matrix)
+    mesh.matrixWorldNeedsUpdate = true
+  }
+
   let label_screen_margin = $derived(site_label_size * 10 + site_label_padding)
 
   function open_bond_context_menu(bond: BondPair) {
     if (!can_edit_bond(bond)) return
+    const target = canonical_bond_target(bond)
     bond_context_target = {
-      site_idx_1: bond.site_idx_1,
-      site_idx_2: bond.site_idx_2,
-      cell_shift: bond.cell_shift,
+      site_idx_1: target.site_idx_1,
+      site_idx_2: target.site_idx_2,
+      cell_shift: target.cell_shift,
       position: midpoint(bond.pos_1, bond.pos_2),
     }
     bond_context_menu = bond_context_target
@@ -451,22 +466,26 @@
     return filtered_bond_pairs.find((bond) => matches_bond_key(bond, key))
   }
 
-  function open_bond_order_menu_for_pair(site_idx_1: number, site_idx_2: number) {
-    const bond = find_visible_bond(site_idx_1, site_idx_2)
+  function open_bond_order_menu_for_pair(
+    site_idx_1: number,
+    site_idx_2: number,
+    cell_shift?: Vec3,
+  ) {
+    const bond = find_visible_bond(site_idx_1, site_idx_2, cell_shift)
     if (bond) open_bond_context_menu(bond)
   }
 
   function add_or_restore_pair(site_idx_1: number, site_idx_2: number, cell_shift?: Vec3) {
-    if (!can_edit_bond({ site_idx_1, site_idx_2, cell_shift })) return
-    const target = { site_idx_1, site_idx_2, cell_shift }
+    const target = canonical_bond_target({ site_idx_1, site_idx_2, cell_shift })
+    if (!can_edit_bond(target)) return
     const result = add_or_restore_bond(
       current_bond_edit_state(),
       target,
-      perceived_bond_pairs,
+      editable_perceived_bond_pairs,
       bond_edit_order,
     )
     if (result.action === `already-visible`) {
-      open_bond_order_menu_for_pair(site_idx_1, site_idx_2)
+      open_bond_order_menu_for_pair(target.site_idx_1, target.site_idx_2, target.cell_shift)
       return
     }
     apply_bond_edit_result(result, false)
@@ -478,12 +497,13 @@
     order: BondOrder,
     cell_shift?: Vec3,
   ) {
-    if (!can_edit_bond({ site_idx_1, site_idx_2, cell_shift })) return
+    const target = canonical_bond_target({ site_idx_1, site_idx_2, cell_shift })
+    if (!can_edit_bond(target)) return
     apply_bond_edit_result(
       apply_set_bond_order(
         current_bond_edit_state(),
-        { site_idx_1, site_idx_2, cell_shift },
-        perceived_bond_pairs,
+        target,
+        editable_perceived_bond_pairs,
         order,
       ),
     )
@@ -496,12 +516,13 @@
   }
 
   function remove_bond(site_idx_1: number, site_idx_2: number, cell_shift?: Vec3) {
-    if (!can_edit_bond({ site_idx_1, site_idx_2, cell_shift })) return
+    const target = canonical_bond_target({ site_idx_1, site_idx_2, cell_shift })
+    if (!can_edit_bond(target)) return
     apply_bond_edit_result(
       apply_delete_bond(
         current_bond_edit_state(),
-        { site_idx_1, site_idx_2, cell_shift },
-        perceived_bond_pairs,
+        target,
+        editable_perceived_bond_pairs,
       ),
     )
   }
@@ -817,6 +838,10 @@
       aromatic_display,
     )
   })
+
+  let editable_perceived_bond_pairs = $derived(
+    perceived_bond_pairs.map((bond) => ({ ...bond, ...canonical_bond_target(bond) })),
+  )
 
   let filtered_bond_pairs = $derived.by(() => {
     if (!structure?.sites) return perceived_bond_pairs
@@ -1433,20 +1458,22 @@
       {#if measure_mode === `edit-bonds` && editable_bond_pairs.length > 0}
         {#each editable_bond_pairs as
           bond
-          (`bond-hit-${bond_key_for(bond)}`)
+          (`bond-hit-${rendered_bond_key_for(bond)}`)
         }
-          {@const bond_key = bond_key_for(bond)}
+          {@const bond_key = rendered_bond_key_for(bond)}
           {@const is_hovered = hovered_bond_key === bond_key}
+          {@const is_delete_mode = bond_edit_mode === `delete`}
+          {@const bond_hit_radius =
+            bond_thickness * (is_delete_mode ? 5 : 1.25)}
+          {@const bond_hover_radius =
+            bond_thickness * (is_delete_mode ? 3 : 1.25)}
           <T.Mesh
             matrixAutoUpdate={false}
-            oncreate={(ref) => {
-              ref.matrix.fromArray(bond.transform_matrix)
-              ref.matrixWorldNeedsUpdate = true
-            }}
+            oncreate={(ref) => apply_bond_transform(ref, bond)}
             onpointerdown={(event: PointerEvent & { nativeEvent?: PointerEvent }) => {
               if (event.nativeEvent?.button === 2) return
               event.stopPropagation()
-              if (bond_edit_mode === `delete`) {
+              if (is_delete_mode) {
                 remove_bond(bond.site_idx_1, bond.site_idx_2, bond.cell_shift)
                 measured_sites = []
                 selected_sites = []
@@ -1465,19 +1492,39 @@
           >
             <T.CylinderGeometry
               args={[
-                bond_thickness * (bond_edit_mode === `delete` ? 3 : 1.25),
-                bond_thickness * (bond_edit_mode === `delete` ? 3 : 1.25),
+                bond_hit_radius,
+                bond_hit_radius,
                 1,
                 6,
               ]}
             />
             <T.MeshBasicMaterial
               transparent
-              opacity={is_hovered ? 0.25 : 0}
-              color={is_hovered && bond_edit_mode === `delete` ? `#ff4444` : `#6cf0ff`}
+              opacity={0}
               depthWrite={false}
             />
           </T.Mesh>
+          {#if is_hovered}
+            <T.Mesh
+              matrixAutoUpdate={false}
+              oncreate={(ref) => apply_bond_transform(ref, bond)}
+            >
+              <T.CylinderGeometry
+                args={[
+                  bond_hover_radius,
+                  bond_hover_radius,
+                  1,
+                  6,
+                ]}
+              />
+              <T.MeshBasicMaterial
+                transparent
+                opacity={0.25}
+                color={is_delete_mode ? `#ff4444` : `#6cf0ff`}
+                depthWrite={false}
+              />
+            </T.Mesh>
+          {/if}
         {/each}
       {/if}
 

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -423,9 +423,14 @@
     (pos_1[2] + pos_2[2]) / 2,
   ]
 
-  function apply_bond_transform(mesh: Mesh, bond: BondPair) {
+  function apply_bond_transform(mesh: Mesh, bond: BondPair): void {
     mesh.matrix.fromArray(bond.transform_matrix)
     mesh.matrixWorldNeedsUpdate = true
+  }
+
+  function apply_non_raycastable_bond_transform(mesh: Mesh, bond: BondPair): void {
+    apply_bond_transform(mesh, bond)
+    mesh.raycast = () => undefined
   }
 
   let label_screen_margin = $derived(site_label_size * 10 + site_label_padding)
@@ -1507,7 +1512,7 @@
           {#if is_hovered}
             <T.Mesh
               matrixAutoUpdate={false}
-              oncreate={(ref) => apply_bond_transform(ref, bond)}
+              oncreate={(ref) => apply_non_raycastable_bond_transform(ref, bond)}
             >
               <T.CylinderGeometry
                 args={[

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -52,7 +52,7 @@
   import * as extras from '@threlte/extras'
   import { type ComponentProps, type Snippet, untrack } from 'svelte'
   import { SvelteMap, SvelteSet } from 'svelte/reactivity'
-  import { type Camera, Color, type Mesh, type Scene } from 'three'
+  import { type Camera, Color, type Mesh, type Object3D, type Scene, Vector3 } from 'three'
   import Bond from './Bond.svelte'
   import type { BondEditResult, BondingStrategy, BondKeyTarget } from './bonding'
   import {
@@ -97,6 +97,18 @@
     site_idx_2: number
     cell_shift?: Vec3
     position: Vec3
+  }
+
+  type BondPointerEvent = PointerEvent & {
+    nativeEvent?: PointerEvent
+    object?: Object3D
+    point?: Vector3
+  }
+
+  type BondContextMenuEvent = MouseEvent & {
+    nativeEvent?: MouseEvent
+    object?: Object3D
+    point?: Vector3
   }
 
   let pulse_time = $state(0)
@@ -344,8 +356,7 @@
     }
     if (hovered_idx != null) {
       if (measure_mode === `edit-bonds`) {
-        return bond_edit_mode === `add` && bond_edits_enabled &&
-            is_editable_bond_site(hovered_idx)
+        return bond_edit_mode === `add` && can_select_bond_site(hovered_idx)
           ? `pointer`
           : `not-allowed`
       }
@@ -402,6 +413,9 @@
     return structure?.sites?.[site_idx]?.properties?.orig_site_idx == null
   }
 
+  const can_select_bond_site = (site_idx: number): boolean =>
+    bond_edits_enabled && structure?.sites?.[site_idx] != null
+
   const can_edit_bond = (bond: BondKeyTarget): boolean => {
     const target = canonical_bond_target(bond)
     return bond_edits_enabled &&
@@ -429,7 +443,8 @@
     (pos_1[2] + pos_2[2]) / 2,
   ]
 
-  const ADD_MODE_BOND_HIT_LENGTH_SCALE = 0.6
+  const BOND_ENDPOINT_HIT_FRACTION = 0.3
+  const BOND_ENDPOINT_SITE_MATCH_TOLERANCE = 1e-6
   const EDITABLE_ATOM_HIT_RADIUS_SCALE = 1.15
 
   function apply_bond_transform(mesh: Mesh, bond: BondPair): void {
@@ -437,32 +452,77 @@
     mesh.matrixWorldNeedsUpdate = true
   }
 
-  function apply_editable_bond_hit_transform(mesh: Mesh, bond: BondPair): void {
+  function apply_non_raycastable_bond_hit_transform(mesh: Mesh, bond: BondPair): void {
     apply_bond_transform(mesh, bond)
-    if (bond_edit_mode !== `add`) return
-
-    const { elements } = mesh.matrix
-    for (const matrix_idx of [4, 5, 6]) {
-      elements[matrix_idx] *= ADD_MODE_BOND_HIT_LENGTH_SCALE
-    }
-    mesh.matrixWorldNeedsUpdate = true
+    mesh.raycast = () => undefined
   }
 
-  function apply_non_raycastable_bond_hit_transform(mesh: Mesh, bond: BondPair): void {
-    apply_editable_bond_hit_transform(mesh, bond)
-    mesh.raycast = () => undefined
+  function get_bond_endpoint_site_idx(site_idx: number, position: Vec3): number {
+    if (!structure?.sites) return site_idx
+    const site = structure.sites[site_idx]
+    if (!site) return site_idx
+    if (math.euclidean_dist(site.xyz, position) <= BOND_ENDPOINT_SITE_MATCH_TOLERANCE) {
+      return site_idx
+    }
+
+    const image_site_idx = structure.sites.findIndex((candidate_site) =>
+      candidate_site.properties?.orig_site_idx === site_idx &&
+      math.euclidean_dist(candidate_site.xyz, position) <=
+        BOND_ENDPOINT_SITE_MATCH_TOLERANCE
+    )
+    return image_site_idx === -1 ? site_idx : image_site_idx
+  }
+
+  function get_bond_endpoint_hit_site_idx(
+    bond: BondPair,
+    event: BondPointerEvent,
+  ): number | null {
+    if (!event.point) return null
+    const parent = event.object?.parent
+    if (!parent) return null
+
+    const pos_1 = new Vector3(...bond.pos_1)
+    const pos_2 = new Vector3(...bond.pos_2)
+    parent.localToWorld(pos_1)
+    parent.localToWorld(pos_2)
+
+    const bond_vec = pos_2.sub(pos_1)
+    const length_sq = bond_vec.lengthSq()
+    if (length_sq <= math.EPS) return null
+
+    const hit_vec = event.point.clone().sub(pos_1)
+    const t = hit_vec.dot(bond_vec) / length_sq
+    if (t <= BOND_ENDPOINT_HIT_FRACTION) {
+      return get_bond_endpoint_site_idx(bond.site_idx_1, bond.pos_1)
+    }
+    if (t >= 1 - BOND_ENDPOINT_HIT_FRACTION) {
+      return get_bond_endpoint_site_idx(bond.site_idx_2, bond.pos_2)
+    }
+    return null
   }
 
   let label_screen_margin = $derived(site_label_size * 10 + site_label_padding)
 
-  function open_bond_context_menu(bond: BondPair) {
+  function get_bond_context_menu_position(
+    bond: BondPair,
+    event?: BondContextMenuEvent,
+  ): Vec3 {
+    const parent = event?.object?.parent
+    if (!event?.point || !parent) return midpoint(bond.pos_1, bond.pos_2)
+
+    const local_point = event.point.clone()
+    parent.worldToLocal(local_point)
+    return [local_point.x, local_point.y, local_point.z]
+  }
+
+  function open_bond_context_menu(bond: BondPair, event?: BondContextMenuEvent) {
     if (!can_edit_bond(bond)) return
     const target = canonical_bond_target(bond)
     bond_context_target = {
       site_idx_1: target.site_idx_1,
       site_idx_2: target.site_idx_2,
       cell_shift: target.cell_shift,
-      position: midpoint(bond.pos_1, bond.pos_2),
+      position: get_bond_context_menu_position(bond, event),
     }
     bond_context_menu = bond_context_target
   }
@@ -606,7 +666,7 @@
         selected_sites = []
         return
       }
-      if (!bond_edits_enabled || !is_editable_bond_site(site_index)) return
+      if (!can_select_bond_site(site_index)) return
       // In Add mode, select atom pairs without making existing bonds destructive.
       const new_sites = measured_sites.includes(site_index)
         ? measured_sites.filter((idx) => idx !== site_index)
@@ -1019,7 +1079,7 @@
 
     const targets = new SvelteMap<number, EditableAtomHitTarget>()
     for (const atom of atom_data) {
-      if (atom.is_image_atom || !is_editable_bond_site(atom.site_idx)) continue
+      if (!can_select_bond_site(atom.site_idx)) continue
       if (targets.has(atom.site_idx)) continue
       targets.set(atom.site_idx, {
         site_idx: atom.site_idx,
@@ -1576,12 +1636,12 @@
           {@const is_delete_mode = bond_edit_mode === `delete`}
           {@const bond_hit_radius =
             bond_thickness * (is_delete_mode ? 5 : 1.25)}
+          {@const bond_hover_radius = bond_thickness * 1.1}
           <T.Mesh
             matrixAutoUpdate={false}
-            oncreate={(ref) => apply_editable_bond_hit_transform(ref, bond)}
-            onpointerdown={(event: PointerEvent & { nativeEvent?: PointerEvent }) => {
+            oncreate={(ref) => apply_bond_transform(ref, bond)}
+            onpointerdown={(event: BondPointerEvent) => {
               if (event.nativeEvent?.button === 2) return
-              if (!is_delete_mode && hovered_idx != null) return
               event.stopPropagation()
               if (is_delete_mode) {
                 remove_bond(bond.site_idx_1, bond.site_idx_2, bond.cell_shift)
@@ -1589,13 +1649,17 @@
                 selected_sites = []
                 hovered_bond_key = null
               } else {
-                setTimeout(() => open_bond_context_menu(bond))
+                const endpoint_site_idx = get_bond_endpoint_hit_site_idx(bond, event)
+                if (endpoint_site_idx != null) {
+                  toggle_selection(endpoint_site_idx, event)
+                  remember_edit_bonds_pointerdown_site(endpoint_site_idx)
+                }
               }
             }}
-            oncontextmenu={(event: MouseEvent & { nativeEvent?: MouseEvent }) => {
+            oncontextmenu={(event: BondContextMenuEvent) => {
               event.nativeEvent?.preventDefault()
               event.stopPropagation?.()
-              open_bond_context_menu(bond)
+              open_bond_context_menu(bond, event)
             }}
             onpointerenter={() => (hovered_bond_key = bond_key)}
             onpointermove={() => (hovered_bond_key = bond_key)}
@@ -1620,7 +1684,7 @@
               matrixAutoUpdate={false}
               oncreate={(ref) => apply_non_raycastable_bond_hit_transform(ref, bond)}
             >
-              <T.CylinderGeometry args={[bond_hit_radius, bond_hit_radius, 1, 6]} />
+              <T.CylinderGeometry args={[bond_hover_radius, bond_hover_radius, 1, 6]} />
               <T.MeshBasicMaterial
                 transparent
                 opacity={0.25}
@@ -1665,7 +1729,7 @@
           bond_context_menu.site_idx_2,
           bond_context_menu.cell_shift,
         )}
-        <extras.HTML center position={bond_context_menu.position}>
+        <extras.HTML autoRender={false} position={bond_context_menu.position}>
           <div class="bond-context-menu">
             <strong>Bond Order ({format_bond_order(current_order)})</strong>
             {#each BOND_ORDER_OPTIONS as { order, label } (label)}
@@ -2086,7 +2150,7 @@
     display: grid;
     min-width: 8rem;
     gap: 2pt;
-    padding: 5pt;
+    padding: 3pt 5pt;
     border-radius: var(--border-radius, 3pt);
     background: var(--surface-bg, Canvas);
     color: var(--text-color, currentColor);

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -86,6 +86,12 @@
     atoms: (typeof atom_data)[number][]
   }
 
+  type EditableAtomHitTarget = {
+    site_idx: number
+    position: Vec3
+    radius: number
+  }
+
   type BondContextMenu = {
     site_idx_1: number
     site_idx_2: number
@@ -423,13 +429,27 @@
     (pos_1[2] + pos_2[2]) / 2,
   ]
 
+  const ADD_MODE_BOND_HIT_LENGTH_SCALE = 0.6
+  const EDITABLE_ATOM_HIT_RADIUS_SCALE = 1.15
+
   function apply_bond_transform(mesh: Mesh, bond: BondPair): void {
     mesh.matrix.fromArray(bond.transform_matrix)
     mesh.matrixWorldNeedsUpdate = true
   }
 
-  function apply_non_raycastable_bond_transform(mesh: Mesh, bond: BondPair): void {
+  function apply_editable_bond_hit_transform(mesh: Mesh, bond: BondPair): void {
     apply_bond_transform(mesh, bond)
+    if (bond_edit_mode !== `add`) return
+
+    const { elements } = mesh.matrix
+    for (const matrix_idx of [4, 5, 6]) {
+      elements[matrix_idx] *= ADD_MODE_BOND_HIT_LENGTH_SCALE
+    }
+    mesh.matrixWorldNeedsUpdate = true
+  }
+
+  function apply_non_raycastable_bond_hit_transform(mesh: Mesh, bond: BondPair): void {
+    apply_editable_bond_hit_transform(mesh, bond)
     mesh.raycast = () => undefined
   }
 
@@ -542,6 +562,34 @@
   // intercept the same native click, only the first intersection should fire.
   // All threlte intersection events from one click share the same nativeEvent ref.
   let last_native_event: Event | null = null
+  // extras.Instance does not always emit pointerdown, so edit-bonds also falls
+  // back to click. When pointerdown did fire, skip the matching click once.
+  let last_edit_bonds_pointerdown_site_idx: number | null = null
+  let clear_edit_bonds_pointerdown_site_timeout:
+    | ReturnType<typeof setTimeout>
+    | null = null
+
+  function remember_edit_bonds_pointerdown_site(site_idx: number) {
+    last_edit_bonds_pointerdown_site_idx = site_idx
+    if (clear_edit_bonds_pointerdown_site_timeout != null) {
+      clearTimeout(clear_edit_bonds_pointerdown_site_timeout)
+    }
+    clear_edit_bonds_pointerdown_site_timeout = setTimeout(() => {
+      last_edit_bonds_pointerdown_site_idx = null
+      clear_edit_bonds_pointerdown_site_timeout = null
+    }, 250)
+  }
+
+  function skip_duplicate_edit_bonds_click(site_idx: number) {
+    if (last_edit_bonds_pointerdown_site_idx !== site_idx) return false
+
+    last_edit_bonds_pointerdown_site_idx = null
+    if (clear_edit_bonds_pointerdown_site_timeout != null) {
+      clearTimeout(clear_edit_bonds_pointerdown_site_timeout)
+      clear_edit_bonds_pointerdown_site_timeout = null
+    }
+    return true
+  }
 
   function toggle_selection(site_index: number, evt?: Event) {
     evt?.stopPropagation?.()
@@ -568,8 +616,8 @@
       selected_sites = new_sites
 
       // When two atoms are selected, add/restore or open order editing.
-      if (measured_sites.length === 2) {
-        add_or_restore_pair(measured_sites[0], measured_sites[1])
+      if (new_sites.length === 2) {
+        add_or_restore_pair(new_sites[0], new_sites[1])
         measured_sites = []
         selected_sites = []
       }
@@ -960,6 +1008,28 @@
     return map
   })
 
+  let editable_atom_hit_targets = $derived.by(() => {
+    if (
+      measure_mode !== `edit-bonds` ||
+      bond_edit_mode !== `add` ||
+      !bond_edits_enabled
+    ) {
+      return []
+    }
+
+    const targets = new SvelteMap<number, EditableAtomHitTarget>()
+    for (const atom of atom_data) {
+      if (atom.is_image_atom || !is_editable_bond_site(atom.site_idx)) continue
+      if (targets.has(atom.site_idx)) continue
+      targets.set(atom.site_idx, {
+        site_idx: atom.site_idx,
+        position: atom.position,
+        radius: atom.radius,
+      })
+    }
+    return [...targets.values()]
+  })
+
   // Get radius for a site (for highlight fallback when site is hidden/filtered)
   // Checks site_radius_overrides first for consistency with visible atoms
   const get_site_radius = (site: Site, site_idx: number | null): number => {
@@ -1334,8 +1404,26 @@
                   hovered_idx = null
                   active_tooltip = null
                 }}
+                onpointerdown={(event: PointerEvent) => {
+                  if (
+                    edit_mode_image ||
+                    measure_mode !== `edit-bonds` ||
+                    bond_edit_mode !== `add`
+                  ) {
+                    return
+                  }
+                  toggle_selection(atom.site_idx, event)
+                  remember_edit_bonds_pointerdown_site(atom.site_idx)
+                }}
                 onclick={(event: MouseEvent) => {
                   if (edit_mode_image) return
+                  if (measure_mode === `edit-bonds`) {
+                    if (bond_edit_mode !== `add`) return
+                    if (skip_duplicate_edit_bonds_click(atom.site_idx)) {
+                      event.stopPropagation()
+                      return
+                    }
+                  }
                   toggle_selection(atom.site_idx, event)
                 }}
               />
@@ -1363,8 +1451,26 @@
               hovered_idx = null
               active_tooltip = null
             }}
+            onpointerdown={(event: PointerEvent) => {
+              if (
+                partial_edit_image ||
+                measure_mode !== `edit-bonds` ||
+                bond_edit_mode !== `add`
+              ) {
+                return
+              }
+              toggle_selection(atom.site_idx, event)
+              remember_edit_bonds_pointerdown_site(atom.site_idx)
+            }}
             onclick={(event: MouseEvent) => {
               if (partial_edit_image) return
+              if (measure_mode === `edit-bonds`) {
+                if (bond_edit_mode !== `add`) return
+                if (skip_duplicate_edit_bonds_click(atom.site_idx)) {
+                  event.stopPropagation()
+                  return
+                }
+              }
               toggle_selection(atom.site_idx, event)
             }}
           >
@@ -1463,20 +1569,19 @@
       {#if measure_mode === `edit-bonds` && editable_bond_pairs.length > 0}
         {#each editable_bond_pairs as
           bond
-          (`bond-hit-${rendered_bond_key_for(bond)}`)
+          (`bond-hit-${bond_edit_mode}-${rendered_bond_key_for(bond)}`)
         }
           {@const bond_key = rendered_bond_key_for(bond)}
           {@const is_hovered = hovered_bond_key === bond_key}
           {@const is_delete_mode = bond_edit_mode === `delete`}
           {@const bond_hit_radius =
             bond_thickness * (is_delete_mode ? 5 : 1.25)}
-          {@const bond_hover_radius =
-            bond_thickness * (is_delete_mode ? 3 : 1.25)}
           <T.Mesh
             matrixAutoUpdate={false}
-            oncreate={(ref) => apply_bond_transform(ref, bond)}
+            oncreate={(ref) => apply_editable_bond_hit_transform(ref, bond)}
             onpointerdown={(event: PointerEvent & { nativeEvent?: PointerEvent }) => {
               if (event.nativeEvent?.button === 2) return
+              if (!is_delete_mode && hovered_idx != null) return
               event.stopPropagation()
               if (is_delete_mode) {
                 remove_bond(bond.site_idx_1, bond.site_idx_2, bond.cell_shift)
@@ -1493,6 +1598,7 @@
               open_bond_context_menu(bond)
             }}
             onpointerenter={() => (hovered_bond_key = bond_key)}
+            onpointermove={() => (hovered_bond_key = bond_key)}
             onpointerleave={() => (hovered_bond_key = null)}
           >
             <T.CylinderGeometry
@@ -1512,16 +1618,9 @@
           {#if is_hovered}
             <T.Mesh
               matrixAutoUpdate={false}
-              oncreate={(ref) => apply_non_raycastable_bond_transform(ref, bond)}
+              oncreate={(ref) => apply_non_raycastable_bond_hit_transform(ref, bond)}
             >
-              <T.CylinderGeometry
-                args={[
-                  bond_hover_radius,
-                  bond_hover_radius,
-                  1,
-                  6,
-                ]}
-              />
+              <T.CylinderGeometry args={[bond_hit_radius, bond_hit_radius, 1, 6]} />
               <T.MeshBasicMaterial
                 transparent
                 opacity={0.25}
@@ -1530,6 +1629,33 @@
               />
             </T.Mesh>
           {/if}
+        {/each}
+      {/if}
+
+      {#if editable_atom_hit_targets.length > 0}
+        {#each editable_atom_hit_targets as atom_hit (atom_hit.site_idx)}
+          <T.Mesh
+            position={atom_hit.position}
+            scale={atom_hit.radius * EDITABLE_ATOM_HIT_RADIUS_SCALE}
+            onpointerenter={() => {
+              hovered_idx = atom_hit.site_idx
+              active_tooltip = `atom`
+            }}
+            onpointerleave={() => {
+              if (hovered_idx === atom_hit.site_idx) hovered_idx = null
+              if (active_tooltip === `atom`) active_tooltip = null
+            }}
+            onpointerdown={(event: PointerEvent) => {
+              toggle_selection(atom_hit.site_idx, event)
+            }}
+          >
+            <T.SphereGeometry args={[0.5, 12, 12]} />
+            <T.MeshBasicMaterial
+              transparent
+              opacity={0}
+              depthWrite={false}
+            />
+          </T.Mesh>
         {/each}
       {/if}
 

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -345,7 +345,7 @@
   })
 
   let bond_pairs: BondPair[] = $state([])
-  let active_tooltip = $state<`atom` | `bond` | null>(null)
+  let atom_tooltip_active = $state(false)
   let hovered_bond_key = $state<string | null>(null)
   const ATOM_HOVER_CLEAR_DELAY_MS = 200
   let clear_atom_hover_timeout: ReturnType<typeof setTimeout> | null = null
@@ -359,7 +359,7 @@
   function set_atom_hover(site_idx: number): void {
     cancel_atom_hover_clear()
     if (hovered_idx !== site_idx) hovered_idx = site_idx
-    if (active_tooltip !== `atom`) active_tooltip = `atom`
+    if (!atom_tooltip_active) atom_tooltip_active = true
   }
 
   function schedule_atom_hover_clear(site_idx: number): void {
@@ -368,17 +368,21 @@
       clear_atom_hover_timeout = null
       if (hovered_idx !== site_idx) return
       hovered_idx = null
-      if (active_tooltip === `atom`) active_tooltip = null
+      atom_tooltip_active = false
     }, ATOM_HOVER_CLEAR_DELAY_MS)
   }
 
-  function set_nullable_atom_hover(site_idx: number | null): void {
-    if (site_idx != null) set_atom_hover(site_idx)
-  }
-
-  function schedule_nullable_atom_hover_clear(site_idx: number | null): void {
-    if (site_idx != null) schedule_atom_hover_clear(site_idx)
-  }
+  const atom_hover_props = (site_idx: number | null, disabled = false) => ({
+    onpointerenter: () => {
+      if (!disabled && site_idx != null) set_atom_hover(site_idx)
+    },
+    onpointermove: () => {
+      if (!disabled && site_idx != null) set_atom_hover(site_idx)
+    },
+    onpointerleave: () => {
+      if (!disabled && site_idx != null) schedule_atom_hover_clear(site_idx)
+    },
+  })
 
   // Cursor style for the canvas, derived from mode and hover state
   let canvas_cursor = $derived.by(() => {
@@ -1495,18 +1499,7 @@
               <extras.Instance
                 position={atom.position}
                 scale={atom.radius}
-                onpointerenter={() => {
-                  if (edit_mode_image) return
-                  set_atom_hover(atom.site_idx)
-                }}
-                onpointermove={() => {
-                  if (edit_mode_image) return
-                  set_atom_hover(atom.site_idx)
-                }}
-                onpointerleave={() => {
-                  if (edit_mode_image) return
-                  schedule_atom_hover_clear(atom.site_idx)
-                }}
+                {...atom_hover_props(atom.site_idx, edit_mode_image)}
                 onpointerdown={(event: PointerEvent) => {
                   if (
                     edit_mode_image ||
@@ -1544,18 +1537,7 @@
           <T.Group
             position={atom.position}
             scale={atom.radius}
-            onpointerenter={() => {
-              if (partial_edit_image) return
-              set_atom_hover(atom.site_idx)
-            }}
-            onpointermove={() => {
-              if (partial_edit_image) return
-              set_atom_hover(atom.site_idx)
-            }}
-            onpointerleave={() => {
-              if (partial_edit_image) return
-              schedule_atom_hover_clear(atom.site_idx)
-            }}
+            {...atom_hover_props(atom.site_idx, partial_edit_image)}
             onpointerdown={(event: PointerEvent) => {
               if (
                 partial_edit_image ||
@@ -1746,15 +1728,7 @@
           <T.Mesh
             position={atom_hit.position}
             scale={atom_hit.radius * EDITABLE_ATOM_HIT_RADIUS_SCALE}
-            onpointerenter={() => {
-              set_atom_hover(atom_hit.site_idx)
-            }}
-            onpointermove={() => {
-              set_atom_hover(atom_hit.site_idx)
-            }}
-            onpointerleave={() => {
-              schedule_atom_hover_clear(atom_hit.site_idx)
-            }}
+            {...atom_hover_props(atom_hit.site_idx)}
             onpointerdown={(event: PointerEvent) => {
               toggle_selection(atom_hit.site_idx, event)
             }}
@@ -1869,15 +1843,7 @@
           <T.Mesh
             position={xyz}
             scale={1.2 * highlight_radius}
-            onpointerenter={() => {
-              set_nullable_atom_hover(site_idx)
-            }}
-            onpointermove={() => {
-              set_nullable_atom_hover(site_idx)
-            }}
-            onpointerleave={() => {
-              schedule_nullable_atom_hover_clear(site_idx)
-            }}
+            {...atom_hover_props(site_idx)}
             onclick={(event: MouseEvent) => {
               if (site_idx != null) {
                 toggle_selection(site_idx, event)
@@ -1916,7 +1882,7 @@
 
       <!-- hovered site tooltip -->
       {#if hovered_site && !camera_is_moving &&
-        (active_tooltip === `atom` || active_sites.includes(hovered_idx ?? -1))}
+        (atom_tooltip_active || active_sites.includes(hovered_idx ?? -1))}
         {@const abc = hovered_site.abc.map((val) => format_num(val, float_fmt)).join(
           `, `,
         )}

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -20,6 +20,7 @@
   import { colors } from '$lib/state.svelte'
   import type {
     AnyStructure,
+    BondEditMode,
     BondOrder,
     BondPair,
     MeasureMode,
@@ -54,13 +55,16 @@
   import { SvelteMap, SvelteSet } from 'svelte/reactivity'
   import { type Camera, Color, type Mesh, type Scene } from 'three'
   import Bond from './Bond.svelte'
-  import type { BondingStrategy } from './bonding'
+  import type { BondEditResult, BondingStrategy } from './bonding'
   import {
+    add_or_restore_bond,
     BONDING_STRATEGIES,
+    BOND_ORDER_OPTIONS,
+    delete_bond as apply_delete_bond,
     get_bond_key,
     get_bond_render_matrices,
     get_explicit_bond_metadata,
-    normalize_structure_bond,
+    set_bond_order as apply_set_bond_order,
     structure_bond_to_bond_pair,
   } from './bonding'
   import {
@@ -169,6 +173,8 @@
     removed_bonds = $bindable([]),
     bond_order_overrides = $bindable([]),
     bond_edits_enabled = true,
+    bond_edit_mode = $bindable<BondEditMode>(`add`),
+    bond_edit_order = 1,
     selection_highlight_color = `#6cf0ff`,
     // Active highlight group with different color
     active_sites = $bindable([]),
@@ -192,6 +198,7 @@
     // Edit-atoms mode callbacks
     on_sites_moved,
     on_operation_start,
+    on_bond_edit_start,
     on_add_atom,
     add_atom_mode = $bindable(false),
     add_element = $bindable(`C`),
@@ -265,6 +272,8 @@
     removed_bonds?: StructureBond[]
     bond_order_overrides?: StructureBond[]
     bond_edits_enabled?: boolean
+    bond_edit_mode?: BondEditMode
+    bond_edit_order?: BondOrder
     selection_highlight_color?: string
     // Support for active highlight group with different color
     active_sites?: number[]
@@ -285,6 +294,7 @@
     // Edit-atoms mode callbacks and state
     on_sites_moved?: (scene_indices: number[], delta: Vec3) => void
     on_operation_start?: () => void
+    on_bond_edit_start?: () => void
     on_add_atom?: (xyz: Vec3, element: ElementSymbol) => void
     add_atom_mode?: boolean // whether user is in click-to-place add-atom sub-mode
     add_element?: ElementSymbol // element to add when clicking in add-atom mode
@@ -324,9 +334,13 @@
   // Cursor style for the canvas, derived from mode and hover state
   let canvas_cursor = $derived.by(() => {
     if (measure_mode === `edit-atoms` && add_atom_mode) return `crosshair`
+    if (measure_mode === `edit-bonds` && hovered_bond_key != null) {
+      return bond_edits_enabled ? `pointer` : `not-allowed`
+    }
     if (hovered_idx != null) {
       if (measure_mode === `edit-bonds`) {
-        return bond_edits_enabled && is_editable_bond_site(hovered_idx)
+        return bond_edit_mode === `add` && bond_edits_enabled &&
+            is_editable_bond_site(hovered_idx)
           ? `pointer`
           : `not-allowed`
       }
@@ -356,12 +370,6 @@
   // snaps to the new wrapped centroid.
   let frozen_centroid = $state<Vec3 | null>(null)
 
-  const BOND_ORDER_OPTIONS: { order: BondOrder; label: string }[] = [
-    { order: 1, label: `Single` },
-    { order: 2, label: `Double` },
-    { order: 3, label: `Triple` },
-    { order: `aromatic`, label: `Aromatic` },
-  ]
   let bond_context_menu = $state<BondContextMenu | null>(null)
   // Threlte/HTML pointer events can close the visible menu before a button
   // handler runs, so keep the target bond separately for menu actions.
@@ -371,13 +379,6 @@
     bond_context_menu = null
     bond_context_target = null
   }
-
-  const make_bond_record = (
-    site_idx_1: number,
-    site_idx_2: number,
-    order: BondOrder,
-    cell_shift?: Vec3,
-  ): StructureBond => normalize_structure_bond(site_idx_1, site_idx_2, order, cell_shift)
 
   const bond_key_for = (bond: BondKeyTarget): string =>
     get_bond_key(bond.site_idx_1, bond.site_idx_2, bond.cell_shift)
@@ -427,29 +428,49 @@
     bond_context_menu = bond_context_target
   }
 
-  // Toggle a bond between two atoms: cycles through add → remove → restore states
-  function toggle_bond(site_1: number, site_2: number, cell_shift?: Vec3) {
-    if (!can_edit_bond({ site_idx_1: site_1, site_idx_2: site_2, cell_shift })) return
-    const record = make_bond_record(site_1, site_2, 1, cell_shift)
-    const key = bond_key_for(record)
-    if (added_bonds.some((bond) => matches_bond_key(bond, key))) {
-      added_bonds = added_bonds.filter((bond) => !matches_bond_key(bond, key))
+  const current_bond_edit_state = () => ({
+    added_bonds,
+    removed_bonds,
+    bond_order_overrides,
+  })
+
+  function apply_bond_edit_result(result: BondEditResult, close_menu = true) {
+    if (!result.changed) return
+    on_bond_edit_start?.()
+    added_bonds = result.state.added_bonds
+    removed_bonds = result.state.removed_bonds
+    bond_order_overrides = result.state.bond_order_overrides
+    if (close_menu) close_bond_context_menu()
+  }
+
+  const find_visible_bond = (
+    site_idx_1: number,
+    site_idx_2: number,
+    cell_shift?: Vec3,
+  ): BondPair | undefined => {
+    const key = get_bond_key(site_idx_1, site_idx_2, cell_shift)
+    return filtered_bond_pairs.find((bond) => matches_bond_key(bond, key))
+  }
+
+  function open_bond_order_menu_for_pair(site_idx_1: number, site_idx_2: number) {
+    const bond = find_visible_bond(site_idx_1, site_idx_2)
+    if (bond) open_bond_context_menu(bond)
+  }
+
+  function add_or_restore_pair(site_idx_1: number, site_idx_2: number, cell_shift?: Vec3) {
+    if (!can_edit_bond({ site_idx_1, site_idx_2, cell_shift })) return
+    const target = { site_idx_1, site_idx_2, cell_shift }
+    const result = add_or_restore_bond(
+      current_bond_edit_state(),
+      target,
+      perceived_bond_pairs,
+      bond_edit_order,
+    )
+    if (result.action === `already-visible`) {
+      open_bond_order_menu_for_pair(site_idx_1, site_idx_2)
       return
     }
-    if (removed_bonds.some((bond) => matches_bond_key(bond, key))) {
-      removed_bonds = removed_bonds.filter((bond) => !matches_bond_key(bond, key))
-      return
-    }
-    const has_calculated_bond = bond_pairs.some((bond) => matches_bond_key(bond, key))
-    if (bond_order_overrides.some((bond) => matches_bond_key(bond, key))) {
-      bond_order_overrides = bond_order_overrides.filter((bond) =>
-        !matches_bond_key(bond, key)
-      )
-      if (has_calculated_bond) removed_bonds = [...removed_bonds, record]
-      return
-    }
-    if (has_calculated_bond) removed_bonds = [...removed_bonds, record]
-    else added_bonds = [...added_bonds, record]
+    apply_bond_edit_result(result, false)
   }
 
   function set_bond_order(
@@ -459,20 +480,14 @@
     cell_shift?: Vec3,
   ) {
     if (!can_edit_bond({ site_idx_1, site_idx_2, cell_shift })) return
-    const key = get_bond_key(site_idx_1, site_idx_2, cell_shift)
-    const new_record = make_bond_record(site_idx_1, site_idx_2, order, cell_shift)
-    added_bonds = added_bonds.filter((bond) => !matches_bond_key(bond, key))
-    const has_calculated_bond = bond_pairs.some((bond) => matches_bond_key(bond, key))
-    if (has_calculated_bond) {
-      bond_order_overrides = [
-        ...bond_order_overrides.filter((bond) => !matches_bond_key(bond, key)),
-        new_record,
-      ]
-      removed_bonds = removed_bonds.filter((bond) => !matches_bond_key(bond, key))
-    } else {
-      added_bonds = [...added_bonds, new_record]
-    }
-    close_bond_context_menu()
+    apply_bond_edit_result(
+      apply_set_bond_order(
+        current_bond_edit_state(),
+        { site_idx_1, site_idx_2, cell_shift },
+        perceived_bond_pairs,
+        order,
+      ),
+    )
   }
 
   function set_context_bond_order(order: BondOrder) {
@@ -483,21 +498,13 @@
 
   function remove_bond(site_idx_1: number, site_idx_2: number, cell_shift?: Vec3) {
     if (!can_edit_bond({ site_idx_1, site_idx_2, cell_shift })) return
-    const key = get_bond_key(site_idx_1, site_idx_2, cell_shift)
-    added_bonds = added_bonds.filter((bond) => !matches_bond_key(bond, key))
-    bond_order_overrides = bond_order_overrides.filter((bond) =>
-      !matches_bond_key(bond, key)
+    apply_bond_edit_result(
+      apply_delete_bond(
+        current_bond_edit_state(),
+        { site_idx_1, site_idx_2, cell_shift },
+        perceived_bond_pairs,
+      ),
     )
-    if (
-      bond_pairs.some((bond) => matches_bond_key(bond, key)) &&
-      !removed_bonds.some((bond) => matches_bond_key(bond, key))
-    ) {
-      removed_bonds = [
-        ...removed_bonds,
-        make_bond_record(site_idx_1, site_idx_2, 1, cell_shift),
-      ]
-    }
-    close_bond_context_menu()
   }
 
   function remove_context_bond() {
@@ -521,8 +528,13 @@
     }
 
     if (measure_mode === `edit-bonds`) {
+      if (bond_edit_mode === `delete`) {
+        measured_sites = []
+        selected_sites = []
+        return
+      }
       if (!bond_edits_enabled || !is_editable_bond_site(site_index)) return
-      // In edit-bonds mode, select atoms to add/remove bonds between them
+      // In Add mode, select atom pairs without making existing bonds destructive.
       const new_sites = measured_sites.includes(site_index)
         ? measured_sites.filter((idx) => idx !== site_index)
         : [...measured_sites, site_index]
@@ -530,9 +542,9 @@
       measured_sites = new_sites
       selected_sites = new_sites
 
-      // When two atoms are selected, toggle the bond between them
+      // When two atoms are selected, add/restore or open order editing.
       if (measured_sites.length === 2) {
-        toggle_bond(measured_sites[0], measured_sites[1])
+        add_or_restore_pair(measured_sites[0], measured_sites[1])
         measured_sites = []
         selected_sites = []
       }
@@ -584,6 +596,7 @@
   $effect(() => {
     void structure
     void measure_mode
+    void bond_edit_mode
     void bond_edits_enabled
     untrack(() => {
       close_bond_context_menu()
@@ -626,9 +639,16 @@
       : [0, 0, 0] as Vec3,
   )
 
-  let structure_size = $derived(
-    lattice ? (lattice.a + lattice.b + lattice.c) / 2 : 10,
-  )
+  let structure_size = $derived.by(() => {
+    if (lattice) return (lattice.a + lattice.b + lattice.c) / 2
+    if (!structure?.sites?.length) return 10
+
+    const ranges = [0, 1, 2].map((axis_idx) => {
+      const coords = structure.sites.map((site) => site.xyz[axis_idx])
+      return Math.max(...coords) - Math.min(...coords)
+    })
+    return Math.max(1, ...ranges)
+  })
 
   // Characteristic inter-atomic spacing: cube root of volume per atom.
   // Excludes PBC image atoms (orig_site_idx) so toggling image atoms doesn't affect arrow sizing.
@@ -806,14 +826,18 @@
     const removed_keys = new Set(
       removed_bonds.map(bond_key_for),
     )
+    const added_keys = new Set(
+      added_bonds.map(bond_key_for),
+    )
     const order_overrides = new Map(
       bond_order_overrides.map((bond) => [bond_key_for(bond), bond.order]),
     )
 
-    // Filter calculated bonds: exclude removed and hidden
+    // Filter calculated bonds: exclude removed, replaced by manual additions, and hidden.
     const calculated = perceived_bond_pairs
       .filter((bond) => {
-        if (removed_keys.has(bond_key_for(bond))) return false
+        const key = bond_key_for(bond)
+        if (removed_keys.has(key) || added_keys.has(key)) return false
         return is_site_visible(bond.site_idx_1) && is_site_visible(bond.site_idx_2)
       })
       .map((bond) => {
@@ -1178,12 +1202,22 @@
     {#if atom_label}
       {@render atom_label({ site, site_idx })}
     {:else}
-      <span
+      <button
+        type="button"
         class="atom-label"
         style:font-size="{site_label_size * 0.85}em"
         style:background={site_label_bg_color}
         style:padding="{site_label_padding}px"
         style:color={site_label_color}
+        onpointerdown={(event) => {
+          event.preventDefault()
+          toggle_selection(site_idx, event)
+        }}
+        onkeydown={(event) => {
+          if (event.key !== `Enter` && event.key !== ` `) return
+          event.preventDefault()
+          toggle_selection(site_idx, event)
+        }}
       >
         {#if show_site_labels}
           {#if site.species.length === 1}
@@ -1200,7 +1234,7 @@
         {:else if show_site_indices}
           {site_idx + 1}
         {/if}
-      </span>
+      </button>
     {/if}
   </extras.HTML>
 {/snippet}
@@ -1413,10 +1447,14 @@
             onpointerdown={(event: PointerEvent & { nativeEvent?: PointerEvent }) => {
               if (event.nativeEvent?.button === 2) return
               event.stopPropagation()
-              toggle_bond(bond.site_idx_1, bond.site_idx_2, bond.cell_shift)
-              measured_sites = []
-              selected_sites = []
-              hovered_bond_key = null
+              if (bond_edit_mode === `delete`) {
+                remove_bond(bond.site_idx_1, bond.site_idx_2, bond.cell_shift)
+                measured_sites = []
+                selected_sites = []
+                hovered_bond_key = null
+              } else {
+                setTimeout(() => open_bond_context_menu(bond))
+              }
             }}
             oncontextmenu={(event: MouseEvent & { nativeEvent?: MouseEvent }) => {
               event.nativeEvent?.preventDefault()
@@ -1426,11 +1464,18 @@
             onpointerenter={() => (hovered_bond_key = bond_key)}
             onpointerleave={() => (hovered_bond_key = null)}
           >
-            <T.CylinderGeometry args={[bond_thickness * 3, bond_thickness * 3, 1, 6]} />
+            <T.CylinderGeometry
+              args={[
+                bond_thickness * (bond_edit_mode === `delete` ? 3 : 1.25),
+                bond_thickness * (bond_edit_mode === `delete` ? 3 : 1.25),
+                1,
+                6,
+              ]}
+            />
             <T.MeshBasicMaterial
               transparent
               opacity={is_hovered ? 0.25 : 0}
-              color={is_hovered ? `#ff4444` : `white`}
+              color={is_hovered && bond_edit_mode === `delete` ? `#ff4444` : `#6cf0ff`}
               depthWrite={false}
             />
           </T.Mesh>
@@ -1822,7 +1867,11 @@
   }
   .atom-label {
     background: var(--struct-atom-label-bg, rgba(0, 0, 0, 0.1));
+    border: 0;
     border-radius: var(--struct-atom-label-border-radius, var(--border-radius, 3pt));
+    color: inherit;
+    cursor: pointer;
+    font: inherit;
     padding: var(--struct-atom-label-padding, 0 3px);
     white-space: nowrap;
   }

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -16,7 +16,6 @@
     VectorLayerConfig,
   } from '$lib/settings'
   import { DEFAULTS } from '$lib/settings'
-  import { sanitize_html } from '$lib/sanitize'
   import { colors } from '$lib/state.svelte'
   import type {
     AnyStructure,
@@ -1223,13 +1222,13 @@
           {#if site.species.length === 1}
             {site.species[0].element}{#if show_site_indices}-{site_idx + 1}{/if}
           {:else}
-            {@html sanitize_html(site.species.map((spec) =>
-        `${spec.element}<sub>${
-          format_num(spec.occu, `.3~`).replace(`0.`, `.`)
-        }</sub>`
-      ).join(``))}{#if show_site_indices}-{
-                site_idx + 1
-              }{/if}
+            {#each site.species as
+              { element, occu, oxidation_state }
+              (`${element}-${occu}-${oxidation_state}`)
+            }
+              {element}<sub>{format_num(occu, `.3~`).replace(`0.`, `.`)}</sub>
+            {/each}
+            {#if show_site_indices}-{site_idx + 1}{/if}
           {/if}
         {:else if show_site_indices}
           {site_idx + 1}
@@ -1659,11 +1658,6 @@
               idx
               (`${element ?? ``}-${occu ?? ``}-${oxi_state ?? ``}-${idx}`)
             }
-              {@const oxi_str = (oxi_state != null && oxi_state !== 0)
-              ? `<sup>${Math.abs(oxi_state)}${
-                oxi_state > 0 ? `+` : `−`
-              }</sup>`
-              : ``}
               {@const element_name = element_data.find((elem) =>
               elem.symbol === element
             )?.name ??
@@ -1672,7 +1666,11 @@
               {#if occu !== 1}<span class="occupancy">{
                   format_num(occu, `.3~f`)
                 }</span>{/if}
-              <strong>{element}{@html sanitize_html(oxi_str)}</strong>
+              <strong>
+                {element}{#if oxi_state != null && oxi_state !== 0}<sup>{Math.abs(
+                    oxi_state,
+                  )}{oxi_state > 0 ? `+` : `−`}</sup>{/if}
+              </strong>
               {#if element_name}<span class="elem-name">{element_name}</span>{/if}
             {/each}
           </div>

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -347,6 +347,38 @@
   let bond_pairs: BondPair[] = $state([])
   let active_tooltip = $state<`atom` | `bond` | null>(null)
   let hovered_bond_key = $state<string | null>(null)
+  const ATOM_HOVER_CLEAR_DELAY_MS = 200
+  let clear_atom_hover_timeout: ReturnType<typeof setTimeout> | null = null
+
+  function cancel_atom_hover_clear(): void {
+    if (clear_atom_hover_timeout == null) return
+    clearTimeout(clear_atom_hover_timeout)
+    clear_atom_hover_timeout = null
+  }
+
+  function set_atom_hover(site_idx: number): void {
+    cancel_atom_hover_clear()
+    if (hovered_idx !== site_idx) hovered_idx = site_idx
+    if (active_tooltip !== `atom`) active_tooltip = `atom`
+  }
+
+  function schedule_atom_hover_clear(site_idx: number): void {
+    cancel_atom_hover_clear()
+    clear_atom_hover_timeout = setTimeout(() => {
+      clear_atom_hover_timeout = null
+      if (hovered_idx !== site_idx) return
+      hovered_idx = null
+      if (active_tooltip === `atom`) active_tooltip = null
+    }, ATOM_HOVER_CLEAR_DELAY_MS)
+  }
+
+  function set_nullable_atom_hover(site_idx: number | null): void {
+    if (site_idx != null) set_atom_hover(site_idx)
+  }
+
+  function schedule_nullable_atom_hover_clear(site_idx: number | null): void {
+    if (site_idx != null) schedule_atom_hover_clear(site_idx)
+  }
 
   // Cursor style for the canvas, derived from mode and hover state
   let canvas_cursor = $derived.by(() => {
@@ -409,8 +441,8 @@
   const matches_bond_key = (bond: BondKeyTarget, key: string): boolean =>
     bond_key_for(bond) === key
 
-  function is_editable_bond_site(site_idx: number): boolean {
-    return structure?.sites?.[site_idx]?.properties?.orig_site_idx == null
+  function is_image_bond_site(site_idx: number): boolean {
+    return structure?.sites?.[site_idx]?.properties?.orig_site_idx != null
   }
 
   const can_select_bond_site = (site_idx: number): boolean =>
@@ -419,8 +451,8 @@
   const can_edit_bond = (bond: BondKeyTarget): boolean => {
     const target = canonical_bond_target(bond)
     return bond_edits_enabled &&
-      is_editable_bond_site(target.site_idx_1) &&
-      is_editable_bond_site(target.site_idx_2)
+      !is_image_bond_site(target.site_idx_1) &&
+      !is_image_bond_site(target.site_idx_2)
   }
 
   const format_bond_order = (order: BondOrder | undefined): string =>
@@ -561,6 +593,8 @@
   }
 
   function add_or_restore_pair(site_idx_1: number, site_idx_2: number, cell_shift?: Vec3) {
+    if (is_image_bond_site(site_idx_1) && is_image_bond_site(site_idx_2)) return
+
     const target = canonical_bond_target({ site_idx_1, site_idx_2, cell_shift })
     if (!can_edit_bond(target)) return
     const result = add_or_restore_bond(
@@ -653,8 +687,8 @@
 
   function toggle_selection(site_index: number, evt?: Event) {
     evt?.stopPropagation?.()
-    const native_event = (evt as Event & { nativeEvent?: unknown } | undefined)
-      ?.nativeEvent
+    const event_with_native = evt as Event & { nativeEvent?: unknown } | undefined
+    const native_event = event_with_native?.nativeEvent ?? evt
     if (native_event instanceof Event) {
       if (native_event === last_native_event) return
       last_native_event = native_event
@@ -1321,6 +1355,7 @@
     dampingFactor: rotation_damping,
     onstart: () => {
       camera_is_moving = true
+      cancel_atom_hover_clear()
       hovered_idx = null
       bond_context_menu = null
     },
@@ -1370,11 +1405,17 @@
         style:color={site_label_color}
         onpointerdown={(event) => {
           event.preventDefault()
+          event.stopImmediatePropagation()
           toggle_selection(site_idx, event)
+        }}
+        onclick={(event) => {
+          event.preventDefault()
+          event.stopImmediatePropagation()
         }}
         onkeydown={(event) => {
           if (event.key !== `Enter` && event.key !== ` `) return
           event.preventDefault()
+          event.stopPropagation()
           toggle_selection(site_idx, event)
         }}
       >
@@ -1456,13 +1497,15 @@
                 scale={atom.radius}
                 onpointerenter={() => {
                   if (edit_mode_image) return
-                  hovered_idx = atom.site_idx
-                  active_tooltip = `atom`
+                  set_atom_hover(atom.site_idx)
+                }}
+                onpointermove={() => {
+                  if (edit_mode_image) return
+                  set_atom_hover(atom.site_idx)
                 }}
                 onpointerleave={() => {
                   if (edit_mode_image) return
-                  hovered_idx = null
-                  active_tooltip = null
+                  schedule_atom_hover_clear(atom.site_idx)
                 }}
                 onpointerdown={(event: PointerEvent) => {
                   if (
@@ -1503,13 +1546,15 @@
             scale={atom.radius}
             onpointerenter={() => {
               if (partial_edit_image) return
-              hovered_idx = atom.site_idx
-              active_tooltip = `atom`
+              set_atom_hover(atom.site_idx)
+            }}
+            onpointermove={() => {
+              if (partial_edit_image) return
+              set_atom_hover(atom.site_idx)
             }}
             onpointerleave={() => {
               if (partial_edit_image) return
-              hovered_idx = null
-              active_tooltip = null
+              schedule_atom_hover_clear(atom.site_idx)
             }}
             onpointerdown={(event: PointerEvent) => {
               if (
@@ -1702,12 +1747,13 @@
             position={atom_hit.position}
             scale={atom_hit.radius * EDITABLE_ATOM_HIT_RADIUS_SCALE}
             onpointerenter={() => {
-              hovered_idx = atom_hit.site_idx
-              active_tooltip = `atom`
+              set_atom_hover(atom_hit.site_idx)
+            }}
+            onpointermove={() => {
+              set_atom_hover(atom_hit.site_idx)
             }}
             onpointerleave={() => {
-              if (hovered_idx === atom_hit.site_idx) hovered_idx = null
-              if (active_tooltip === `atom`) active_tooltip = null
+              schedule_atom_hover_clear(atom_hit.site_idx)
             }}
             onpointerdown={(event: PointerEvent) => {
               toggle_selection(atom_hit.site_idx, event)
@@ -1823,8 +1869,17 @@
           <T.Mesh
             position={xyz}
             scale={1.2 * highlight_radius}
+            onpointerenter={() => {
+              set_nullable_atom_hover(site_idx)
+            }}
+            onpointermove={() => {
+              set_nullable_atom_hover(site_idx)
+            }}
+            onpointerleave={() => {
+              schedule_nullable_atom_hover_clear(site_idx)
+            }}
             onclick={(event: MouseEvent) => {
-              if (site_idx !== null && Number.isInteger(site_idx)) {
+              if (site_idx != null) {
                 toggle_selection(site_idx, event)
               }
             }}
@@ -1843,9 +1898,9 @@
         {/if}
       {/each}
 
-      <!-- selection order labels (1, 2, 3, ...) for measured sites (hidden in edit-atoms mode) -->
+      <!-- selection order labels (1, 2, 3, ...) for distance/angle measurements -->
       {#if structure?.sites && (measured_sites?.length ?? 0) > 0 &&
-          measure_mode !== `edit-atoms`}
+        (measure_mode === `distance` || measure_mode === `angle`)}
         {#each measured_sites as site_index, loop_idx (site_index)}
           {@const site = structure.sites[site_index]}
           {#if site}

--- a/src/lib/structure/bonding.ts
+++ b/src/lib/structure/bonding.ts
@@ -107,10 +107,8 @@ const remove_bond_key = (bonds: StructureBond[], key: string): StructureBond[] =
 const includes_bond_key = (bonds: BondKeyTarget[], key: string): boolean =>
   bonds.some((bond) => matches_bond_key(bond, key))
 
-const has_calculated_bond = (
-  calculated_bonds: BondKeyTarget[],
-  key: string,
-): boolean => includes_bond_key(calculated_bonds, key)
+const has_calculated_bond = (calculated_bonds: BondKeyTarget[], key: string): boolean =>
+  includes_bond_key(calculated_bonds, key)
 
 const make_bond_record = (bond: BondKeyTarget, order: BondOrder): StructureBond =>
   normalize_structure_bond(bond.site_idx_1, bond.site_idx_2, order, bond.cell_shift)
@@ -137,7 +135,7 @@ export function add_or_restore_bond(
   const record = make_bond_record(bond, order)
   const key = bond_key_for(record)
   const removed_bond = edit_state.removed_bonds.find((edit_bond) =>
-    matches_bond_key(edit_bond, key)
+    matches_bond_key(edit_bond, key),
   )
   if (removed_bond) {
     return {
@@ -146,9 +144,10 @@ export function add_or_restore_bond(
       state: {
         ...edit_state,
         removed_bonds: remove_bond_key(edit_state.removed_bonds, key),
-        bond_order_overrides: removed_bond.order === order
-          ? edit_state.bond_order_overrides
-          : replace_bond(edit_state.bond_order_overrides, record),
+        bond_order_overrides:
+          removed_bond.order === order
+            ? edit_state.bond_order_overrides
+            : replace_bond(edit_state.bond_order_overrides, record),
       },
     }
   }

--- a/src/lib/structure/bonding.ts
+++ b/src/lib/structure/bonding.ts
@@ -58,6 +58,177 @@ export const get_bond_key = (idx_1: number, idx_2: number, cell_shift?: Vec3): s
   )}`
 }
 
+export type BondEditState = {
+  added_bonds: StructureBond[]
+  removed_bonds: StructureBond[]
+  bond_order_overrides: StructureBond[]
+}
+
+export type BondEditAction =
+  | `added`
+  | `already-visible`
+  | `deleted-added`
+  | `deleted-calculated`
+  | `not-visible`
+  | `ordered-added`
+  | `ordered-calculated`
+  | `restored`
+
+export type BondEditResult = {
+  action: BondEditAction
+  changed: boolean
+  state: BondEditState
+}
+
+type BondKeyTarget = Pick<StructureBond, `site_idx_1` | `site_idx_2` | `cell_shift`>
+
+export const BOND_ORDER_OPTIONS: { order: BondOrder; label: string }[] = [
+  { order: 1, label: `Single` },
+  { order: 1.5, label: `1.5` },
+  { order: 2, label: `Double` },
+  { order: 3, label: `Triple` },
+  { order: `aromatic`, label: `Aromatic` },
+]
+
+const bond_key_for = (bond: BondKeyTarget): string =>
+  get_bond_key(bond.site_idx_1, bond.site_idx_2, bond.cell_shift)
+
+const matches_bond_key = (bond: BondKeyTarget, key: string): boolean =>
+  bond_key_for(bond) === key
+
+const replace_bond = (bonds: StructureBond[], next_bond: StructureBond): StructureBond[] => {
+  const key = bond_key_for(next_bond)
+  return [...bonds.filter((bond) => !matches_bond_key(bond, key)), next_bond]
+}
+
+const remove_bond_key = (bonds: StructureBond[], key: string): StructureBond[] =>
+  bonds.filter((bond) => !matches_bond_key(bond, key))
+
+const includes_bond_key = (bonds: BondKeyTarget[], key: string): boolean =>
+  bonds.some((bond) => matches_bond_key(bond, key))
+
+const has_calculated_bond = (
+  calculated_bonds: BondKeyTarget[],
+  key: string,
+): boolean => includes_bond_key(calculated_bonds, key)
+
+const make_bond_record = (bond: BondKeyTarget, order: BondOrder): StructureBond =>
+  normalize_structure_bond(bond.site_idx_1, bond.site_idx_2, order, bond.cell_shift)
+
+export function has_visible_bond(
+  edit_state: BondEditState,
+  bond: BondKeyTarget,
+  calculated_bonds: BondKeyTarget[],
+): boolean {
+  const key = bond_key_for(bond)
+  if (includes_bond_key(edit_state.added_bonds, key)) return true
+  if (includes_bond_key(edit_state.removed_bonds, key)) {
+    return false
+  }
+  return has_calculated_bond(calculated_bonds, key)
+}
+
+export function add_or_restore_bond(
+  edit_state: BondEditState,
+  bond: BondKeyTarget,
+  calculated_bonds: BondKeyTarget[],
+  order: BondOrder,
+): BondEditResult {
+  const record = make_bond_record(bond, order)
+  const key = bond_key_for(record)
+  const removed_bond = edit_state.removed_bonds.find((edit_bond) =>
+    matches_bond_key(edit_bond, key)
+  )
+  if (removed_bond) {
+    return {
+      action: `restored`,
+      changed: true,
+      state: {
+        ...edit_state,
+        removed_bonds: remove_bond_key(edit_state.removed_bonds, key),
+        bond_order_overrides: removed_bond.order === order
+          ? edit_state.bond_order_overrides
+          : replace_bond(edit_state.bond_order_overrides, record),
+      },
+    }
+  }
+  if (has_visible_bond(edit_state, record, calculated_bonds)) {
+    return { action: `already-visible`, changed: false, state: edit_state }
+  }
+  return {
+    action: `added`,
+    changed: true,
+    state: {
+      ...edit_state,
+      added_bonds: replace_bond(edit_state.added_bonds, record),
+      bond_order_overrides: remove_bond_key(edit_state.bond_order_overrides, key),
+    },
+  }
+}
+
+export function delete_bond(
+  edit_state: BondEditState,
+  bond: BondKeyTarget,
+  calculated_bonds: BondKeyTarget[],
+): BondEditResult {
+  const record = make_bond_record(bond, 1)
+  const key = bond_key_for(record)
+  const has_added_bond = includes_bond_key(edit_state.added_bonds, key)
+  if (has_added_bond) {
+    return {
+      action: `deleted-added`,
+      changed: true,
+      state: {
+        ...edit_state,
+        added_bonds: remove_bond_key(edit_state.added_bonds, key),
+        bond_order_overrides: remove_bond_key(edit_state.bond_order_overrides, key),
+      },
+    }
+  }
+  const calculated = has_calculated_bond(calculated_bonds, key)
+  const already_removed = includes_bond_key(edit_state.removed_bonds, key)
+  if (!calculated || already_removed) {
+    return { action: `not-visible`, changed: false, state: edit_state }
+  }
+  return {
+    action: `deleted-calculated`,
+    changed: true,
+    state: {
+      ...edit_state,
+      removed_bonds: [...edit_state.removed_bonds, record],
+      bond_order_overrides: remove_bond_key(edit_state.bond_order_overrides, key),
+    },
+  }
+}
+
+export function set_bond_order(
+  edit_state: BondEditState,
+  bond: BondKeyTarget,
+  calculated_bonds: BondKeyTarget[],
+  order: BondOrder,
+): BondEditResult {
+  const record = make_bond_record(bond, order)
+  const key = bond_key_for(record)
+  const calculated = has_calculated_bond(calculated_bonds, key)
+  if (calculated) {
+    const next_state = {
+      added_bonds: remove_bond_key(edit_state.added_bonds, key),
+      removed_bonds: remove_bond_key(edit_state.removed_bonds, key),
+      bond_order_overrides: replace_bond(edit_state.bond_order_overrides, record),
+    }
+    return { action: `ordered-calculated`, changed: true, state: next_state }
+  }
+  return {
+    action: `ordered-added`,
+    changed: true,
+    state: {
+      ...edit_state,
+      added_bonds: replace_bond(edit_state.added_bonds, record),
+      bond_order_overrides: remove_bond_key(edit_state.bond_order_overrides, key),
+    },
+  }
+}
+
 export const merge_bond_edits = (
   base_bonds: StructureBond[],
   added: StructureBond[],

--- a/src/lib/structure/bonding.ts
+++ b/src/lib/structure/bonding.ts
@@ -92,7 +92,7 @@ export type BondEditResult = {
   state: BondEditState
 }
 
-type BondKeyTarget = Pick<StructureBond, `site_idx_1` | `site_idx_2` | `cell_shift`>
+export type BondKeyTarget = Pick<StructureBond, `site_idx_1` | `site_idx_2` | `cell_shift`>
 type BondOrderTarget = BondKeyTarget & {
   bond_order?: BondOrder
   order?: BondOrder
@@ -105,6 +105,39 @@ export const BOND_ORDER_OPTIONS: { order: BondOrder; label: string }[] = [
   { order: 3, label: `Triple` },
   { order: `aromatic`, label: `Aromatic` },
 ]
+
+const site_image_shift = (sites: Site[] | undefined, site_idx: number): Vec3 => {
+  const site = sites?.[site_idx]
+  const orig_site_idx = site?.properties?.orig_site_idx
+  if (typeof orig_site_idx !== `number`) return [0, 0, 0]
+  const orig_site = sites?.[orig_site_idx]
+  if (!site?.abc || !orig_site?.abc) return [0, 0, 0]
+  return site.abc.map((coord, coord_idx) =>
+    Math.round(coord - orig_site.abc[coord_idx]),
+  ) as Vec3
+}
+
+const original_site_idx = (sites: Site[] | undefined, site_idx: number): number => {
+  const orig_site_idx = sites?.[site_idx]?.properties?.orig_site_idx
+  return typeof orig_site_idx === `number` ? orig_site_idx : site_idx
+}
+
+export const canonicalize_bond_target = (
+  bond: BondKeyTarget,
+  sites: Site[] | undefined,
+): BondKeyTarget => {
+  const shift_1 = site_image_shift(sites, bond.site_idx_1)
+  const shift_2 = site_image_shift(sites, bond.site_idx_2)
+  const base_shift = bond.cell_shift ?? [0, 0, 0]
+  const cell_shift = base_shift.map(
+    (shift_val, shift_idx) => shift_val + shift_2[shift_idx] - shift_1[shift_idx],
+  ) as Vec3
+  return normalize_bond_endpoints(
+    original_site_idx(sites, bond.site_idx_1),
+    original_site_idx(sites, bond.site_idx_2),
+    cell_shift,
+  )
+}
 
 const bond_key_for = (bond: BondKeyTarget): string =>
   get_bond_key(bond.site_idx_1, bond.site_idx_2, bond.cell_shift)

--- a/src/lib/structure/bonding.ts
+++ b/src/lib/structure/bonding.ts
@@ -25,11 +25,23 @@ const format_cell_shift = (cell_shift: Vec3 | undefined): string => {
 const negate_cell_shift = (cell_shift: Vec3): Vec3 =>
   cell_shift.map((val) => (val === 0 ? 0 : -val)) as Vec3
 
+const canonical_self_bond_shift = (cell_shift: Vec3): Vec3 => {
+  const first_non_zero = cell_shift.find((val) => val !== 0)
+  return first_non_zero !== undefined && first_non_zero < 0
+    ? negate_cell_shift(cell_shift)
+    : cell_shift
+}
+
 const normalize_bond_endpoints = (
   site_idx_1: number,
   site_idx_2: number,
   cell_shift?: Vec3,
 ): Pick<StructureBond, `site_idx_1` | `site_idx_2` | `cell_shift`> => {
+  if (site_idx_1 === site_idx_2) {
+    const ordered = { site_idx_1, site_idx_2 }
+    if (cell_shift === undefined || is_zero_cell_shift(cell_shift)) return ordered
+    return { ...ordered, cell_shift: canonical_self_bond_shift(cell_shift) }
+  }
   const ordered =
     site_idx_1 < site_idx_2
       ? { site_idx_1, site_idx_2 }
@@ -81,6 +93,10 @@ export type BondEditResult = {
 }
 
 type BondKeyTarget = Pick<StructureBond, `site_idx_1` | `site_idx_2` | `cell_shift`>
+type BondOrderTarget = BondKeyTarget & {
+  bond_order?: BondOrder
+  order?: BondOrder
+}
 
 export const BOND_ORDER_OPTIONS: { order: BondOrder; label: string }[] = [
   { order: 1, label: `Single` },
@@ -107,8 +123,13 @@ const remove_bond_key = (bonds: StructureBond[], key: string): StructureBond[] =
 const includes_bond_key = (bonds: BondKeyTarget[], key: string): boolean =>
   bonds.some((bond) => matches_bond_key(bond, key))
 
-const has_calculated_bond = (calculated_bonds: BondKeyTarget[], key: string): boolean =>
-  includes_bond_key(calculated_bonds, key)
+const get_bond_order = (bond: BondOrderTarget | undefined): BondOrder =>
+  bond?.bond_order ?? bond?.order ?? 1
+
+const find_bond_by_key = <BondType extends BondKeyTarget>(
+  bonds: BondType[],
+  key: string,
+): BondType | undefined => bonds.find((bond) => matches_bond_key(bond, key))
 
 const make_bond_record = (bond: BondKeyTarget, order: BondOrder): StructureBond =>
   normalize_structure_bond(bond.site_idx_1, bond.site_idx_2, order, bond.cell_shift)
@@ -116,37 +137,36 @@ const make_bond_record = (bond: BondKeyTarget, order: BondOrder): StructureBond 
 export function has_visible_bond(
   edit_state: BondEditState,
   bond: BondKeyTarget,
-  calculated_bonds: BondKeyTarget[],
+  calculated_bonds: BondOrderTarget[],
 ): boolean {
   const key = bond_key_for(bond)
-  if (includes_bond_key(edit_state.added_bonds, key)) return true
   if (includes_bond_key(edit_state.removed_bonds, key)) {
     return false
   }
-  return has_calculated_bond(calculated_bonds, key)
+  if (includes_bond_key(edit_state.added_bonds, key)) return true
+  return includes_bond_key(calculated_bonds, key)
 }
 
 export function add_or_restore_bond(
   edit_state: BondEditState,
   bond: BondKeyTarget,
-  calculated_bonds: BondKeyTarget[],
+  calculated_bonds: BondOrderTarget[],
   order: BondOrder,
 ): BondEditResult {
   const record = make_bond_record(bond, order)
   const key = bond_key_for(record)
-  const removed_bond = edit_state.removed_bonds.find((edit_bond) =>
-    matches_bond_key(edit_bond, key),
-  )
+  const removed_bond = find_bond_by_key(edit_state.removed_bonds, key)
   if (removed_bond) {
     return {
       action: `restored`,
       changed: true,
       state: {
         ...edit_state,
+        added_bonds: remove_bond_key(edit_state.added_bonds, key),
         removed_bonds: remove_bond_key(edit_state.removed_bonds, key),
         bond_order_overrides:
           removed_bond.order === order
-            ? edit_state.bond_order_overrides
+            ? remove_bond_key(edit_state.bond_order_overrides, key)
             : replace_bond(edit_state.bond_order_overrides, record),
       },
     }
@@ -168,12 +188,11 @@ export function add_or_restore_bond(
 export function delete_bond(
   edit_state: BondEditState,
   bond: BondKeyTarget,
-  calculated_bonds: BondKeyTarget[],
+  calculated_bonds: BondOrderTarget[],
 ): BondEditResult {
   const record = make_bond_record(bond, 1)
   const key = bond_key_for(record)
-  const has_added_bond = includes_bond_key(edit_state.added_bonds, key)
-  if (has_added_bond) {
+  if (includes_bond_key(edit_state.added_bonds, key)) {
     return {
       action: `deleted-added`,
       changed: true,
@@ -184,9 +203,8 @@ export function delete_bond(
       },
     }
   }
-  const calculated = has_calculated_bond(calculated_bonds, key)
-  const already_removed = includes_bond_key(edit_state.removed_bonds, key)
-  if (!calculated || already_removed) {
+  const calculated = find_bond_by_key(calculated_bonds, key)
+  if (!calculated || includes_bond_key(edit_state.removed_bonds, key)) {
     return { action: `not-visible`, changed: false, state: edit_state }
   }
   return {
@@ -194,7 +212,10 @@ export function delete_bond(
     changed: true,
     state: {
       ...edit_state,
-      removed_bonds: [...edit_state.removed_bonds, record],
+      removed_bonds: replace_bond(edit_state.removed_bonds, {
+        ...record,
+        order: get_bond_order(calculated),
+      }),
       bond_order_overrides: remove_bond_key(edit_state.bond_order_overrides, key),
     },
   }
@@ -203,19 +224,32 @@ export function delete_bond(
 export function set_bond_order(
   edit_state: BondEditState,
   bond: BondKeyTarget,
-  calculated_bonds: BondKeyTarget[],
+  calculated_bonds: BondOrderTarget[],
   order: BondOrder,
 ): BondEditResult {
   const record = make_bond_record(bond, order)
   const key = bond_key_for(record)
-  const calculated = has_calculated_bond(calculated_bonds, key)
+  const calculated = find_bond_by_key(calculated_bonds, key)
   if (calculated) {
+    const visible_order = get_bond_order(calculated)
+    const has_existing_edit =
+      includes_bond_key(edit_state.added_bonds, key) ||
+      includes_bond_key(edit_state.removed_bonds, key) ||
+      includes_bond_key(edit_state.bond_order_overrides, key)
+    const next_overrides =
+      order === visible_order
+        ? remove_bond_key(edit_state.bond_order_overrides, key)
+        : replace_bond(edit_state.bond_order_overrides, record)
     const next_state = {
       added_bonds: remove_bond_key(edit_state.added_bonds, key),
       removed_bonds: remove_bond_key(edit_state.removed_bonds, key),
-      bond_order_overrides: replace_bond(edit_state.bond_order_overrides, record),
+      bond_order_overrides: next_overrides,
     }
-    return { action: `ordered-calculated`, changed: true, state: next_state }
+    return {
+      action: `ordered-calculated`,
+      changed: has_existing_edit || order !== visible_order,
+      state: next_state,
+    }
   }
   return {
     action: `ordered-added`,
@@ -236,12 +270,22 @@ export const merge_bond_edits = (
 ): StructureBond[] => {
   const key_for = (bond: StructureBond): string =>
     get_bond_key(bond.site_idx_1, bond.site_idx_2, bond.cell_shift)
-  const merged = new Map(base_bonds.map((bond) => [key_for(bond), bond]))
-  for (const bond of removed) merged.delete(key_for(bond))
+  const normalize_record = (bond: StructureBond): StructureBond =>
+    normalize_structure_bond(bond.site_idx_1, bond.site_idx_2, bond.order, bond.cell_shift)
+  const removed_keys = new Set(removed.map(key_for))
+  const merged = new Map(
+    base_bonds
+      .filter((bond) => !removed_keys.has(key_for(bond)))
+      .map((bond) => [key_for(bond), normalize_record(bond)]),
+  )
   // Apply additions before overrides so user-set bond orders win even if
   // callers accidentally pass overlapping edit lists.
-  for (const bond of added) merged.set(key_for(bond), bond)
-  for (const bond of overrides) merged.set(key_for(bond), bond)
+  for (const bond of added) {
+    if (!removed_keys.has(key_for(bond))) merged.set(key_for(bond), normalize_record(bond))
+  }
+  for (const bond of overrides) {
+    if (!removed_keys.has(key_for(bond))) merged.set(key_for(bond), normalize_record(bond))
+  }
   return [...merged.values()]
 }
 
@@ -344,10 +388,6 @@ export function get_explicit_bond_metadata(structure: AnyStructure): StructureBo
       )
       continue
     }
-    if (site_idx_1 === site_idx_2) {
-      console.warn(`Ignoring invalid explicit bond at index ${entry_idx}: endpoints match`)
-      continue
-    }
     const bond_order = normalize_bond_order(order)
     if (bond_order === null) {
       console.warn(
@@ -362,6 +402,10 @@ export function get_explicit_bond_metadata(structure: AnyStructure): StructureBo
       console.warn(
         `Ignoring invalid explicit bond at index ${entry_idx}: cell_shift must be three integers`,
       )
+      continue
+    }
+    if (site_idx_1 === site_idx_2 && is_zero_cell_shift(cell_shift)) {
+      console.warn(`Ignoring invalid explicit bond at index ${entry_idx}: endpoints match`)
       continue
     }
     if (

--- a/src/lib/structure/index.ts
+++ b/src/lib/structure/index.ts
@@ -26,6 +26,7 @@ export { default as StructureScene } from './StructureScene.svelte'
 export * from './supercell'
 
 export type MeasureMode = `distance` | `angle` | `edit-bonds` | `edit-atoms`
+export type BondEditMode = `add` | `delete`
 
 export type Species = {
   element: ElementSymbol

--- a/src/lib/theme/themes.mjs
+++ b/src/lib/theme/themes.mjs
@@ -148,6 +148,18 @@ const themes = {
 
   // Tooltips
   'tooltip-bg': tooltip_bg(`243, 244, 246`, `0, 40, 60`),
+  'canvas-tooltip-bg': {
+    light: `rgba(226, 232, 240, 0.96)`,
+    dark: `rgba(15, 23, 42, 0.96)`,
+    white: `rgba(241, 245, 249, 0.98)`,
+    black: `rgba(20, 20, 20, 0.98)`,
+  },
+  'canvas-tooltip-text-color': {
+    light: `#0f172a`,
+    dark: `#f8fafc`,
+    white: `#0f172a`,
+    black: `#f8fafc`,
+  },
   'tooltip-border': {
     light: `1px solid rgba(0, 0, 0, 0.15)`,
     dark: `1px solid rgba(255, 255, 255, 0.15)`,

--- a/src/lib/xrd/calc-xrd.ts
+++ b/src/lib/xrd/calc-xrd.ts
@@ -354,7 +354,8 @@ export async function add_xrd_pattern(
       if (typeof content === `string`) {
         buffer_content = content
       } else {
-        buffer_content = new Uint8Array(content).slice().buffer
+        buffer_content =
+          content instanceof ArrayBuffer ? content : new Uint8Array(content).slice().buffer
       }
       const pattern = await parse_xrd_file(buffer_content, filename)
       if (pattern && pattern.x.length > 0) {

--- a/src/lib/xrd/calc-xrd.ts
+++ b/src/lib/xrd/calc-xrd.ts
@@ -354,7 +354,7 @@ export async function add_xrd_pattern(
       if (typeof content === `string`) {
         buffer_content = content
       } else {
-        buffer_content = new Uint8Array(content).buffer as ArrayBuffer
+        buffer_content = new Uint8Array(content).slice().buffer
       }
       const pattern = await parse_xrd_file(buffer_content, filename)
       if (pattern && pattern.x.length > 0) {

--- a/src/routes/(demos)/structure/+page.md
+++ b/src/routes/(demos)/structure/+page.md
@@ -74,7 +74,10 @@ MatterViz accepts explicit bond metadata on `structure.properties.bonds`. The
 viewer still computes normal proximity bonds, but any matching explicit entries
 set the rendered order, and explicit-only entries are added to the scene.
 
-Right-click a bond while in **Edit Bonds** mode to change its order interactively.
+In **Edit Bonds** mode, **Add** is the safe default: click two atoms to add or
+restore a bond without risking accidental deletion. Switch to **Delete** to remove
+existing bonds by clicking them. Use the order selector for new bonds, or open a
+bond's context menu to update an existing bond order interactively.
 
 ```svelte example
 <script lang="ts">

--- a/src/routes/test/structure/+page.svelte
+++ b/src/routes/test/structure/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { Crystal } from '$lib'
   import { DEFAULTS } from '$lib/settings'
-  import type { MeasureMode, StructureBond } from '$lib/structure'
+  import type { BondEditMode, BondOrder, MeasureMode, StructureBond } from '$lib/structure'
   import Structure from '$lib/structure/Structure.svelte'
   import StructureScene from '$lib/structure/StructureScene.svelte'
   import mp1_struct from '$site/structures/mp-1.json' with { type: 'json' }
@@ -20,6 +20,8 @@
   let measured_sites = $state<number[]>([])
   let enable_measure_mode = $state(true)
   let measure_mode = $state<MeasureMode>(`distance`)
+  let bond_edit_mode = $state<BondEditMode>(`add`)
+  let bond_edit_order = $state<BondOrder>(1)
   let supercell_scaling = $state(`1x1x1`)
   let show_image_atoms = $state(true)
   let fullscreen = $state(false)
@@ -154,16 +156,23 @@
       scene_props.vector_configs = detail.vector_configs ?? {}
     }
 
+    const handle_set_bonds = (event: Event) => {
+      const { detail } = event as CustomEvent
+      bonds = detail.bonds as StructureBond[] | undefined
+    }
+
     window.addEventListener(`set-lattice-props`, handle_lattice_props)
     window.addEventListener(`set-show-buttons`, handle_show_controls)
     window.addEventListener(`set-scene-props`, handle_scene_props)
     window.addEventListener(`set-structure`, handle_set_structure)
+    window.addEventListener(`set-bonds`, handle_set_bonds)
 
     return () => {
       window.removeEventListener(`set-lattice-props`, handle_lattice_props)
       window.removeEventListener(`set-show-buttons`, handle_show_controls)
       window.removeEventListener(`set-scene-props`, handle_scene_props)
       window.removeEventListener(`set-structure`, handle_set_structure)
+      window.removeEventListener(`set-bonds`, handle_set_bonds)
     }
   })
 
@@ -176,6 +185,11 @@
   $effect(() => {
     if (typeof window === `undefined`) return
     ;(globalThis as Record<string, unknown>).structure_bonds = bonds
+  })
+
+  $effect(() => {
+    if (typeof window === `undefined`) return
+    ;(globalThis as Record<string, unknown>).bond_edit_mode = bond_edit_mode
   })
 </script>
 
@@ -256,6 +270,8 @@
         [`clear-measured`, () => measured_sites = []],
         [`set-edit-atoms`, () => measure_mode = `edit-atoms`],
         [`set-edit-bonds`, () => measure_mode = `edit-bonds`],
+        [`set-bond-add`, () => bond_edit_mode = `add`],
+        [`set-bond-delete`, () => bond_edit_mode = `delete`],
         [`set-distance-mode`, () => measure_mode = `distance`],
       ] as const as
       [btn_type, onclick]
@@ -296,6 +312,8 @@
   bind:measured_sites
   {enable_measure_mode}
   bind:measure_mode
+  bind:bond_edit_mode
+  bind:bond_edit_order
   bind:supercell_scaling
   bind:show_image_atoms
   bind:fullscreen
@@ -313,6 +331,7 @@
 <div data-testid="gizmo-status">Gizmo Status: {scene_props.show_gizmo}</div>
 <div data-testid="show-buttons-status">Show Buttons Status: {show_controls}</div>
 <div data-testid="measure-mode-status">Measure Mode: {measure_mode}</div>
+<div data-testid="bond-edit-mode-status">Bond Edit Mode: {bond_edit_mode}</div>
 <div data-testid="fullscreen-status">Fullscreen Status: {fullscreen}</div>
 <div data-testid="performance-mode-status">
   Performance Mode Status: {performance_mode}

--- a/tests/playwright/structure/bonds.test.ts
+++ b/tests/playwright/structure/bonds.test.ts
@@ -620,51 +620,54 @@ test.describe(`Bond component`, () => {
     const console_errors = await goto_structure_page(page)
     await dispatch_two_atom_bond_structure(page, 1)
     const canvas = await wait_for_3d_canvas(page, `#test-structure`)
-    await page.locator(`[data-testid="btn-set-edit-bonds"]`).click()
-    await page.locator(`[data-testid="btn-set-bond-delete"]`).click()
+    const redo_button = page.getByRole(`button`, {
+      name: `Redo bond edit (Cmd/Ctrl+Y or Cmd+Shift+Z)`,
+    })
+    const expect_bonds = async (expected_bonds: unknown) => {
+      await expect.poll(() => get_structure_bonds(page)).toEqual(expected_bonds)
+    }
+    const delete_center_bond = async () => {
+      await page.locator(`[data-testid="btn-set-bond-delete"]`).click()
+      await click_canvas_center(page, canvas)
+      await expect_bonds([])
+    }
+    const undo_bond_delete = async (expected_bonds: unknown) => {
+      await page.getByRole(`button`, { name: `Undo bond edit (Cmd/Ctrl+Z)` }).click()
+      await expect_bonds(expected_bonds)
+    }
 
-    await click_canvas_center(page, canvas)
-    await expect.poll(() => get_structure_bonds(page)).toEqual([])
-    await page.getByRole(`button`, { name: `Undo bond edit (Cmd/Ctrl+Z)` }).click()
-    await expect
-      .poll(() => get_structure_bonds(page))
-      .toEqual([{ site_idx_1: 0, site_idx_2: 1, order: 1 }])
+    await page.locator(`[data-testid="btn-set-edit-bonds"]`).click()
+
+    await delete_center_bond()
+    await undo_bond_delete([{ site_idx_1: 0, site_idx_2: 1, order: 1 }])
 
     await dispatch_two_atom_bond_structure(page, 3)
-    await expect(
-      page.getByRole(`button`, { name: `Redo bond edit (Cmd/Ctrl+Y or Cmd+Shift+Z)` }),
-    ).toBeDisabled()
-    await expect
-      .poll(() => get_structure_bonds(page))
-      .toEqual([{ site_idx_1: 0, site_idx_2: 1, order: 3 }])
+    await expect(redo_button).toBeDisabled()
+    await expect_bonds([{ site_idx_1: 0, site_idx_2: 1, order: 3 }])
 
-    await page.locator(`[data-testid="btn-set-bond-delete"]`).click()
-    await click_canvas_center(page, canvas)
-    await expect.poll(() => get_structure_bonds(page)).toEqual([])
-    await page.getByRole(`button`, { name: `Undo bond edit (Cmd/Ctrl+Z)` }).click()
-    await expect
-      .poll(() => get_structure_bonds(page))
-      .toEqual([{ site_idx_1: 0, site_idx_2: 1, order: 3 }])
+    await delete_center_bond()
+    await undo_bond_delete([{ site_idx_1: 0, site_idx_2: 1, order: 3 }])
     await set_structure_bonds(page, [{ site_idx_1: 0, site_idx_2: 1, order: 2 }])
-    await expect(
-      page.getByRole(`button`, { name: `Redo bond edit (Cmd/Ctrl+Y or Cmd+Shift+Z)` }),
-    ).toBeDisabled()
-    await expect
-      .poll(() => get_structure_bonds(page))
-      .toEqual([{ site_idx_1: 0, site_idx_2: 1, order: 2 }])
+    await expect(redo_button).toBeDisabled()
+    await expect_bonds([{ site_idx_1: 0, site_idx_2: 1, order: 2 }])
 
-    await page.locator(`[data-testid="btn-set-bond-delete"]`).click()
-    await click_canvas_center(page, canvas)
-    await expect.poll(() => get_structure_bonds(page)).toEqual([])
-    await page.getByRole(`button`, { name: `Undo bond edit (Cmd/Ctrl+Z)` }).click()
-    await expect
-      .poll(() => get_structure_bonds(page))
-      .toEqual([{ site_idx_1: 0, site_idx_2: 1, order: 2 }])
+    await delete_center_bond()
+    await undo_bond_delete([{ site_idx_1: 0, site_idx_2: 1, order: 2 }])
     await page.locator(`[data-testid="btn-set-edit-atoms"]`).click()
     await page.locator(`[data-testid="btn-set-edit-bonds"]`).click()
-    await expect(
-      page.getByRole(`button`, { name: `Redo bond edit (Cmd/Ctrl+Y or Cmd+Shift+Z)` }),
-    ).toBeDisabled()
+    await expect(redo_button).toBeDisabled()
+
+    await dispatch_two_atom_unbonded_structure(page)
+    await set_structure_bonds(page, [{ site_idx_1: 0, site_idx_2: 1, order: 1 }])
+    await page.locator(`[data-testid="btn-set-edit-bonds"]`).click()
+    await delete_center_bond()
+    await undo_bond_delete([{ site_idx_1: 0, site_idx_2: 1, order: 1 }])
+    await page.locator(`[data-testid="btn-set-edit-atoms"]`).click()
+    await page.locator(`[data-testid="btn-set-edit-bonds"]`).click()
+    await delete_center_bond()
+    await undo_bond_delete([{ site_idx_1: 0, site_idx_2: 1, order: 1 }])
+    await set_structure_bonds(page, undefined)
+    await expect(redo_button).toBeDisabled()
     expect(console_errors).toHaveLength(0)
   })
 

--- a/tests/playwright/structure/bonds.test.ts
+++ b/tests/playwright/structure/bonds.test.ts
@@ -381,7 +381,7 @@ test.describe(`Bond component`, () => {
 
     await dispatch_two_atom_bond_structure(page, 3)
     await expect(
-      page.getByRole(`button`, { name: `Redo bond edit (Cmd/Ctrl+Y)` }),
+      page.getByRole(`button`, { name: `Redo bond edit (Cmd/Ctrl+Y or Cmd+Shift+Z)` }),
     ).toBeDisabled()
     await expect
       .poll(() => get_structure_bonds(page))
@@ -396,7 +396,7 @@ test.describe(`Bond component`, () => {
       .toEqual([{ site_idx_1: 0, site_idx_2: 1, order: 3 }])
     await set_structure_bonds(page, [{ site_idx_1: 0, site_idx_2: 1, order: 2 }])
     await expect(
-      page.getByRole(`button`, { name: `Redo bond edit (Cmd/Ctrl+Y)` }),
+      page.getByRole(`button`, { name: `Redo bond edit (Cmd/Ctrl+Y or Cmd+Shift+Z)` }),
     ).toBeDisabled()
     await expect
       .poll(() => get_structure_bonds(page))
@@ -412,7 +412,7 @@ test.describe(`Bond component`, () => {
     await page.locator(`[data-testid="btn-set-edit-atoms"]`).click()
     await page.locator(`[data-testid="btn-set-edit-bonds"]`).click()
     await expect(
-      page.getByRole(`button`, { name: `Redo bond edit (Cmd/Ctrl+Y)` }),
+      page.getByRole(`button`, { name: `Redo bond edit (Cmd/Ctrl+Y or Cmd+Shift+Z)` }),
     ).toBeDisabled()
     expect(console_errors).toHaveLength(0)
   })

--- a/tests/playwright/structure/bonds.test.ts
+++ b/tests/playwright/structure/bonds.test.ts
@@ -37,27 +37,37 @@ const goto_structure_page = async (page: Page): Promise<string[]> => {
 }
 
 type StructureCanvas = Awaited<ReturnType<typeof wait_for_3d_canvas>>
+type CanvasOffset = { x?: number; y?: number }
 
 const get_canvas_center = async (
   canvas: StructureCanvas,
+  offset: CanvasOffset = {},
 ): Promise<{ x: number; y: number }> => {
   await canvas.scrollIntoViewIfNeeded()
   const box = await canvas.boundingBox()
   if (!box) throw new Error(`canvas has no bounding box`)
-  return { x: box.x + box.width / 2, y: box.y + box.height / 2 }
+  return {
+    x: box.x + box.width / 2 + (offset.x ?? 0),
+    y: box.y + box.height / 2 + (offset.y ?? 0),
+  }
 }
 
 const click_canvas_center = async (
   page: Page,
   canvas: StructureCanvas,
   button: `left` | `right` = `left`,
+  offset?: CanvasOffset,
 ): Promise<void> => {
-  const center = await get_canvas_center(canvas)
+  const center = await get_canvas_center(canvas, offset)
   await page.mouse.click(center.x, center.y, { button })
 }
 
-const hover_canvas_center = async (page: Page, canvas: StructureCanvas): Promise<void> => {
-  const center = await get_canvas_center(canvas)
+const hover_canvas_center = async (
+  page: Page,
+  canvas: StructureCanvas,
+  offset?: CanvasOffset,
+): Promise<void> => {
+  const center = await get_canvas_center(canvas, offset)
   await page.mouse.move(center.x, center.y)
   await page.waitForTimeout(100)
 }
@@ -336,18 +346,26 @@ test.describe(`Bond component`, () => {
     expect(console_errors).toHaveLength(0)
   })
 
-  test(`edit-bonds add mode opens order editing without deleting`, async ({ page }) => {
+  test(`edit-bonds add mode opens order editing after clicking two atoms`, async ({
+    page,
+  }) => {
     const console_errors = await goto_structure_page(page)
     await dispatch_two_atom_bond_structure(page, 1)
     const canvas = await wait_for_3d_canvas(page, `#test-structure`)
+    await set_scene_props(page, { show_site_labels: true, site_label_offset: [0, 0, 0] })
     await page.locator(`[data-testid="btn-set-edit-bonds"]`).click()
     await expect(page.locator(`[data-testid="bond-edit-mode-status"]`)).toContainText(`add`)
 
     await click_canvas_center(page, canvas)
     const menu = page.locator(`#test-structure .bond-context-menu`)
     await expect(menu).toBeVisible()
-    // This test's click_canvas_center/get_structure_bonds check verifies no set-bonds emission occurred yet.
+    await menu.getByRole(`button`, { name: `Close` }).click()
     await expect.poll(() => get_structure_bonds(page)).toBeUndefined()
+
+    await click_atom_label(page, `C`)
+    await expect(menu).toBeHidden()
+    await click_atom_label(page, `O`)
+    await expect(menu).toBeVisible()
     await menu.getByRole(`button`, { name: `Close` }).click()
     expect(console_errors).toHaveLength(0)
   })
@@ -426,7 +444,10 @@ test.describe(`Bond component`, () => {
     await page.locator(`[data-testid="btn-set-edit-bonds"]`).click()
     await page.locator(`[data-testid="btn-set-bond-delete"]`).click()
 
-    await hover_canvas_center(page, canvas)
+    const unhovered = await canvas.screenshot()
+    const outer_delete_area = { y: 24 }
+    await hover_canvas_center(page, canvas, outer_delete_area)
+    await expect_canvas_changed(canvas, unhovered)
     await click_canvas_center(page, canvas)
 
     await expect.poll(() => get_structure_bonds(page)).toEqual([])

--- a/tests/playwright/structure/bonds.test.ts
+++ b/tests/playwright/structure/bonds.test.ts
@@ -49,23 +49,6 @@ const click_canvas_center = async (
   await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2, { button })
 }
 
-const click_canvas_offset = async (
-  page: Page,
-  canvas: StructureCanvas,
-  offset_x: number,
-  offset_y = 0,
-  button: `left` | `right` = `left`,
-): Promise<void> => {
-  await canvas.scrollIntoViewIfNeeded()
-  const box = await canvas.boundingBox()
-  if (!box) throw new Error(`canvas has no bounding box`)
-  await page.mouse.click(box.x + box.width / 2 + offset_x, box.y + box.height / 2 + offset_y, {
-    button,
-  })
-}
-
-const BOND_CLICK_OFFSETS = [0, 45, -45, 70, -70, 30, -30, 90, -90]
-
 const click_atom_label = async (page: Page, label_text: string): Promise<void> => {
   const label = page
     .locator(`#test-structure .atom-label`)
@@ -83,48 +66,6 @@ const set_structure_bonds = (page: Page, bonds: unknown) =>
   page.evaluate((next_bonds) => {
     window.dispatchEvent(new CustomEvent(`set-bonds`, { detail: { bonds: next_bonds } }))
   }, bonds)
-
-const open_bond_menu_near_center = async (
-  page: Page,
-  canvas: StructureCanvas,
-): Promise<number> => {
-  const menu = page.locator(`#test-structure .bond-context-menu`)
-  for (const offset_x of BOND_CLICK_OFFSETS) {
-    await click_canvas_offset(page, canvas, offset_x, 0, `right`)
-    try {
-      await expect(menu).toBeVisible({ timeout: 500 })
-      return offset_x
-    } catch {
-      // Try the next likely bond midpoint in screen space.
-    }
-  }
-  try {
-    await expect(menu).toBeVisible({ timeout: 500 })
-    return 0
-  } catch (error) {
-    throw new Error(
-      `open_bond_menu_near_center failed to open #test-structure .bond-context-menu ` +
-        `after trying BOND_CLICK_OFFSETS with click_canvas_offset: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      { cause: error },
-    )
-  }
-}
-
-const delete_bond_near_center = async (page: Page, canvas: StructureCanvas): Promise<void> => {
-  for (const offset_x of BOND_CLICK_OFFSETS) {
-    await click_canvas_offset(page, canvas, offset_x)
-    const bonds = await get_structure_bonds(page)
-    if (Array.isArray(bonds) && bonds.length === 0) return
-  }
-  const final_bonds = await get_structure_bonds(page)
-  expect(
-    final_bonds,
-    `delete_bond_near_center failed to delete bond near center after trying ` +
-      `BOND_CLICK_OFFSETS with click_canvas_offset and get_structure_bonds`,
-  ).toEqual([])
-}
 
 const dispatch_co2 = (page: Page) =>
   page.evaluate(() => {
@@ -157,7 +98,12 @@ const dispatch_co2 = (page: Page) =>
     window.dispatchEvent(new CustomEvent(`set-structure`, { detail: { structure } }))
     window.dispatchEvent(
       new CustomEvent(`set-scene-props`, {
-        detail: { camera_position: [0, 0, 8], show_bonds: `always` },
+        detail: {
+          bond_thickness: 0.25,
+          camera_position: [0, 0, 8],
+          camera_target: [0, 0, 0],
+          show_bonds: `always`,
+        },
       }),
     )
   })
@@ -231,11 +177,8 @@ const dispatch_two_atom_unbonded_structure = (page: Page) =>
   })
 
 test.describe(`Bond component`, () => {
-  test.beforeEach(() => {
-    test.skip(IS_CI, `Bonds tests timeout in CI`)
-  })
-
   test(`renders bonds and handles rotation/zoom without errors`, async ({ page }) => {
+    test.skip(IS_CI, `Visual bonds test times out in CI`)
     const console_errors = await goto_structure_page(page)
     // wait_for_3d_canvas ensures canvas is visible with non-zero dimensions
     const canvas = await wait_for_3d_canvas(page, `#test-structure`)
@@ -273,6 +216,7 @@ test.describe(`Bond component`, () => {
   })
 
   test(`bonds visible from multiple angles with proper gradients`, async ({ page }) => {
+    test.skip(IS_CI, `Visual bonds test times out in CI`)
     const console_errors = await goto_structure_page(page)
     const canvas = await wait_for_3d_canvas(page, `#test-structure`)
 
@@ -430,13 +374,15 @@ test.describe(`Bond component`, () => {
 
     await click_canvas_center(page, canvas)
     await expect.poll(() => get_structure_bonds(page)).toEqual([])
-    await page.getByRole(`button`, { name: `Undo bond edit (Ctrl+Z)` }).click()
+    await page.getByRole(`button`, { name: `Undo bond edit (Cmd/Ctrl+Z)` }).click()
     await expect
       .poll(() => get_structure_bonds(page))
       .toEqual([{ site_idx_1: 0, site_idx_2: 1, order: 1 }])
 
     await dispatch_two_atom_bond_structure(page, 3)
-    await expect(page.getByRole(`button`, { name: `Redo bond edit (Ctrl+Y)` })).toBeDisabled()
+    await expect(
+      page.getByRole(`button`, { name: `Redo bond edit (Cmd/Ctrl+Y)` }),
+    ).toBeDisabled()
     await expect
       .poll(() => get_structure_bonds(page))
       .toEqual([{ site_idx_1: 0, site_idx_2: 1, order: 3 }])
@@ -444,12 +390,14 @@ test.describe(`Bond component`, () => {
     await page.locator(`[data-testid="btn-set-bond-delete"]`).click()
     await click_canvas_center(page, canvas)
     await expect.poll(() => get_structure_bonds(page)).toEqual([])
-    await page.getByRole(`button`, { name: `Undo bond edit (Ctrl+Z)` }).click()
+    await page.getByRole(`button`, { name: `Undo bond edit (Cmd/Ctrl+Z)` }).click()
     await expect
       .poll(() => get_structure_bonds(page))
       .toEqual([{ site_idx_1: 0, site_idx_2: 1, order: 3 }])
     await set_structure_bonds(page, [{ site_idx_1: 0, site_idx_2: 1, order: 2 }])
-    await expect(page.getByRole(`button`, { name: `Redo bond edit (Ctrl+Y)` })).toBeDisabled()
+    await expect(
+      page.getByRole(`button`, { name: `Redo bond edit (Cmd/Ctrl+Y)` }),
+    ).toBeDisabled()
     await expect
       .poll(() => get_structure_bonds(page))
       .toEqual([{ site_idx_1: 0, site_idx_2: 1, order: 2 }])
@@ -457,13 +405,15 @@ test.describe(`Bond component`, () => {
     await page.locator(`[data-testid="btn-set-bond-delete"]`).click()
     await click_canvas_center(page, canvas)
     await expect.poll(() => get_structure_bonds(page)).toEqual([])
-    await page.getByRole(`button`, { name: `Undo bond edit (Ctrl+Z)` }).click()
+    await page.getByRole(`button`, { name: `Undo bond edit (Cmd/Ctrl+Z)` }).click()
     await expect
       .poll(() => get_structure_bonds(page))
       .toEqual([{ site_idx_1: 0, site_idx_2: 1, order: 2 }])
     await page.locator(`[data-testid="btn-set-edit-atoms"]`).click()
     await page.locator(`[data-testid="btn-set-edit-bonds"]`).click()
-    await expect(page.getByRole(`button`, { name: `Redo bond edit (Ctrl+Y)` })).toBeDisabled()
+    await expect(
+      page.getByRole(`button`, { name: `Redo bond edit (Cmd/Ctrl+Y)` }),
+    ).toBeDisabled()
     expect(console_errors).toHaveLength(0)
   })
 
@@ -490,6 +440,7 @@ test.describe(`Bond component`, () => {
   })
 
   test(`auto bond-order toggle changes rendered bond geometry`, async ({ page }) => {
+    test.skip(IS_CI, `Visual bonds test times out in CI`)
     const console_errors = await goto_structure_page(page)
     await dispatch_co2(page)
     const canvas = await wait_for_3d_canvas(page, `#test-structure`)
@@ -513,6 +464,7 @@ test.describe(`Bond component`, () => {
   })
 
   test(`aromatic display toggle switches benzene representation`, async ({ page }) => {
+    test.skip(IS_CI, `Visual bonds test times out in CI`)
     const console_errors = await goto_structure_page(page)
     // Planar benzene ring (6 C in a hexagon, 1.39 Å radius), no explicit
     // bonds -> connectivity ring detected, perception flags it aromatic.
@@ -558,6 +510,7 @@ test.describe(`Bond component`, () => {
   })
 
   test(`manual override wins over perceived bond order`, async ({ page }) => {
+    test.skip(IS_CI, `Visual bonds test times out in CI`)
     const console_errors = await goto_structure_page(page)
     await dispatch_co2(page)
     await expect.poll(() => get_structure_bonds(page)).toBeUndefined()
@@ -568,7 +521,7 @@ test.describe(`Bond component`, () => {
     // carbon, so the midpoint is slightly right of the canvas center.
     await page.locator(`[data-testid="btn-set-edit-bonds"]`).click()
 
-    const target_offset_x = await open_bond_menu_near_center(page, canvas)
+    await click_canvas_center(page, canvas, `right`)
     const menu = page.locator(`#test-structure .bond-context-menu`)
     await expect(menu).toBeVisible()
     // Pre-override: the menu reports the PERCEIVED order. Perception relabels
@@ -584,16 +537,16 @@ test.describe(`Bond component`, () => {
       .poll(() => get_structure_bonds(page))
       .toContainEqual(expect.objectContaining({ order: 3 }))
 
-    // Re-open the edited bond with the same target offset to ensure the
-    // context menu still supports follow-up actions after the override.
-    await click_canvas_offset(page, canvas, target_offset_x, 0, `right`)
+    // Re-open the edited bond to ensure the context menu still supports
+    // follow-up actions after the override.
+    await click_canvas_center(page, canvas, `right`)
     await expect(menu).toBeVisible()
     await menu.getByRole(`button`, { name: `Close` }).focus()
     await page.keyboard.press(`Enter`)
     await expect(menu).toBeHidden()
 
     await page.locator(`[data-testid="btn-set-bond-delete"]`).click()
-    await delete_bond_near_center(page, canvas)
+    await click_canvas_center(page, canvas)
     await expect.poll(() => get_structure_bonds(page)).toEqual([])
     await page.getByRole(`button`, { name: `Reset selection and bond edits` }).click()
     await expect.poll(() => get_structure_bonds(page)).toBeUndefined()
@@ -601,6 +554,7 @@ test.describe(`Bond component`, () => {
   })
 
   test(`site labels avoid adjacent bond directions`, async ({ page }) => {
+    test.skip(IS_CI, `Visual bonds test times out in CI`)
     const console_errors = await goto_structure_page(page)
     await page.evaluate(() => {
       const structure = {

--- a/tests/playwright/structure/bonds.test.ts
+++ b/tests/playwright/structure/bonds.test.ts
@@ -49,10 +49,83 @@ const click_canvas_center = async (
   await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2, { button })
 }
 
+const click_canvas_offset = async (
+  page: Page,
+  canvas: StructureCanvas,
+  offset_x: number,
+  offset_y = 0,
+  button: `left` | `right` = `left`,
+): Promise<void> => {
+  await canvas.scrollIntoViewIfNeeded()
+  const box = await canvas.boundingBox()
+  if (!box) throw new Error(`canvas has no bounding box`)
+  await page.mouse.click(
+    box.x + box.width / 2 + offset_x,
+    box.y + box.height / 2 + offset_y,
+    { button },
+  )
+}
+
+const BOND_CLICK_OFFSETS = [0, 45, -45, 70, -70, 30, -30, 90, -90]
+
+const click_atom_label = async (page: Page, label_text: string): Promise<void> => {
+  const label = page.locator(`#test-structure .atom-label`).filter({ hasText: label_text }).last()
+  await expect(label).toBeVisible()
+  await label.click()
+}
 const set_scene_props = (page: Page, detail: Record<string, unknown>) =>
   page.evaluate((props) => {
     window.dispatchEvent(new CustomEvent(`set-scene-props`, { detail: props }))
   }, detail)
+
+const set_structure_bonds = (page: Page, bonds: unknown) =>
+  page.evaluate((next_bonds) => {
+    window.dispatchEvent(new CustomEvent(`set-bonds`, { detail: { bonds: next_bonds } }))
+  }, bonds)
+
+const open_bond_menu_near_center = async (
+  page: Page,
+  canvas: StructureCanvas,
+): Promise<number> => {
+  const menu = page.locator(`#test-structure .bond-context-menu`)
+  for (const offset_x of BOND_CLICK_OFFSETS) {
+    await click_canvas_offset(page, canvas, offset_x, 0, `right`)
+    try {
+      await expect(menu).toBeVisible({ timeout: 500 })
+      return offset_x
+    } catch {
+      // Try the next likely bond midpoint in screen space.
+    }
+  }
+  try {
+    await expect(menu).toBeVisible({ timeout: 500 })
+    return 0
+  } catch (error) {
+    throw new Error(
+      `open_bond_menu_near_center failed to open #test-structure .bond-context-menu ` +
+        `after trying BOND_CLICK_OFFSETS with click_canvas_offset: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+    )
+  }
+}
+
+const delete_bond_near_center = async (
+  page: Page,
+  canvas: StructureCanvas,
+): Promise<void> => {
+  for (const offset_x of BOND_CLICK_OFFSETS) {
+    await click_canvas_offset(page, canvas, offset_x)
+    const bonds = await get_structure_bonds(page)
+    if (Array.isArray(bonds) && bonds.length === 0) return
+  }
+  const final_bonds = await get_structure_bonds(page)
+  expect(
+    final_bonds,
+    `delete_bond_near_center failed to delete bond near center after trying ` +
+      `BOND_CLICK_OFFSETS with click_canvas_offset and get_structure_bonds`,
+  ).toEqual([])
+}
 
 const dispatch_co2 = (page: Page) =>
   page.evaluate(() => {
@@ -120,6 +193,43 @@ const dispatch_two_atom_bond_structure = (page: Page, order: 1 | 2 | 3) =>
       }),
     )
   }, order)
+
+const dispatch_two_atom_unbonded_structure = (page: Page) =>
+  page.evaluate(() => {
+    const structure = {
+      sites: [
+        {
+          species: [{ element: `C`, occu: 1, oxidation_state: 0 }],
+          abc: [0, 0, 0],
+          xyz: [-0.7, 0, 0],
+          label: `C1`,
+          properties: {},
+        },
+        {
+          species: [{ element: `O`, occu: 1, oxidation_state: 0 }],
+          abc: [0, 0, 0],
+          xyz: [0.7, 0, 0],
+          label: `O1`,
+          properties: {},
+        },
+      ],
+      properties: {},
+    }
+    window.dispatchEvent(new CustomEvent(`set-structure`, { detail: { structure } }))
+    window.dispatchEvent(
+      new CustomEvent(`set-scene-props`, {
+        detail: {
+          atom_radius: 2.5,
+          bonding_options: { strength_threshold: 10 },
+          camera_position: [0, 0, 8],
+          camera_target: [0, 0, 0],
+          show_bonds: `always`,
+          show_site_labels: true,
+          site_label_offset: [0, 0, 0],
+        },
+      }),
+    )
+  })
 
 test.describe(`Bond component`, () => {
   test.beforeEach(() => {
@@ -227,6 +337,133 @@ test.describe(`Bond component`, () => {
     expect(console_errors).toHaveLength(0)
   })
 
+  test(`edit-bonds add mode opens order editing without deleting`, async ({ page }) => {
+    const console_errors = await goto_structure_page(page)
+    await dispatch_two_atom_bond_structure(page, 1)
+    const canvas = await wait_for_3d_canvas(page, `#test-structure`)
+    await page.locator(`[data-testid="btn-set-edit-bonds"]`).click()
+    await expect(page.locator(`[data-testid="bond-edit-mode-status"]`)).toContainText(`add`)
+
+    await click_canvas_center(page, canvas)
+    const menu = page.locator(`#test-structure .bond-context-menu`)
+    await expect(menu).toBeVisible()
+    // This test's click_canvas_center/get_structure_bonds check verifies no set-bonds emission occurred yet.
+    await expect.poll(() => get_structure_bonds(page)).toBeUndefined()
+    await menu.getByRole(`button`, { name: `Close` }).click()
+    expect(console_errors).toHaveLength(0)
+  })
+
+  test(`edit-bonds add mode creates selected-order bond between unbonded atoms`, async ({ page }) => {
+    const console_errors = await goto_structure_page(page)
+    await dispatch_two_atom_unbonded_structure(page)
+    await wait_for_3d_canvas(page, `#test-structure`)
+    await page.locator(`[data-testid="btn-set-edit-bonds"]`).click()
+    await page.locator(`#test-structure .bond-edit-toolbar select`).selectOption({
+      label: `Double`,
+    })
+
+    await click_atom_label(page, `C`)
+    await click_atom_label(page, `O`)
+    await expect.poll(() => get_structure_bonds(page)).toContainEqual(
+      expect.objectContaining({ site_idx_1: 0, site_idx_2: 1, order: 2 }),
+    )
+    expect(console_errors).toHaveLength(0)
+  })
+
+  test(`edit-bonds shortcuts switch modes and keyboard undo redo`, async ({ page }) => {
+    const console_errors = await goto_structure_page(page)
+    await dispatch_two_atom_bond_structure(page, 1)
+    const canvas = await wait_for_3d_canvas(page, `#test-structure`)
+    await page.locator(`[data-testid="btn-set-edit-bonds"]`).click()
+    await page.locator(`#test-structure`).getByRole(`button`, { name: `Add` }).focus()
+    await page.keyboard.press(`d`)
+    await expect(page.locator(`[data-testid="bond-edit-mode-status"]`)).toContainText(`delete`)
+    await page.keyboard.press(`a`)
+    await expect(page.locator(`[data-testid="bond-edit-mode-status"]`)).toContainText(`add`)
+    const order_select = page.locator(`#test-structure .bond-edit-toolbar select`)
+    await order_select.focus()
+    await page.keyboard.press(`d`)
+    await expect(page.locator(`[data-testid="bond-edit-mode-status"]`)).toContainText(`add`)
+    await expect(order_select).toBeEnabled()
+    await page.locator(`#test-structure`).getByRole(`button`, { name: `Add` }).focus()
+    await page.keyboard.press(`d`)
+
+    await click_canvas_center(page, canvas)
+    await expect.poll(() => get_structure_bonds(page)).toEqual([])
+
+    await page.keyboard.press(process.platform === `darwin` ? `Meta+Z` : `Control+Z`)
+    await expect
+      .poll(() => get_structure_bonds(page))
+      .toEqual([{ site_idx_1: 0, site_idx_2: 1, order: 1 }])
+
+    await page.keyboard.press(process.platform === `darwin` ? `Meta+Y` : `Control+Y`)
+    await expect.poll(() => get_structure_bonds(page)).toEqual([])
+    expect(console_errors).toHaveLength(0)
+  })
+
+  test(`edit-bonds delete mode still supports right-click order editing`, async ({ page }) => {
+    const console_errors = await goto_structure_page(page)
+    await dispatch_two_atom_bond_structure(page, 1)
+    const canvas = await wait_for_3d_canvas(page, `#test-structure`)
+    await page.locator(`[data-testid="btn-set-edit-bonds"]`).click()
+    await page.locator(`[data-testid="btn-set-bond-delete"]`).click()
+
+    await click_canvas_center(page, canvas, `right`)
+    const menu = page.locator(`#test-structure .bond-context-menu`)
+    await expect(menu).toBeVisible()
+    await menu.getByRole(`button`, { name: `Triple` }).click()
+    await expect
+      .poll(() => get_structure_bonds(page))
+      .toEqual([{ site_idx_1: 0, site_idx_2: 1, order: 3 }])
+    expect(console_errors).toHaveLength(0)
+  })
+
+  test(`bond redo history is cleared after source changes and edit-atoms`, async ({ page }) => {
+    const console_errors = await goto_structure_page(page)
+    await dispatch_two_atom_bond_structure(page, 1)
+    const canvas = await wait_for_3d_canvas(page, `#test-structure`)
+    await page.locator(`[data-testid="btn-set-edit-bonds"]`).click()
+    await page.locator(`[data-testid="btn-set-bond-delete"]`).click()
+
+    await click_canvas_center(page, canvas)
+    await expect.poll(() => get_structure_bonds(page)).toEqual([])
+    await page.getByRole(`button`, { name: `Undo bond edit (Ctrl+Z)` }).click()
+    await expect
+      .poll(() => get_structure_bonds(page))
+      .toEqual([{ site_idx_1: 0, site_idx_2: 1, order: 1 }])
+
+    await dispatch_two_atom_bond_structure(page, 3)
+    await expect(page.getByRole(`button`, { name: `Redo bond edit (Ctrl+Y)` })).toBeDisabled()
+    await expect
+      .poll(() => get_structure_bonds(page))
+      .toEqual([{ site_idx_1: 0, site_idx_2: 1, order: 3 }])
+
+    await page.locator(`[data-testid="btn-set-bond-delete"]`).click()
+    await click_canvas_center(page, canvas)
+    await expect.poll(() => get_structure_bonds(page)).toEqual([])
+    await page.getByRole(`button`, { name: `Undo bond edit (Ctrl+Z)` }).click()
+    await expect
+      .poll(() => get_structure_bonds(page))
+      .toEqual([{ site_idx_1: 0, site_idx_2: 1, order: 3 }])
+    await set_structure_bonds(page, [{ site_idx_1: 0, site_idx_2: 1, order: 2 }])
+    await expect(page.getByRole(`button`, { name: `Redo bond edit (Ctrl+Y)` })).toBeDisabled()
+    await expect
+      .poll(() => get_structure_bonds(page))
+      .toEqual([{ site_idx_1: 0, site_idx_2: 1, order: 2 }])
+
+    await page.locator(`[data-testid="btn-set-bond-delete"]`).click()
+    await click_canvas_center(page, canvas)
+    await expect.poll(() => get_structure_bonds(page)).toEqual([])
+    await page.getByRole(`button`, { name: `Undo bond edit (Ctrl+Z)` }).click()
+    await expect
+      .poll(() => get_structure_bonds(page))
+      .toEqual([{ site_idx_1: 0, site_idx_2: 1, order: 2 }])
+    await page.locator(`[data-testid="btn-set-edit-atoms"]`).click()
+    await page.locator(`[data-testid="btn-set-edit-bonds"]`).click()
+    await expect(page.getByRole(`button`, { name: `Redo bond edit (Ctrl+Y)` })).toBeDisabled()
+    expect(console_errors).toHaveLength(0)
+  })
+
   test(`structure change during bond edit emits new structure bonds`, async ({ page }) => {
     const console_errors = await goto_structure_page(page)
     await dispatch_two_atom_bond_structure(page, 1)
@@ -324,11 +561,11 @@ test.describe(`Bond component`, () => {
     await set_scene_props(page, { auto_bond_order: true })
     const canvas = await wait_for_3d_canvas(page, `#test-structure`)
 
-    // Drive the SAME edit-bonds context menu the existing explicit-order test
-    // uses, targeting the C-O1 bond midpoint (world origin -> canvas center).
+    // Target the right-side C-O1 bond midpoint. The molecule is centered near
+    // carbon, so the midpoint is slightly right of the canvas center.
     await page.locator(`[data-testid="btn-set-edit-bonds"]`).click()
 
-    await click_canvas_center(page, canvas, `right`)
+    const target_offset_x = await open_bond_menu_near_center(page, canvas)
     const menu = page.locator(`#test-structure .bond-context-menu`)
     await expect(menu).toBeVisible()
     // Pre-override: the menu reports the PERCEIVED order. Perception relabels
@@ -338,22 +575,22 @@ test.describe(`Bond component`, () => {
     // Manually override to Triple - must win over the perceived double.
     await menu.getByRole(`button`, { name: `Triple` }).click()
     await expect(menu).toBeHidden()
-
-    // Re-open the menu on the same bond: it must now report order 3, proving
-    // the manual bond_order_overrides path takes precedence over perception.
-    await click_canvas_center(page, canvas, `right`)
-    await expect(menu).toBeVisible()
-    await expect(menu).toContainText(`Bond Order (3)`)
     // The override is recorded in the bound bonds list (globalThis hook),
     // not the perceived order - concrete proof of precedence.
     await expect
       .poll(() => get_structure_bonds(page))
       .toContainEqual(expect.objectContaining({ order: 3 }))
+
+    // Re-open the edited bond with the same target offset to ensure the
+    // context menu still supports follow-up actions after the override.
+    await click_canvas_offset(page, canvas, target_offset_x, 0, `right`)
+    await expect(menu).toBeVisible()
     await menu.getByRole(`button`, { name: `Close` }).focus()
     await page.keyboard.press(`Enter`)
     await expect(menu).toBeHidden()
 
-    await click_canvas_center(page, canvas)
+    await page.locator(`[data-testid="btn-set-bond-delete"]`).click()
+    await delete_bond_near_center(page, canvas)
     await expect.poll(() => get_structure_bonds(page)).toEqual([])
     await page.getByRole(`button`, { name: `Reset selection and bond edits` }).click()
     await expect.poll(() => get_structure_bonds(page)).toBeUndefined()

--- a/tests/playwright/structure/bonds.test.ts
+++ b/tests/playwright/structure/bonds.test.ts
@@ -358,8 +358,7 @@ test.describe(`Bond component`, () => {
 
     await click_canvas_center(page, canvas)
     const menu = page.locator(`#test-structure .bond-context-menu`)
-    await expect(menu).toBeVisible()
-    await menu.getByRole(`button`, { name: `Close` }).click()
+    await expect(menu).toBeHidden()
     await expect.poll(() => get_structure_bonds(page)).toBeUndefined()
 
     await click_atom_label(page, `C`)

--- a/tests/playwright/structure/bonds.test.ts
+++ b/tests/playwright/structure/bonds.test.ts
@@ -219,47 +219,70 @@ const dispatch_two_atom_unbonded_structure = (page: Page) =>
     )
   })
 
-const dispatch_periodic_image_bond_structure = (page: Page) =>
-  page.evaluate(() => {
-    const structure = {
-      lattice: {
-        matrix: [
-          [10, 0, 0],
-          [0, 10, 0],
-          [0, 0, 10],
+const dispatch_periodic_image_structure = (
+  page: Page,
+  {
+    bonding_options,
+    show_site_labels = false,
+  }: { bonding_options: Record<string, unknown>; show_site_labels?: boolean },
+) =>
+  page.evaluate(
+    (scene_options) => {
+      const structure = {
+        lattice: {
+          matrix: [
+            [10, 0, 0],
+            [0, 10, 0],
+            [0, 0, 10],
+          ],
+          pbc: [true, true, true],
+        },
+        sites: [
+          {
+            species: [{ element: `C`, occu: 1, oxidation_state: 0 }],
+            abc: [0.95, 0.5, 0.5],
+            xyz: [9.5, 5, 5],
+            label: `C1`,
+            properties: {},
+          },
+          {
+            species: [{ element: `O`, occu: 1, oxidation_state: 0 }],
+            abc: [0.04, 0.5, 0.5],
+            xyz: [0.4, 5, 5],
+            label: `O1`,
+            properties: {},
+          },
         ],
-        pbc: [true, true, true],
-      },
-      sites: [
-        {
-          species: [{ element: `C`, occu: 1, oxidation_state: 0 }],
-          abc: [0.95, 0.5, 0.5],
-          xyz: [9.5, 5, 5],
-          label: `C1`,
-          properties: {},
-        },
-        {
-          species: [{ element: `O`, occu: 1, oxidation_state: 0 }],
-          abc: [0.04, 0.5, 0.5],
-          xyz: [0.4, 5, 5],
-          label: `O1`,
-          properties: {},
-        },
-      ],
-      properties: {},
-    }
-    window.dispatchEvent(new CustomEvent(`set-structure`, { detail: { structure } }))
-    window.dispatchEvent(
-      new CustomEvent(`set-scene-props`, {
-        detail: {
-          bond_thickness: 0.25,
-          bonding_options: { strategy: `electroneg_ratio` },
-          camera_position: [9.95, 5, 17],
-          camera_target: [9.95, 5, 5],
-          show_bonds: `always`,
-        },
-      }),
-    )
+        properties: {},
+      }
+      window.dispatchEvent(new CustomEvent(`set-structure`, { detail: { structure } }))
+      window.dispatchEvent(
+        new CustomEvent(`set-scene-props`, {
+          detail: {
+            bond_thickness: 0.25,
+            bonding_options: scene_options.bonding_options,
+            camera_position: [9.95, 5, 17],
+            camera_target: [9.95, 5, 5],
+            show_bonds: `always`,
+            ...(scene_options.show_site_labels
+              ? { show_site_labels: true, site_label_offset: [0, 0, 0] }
+              : {}),
+          },
+        }),
+      )
+    },
+    { bonding_options, show_site_labels },
+  )
+
+const dispatch_periodic_image_bond_structure = (page: Page) =>
+  dispatch_periodic_image_structure(page, {
+    bonding_options: { strategy: `electroneg_ratio` },
+  })
+
+const dispatch_periodic_image_unbonded_structure = (page: Page) =>
+  dispatch_periodic_image_structure(page, {
+    bonding_options: { strength_threshold: 10 },
+    show_site_labels: true,
   })
 
 const dispatch_two_image_atom_unbonded_structure = (page: Page) =>
@@ -428,7 +451,7 @@ test.describe(`Bond component`, () => {
 
     await click_atom_label(page, `C`)
     await expect(menu).toBeHidden()
-    await expect(page.locator(`#test-structure .selection-label`)).toBeHidden()
+    await expect(page.locator(`#test-structure .selection-label`)).toBeVisible()
     await click_atom_label(page, `O`)
     await expect(menu).toBeVisible()
     await menu.getByRole(`button`, { name: `Close` }).click()
@@ -442,15 +465,25 @@ test.describe(`Bond component`, () => {
     await dispatch_two_atom_unbonded_structure(page)
     await wait_for_3d_canvas(page, `#test-structure`)
     await page.locator(`[data-testid="btn-set-edit-bonds"]`).click()
-    await page.locator(`#test-structure .bond-edit-toolbar select`).selectOption({
-      label: `Double`,
-    })
+    const order_select = page.locator(`#test-structure .bond-edit-toolbar select`)
+    await order_select.selectOption({ label: `Double` })
 
     await click_atom_label(page, `C`)
     await click_atom_label(page, `O`)
     await expect
       .poll(() => get_structure_bonds(page))
-      .toContainEqual(expect.objectContaining({ site_idx_1: 0, site_idx_2: 1, order: 2 }))
+      .toEqual([{ site_idx_1: 0, site_idx_2: 1, order: 2 }])
+
+    await order_select.selectOption({ label: `Triple` })
+    await page.getByRole(`button`, { name: `Undo bond edit (Cmd/Ctrl+Z)` }).click()
+    await expect(order_select).toHaveValue(`2`)
+    await expect.poll(() => get_structure_bonds(page)).toBeUndefined()
+
+    await click_atom_label(page, `C`)
+    await click_atom_label(page, `O`)
+    await expect
+      .poll(() => get_structure_bonds(page))
+      .toEqual([{ site_idx_1: 0, site_idx_2: 1, order: 2 }])
     expect(console_errors).toHaveLength(0)
   })
 
@@ -478,6 +511,27 @@ test.describe(`Bond component`, () => {
     await expect
       .poll(() => get_structure_bonds(page))
       .toEqual([{ site_idx_1: 0, site_idx_2: 2, order: 1 }])
+    expect(console_errors).toHaveLength(0)
+  })
+
+  test(`edit-bonds add mode opens order editing for existing image bonds`, async ({
+    page,
+  }) => {
+    const console_errors = await goto_structure_page(page)
+    await dispatch_periodic_image_structure(page, {
+      bonding_options: { strategy: `electroneg_ratio` },
+      show_site_labels: true,
+    })
+    await wait_for_3d_canvas(page, `#test-structure`)
+    await page.locator(`[data-testid="btn-set-edit-bonds"]`).click()
+
+    const menu = page.locator(`#test-structure .bond-context-menu`)
+    await select_atom_label_with_keyboard(page, `C`, `first`)
+    await expect(menu).toBeHidden()
+    await select_atom_label_with_keyboard(page, `O`)
+
+    await expect(menu).toBeVisible()
+    await expect.poll(() => get_structure_bonds(page)).toBeUndefined()
     expect(console_errors).toHaveLength(0)
   })
 
@@ -543,6 +597,27 @@ test.describe(`Bond component`, () => {
     await click_canvas_center(page, canvas)
 
     await expect.poll(() => get_structure_bonds(page)).toEqual([])
+    expect(console_errors).toHaveLength(0)
+  })
+
+  test(`edit-bonds delete mode removes manually added bonds to image atoms`, async ({
+    page,
+  }) => {
+    const console_errors = await goto_structure_page(page)
+    await dispatch_periodic_image_unbonded_structure(page)
+    const canvas = await wait_for_3d_canvas(page, `#test-structure`)
+    await page.locator(`[data-testid="btn-set-edit-bonds"]`).click()
+
+    await select_atom_label_with_keyboard(page, `C`, `first`)
+    await select_atom_label_with_keyboard(page, `O`)
+    await expect
+      .poll(() => get_structure_bonds(page))
+      .toEqual([{ site_idx_1: 0, site_idx_2: 2, order: 1 }])
+
+    await page.locator(`[data-testid="btn-set-bond-delete"]`).click()
+    await click_canvas_center(page, canvas)
+
+    await expect.poll(() => get_structure_bonds(page)).toBeUndefined()
     expect(console_errors).toHaveLength(0)
   })
 

--- a/tests/playwright/structure/bonds.test.ts
+++ b/tests/playwright/structure/bonds.test.ts
@@ -38,15 +38,28 @@ const goto_structure_page = async (page: Page): Promise<string[]> => {
 
 type StructureCanvas = Awaited<ReturnType<typeof wait_for_3d_canvas>>
 
+const get_canvas_center = async (
+  canvas: StructureCanvas,
+): Promise<{ x: number; y: number }> => {
+  await canvas.scrollIntoViewIfNeeded()
+  const box = await canvas.boundingBox()
+  if (!box) throw new Error(`canvas has no bounding box`)
+  return { x: box.x + box.width / 2, y: box.y + box.height / 2 }
+}
+
 const click_canvas_center = async (
   page: Page,
   canvas: StructureCanvas,
   button: `left` | `right` = `left`,
 ): Promise<void> => {
-  await canvas.scrollIntoViewIfNeeded()
-  const box = await canvas.boundingBox()
-  if (!box) throw new Error(`canvas has no bounding box`)
-  await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2, { button })
+  const center = await get_canvas_center(canvas)
+  await page.mouse.click(center.x, center.y, { button })
+}
+
+const hover_canvas_center = async (page: Page, canvas: StructureCanvas): Promise<void> => {
+  const center = await get_canvas_center(canvas)
+  await page.mouse.move(center.x, center.y)
+  await page.waitForTimeout(100)
 }
 
 const click_atom_label = async (page: Page, label_text: string): Promise<void> => {
@@ -171,6 +184,49 @@ const dispatch_two_atom_unbonded_structure = (page: Page) =>
           show_bonds: `always`,
           show_site_labels: true,
           site_label_offset: [0, 0, 0],
+        },
+      }),
+    )
+  })
+
+const dispatch_periodic_image_bond_structure = (page: Page) =>
+  page.evaluate(() => {
+    const structure = {
+      lattice: {
+        matrix: [
+          [10, 0, 0],
+          [0, 10, 0],
+          [0, 0, 10],
+        ],
+        pbc: [true, true, true],
+      },
+      sites: [
+        {
+          species: [{ element: `C`, occu: 1, oxidation_state: 0 }],
+          abc: [0.95, 0.5, 0.5],
+          xyz: [9.5, 5, 5],
+          label: `C1`,
+          properties: {},
+        },
+        {
+          species: [{ element: `O`, occu: 1, oxidation_state: 0 }],
+          abc: [0.04, 0.5, 0.5],
+          xyz: [0.4, 5, 5],
+          label: `O1`,
+          properties: {},
+        },
+      ],
+      properties: {},
+    }
+    window.dispatchEvent(new CustomEvent(`set-structure`, { detail: { structure } }))
+    window.dispatchEvent(
+      new CustomEvent(`set-scene-props`, {
+        detail: {
+          bond_thickness: 0.25,
+          bonding_options: { strategy: `electroneg_ratio` },
+          camera_position: [9.95, 5, 17],
+          camera_target: [9.95, 5, 5],
+          show_bonds: `always`,
         },
       }),
     )
@@ -360,6 +416,20 @@ test.describe(`Bond component`, () => {
     await expect
       .poll(() => get_structure_bonds(page))
       .toEqual([{ site_idx_1: 0, site_idx_2: 1, order: 3 }])
+    expect(console_errors).toHaveLength(0)
+  })
+
+  test(`edit-bonds delete mode removes bonds to image atoms`, async ({ page }) => {
+    const console_errors = await goto_structure_page(page)
+    await dispatch_periodic_image_bond_structure(page)
+    const canvas = await wait_for_3d_canvas(page, `#test-structure`)
+    await page.locator(`[data-testid="btn-set-edit-bonds"]`).click()
+    await page.locator(`[data-testid="btn-set-bond-delete"]`).click()
+
+    await hover_canvas_center(page, canvas)
+    await click_canvas_center(page, canvas)
+
+    await expect.poll(() => get_structure_bonds(page)).toEqual([])
     expect(console_errors).toHaveLength(0)
   })
 

--- a/tests/playwright/structure/bonds.test.ts
+++ b/tests/playwright/structure/bonds.test.ts
@@ -1,4 +1,4 @@
-import { expect, type Page, test } from '@playwright/test'
+import { expect, type Locator, type Page, test } from '@playwright/test'
 import { expect_canvas_changed, IS_CI, wait_for_3d_canvas } from '../helpers'
 
 // Get non-white pixel count to detect if content is rendered.
@@ -72,17 +72,33 @@ const hover_canvas_center = async (
   await page.waitForTimeout(100)
 }
 
+const atom_label = (
+  page: Page,
+  label_text: string,
+  occurrence: `first` | `last` = `last`,
+): Locator => {
+  const labels = page.locator(`#test-structure .atom-label`).filter({ hasText: label_text })
+  return occurrence === `first` ? labels.first() : labels.last()
+}
+
 const click_atom_label = async (
   page: Page,
   label_text: string,
   options: { force?: boolean } = {},
 ): Promise<void> => {
-  const label = page
-    .locator(`#test-structure .atom-label`)
-    .filter({ hasText: label_text })
-    .last()
+  const label = atom_label(page, label_text)
   await expect(label).toBeVisible()
   await label.click(options)
+}
+
+const select_atom_label_with_keyboard = async (
+  page: Page,
+  label_text: string,
+  occurrence: `first` | `last` = `last`,
+): Promise<void> => {
+  const label = atom_label(page, label_text, occurrence)
+  await expect(label).toBeVisible()
+  await label.press(`Enter`)
 }
 const set_scene_props = (page: Page, detail: Record<string, unknown>) =>
   page.evaluate((props) => {
@@ -438,21 +454,30 @@ test.describe(`Bond component`, () => {
     expect(console_errors).toHaveLength(0)
   })
 
-  test(`edit-bonds add mode does not add original-cell bond from two image atoms`, async ({
-    page,
-  }) => {
+  test(`edit-bonds add mode bonds the exact clicked image atom`, async ({ page }) => {
     const console_errors = await goto_structure_page(page)
     await dispatch_two_image_atom_unbonded_structure(page)
     await wait_for_3d_canvas(page, `#test-structure`)
     await page.locator(`[data-testid="btn-set-edit-bonds"]`).click()
 
     const menu = page.locator(`#test-structure .bond-context-menu`)
-    await click_atom_label(page, `C`, { force: true })
+    await select_atom_label_with_keyboard(page, `C`, `first`)
     await expect(menu).toBeHidden()
-    await click_atom_label(page, `O`, { force: true })
+    await select_atom_label_with_keyboard(page, `O`)
 
     await expect(menu).toBeHidden()
+    await expect
+      .poll(() => get_structure_bonds(page))
+      .toEqual([{ site_idx_1: 0, site_idx_2: 3, order: 1 }])
+
+    await page.getByRole(`button`, { name: `Reset selection and bond edits` }).click()
     await expect.poll(() => get_structure_bonds(page)).toBeUndefined()
+
+    await select_atom_label_with_keyboard(page, `C`, `first`)
+    await select_atom_label_with_keyboard(page, `C`)
+    await expect
+      .poll(() => get_structure_bonds(page))
+      .toEqual([{ site_idx_1: 0, site_idx_2: 2, order: 1 }])
     expect(console_errors).toHaveLength(0)
   })
 

--- a/tests/playwright/structure/bonds.test.ts
+++ b/tests/playwright/structure/bonds.test.ts
@@ -72,13 +72,17 @@ const hover_canvas_center = async (
   await page.waitForTimeout(100)
 }
 
-const click_atom_label = async (page: Page, label_text: string): Promise<void> => {
+const click_atom_label = async (
+  page: Page,
+  label_text: string,
+  options: { force?: boolean } = {},
+): Promise<void> => {
   const label = page
     .locator(`#test-structure .atom-label`)
     .filter({ hasText: label_text })
     .last()
   await expect(label).toBeVisible()
-  await label.click()
+  await label.click(options)
 }
 const set_scene_props = (page: Page, detail: Record<string, unknown>) =>
   page.evaluate((props) => {
@@ -242,6 +246,51 @@ const dispatch_periodic_image_bond_structure = (page: Page) =>
     )
   })
 
+const dispatch_two_image_atom_unbonded_structure = (page: Page) =>
+  page.evaluate(() => {
+    const structure = {
+      lattice: {
+        matrix: [
+          [10, 0, 0],
+          [0, 10, 0],
+          [0, 0, 10],
+        ],
+        pbc: [true, true, true],
+      },
+      sites: [
+        {
+          species: [{ element: `C`, occu: 1, oxidation_state: 0 }],
+          abc: [0.04, 0.5, 0.5],
+          xyz: [0.4, 5, 5],
+          label: `C1`,
+          properties: {},
+        },
+        {
+          species: [{ element: `O`, occu: 1, oxidation_state: 0 }],
+          abc: [0.045, 0.5, 0.5],
+          xyz: [0.45, 5, 5],
+          label: `O1`,
+          properties: {},
+        },
+      ],
+      properties: {},
+    }
+    window.dispatchEvent(new CustomEvent(`set-structure`, { detail: { structure } }))
+    window.dispatchEvent(
+      new CustomEvent(`set-scene-props`, {
+        detail: {
+          atom_radius: 2.5,
+          bonding_options: { strength_threshold: 10 },
+          camera_position: [10.5, 5, 17],
+          camera_target: [10.5, 5, 5],
+          show_bonds: `always`,
+          show_site_labels: true,
+          site_label_offset: [0, 0, 0],
+        },
+      }),
+    )
+  })
+
 test.describe(`Bond component`, () => {
   test(`renders bonds and handles rotation/zoom without errors`, async ({ page }) => {
     test.skip(IS_CI, `Visual bonds test times out in CI`)
@@ -363,6 +412,7 @@ test.describe(`Bond component`, () => {
 
     await click_atom_label(page, `C`)
     await expect(menu).toBeHidden()
+    await expect(page.locator(`#test-structure .selection-label`)).toBeHidden()
     await click_atom_label(page, `O`)
     await expect(menu).toBeVisible()
     await menu.getByRole(`button`, { name: `Close` }).click()
@@ -385,6 +435,24 @@ test.describe(`Bond component`, () => {
     await expect
       .poll(() => get_structure_bonds(page))
       .toContainEqual(expect.objectContaining({ site_idx_1: 0, site_idx_2: 1, order: 2 }))
+    expect(console_errors).toHaveLength(0)
+  })
+
+  test(`edit-bonds add mode does not add original-cell bond from two image atoms`, async ({
+    page,
+  }) => {
+    const console_errors = await goto_structure_page(page)
+    await dispatch_two_image_atom_unbonded_structure(page)
+    await wait_for_3d_canvas(page, `#test-structure`)
+    await page.locator(`[data-testid="btn-set-edit-bonds"]`).click()
+
+    const menu = page.locator(`#test-structure .bond-context-menu`)
+    await click_atom_label(page, `C`, { force: true })
+    await expect(menu).toBeHidden()
+    await click_atom_label(page, `O`, { force: true })
+
+    await expect(menu).toBeHidden()
+    await expect.poll(() => get_structure_bonds(page)).toBeUndefined()
     expect(console_errors).toHaveLength(0)
   })
 

--- a/tests/playwright/structure/bonds.test.ts
+++ b/tests/playwright/structure/bonds.test.ts
@@ -487,7 +487,7 @@ test.describe(`Bond component`, () => {
     expect(console_errors).toHaveLength(0)
   })
 
-  test(`edit-bonds add mode bonds the exact clicked image atom`, async ({ page }) => {
+  test(`edit-bonds add mode handles image atom bonds`, async ({ page }) => {
     const console_errors = await goto_structure_page(page)
     await dispatch_two_image_atom_unbonded_structure(page)
     await wait_for_3d_canvas(page, `#test-structure`)
@@ -511,21 +511,14 @@ test.describe(`Bond component`, () => {
     await expect
       .poll(() => get_structure_bonds(page))
       .toEqual([{ site_idx_1: 0, site_idx_2: 2, order: 1 }])
-    expect(console_errors).toHaveLength(0)
-  })
 
-  test(`edit-bonds add mode opens order editing for existing image bonds`, async ({
-    page,
-  }) => {
-    const console_errors = await goto_structure_page(page)
     await dispatch_periodic_image_structure(page, {
       bonding_options: { strategy: `electroneg_ratio` },
       show_site_labels: true,
     })
     await wait_for_3d_canvas(page, `#test-structure`)
-    await page.locator(`[data-testid="btn-set-edit-bonds"]`).click()
+    await expect.poll(() => get_structure_bonds(page)).toBeUndefined()
 
-    const menu = page.locator(`#test-structure .bond-context-menu`)
     await select_atom_label_with_keyboard(page, `C`, `first`)
     await expect(menu).toBeHidden()
     await select_atom_label_with_keyboard(page, `O`)

--- a/tests/playwright/structure/bonds.test.ts
+++ b/tests/playwright/structure/bonds.test.ts
@@ -59,17 +59,18 @@ const click_canvas_offset = async (
   await canvas.scrollIntoViewIfNeeded()
   const box = await canvas.boundingBox()
   if (!box) throw new Error(`canvas has no bounding box`)
-  await page.mouse.click(
-    box.x + box.width / 2 + offset_x,
-    box.y + box.height / 2 + offset_y,
-    { button },
-  )
+  await page.mouse.click(box.x + box.width / 2 + offset_x, box.y + box.height / 2 + offset_y, {
+    button,
+  })
 }
 
 const BOND_CLICK_OFFSETS = [0, 45, -45, 70, -70, 30, -30, 90, -90]
 
 const click_atom_label = async (page: Page, label_text: string): Promise<void> => {
-  const label = page.locator(`#test-structure .atom-label`).filter({ hasText: label_text }).last()
+  const label = page
+    .locator(`#test-structure .atom-label`)
+    .filter({ hasText: label_text })
+    .last()
   await expect(label).toBeVisible()
   await label.click()
 }
@@ -106,14 +107,12 @@ const open_bond_menu_near_center = async (
         `after trying BOND_CLICK_OFFSETS with click_canvas_offset: ${
           error instanceof Error ? error.message : String(error)
         }`,
+      { cause: error },
     )
   }
 }
 
-const delete_bond_near_center = async (
-  page: Page,
-  canvas: StructureCanvas,
-): Promise<void> => {
+const delete_bond_near_center = async (page: Page, canvas: StructureCanvas): Promise<void> => {
   for (const offset_x of BOND_CLICK_OFFSETS) {
     await click_canvas_offset(page, canvas, offset_x)
     const bonds = await get_structure_bonds(page)
@@ -353,7 +352,9 @@ test.describe(`Bond component`, () => {
     expect(console_errors).toHaveLength(0)
   })
 
-  test(`edit-bonds add mode creates selected-order bond between unbonded atoms`, async ({ page }) => {
+  test(`edit-bonds add mode creates selected-order bond between unbonded atoms`, async ({
+    page,
+  }) => {
     const console_errors = await goto_structure_page(page)
     await dispatch_two_atom_unbonded_structure(page)
     await wait_for_3d_canvas(page, `#test-structure`)
@@ -364,9 +365,9 @@ test.describe(`Bond component`, () => {
 
     await click_atom_label(page, `C`)
     await click_atom_label(page, `O`)
-    await expect.poll(() => get_structure_bonds(page)).toContainEqual(
-      expect.objectContaining({ site_idx_1: 0, site_idx_2: 1, order: 2 }),
-    )
+    await expect
+      .poll(() => get_structure_bonds(page))
+      .toContainEqual(expect.objectContaining({ site_idx_1: 0, site_idx_2: 1, order: 2 }))
     expect(console_errors).toHaveLength(0)
   })
 
@@ -418,7 +419,9 @@ test.describe(`Bond component`, () => {
     expect(console_errors).toHaveLength(0)
   })
 
-  test(`bond redo history is cleared after source changes and edit-atoms`, async ({ page }) => {
+  test(`bond redo history is cleared after source changes and edit-atoms`, async ({
+    page,
+  }) => {
     const console_errors = await goto_structure_page(page)
     await dispatch_two_atom_bond_structure(page, 1)
     const canvas = await wait_for_3d_canvas(page, `#test-structure`)

--- a/tests/playwright/structure/structure-scene.test.ts
+++ b/tests/playwright/structure/structure-scene.test.ts
@@ -82,7 +82,7 @@ function setup_console_monitoring(page: Page): string[] {
   return console_errors
 }
 
-async function dispatch_centered_atom_structure(page: Page): Promise<void> {
+async function load_single_centered_atom_scene(page: Page): Promise<void> {
   await page.evaluate(async () => {
     const structure = {
       sites: [
@@ -214,7 +214,7 @@ test.describe(`StructureScene Component Tests`, () => {
   })
 
   test(`atom tooltip stays visible while cursor remains over atom`, async ({ page }) => {
-    await dispatch_centered_atom_structure(page)
+    await load_single_centered_atom_scene(page)
     const canvas = page.locator(`#test-structure canvas`)
     const box = await canvas.boundingBox()
     if (!box) throw new Error(`canvas has no bounding box`)
@@ -226,15 +226,14 @@ test.describe(`StructureScene Component Tests`, () => {
     const tooltip = page.locator(`[role="tooltip"]:has(.coordinates)`)
     await expect(tooltip).toBeVisible({ timeout: get_canvas_timeout() })
     await expect(tooltip.locator(`.elements`)).toContainText(`C`)
-
-    const stayed_visible = await page.evaluate(async () => {
-      for (let frame_idx = 0; frame_idx < 20; frame_idx++) {
-        await new Promise(requestAnimationFrame)
-        if (!document.querySelector(`[role="tooltip"] .coordinates`)) return false
-      }
-      return true
-    })
-    expect(stayed_visible).toBe(true)
+    // The hover highlight can become the raycast target after it mounts.
+    // Check visibility immediately after each frame so a short disappearance fails.
+    for (let frame_idx = 0; frame_idx < 20; frame_idx++) {
+      await page.evaluate(
+        () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())),
+      )
+      expect(await tooltip.isVisible()).toBe(true)
+    }
   })
 
   // Combined interaction tests

--- a/tests/playwright/structure/structure-scene.test.ts
+++ b/tests/playwright/structure/structure-scene.test.ts
@@ -82,6 +82,37 @@ function setup_console_monitoring(page: Page): string[] {
   return console_errors
 }
 
+async function dispatch_centered_atom_structure(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    const structure = {
+      sites: [
+        {
+          species: [{ element: `C`, occu: 1, oxidation_state: 0 }],
+          abc: [0, 0, 0],
+          xyz: [0, 0, 0],
+          label: `C1`,
+          properties: {},
+        },
+      ],
+      properties: {},
+    }
+    window.dispatchEvent(new CustomEvent(`set-structure`, { detail: { structure } }))
+    window.dispatchEvent(
+      new CustomEvent(`set-scene-props`, {
+        detail: {
+          atom_radius: 2.5,
+          camera_position: [0, 0, 8],
+          camera_target: [0, 0, 0],
+          show_bonds: `never`,
+          show_site_indices: false,
+          show_site_labels: false,
+        },
+      }),
+    )
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+  })
+}
+
 test.describe(`StructureScene Component Tests`, () => {
   test.beforeEach(async ({ page }: { page: Page }) => {
     // Skip in CI - 3D canvas and camera control tests are unreliable
@@ -180,6 +211,30 @@ test.describe(`StructureScene Component Tests`, () => {
     // Test tooltip disappears when moving away
     await canvas.hover({ position: { x: 50, y: 50 } })
     await expect(tooltip).toBeHidden({ timeout: get_canvas_timeout() })
+  })
+
+  test(`atom tooltip stays visible while cursor remains over atom`, async ({ page }) => {
+    await dispatch_centered_atom_structure(page)
+    const canvas = page.locator(`#test-structure canvas`)
+    const box = await canvas.boundingBox()
+    if (!box) throw new Error(`canvas has no bounding box`)
+
+    await canvas.hover({
+      position: { x: box.width / 2, y: box.height / 2 },
+      force: true,
+    })
+    const tooltip = page.locator(`[role="tooltip"]:has(.coordinates)`)
+    await expect(tooltip).toBeVisible({ timeout: get_canvas_timeout() })
+    await expect(tooltip.locator(`.elements`)).toContainText(`C`)
+
+    const stayed_visible = await page.evaluate(async () => {
+      for (let frame_idx = 0; frame_idx < 20; frame_idx++) {
+        await new Promise(requestAnimationFrame)
+        if (!document.querySelector(`[role="tooltip"] .coordinates`)) return false
+      }
+      return true
+    })
+    expect(stayed_visible).toBe(true)
   })
 
   // Combined interaction tests

--- a/tests/playwright/structure/structure-scene.test.ts
+++ b/tests/playwright/structure/structure-scene.test.ts
@@ -109,7 +109,9 @@ async function load_single_centered_atom_scene(page: Page): Promise<void> {
         },
       }),
     )
-    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+    for (let frame_idx = 0; frame_idx < 3; frame_idx++) {
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+    }
   })
 }
 
@@ -228,6 +230,7 @@ test.describe(`StructureScene Component Tests`, () => {
     await expect(tooltip.locator(`.elements`)).toContainText(`C`)
     // The hover highlight can become the raycast target after it mounts.
     // Check visibility immediately after each frame so a short disappearance fails.
+    // 20 frames covers roughly 1/3 s at 60fps, enough to catch transient hover loss.
     for (let frame_idx = 0; frame_idx < 20; frame_idx++) {
       await page.evaluate(
         () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())),

--- a/tests/vitest/periodic-table/PeriodicTable.test.svelte.ts
+++ b/tests/vitest/periodic-table/PeriodicTable.test.svelte.ts
@@ -245,8 +245,9 @@ describe(`PeriodicTable`, () => {
         },
       },
     })
+    const active_symbol = () => active_element?.symbol ?? null
     ;(document.querySelector(`.element-tile`) as HTMLElement).dispatchEvent(mouseenter)
-    expect((active_element as ChemicalElement | null)?.symbol || null).toBe(expected)
+    expect(active_symbol()).toBe(expected)
   })
 
   test.each([

--- a/tests/vitest/structure/Structure.test.svelte.ts
+++ b/tests/vitest/structure/Structure.test.svelte.ts
@@ -137,8 +137,9 @@ describe(`Structure`, () => {
       `Add`,
     )
     expect(doc_query<HTMLSelectElement>(`.bond-edit-toolbar select`).value).toBe(`1`)
-    expect(doc_query<HTMLButtonElement>(`button[aria-label="Undo bond edit (Ctrl+Z)"]`).disabled)
-      .toBe(true)
+    expect(
+      doc_query<HTMLButtonElement>(`button[aria-label="Undo bond edit (Ctrl+Z)"]`).disabled,
+    ).toBe(true)
   })
 
   const formats = [`JSON`, `XYZ`, `CIF`, `POSCAR`] as const
@@ -856,7 +857,9 @@ describe(`Structure string parsing`, () => {
       if (parse_state.parsed) {
         expect(parse_state.parsed.sites).toHaveLength(atoms)
         elements.forEach((el) =>
-          expect(parse_state.parsed?.sites.map((site) => site.species[0].element)).toContain(el),
+          expect(parse_state.parsed?.sites.map((site) => site.species[0].element)).toContain(
+            el,
+          ),
         )
         expect(!!(`lattice` in parse_state.parsed && parse_state.parsed.lattice)).toBe(
           has_lattice,

--- a/tests/vitest/structure/Structure.test.svelte.ts
+++ b/tests/vitest/structure/Structure.test.svelte.ts
@@ -133,10 +133,18 @@ describe(`Structure`, () => {
     await tick()
 
     expect(doc_query(`.bond-edit-toolbar`)).toBeInstanceOf(HTMLElement)
-    expect(doc_query<HTMLButtonElement>(`button[aria-pressed="true"]`).textContent).toContain(
-      `Add`,
+    const selector = `.bond-edit-mode-toggle button[aria-pressed="true"]`
+    const active_button = doc_query<HTMLButtonElement>(selector)
+    const order_select = doc_query<HTMLSelectElement>(`.bond-edit-toolbar select`)
+    expect(active_button.textContent).toContain(`Add`)
+    expect(order_select.value).toBe(`1`)
+    expect(order_select.compareDocumentPosition(active_button)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
     )
-    expect(doc_query<HTMLSelectElement>(`.bond-edit-toolbar select`).value).toBe(`1`)
+    doc_query<HTMLButtonElement>(`.bond-edit-mode-toggle button[title^="Delete"]`).click()
+    await tick()
+    expect(doc_query<HTMLButtonElement>(selector).textContent).toContain(`Delete`)
+    expect(document.querySelector(`.bond-edit-toolbar select`)).toBeNull()
     expect(
       doc_query<HTMLButtonElement>(`button[aria-label="Undo bond edit (Cmd/Ctrl+Z)"]`)
         .disabled,

--- a/tests/vitest/structure/Structure.test.svelte.ts
+++ b/tests/vitest/structure/Structure.test.svelte.ts
@@ -121,6 +121,26 @@ describe(`Structure`, () => {
     expect(measure_mode).toBe(`distance`)
   })
 
+  test(`shows safe bond editing controls by default`, async () => {
+    mount(Structure, {
+      target: document.body,
+      props: {
+        structure,
+        measure_mode: `edit-bonds`,
+        show_controls: true,
+      },
+    })
+    await tick()
+
+    expect(doc_query(`.bond-edit-toolbar`)).toBeInstanceOf(HTMLElement)
+    expect(doc_query<HTMLButtonElement>(`button[aria-pressed="true"]`).textContent).toContain(
+      `Add`,
+    )
+    expect(doc_query<HTMLSelectElement>(`.bond-edit-toolbar select`).value).toBe(`1`)
+    expect(doc_query<HTMLButtonElement>(`button[aria-label="Undo bond edit (Ctrl+Z)"]`).disabled)
+      .toBe(true)
+  })
+
   const formats = [`JSON`, `XYZ`, `CIF`, `POSCAR`] as const
 
   test.each(
@@ -810,7 +830,7 @@ describe(`Structure string parsing`, () => {
   test.each(test_data)(
     `parses %s format correctly`,
     async (_format, content, atoms, elements, has_lattice) => {
-      let parsed = $state<AnyStructure | undefined>(undefined)
+      let parse_state = $state<{ parsed?: AnyStructure }>({})
       let loaded = false
 
       mount(Structure, {
@@ -818,10 +838,10 @@ describe(`Structure string parsing`, () => {
         props: {
           structure_string: content,
           get structure() {
-            return parsed
+            return parse_state.parsed
           },
           set structure(val) {
-            parsed = val
+            parse_state.parsed = val
           },
           on_file_load: (data: StructureHandlerData) => {
             loaded = true
@@ -832,13 +852,15 @@ describe(`Structure string parsing`, () => {
       })
 
       await tick()
-      expect(parsed).toBeDefined()
-      if (parsed) {
-        expect(parsed.sites).toHaveLength(atoms)
+      expect(parse_state.parsed).toBeDefined()
+      if (parse_state.parsed) {
+        expect(parse_state.parsed.sites).toHaveLength(atoms)
         elements.forEach((el) =>
-          expect(parsed?.sites.map((site) => site.species[0].element)).toContain(el),
+          expect(parse_state.parsed?.sites.map((site) => site.species[0].element)).toContain(el),
         )
-        expect(!!(`lattice` in parsed && parsed.lattice)).toBe(has_lattice)
+        expect(!!(`lattice` in parse_state.parsed && parse_state.parsed.lattice)).toBe(
+          has_lattice,
+        )
       }
       expect(loaded).toBe(true)
     },
@@ -858,21 +880,21 @@ describe(`Structure string parsing`, () => {
   })
 
   test(`loading state works correctly`, async () => {
-    let loading = $state(false)
+    let loading_state = $state({ loading: false })
     mount(Structure, {
       target: document.body,
       props: {
         structure_string: SAMPLE_POSCAR_CONTENT,
         get loading() {
-          return loading
+          return loading_state.loading
         },
         set loading(val) {
-          loading = val
+          loading_state.loading = val
         },
       },
     })
     await tick()
-    expect(loading).toBe(false)
+    expect(loading_state.loading).toBe(false)
   })
 
   test(`file size emission works correctly`, async () => {

--- a/tests/vitest/structure/Structure.test.svelte.ts
+++ b/tests/vitest/structure/Structure.test.svelte.ts
@@ -151,6 +151,29 @@ describe(`Structure`, () => {
     ).toBe(true)
   })
 
+  test.each([
+    { mode: `distance`, shows_limit: true },
+    { mode: `angle`, shows_limit: true },
+    { mode: `edit-bonds`, shows_limit: false },
+    { mode: `edit-atoms`, shows_limit: false },
+  ] as const)(
+    `selection limit badge visibility in $mode mode`,
+    async ({ mode, shows_limit }) => {
+      mount(Structure, {
+        target: document.body,
+        props: {
+          structure,
+          measured_sites: [0, 1, 2, 3, 4, 5, 6, 7],
+          measure_mode: mode,
+          show_controls: true,
+        },
+      })
+      await tick()
+
+      expect(document.querySelector(`.selection-limit-text`) != null).toBe(shows_limit)
+    },
+  )
+
   const formats = [`JSON`, `XYZ`, `CIF`, `POSCAR`] as const
 
   test.each(

--- a/tests/vitest/structure/Structure.test.svelte.ts
+++ b/tests/vitest/structure/Structure.test.svelte.ts
@@ -138,7 +138,8 @@ describe(`Structure`, () => {
     )
     expect(doc_query<HTMLSelectElement>(`.bond-edit-toolbar select`).value).toBe(`1`)
     expect(
-      doc_query<HTMLButtonElement>(`button[aria-label="Undo bond edit (Ctrl+Z)"]`).disabled,
+      doc_query<HTMLButtonElement>(`button[aria-label="Undo bond edit (Cmd/Ctrl+Z)"]`)
+        .disabled,
     ).toBe(true)
   })
 

--- a/tests/vitest/structure/Structure.test.svelte.ts
+++ b/tests/vitest/structure/Structure.test.svelte.ts
@@ -174,6 +174,54 @@ describe(`Structure`, () => {
     },
   )
 
+  const selection_control_cases: {
+    mode: MeasureMode
+    measured_sites: number[]
+    selected_sites: number[]
+    shows_reset: boolean
+  }[] = [
+    {
+      mode: `distance`,
+      measured_sites: [0],
+      selected_sites: [],
+      shows_reset: true,
+    },
+    {
+      mode: `angle`,
+      measured_sites: [0],
+      selected_sites: [],
+      shows_reset: true,
+    },
+    {
+      mode: `edit-bonds`,
+      measured_sites: [0],
+      selected_sites: [0],
+      shows_reset: false,
+    },
+  ]
+
+  test.each(selection_control_cases)(
+    `selection controls visibility in $mode mode`,
+    async ({ mode, measured_sites, selected_sites, shows_reset }) => {
+      mount(Structure, {
+        target: document.body,
+        props: {
+          structure,
+          measured_sites,
+          selected_sites,
+          measure_mode: mode,
+          show_controls: true,
+        },
+      })
+      await tick()
+
+      expect(
+        document.querySelector(`button[aria-label="Reset selection and bond edits"]`) != null,
+      ).toBe(shows_reset)
+      expect(document.querySelector(`.site-radius-control`)).toBeNull()
+    },
+  )
+
   const formats = [`JSON`, `XYZ`, `CIF`, `POSCAR`] as const
 
   test.each(

--- a/tests/vitest/structure/bonding.test.ts
+++ b/tests/vitest/structure/bonding.test.ts
@@ -227,28 +227,72 @@ describe(`Explicit Bond Metadata`, () => {
     }
   })
 
-  test(`bond order overrides take precedence over added bonds`, () => {
-    const calculated_bond = { site_idx_1: 0, site_idx_2: 1 }
-    const override_bond: StructureBond = { ...calculated_bond, order: 3 }
-    const added_bond: StructureBond = { ...calculated_bond, order: 1 }
-
-    expect(bonding.merge_bond_edits([], [added_bond], [], [override_bond])).toEqual([
-      override_bond,
-    ])
-  })
-
   const empty_bond_edit_state = (): BondEditState => ({
     added_bonds: [],
     removed_bonds: [],
     bond_order_overrides: [],
   })
 
+  const calculated_bonds = (bond_order?: BondOrder) => [
+    {
+      site_idx_1: 0,
+      site_idx_2: 1,
+      ...(bond_order === undefined ? {} : { bond_order }),
+    },
+  ]
+
+  test.each([
+    {
+      desc: `lets overrides win over additions`,
+      base: [],
+      added: [{ site_idx_1: 0, site_idx_2: 1, order: 1 }],
+      removed: [],
+      overrides: [{ site_idx_1: 0, site_idx_2: 1, order: 3 }],
+      expected: [{ site_idx_1: 0, site_idx_2: 1, order: 3 }],
+    },
+    {
+      desc: `lets removals win over stale additions and overrides`,
+      base: [{ site_idx_1: 0, site_idx_2: 1, order: 1 }],
+      added: [{ site_idx_1: 0, site_idx_2: 1, order: 1 }],
+      removed: [{ site_idx_1: 1, site_idx_2: 0, order: 1 }],
+      overrides: [{ site_idx_1: 0, site_idx_2: 1, order: 3 }],
+      expected: [],
+      visible: false,
+    },
+    {
+      desc: `normalizes reversed bond records`,
+      base: [],
+      added: [{ site_idx_1: 3, site_idx_2: 1, order: 2 }],
+      removed: [],
+      overrides: [],
+      expected: [{ site_idx_1: 1, site_idx_2: 3, order: 2 }],
+    },
+  ] satisfies {
+    desc: string
+    base: StructureBond[]
+    added: StructureBond[]
+    removed: StructureBond[]
+    overrides: StructureBond[]
+    expected: StructureBond[]
+    visible?: boolean
+  }[])(`merge_bond_edits $desc`, ({ base, added, removed, overrides, expected, visible }) => {
+    expect(bonding.merge_bond_edits(base, added, removed, overrides)).toEqual(expected)
+    if (visible !== undefined) {
+      expect(
+        bonding.has_visible_bond(
+          { added_bonds: added, removed_bonds: removed, bond_order_overrides: overrides },
+          base[0],
+          [],
+        ),
+      ).toBe(visible)
+    }
+  })
+
   test(`adds, reports, and restores bonds without toggling visible bonds`, () => {
-    const calculated_bonds = [{ site_idx_1: 0, site_idx_2: 1 }]
     const add_result = bonding.add_or_restore_bond(
       empty_bond_edit_state(),
       { site_idx_1: 2, site_idx_2: 0 },
-      calculated_bonds,
+      calculated_bonds(),
       2,
     )
     expect(add_result).toMatchObject({ action: `added`, changed: true })
@@ -257,7 +301,7 @@ describe(`Explicit Bond Metadata`, () => {
     const visible_result = bonding.add_or_restore_bond(
       add_result.state,
       { site_idx_1: 0, site_idx_2: 1 },
-      calculated_bonds,
+      calculated_bonds(),
       3,
     )
     expect(visible_result).toMatchObject({ action: `already-visible`, changed: false })
@@ -270,7 +314,7 @@ describe(`Explicit Bond Metadata`, () => {
     const restore_result = bonding.add_or_restore_bond(
       removed_state,
       { site_idx_1: 1, site_idx_2: 0 },
-      calculated_bonds,
+      calculated_bonds(),
       1,
     )
     expect(restore_result).toMatchObject({ action: `restored`, changed: true })
@@ -280,7 +324,7 @@ describe(`Explicit Bond Metadata`, () => {
     const restore_with_order_result = bonding.add_or_restore_bond(
       removed_state,
       { site_idx_1: 1, site_idx_2: 0 },
-      calculated_bonds,
+      calculated_bonds(),
       2,
     )
     expect(restore_with_order_result).toMatchObject({ action: `restored`, changed: true })
@@ -291,11 +335,10 @@ describe(`Explicit Bond Metadata`, () => {
   })
 
   test(`deletes calculated and manually added bonds explicitly`, () => {
-    const calculated_bonds = [{ site_idx_1: 0, site_idx_2: 1 }]
     const calculated_result = bonding.delete_bond(
       empty_bond_edit_state(),
       { site_idx_1: 1, site_idx_2: 0 },
-      calculated_bonds,
+      calculated_bonds(),
     )
     expect(calculated_result).toMatchObject({
       action: `deleted-calculated`,
@@ -312,7 +355,7 @@ describe(`Explicit Bond Metadata`, () => {
     const added_result = bonding.delete_bond(
       added_state,
       { site_idx_1: 3, site_idx_2: 2 },
-      calculated_bonds,
+      calculated_bonds(),
     )
     expect(added_result).toMatchObject({ action: `deleted-added`, changed: true })
     expect(added_result.state.added_bonds).toEqual([])
@@ -320,17 +363,67 @@ describe(`Explicit Bond Metadata`, () => {
     const missing_result = bonding.delete_bond(
       empty_bond_edit_state(),
       { site_idx_1: 4, site_idx_2: 5 },
-      calculated_bonds,
+      calculated_bonds(),
     )
     expect(missing_result).toMatchObject({ action: `not-visible`, changed: false })
   })
 
+  test.each([
+    { selected_order: 2 as BondOrder, expected_overrides: [] },
+    {
+      selected_order: 1 as BondOrder,
+      expected_overrides: [{ site_idx_1: 0, site_idx_2: 1, order: 1 }],
+    },
+  ])(
+    `restores deleted order-2 calculated bonds as $selected_order`,
+    ({ selected_order, expected_overrides }) => {
+      const deleted_result = bonding.delete_bond(
+        empty_bond_edit_state(),
+        { site_idx_1: 1, site_idx_2: 0 },
+        calculated_bonds(2),
+      )
+
+      expect(deleted_result.state.removed_bonds).toEqual([
+        { site_idx_1: 0, site_idx_2: 1, order: 2 },
+      ])
+
+      const restored_result = bonding.add_or_restore_bond(
+        deleted_result.state,
+        { site_idx_1: 0, site_idx_2: 1 },
+        calculated_bonds(2),
+        selected_order,
+      )
+
+      expect(restored_result.state.bond_order_overrides).toEqual(expected_overrides)
+    },
+  )
+
+  test(`restoring a deleted bond clears stale same-key edits`, () => {
+    const stale_state: BondEditState = {
+      added_bonds: [{ site_idx_1: 0, site_idx_2: 1, order: 1 }],
+      removed_bonds: [{ site_idx_1: 0, site_idx_2: 1, order: 2 }],
+      bond_order_overrides: [{ site_idx_1: 0, site_idx_2: 1, order: 3 }],
+    }
+
+    const restored_result = bonding.add_or_restore_bond(
+      stale_state,
+      { site_idx_1: 1, site_idx_2: 0 },
+      calculated_bonds(2),
+      2,
+    )
+
+    expect(restored_result.state).toEqual({
+      added_bonds: [],
+      removed_bonds: [],
+      bond_order_overrides: [],
+    })
+  })
+
   test(`sets bond order for calculated, added, and removed bonds`, () => {
-    const calculated_bonds = [{ site_idx_1: 0, site_idx_2: 1 }]
     const calculated_result = bonding.set_bond_order(
       empty_bond_edit_state(),
       { site_idx_1: 1, site_idx_2: 0 },
-      calculated_bonds,
+      calculated_bonds(),
       3,
     )
     expect(calculated_result).toMatchObject({
@@ -348,7 +441,7 @@ describe(`Explicit Bond Metadata`, () => {
     const restored_order_result = bonding.set_bond_order(
       removed_state,
       { site_idx_1: 0, site_idx_2: 1 },
-      calculated_bonds,
+      calculated_bonds(),
       2,
     )
     expect(restored_order_result.state.removed_bonds).toEqual([])
@@ -359,7 +452,7 @@ describe(`Explicit Bond Metadata`, () => {
     const added_result = bonding.set_bond_order(
       empty_bond_edit_state(),
       { site_idx_1: 2, site_idx_2: 3 },
-      calculated_bonds,
+      calculated_bonds(),
       `aromatic`,
     )
     expect(added_result).toMatchObject({ action: `ordered-added`, changed: true })
@@ -368,15 +461,39 @@ describe(`Explicit Bond Metadata`, () => {
     ])
   })
 
+  test.each([
+    { state: empty_bond_edit_state(), expected_changed: false },
+    {
+      state: {
+        ...empty_bond_edit_state(),
+        bond_order_overrides: [{ site_idx_1: 0, site_idx_2: 1, order: 3 }],
+      } satisfies BondEditState,
+      expected_changed: true,
+    },
+  ])(`set_bond_order skips redundant calculated overrides`, ({ state, expected_changed }) => {
+    const result = bonding.set_bond_order(
+      state,
+      { site_idx_1: 1, site_idx_2: 0 },
+      calculated_bonds(2),
+      2,
+    )
+
+    expect(result).toMatchObject({
+      action: `ordered-calculated`,
+      changed: expected_changed,
+    })
+    expect(result.state.bond_order_overrides).toEqual([])
+  })
+
   test(`bond edit helpers preserve periodic cell-shift keys`, () => {
-    const calculated_bonds = [
+    const shifted_bonds = [
       { site_idx_1: 0, site_idx_2: 1, cell_shift: [1, 0, 0] as Vec3 },
       { site_idx_1: 0, site_idx_2: 1, cell_shift: [0, 1, 0] as Vec3 },
     ]
     const result = bonding.delete_bond(
       empty_bond_edit_state(),
       { site_idx_1: 1, site_idx_2: 0, cell_shift: [-1, 0, 0] },
-      calculated_bonds,
+      shifted_bonds,
     )
     expect(result.state.removed_bonds).toEqual([
       { site_idx_1: 0, site_idx_2: 1, order: 1, cell_shift: [1, 0, 0] },
@@ -385,7 +502,7 @@ describe(`Explicit Bond Metadata`, () => {
       bonding.has_visible_bond(
         result.state,
         { site_idx_1: 0, site_idx_2: 1, cell_shift: [0, 1, 0] },
-        calculated_bonds,
+        shifted_bonds,
       ),
     ).toBe(true)
   })
@@ -438,6 +555,29 @@ describe(`Explicit Bond Metadata`, () => {
     expect([...bonds_by_key.keys()].sort()).toEqual([`0-1@-1,0,0`, `0-1@1,0,0`])
     expect(bonds_by_key.get(`0-1@1,0,0`)?.bond_order).toBe(2)
     expect(bonds_by_key.get(`0-1@-1,0,0`)?.bond_order).toBe(3)
+  })
+
+  test(`keeps explicit periodic self-bonds distinct from zero-shift self-bonds`, () => {
+    const structure = make_crystal(10, [[`C`, [0.5, 0.5, 0.5]]])
+    structure.properties = {
+      bonds: [
+        { site_idx_1: 0, site_idx_2: 0, order: 1 },
+        { site_idx_1: 0, site_idx_2: 0, order: 2, cell_shift: [1, 0, 0] },
+        { site_idx_1: 0, site_idx_2: 0, order: 3, cell_shift: [-1, 0, 0] },
+      ],
+    }
+    const warn_spy = vi.spyOn(console, `warn`).mockImplementation(() => undefined)
+
+    try {
+      expect(bonding.get_explicit_bond_metadata(structure)).toEqual([
+        { site_idx_1: 0, site_idx_2: 0, order: 3, cell_shift: [1, 0, 0] },
+      ])
+      expect(warn_spy).toHaveBeenCalledWith(
+        expect.stringContaining(`Ignoring invalid explicit bond at index 0`),
+      )
+    } finally {
+      warn_spy.mockRestore()
+    }
   })
 
   test.each([

--- a/tests/vitest/structure/bonding.test.ts
+++ b/tests/vitest/structure/bonding.test.ts
@@ -507,6 +507,31 @@ describe(`Explicit Bond Metadata`, () => {
     ).toBe(true)
   })
 
+  test(`canonicalizes image-atom bond edit targets to original sites with cell shifts`, () => {
+    const structure = make_crystal(10, [
+      [`C`, [0.95, 0.5, 0.5]],
+      [`O`, [0.04, 0.5, 0.5]],
+    ])
+    const structure_with_images = get_pbc_image_sites(structure)
+    const image_site_idx = structure_with_images.sites.findIndex(
+      (site) => site.properties?.orig_site_idx === 1 && site.abc[0] > 1,
+    )
+
+    expect(image_site_idx).toBeGreaterThan(1)
+    expect(
+      bonding.canonicalize_bond_target(
+        { site_idx_1: 0, site_idx_2: image_site_idx },
+        structure_with_images.sites,
+      ),
+    ).toEqual({ site_idx_1: 0, site_idx_2: 1, cell_shift: [1, 0, 0] })
+    expect(
+      bonding.canonicalize_bond_target(
+        { site_idx_1: image_site_idx, site_idx_2: 0 },
+        structure_with_images.sites,
+      ),
+    ).toEqual({ site_idx_1: 0, site_idx_2: 1, cell_shift: [1, 0, 0] })
+  })
+
   test(`parses and renders explicit crystal bonds with cell shifts`, () => {
     const structure = make_crystal(10, [
       [`C`, [0.95, 0.5, 0.5]],

--- a/tests/vitest/structure/bonding.test.ts
+++ b/tests/vitest/structure/bonding.test.ts
@@ -252,9 +252,7 @@ describe(`Explicit Bond Metadata`, () => {
       2,
     )
     expect(add_result).toMatchObject({ action: `added`, changed: true })
-    expect(add_result.state.added_bonds).toEqual([
-      { site_idx_1: 0, site_idx_2: 2, order: 2 },
-    ])
+    expect(add_result.state.added_bonds).toEqual([{ site_idx_1: 0, site_idx_2: 2, order: 2 }])
 
     const visible_result = bonding.add_or_restore_bond(
       add_result.state,

--- a/tests/vitest/structure/bonding.test.ts
+++ b/tests/vitest/structure/bonding.test.ts
@@ -1,6 +1,6 @@
 import type { BondOrder, BondPair, Vec3 } from '$lib'
 import type { Crystal, StructureBond } from '$lib/structure'
-import type { BondingStrategy } from '$lib/structure/bonding'
+import type { BondEditState, BondingAlgo, BondingStrategy } from '$lib/structure/bonding'
 import * as bonding from '$lib/structure/bonding'
 import { get_pbc_image_sites } from '$lib/structure/pbc'
 import { test_molecules } from '$site/molecules'
@@ -33,7 +33,7 @@ const make_random_structure = (n_atoms: number): Crystal => {
 }
 
 describe(`Bonding Algorithms`, () => {
-  const algorithms: [bonding.BondingAlgo, BondingStrategy, [number, number][]][] = [
+  const algorithms: [BondingAlgo, BondingStrategy, [number, number][]][] = [
     [
       bonding.electroneg_ratio,
       `electroneg_ratio`,
@@ -235,6 +235,161 @@ describe(`Explicit Bond Metadata`, () => {
     expect(bonding.merge_bond_edits([], [added_bond], [], [override_bond])).toEqual([
       override_bond,
     ])
+  })
+
+  const empty_bond_edit_state = (): BondEditState => ({
+    added_bonds: [],
+    removed_bonds: [],
+    bond_order_overrides: [],
+  })
+
+  test(`adds, reports, and restores bonds without toggling visible bonds`, () => {
+    const calculated_bonds = [{ site_idx_1: 0, site_idx_2: 1 }]
+    const add_result = bonding.add_or_restore_bond(
+      empty_bond_edit_state(),
+      { site_idx_1: 2, site_idx_2: 0 },
+      calculated_bonds,
+      2,
+    )
+    expect(add_result).toMatchObject({ action: `added`, changed: true })
+    expect(add_result.state.added_bonds).toEqual([
+      { site_idx_1: 0, site_idx_2: 2, order: 2 },
+    ])
+
+    const visible_result = bonding.add_or_restore_bond(
+      add_result.state,
+      { site_idx_1: 0, site_idx_2: 1 },
+      calculated_bonds,
+      3,
+    )
+    expect(visible_result).toMatchObject({ action: `already-visible`, changed: false })
+    expect(visible_result.state.removed_bonds).toEqual([])
+
+    const removed_state: BondEditState = {
+      ...empty_bond_edit_state(),
+      removed_bonds: [{ site_idx_1: 0, site_idx_2: 1, order: 1 }],
+    }
+    const restore_result = bonding.add_or_restore_bond(
+      removed_state,
+      { site_idx_1: 1, site_idx_2: 0 },
+      calculated_bonds,
+      1,
+    )
+    expect(restore_result).toMatchObject({ action: `restored`, changed: true })
+    expect(restore_result.state.removed_bonds).toEqual([])
+    expect(restore_result.state.bond_order_overrides).toEqual([])
+
+    const restore_with_order_result = bonding.add_or_restore_bond(
+      removed_state,
+      { site_idx_1: 1, site_idx_2: 0 },
+      calculated_bonds,
+      2,
+    )
+    expect(restore_with_order_result).toMatchObject({ action: `restored`, changed: true })
+    expect(restore_with_order_result.state.removed_bonds).toEqual([])
+    expect(restore_with_order_result.state.bond_order_overrides).toEqual([
+      { site_idx_1: 0, site_idx_2: 1, order: 2 },
+    ])
+  })
+
+  test(`deletes calculated and manually added bonds explicitly`, () => {
+    const calculated_bonds = [{ site_idx_1: 0, site_idx_2: 1 }]
+    const calculated_result = bonding.delete_bond(
+      empty_bond_edit_state(),
+      { site_idx_1: 1, site_idx_2: 0 },
+      calculated_bonds,
+    )
+    expect(calculated_result).toMatchObject({
+      action: `deleted-calculated`,
+      changed: true,
+    })
+    expect(calculated_result.state.removed_bonds).toEqual([
+      { site_idx_1: 0, site_idx_2: 1, order: 1 },
+    ])
+
+    const added_state: BondEditState = {
+      ...empty_bond_edit_state(),
+      added_bonds: [{ site_idx_1: 2, site_idx_2: 3, order: 3 }],
+    }
+    const added_result = bonding.delete_bond(
+      added_state,
+      { site_idx_1: 3, site_idx_2: 2 },
+      calculated_bonds,
+    )
+    expect(added_result).toMatchObject({ action: `deleted-added`, changed: true })
+    expect(added_result.state.added_bonds).toEqual([])
+
+    const missing_result = bonding.delete_bond(
+      empty_bond_edit_state(),
+      { site_idx_1: 4, site_idx_2: 5 },
+      calculated_bonds,
+    )
+    expect(missing_result).toMatchObject({ action: `not-visible`, changed: false })
+  })
+
+  test(`sets bond order for calculated, added, and removed bonds`, () => {
+    const calculated_bonds = [{ site_idx_1: 0, site_idx_2: 1 }]
+    const calculated_result = bonding.set_bond_order(
+      empty_bond_edit_state(),
+      { site_idx_1: 1, site_idx_2: 0 },
+      calculated_bonds,
+      3,
+    )
+    expect(calculated_result).toMatchObject({
+      action: `ordered-calculated`,
+      changed: true,
+    })
+    expect(calculated_result.state.bond_order_overrides).toEqual([
+      { site_idx_1: 0, site_idx_2: 1, order: 3 },
+    ])
+
+    const removed_state: BondEditState = {
+      ...empty_bond_edit_state(),
+      removed_bonds: [{ site_idx_1: 0, site_idx_2: 1, order: 1 }],
+    }
+    const restored_order_result = bonding.set_bond_order(
+      removed_state,
+      { site_idx_1: 0, site_idx_2: 1 },
+      calculated_bonds,
+      2,
+    )
+    expect(restored_order_result.state.removed_bonds).toEqual([])
+    expect(restored_order_result.state.bond_order_overrides).toEqual([
+      { site_idx_1: 0, site_idx_2: 1, order: 2 },
+    ])
+
+    const added_result = bonding.set_bond_order(
+      empty_bond_edit_state(),
+      { site_idx_1: 2, site_idx_2: 3 },
+      calculated_bonds,
+      `aromatic`,
+    )
+    expect(added_result).toMatchObject({ action: `ordered-added`, changed: true })
+    expect(added_result.state.added_bonds).toEqual([
+      { site_idx_1: 2, site_idx_2: 3, order: `aromatic` },
+    ])
+  })
+
+  test(`bond edit helpers preserve periodic cell-shift keys`, () => {
+    const calculated_bonds = [
+      { site_idx_1: 0, site_idx_2: 1, cell_shift: [1, 0, 0] as Vec3 },
+      { site_idx_1: 0, site_idx_2: 1, cell_shift: [0, 1, 0] as Vec3 },
+    ]
+    const result = bonding.delete_bond(
+      empty_bond_edit_state(),
+      { site_idx_1: 1, site_idx_2: 0, cell_shift: [-1, 0, 0] },
+      calculated_bonds,
+    )
+    expect(result.state.removed_bonds).toEqual([
+      { site_idx_1: 0, site_idx_2: 1, order: 1, cell_shift: [1, 0, 0] },
+    ])
+    expect(
+      bonding.has_visible_bond(
+        result.state,
+        { site_idx_1: 0, site_idx_2: 1, cell_shift: [0, 1, 0] },
+        calculated_bonds,
+      ),
+    ).toBe(true)
   })
 
   test(`parses and renders explicit crystal bonds with cell shifts`, () => {

--- a/tests/vitest/structure/edit-atoms.test.ts
+++ b/tests/vitest/structure/edit-atoms.test.ts
@@ -542,9 +542,7 @@ function get_canvas_cursor(ctx: CursorContext): string {
   }
   if (ctx.hovered_idx !== null) {
     if (ctx.measure_mode === `edit-bonds`) {
-      return ctx.bond_edit_mode !== `delete` &&
-        (ctx.bond_edits_enabled ?? true) &&
-        !ctx.site_is_image(ctx.hovered_idx)
+      return ctx.bond_edit_mode !== `delete` && (ctx.bond_edits_enabled ?? true)
         ? `pointer`
         : `not-allowed`
     }
@@ -632,6 +630,12 @@ describe(`canvas cursor`, () => {
       expected: `pointer`,
     },
     {
+      desc: `image atom hover in add mode`,
+      bond_edit_mode: `add` as const,
+      image: true,
+      expected: `pointer`,
+    },
+    {
       desc: `atom hover in delete mode`,
       bond_edit_mode: `delete` as const,
       expected: `not-allowed`,
@@ -657,6 +661,7 @@ describe(`canvas cursor`, () => {
       bond_edits_enabled = true,
       hovered_idx = 0,
       hovered_bond_key = null,
+      image = false,
       expected,
     }) => {
       expect(
@@ -667,7 +672,7 @@ describe(`canvas cursor`, () => {
           bond_edits_enabled,
           hovered_idx,
           hovered_bond_key,
-          site_is_image: no_image,
+          site_is_image: image ? all_image : no_image,
         }),
       ).toBe(expected)
     },

--- a/tests/vitest/structure/edit-atoms.test.ts
+++ b/tests/vitest/structure/edit-atoms.test.ts
@@ -626,17 +626,47 @@ describe(`canvas cursor`, () => {
   })
 
   test.each([
-    { bond_edit_mode: `add` as const, expected: `pointer` },
-    { bond_edit_mode: `delete` as const, expected: `not-allowed` },
+    {
+      desc: `atom hover in add mode`,
+      bond_edit_mode: `add` as const,
+      expected: `pointer`,
+    },
+    {
+      desc: `atom hover in delete mode`,
+      bond_edit_mode: `delete` as const,
+      expected: `not-allowed`,
+    },
+    {
+      desc: `disabled atom hover`,
+      bond_edit_mode: `add` as const,
+      bond_edits_enabled: false,
+      expected: `not-allowed`,
+    },
+    {
+      desc: `disabled bond hover`,
+      bond_edit_mode: `add` as const,
+      bond_edits_enabled: false,
+      hovered_idx: null,
+      hovered_bond_key: `0-1`,
+      expected: `not-allowed`,
+    },
   ])(
-    `returns $expected for atom hover in edit-bonds $bond_edit_mode mode`,
-    ({ bond_edit_mode, expected }) => {
+    `returns $expected for edit-bonds $desc`,
+    ({
+      bond_edit_mode,
+      bond_edits_enabled = true,
+      hovered_idx = 0,
+      hovered_bond_key = null,
+      expected,
+    }) => {
       expect(
         get_canvas_cursor({
           measure_mode: `edit-bonds`,
           add_atom_mode: false,
           bond_edit_mode,
-          hovered_idx: 0,
+          bond_edits_enabled,
+          hovered_idx,
+          hovered_bond_key,
           site_is_image: no_image,
         }),
       ).toBe(expected)

--- a/tests/vitest/structure/edit-atoms.test.ts
+++ b/tests/vitest/structure/edit-atoms.test.ts
@@ -2,9 +2,8 @@
 import type { ElementSymbol, Vec3 } from '$lib'
 import { ELEM_SYMBOLS } from '$lib/labels'
 import { create_cart_to_frac } from '$lib/math'
-import type { AnyStructure, Site, StructureBond } from '$lib/structure'
+import type { AnyStructure, Site } from '$lib/structure'
 import { get_pbc_image_sites } from '$lib/structure'
-import { get_bond_key, normalize_structure_bond } from '$lib/structure/bonding'
 import { describe, expect, test } from 'vitest'
 import { get_dummy_structure, make_crystal } from '../setup'
 
@@ -297,132 +296,13 @@ describe(`edit-atoms: image atom detection`, () => {
   })
 })
 
-// === Bond Toggle Logic ===
-// Mirrors toggle_bond from StructureScene.svelte
+// === Bond Neighbor Summary ===
+// Mirrors the bond tooltip logic from StructureScene.svelte
 
 type BondPair = {
   site_idx_1: number
   site_idx_2: number
-  cell_shift?: Vec3
 }
-
-function create_bond_state(calculated: BondPair[] = []) {
-  let added: StructureBond[] = []
-  let removed: StructureBond[] = []
-  const key_for = (bond: BondPair | StructureBond): string =>
-    get_bond_key(bond.site_idx_1, bond.site_idx_2, bond.cell_shift)
-
-  function toggle_bond(site_1: number, site_2: number, cell_shift?: Vec3) {
-    const record = normalize_structure_bond(site_1, site_2, 1, cell_shift)
-    const key = key_for(record)
-    const added_idx = added.findIndex((bond) => key_for(bond) === key)
-    if (added_idx >= 0) {
-      added = added.toSpliced(added_idx, 1)
-      return
-    }
-
-    const removed_idx = removed.findIndex((bond) => key_for(bond) === key)
-    if (removed_idx >= 0) {
-      removed = removed.toSpliced(removed_idx, 1)
-      return
-    }
-
-    if (calculated.some((bond) => key_for(bond) === key)) {
-      removed = [...removed, record]
-    } else {
-      added = [...added, record]
-    }
-  }
-
-  return {
-    toggle_bond,
-    get added_bonds() {
-      return added
-    },
-    get removed_bonds() {
-      return removed
-    },
-  }
-}
-
-describe(`edit-bonds: toggle_bond`, () => {
-  test(`adds bond between unconnected atoms, sorted regardless of input order`, () => {
-    const state = create_bond_state()
-    state.toggle_bond(5, 2)
-    expect(state.added_bonds).toEqual([{ site_idx_1: 2, site_idx_2: 5, order: 1 }])
-    expect(state.removed_bonds).toEqual([])
-  })
-
-  test(`removes manually added bond on second toggle`, () => {
-    const state = create_bond_state()
-    state.toggle_bond(0, 3)
-    expect(state.added_bonds).toHaveLength(1)
-    state.toggle_bond(0, 3)
-    expect(state.added_bonds).toHaveLength(0)
-  })
-
-  test(`removes calculated bond (handles reversed indices in bond_pairs)`, () => {
-    // bond_pairs may have site_idx_1 > site_idx_2
-    const state = create_bond_state([{ site_idx_1: 5, site_idx_2: 2 }])
-    state.toggle_bond(2, 5)
-    expect(state.removed_bonds).toEqual([{ site_idx_1: 2, site_idx_2: 5, order: 1 }])
-    expect(state.added_bonds).toEqual([])
-  })
-
-  test(`restores removed calculated bond on second toggle`, () => {
-    const state = create_bond_state([{ site_idx_1: 0, site_idx_2: 1 }])
-    state.toggle_bond(0, 1) // remove
-    expect(state.removed_bonds).toHaveLength(1)
-    state.toggle_bond(0, 1) // restore
-    expect(state.removed_bonds).toHaveLength(0)
-  })
-
-  test(`full cycle: add → remove → re-add for non-calculated bond`, () => {
-    const state = create_bond_state()
-    state.toggle_bond(1, 4)
-    expect(state.added_bonds).toEqual([{ site_idx_1: 1, site_idx_2: 4, order: 1 }])
-    state.toggle_bond(1, 4)
-    expect(state.added_bonds).toEqual([])
-    state.toggle_bond(1, 4)
-    expect(state.added_bonds).toEqual([{ site_idx_1: 1, site_idx_2: 4, order: 1 }])
-  })
-
-  test(`distinguishes periodic cell shifts for calculated bonds`, () => {
-    const state = create_bond_state([
-      { site_idx_1: 0, site_idx_2: 1, cell_shift: [1, 0, 0] },
-      { site_idx_1: 0, site_idx_2: 1, cell_shift: [0, 1, 0] },
-    ])
-
-    state.toggle_bond(1, 0, [-1, 0, 0])
-
-    expect(state.removed_bonds).toEqual([
-      { site_idx_1: 0, site_idx_2: 1, order: 1, cell_shift: [1, 0, 0] },
-    ])
-    expect(state.added_bonds).toEqual([])
-
-    state.toggle_bond(0, 1, [0, 1, 0])
-
-    expect(state.removed_bonds).toEqual([
-      { site_idx_1: 0, site_idx_2: 1, order: 1, cell_shift: [1, 0, 0] },
-      { site_idx_1: 0, site_idx_2: 1, order: 1, cell_shift: [0, 1, 0] },
-    ])
-  })
-
-  test(`manages multiple bonds independently`, () => {
-    const state = create_bond_state([{ site_idx_1: 0, site_idx_2: 1 }])
-    state.toggle_bond(0, 1) // remove calculated
-    state.toggle_bond(2, 3) // add new
-    state.toggle_bond(4, 5) // add new
-    expect(state.removed_bonds).toEqual([{ site_idx_1: 0, site_idx_2: 1, order: 1 }])
-    expect(state.added_bonds).toEqual([
-      { site_idx_1: 2, site_idx_2: 3, order: 1 },
-      { site_idx_1: 4, site_idx_2: 5, order: 1 },
-    ])
-  })
-})
-
-// === Bond Neighbor Summary ===
-// Mirrors the bond tooltip logic from StructureScene.svelte
 
 function get_bond_neighbors(
   hovered_idx: number,
@@ -648,13 +528,25 @@ describe(`edit-atoms: duplicate atoms`, () => {
 type CursorContext = {
   measure_mode: string
   add_atom_mode: boolean
+  bond_edit_mode?: `add` | `delete`
+  bond_edits_enabled?: boolean
   hovered_idx: number | null
+  hovered_bond_key?: string | null
   site_is_image: (idx: number) => boolean
 }
 
 function get_canvas_cursor(ctx: CursorContext): string {
   if (ctx.measure_mode === `edit-atoms` && ctx.add_atom_mode) return `crosshair`
+  if (ctx.measure_mode === `edit-bonds` && ctx.hovered_bond_key != null) {
+    return ctx.bond_edits_enabled ?? true ? `pointer` : `not-allowed`
+  }
   if (ctx.hovered_idx !== null) {
+    if (ctx.measure_mode === `edit-bonds`) {
+      return ctx.bond_edit_mode !== `delete` && (ctx.bond_edits_enabled ?? true) &&
+          !ctx.site_is_image(ctx.hovered_idx)
+        ? `pointer`
+        : `not-allowed`
+    }
     if (ctx.measure_mode === `edit-atoms`) {
       if (ctx.site_is_image(ctx.hovered_idx)) return `not-allowed`
       return `pointer`
@@ -714,13 +606,14 @@ describe(`canvas cursor`, () => {
       get_canvas_cursor({
         measure_mode: mode,
         add_atom_mode: add,
+        bond_edit_mode: `add`,
         hovered_idx: hover,
         site_is_image: image ? all_image : no_image,
       }),
     ).toBe(expected)
   })
 
-  test.each([`distance`, `angle`, `edit-bonds`])(
+  test.each([`distance`, `angle`])(
     `shows pointer in %s mode when hovering`,
     (mode) => {
       expect(
@@ -733,6 +626,24 @@ describe(`canvas cursor`, () => {
       ).toBe(`pointer`)
     },
   )
+
+  test.each([
+    { bond_edit_mode: `add` as const, expected: `pointer` },
+    { bond_edit_mode: `delete` as const, expected: `not-allowed` },
+  ])(`returns $expected for atom hover in edit-bonds $bond_edit_mode mode`, ({
+    bond_edit_mode,
+    expected,
+  }) => {
+    expect(
+      get_canvas_cursor({
+        measure_mode: `edit-bonds`,
+        add_atom_mode: false,
+        bond_edit_mode,
+        hovered_idx: 0,
+        site_is_image: no_image,
+      }),
+    ).toBe(expected)
+  })
 })
 
 // === Edit-atoms Selection Logic ===

--- a/tests/vitest/structure/edit-atoms.test.ts
+++ b/tests/vitest/structure/edit-atoms.test.ts
@@ -538,12 +538,13 @@ type CursorContext = {
 function get_canvas_cursor(ctx: CursorContext): string {
   if (ctx.measure_mode === `edit-atoms` && ctx.add_atom_mode) return `crosshair`
   if (ctx.measure_mode === `edit-bonds` && ctx.hovered_bond_key != null) {
-    return ctx.bond_edits_enabled ?? true ? `pointer` : `not-allowed`
+    return (ctx.bond_edits_enabled ?? true) ? `pointer` : `not-allowed`
   }
   if (ctx.hovered_idx !== null) {
     if (ctx.measure_mode === `edit-bonds`) {
-      return ctx.bond_edit_mode !== `delete` && (ctx.bond_edits_enabled ?? true) &&
-          !ctx.site_is_image(ctx.hovered_idx)
+      return ctx.bond_edit_mode !== `delete` &&
+        (ctx.bond_edits_enabled ?? true) &&
+        !ctx.site_is_image(ctx.hovered_idx)
         ? `pointer`
         : `not-allowed`
     }
@@ -613,37 +614,34 @@ describe(`canvas cursor`, () => {
     ).toBe(expected)
   })
 
-  test.each([`distance`, `angle`])(
-    `shows pointer in %s mode when hovering`,
-    (mode) => {
-      expect(
-        get_canvas_cursor({
-          measure_mode: mode,
-          add_atom_mode: false,
-          hovered_idx: 0,
-          site_is_image: no_image,
-        }),
-      ).toBe(`pointer`)
-    },
-  )
+  test.each([`distance`, `angle`])(`shows pointer in %s mode when hovering`, (mode) => {
+    expect(
+      get_canvas_cursor({
+        measure_mode: mode,
+        add_atom_mode: false,
+        hovered_idx: 0,
+        site_is_image: no_image,
+      }),
+    ).toBe(`pointer`)
+  })
 
   test.each([
     { bond_edit_mode: `add` as const, expected: `pointer` },
     { bond_edit_mode: `delete` as const, expected: `not-allowed` },
-  ])(`returns $expected for atom hover in edit-bonds $bond_edit_mode mode`, ({
-    bond_edit_mode,
-    expected,
-  }) => {
-    expect(
-      get_canvas_cursor({
-        measure_mode: `edit-bonds`,
-        add_atom_mode: false,
-        bond_edit_mode,
-        hovered_idx: 0,
-        site_is_image: no_image,
-      }),
-    ).toBe(expected)
-  })
+  ])(
+    `returns $expected for atom hover in edit-bonds $bond_edit_mode mode`,
+    ({ bond_edit_mode, expected }) => {
+      expect(
+        get_canvas_cursor({
+          measure_mode: `edit-bonds`,
+          add_atom_mode: false,
+          bond_edit_mode,
+          hovered_idx: 0,
+          site_is_image: no_image,
+        }),
+      ).toBe(expected)
+    },
+  )
 })
 
 // === Edit-atoms Selection Logic ===


### PR DESCRIPTION
Follow-up to #339, closes #341. Extends the edit-bonds interaction with:

- Adds explicit `Add`/`Delete` bond-edit modes with undo/redo history, keyboard shortcuts, order selection, and context-menu order editing.
- Hardens bond edit state handling for explicit, calculated, periodic, image-atom, and self-bond cases by normalizing bond keys and preserving `cell_shift`.
- Improves structure UI polish: safer labels, better bond edit toolbar layout, wider invisible delete hit targets, tooltip theming, and clearer shortcut labels.
- Updates Dash typed wrapper generation and VS Code buffer handling to better classify callback props and avoid unnecessary large-file copies.
- Adds unit (`bonding.test.ts`, `edit-atoms.test.ts`, `Structure.test.svelte.ts`) and Playwright (`bonds.test.ts`) coverage.

- Atom labels are interactive for selection and bond actions.
- Structure exposes props and events for bond-editing actions and bond, camera, fullscreen, and bond-list changes.