### PR TITLE
Adopt shared `@janosh/vite-config` and apply resulting lint fixes

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           node-version: latest
 
-      - run: npx vp install
+      - run: corepack enable && pnpm install
 
       - name: Copy site data to static
         run: |
@@ -31,7 +31,7 @@ jobs:
       - name: Decompress .json.gz data for rolldown glob resolution
         run: find src/site -name '*.json.gz' -exec sh -c 'gunzip -k "$1"' _ {} \;
 
-      - run: npx vp build
+      - run: pnpm exec vp build
 
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: latest
+          node-version: 24
 
       - run: corepack enable && pnpm install
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -19,9 +19,9 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: latest
 
-      - run: npm install
+      - run: npx vp install
 
       - name: Copy site data to static
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           node-version: latest
 
-      - run: npx vp install
+      - run: corepack enable && pnpm install
 
       - uses: j178/prek-action@v2
 
@@ -31,7 +31,7 @@ jobs:
         with:
           node-version: latest
 
-      - run: npx vp install
+      - run: corepack enable && pnpm install
 
       - name: Check for unused dependencies
         run: npm run knip

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: latest
+          node-version: 24
 
       - run: corepack enable && pnpm install
 
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: latest
+          node-version: 24
 
       - run: corepack enable && pnpm install
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,9 +15,9 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: latest
 
-      - run: npm install
+      - run: npx vp install
 
       - uses: j178/prek-action@v2
 
@@ -29,9 +29,9 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: latest
 
-      - run: npm install
+      - run: npx vp install
 
       - name: Check for unused dependencies
         run: npm run knip

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,4 +34,4 @@ jobs:
       - run: corepack enable && pnpm install
 
       - name: Check for unused dependencies
-        run: npm run knip
+        run: pnpm run knip

--- a/.github/workflows/test-dash.yml
+++ b/.github/workflows/test-dash.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: latest
+          node-version: 24
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/test-dash.yml
+++ b/.github/workflows/test-dash.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: latest
 
       - uses: actions/setup-python@v6
         with:
@@ -47,7 +47,7 @@ jobs:
 
       # Build root matterviz package (generates dist/*.d.ts files)
       - name: Build matterviz package
-        run: npm install && npm run package:dist
+        run: npx vp install && npm run package:dist
         working-directory: .
 
       # Install dash extension deps

--- a/.github/workflows/test-dash.yml
+++ b/.github/workflows/test-dash.yml
@@ -47,7 +47,7 @@ jobs:
 
       # Build root matterviz package (generates dist/*.d.ts files)
       - name: Build matterviz package
-        run: corepack enable && pnpm install && npm run package:dist
+        run: corepack enable && pnpm install && pnpm run package:dist
         working-directory: .
 
       # Install dash extension deps

--- a/.github/workflows/test-dash.yml
+++ b/.github/workflows/test-dash.yml
@@ -47,7 +47,7 @@ jobs:
 
       # Build root matterviz package (generates dist/*.d.ts files)
       - name: Build matterviz package
-        run: npx vp install && npm run package:dist
+        run: corepack enable && pnpm install && npm run package:dist
         working-directory: .
 
       # Install dash extension deps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: latest
+          node-version: 24
 
       - run: corepack enable && pnpm install
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,11 +24,11 @@ jobs:
         with:
           node-version: latest
 
-      - run: npx vp install
+      - run: corepack enable && pnpm install
 
       - name: Unit tests
         if: matrix.test-type == 'unit'
-        run: npx vp test --run
+        run: pnpm exec vp test --run
 
       - name: Install Playwright
         if: matrix.test-type == 'end-to-end'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,9 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: latest
 
-      - run: npm install
+      - run: npx vp install
 
       - name: Unit tests
         if: matrix.test-type == 'unit'

--- a/extensions/vscode/src/webview/main.ts
+++ b/extensions/vscode/src/webview/main.ts
@@ -33,6 +33,7 @@ import { FERMI_FILE_RE, VOLUMETRIC_EXT_RE, VOLUMETRIC_VASP_RE } from '../types'
 import type { RenderableType } from './detect'
 import { detect_view_type } from './detect'
 import JsonBrowser from './JsonBrowser.svelte'
+import { to_error } from '$lib/utils'
 
 // Maps detect.ts RenderableType to ViewType for direct rendering.
 // Types not listed here fall through to json_browser (which can render all types
@@ -725,7 +726,6 @@ async function cleanup_matterviz(): Promise<void> {
     current_app = null
   }
 } // Export initialization and cleanup functions to global scope
-
 ;(
   globalThis as unknown as {
     initializeMatterViz?: () => Promise<MatterVizApp | null>
@@ -742,7 +742,7 @@ async function cleanup_matterviz(): Promise<void> {
     current_app = app
     return app
   } catch (error) {
-    const err = error instanceof Error ? error : new Error(String(error))
+    const err = to_error(error)
     const container = document.getElementById(`matterviz-app`)
     if (container) {
       create_error_display(

--- a/package.json
+++ b/package.json
@@ -196,6 +196,7 @@
     "three": "^0.184.0"
   },
   "devDependencies": {
+    "@janosh/vite-config": "github:janosh/dotfiles#path:/vite-config",
     "@playwright/test": "^1.60.0",
     "@sveltejs/adapter-static": "3.0.10",
     "@sveltejs/package": "^2.5.7",

--- a/package.json
+++ b/package.json
@@ -169,9 +169,9 @@
   "scripts": {
     "test": "vp test --run && playwright test",
     "knip": "knip --include dependencies,devDependencies",
-    "package-dist-assets": "NODE_OPTIONS=--experimental-strip-types node scripts/package-dist-assets.ts",
+    "package-dist-assets": "node scripts/package-dist-assets.ts",
     "package:dist": "svelte-package && npm run package-dist-assets",
-    "prepare": "NODE_OPTIONS=--experimental-strip-types svelte-kit sync && npm run package:dist",
+    "prepare": "svelte-kit sync && npm run package:dist",
     "prepublishOnly": "npm run package:dist"
   },
   "dependencies": {
@@ -234,6 +234,7 @@
   "engines": {
     "node": ">=24"
   },
+  "packageManager": "pnpm@11.5.0",
   "knip": {
     "entry": [
       "svelte.config.ts"

--- a/package.json
+++ b/package.json
@@ -170,9 +170,9 @@
     "test": "vp test --run && playwright test",
     "knip": "knip --include dependencies,devDependencies",
     "package-dist-assets": "node scripts/package-dist-assets.ts",
-    "package:dist": "svelte-package && npm run package-dist-assets",
-    "prepare": "svelte-kit sync && npm run package:dist",
-    "prepublishOnly": "npm run package:dist"
+    "package:dist": "svelte-package && pnpm run package-dist-assets",
+    "prepare": "svelte-kit sync && pnpm run package:dist",
+    "prepublishOnly": "pnpm run package:dist"
   },
   "dependencies": {
     "@spglib/moyo-wasm": "^0.10.0",
@@ -196,7 +196,7 @@
     "three": "^0.184.0"
   },
   "devDependencies": {
-    "@janosh/vite-config": "github:janosh/dotfiles#path:/vite-config",
+    "@janosh/vite-config": "github:janosh/dotfiles",
     "@playwright/test": "^1.60.0",
     "@sveltejs/adapter-static": "3.0.10",
     "@sveltejs/package": "^2.5.7",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+# Allow the shared lint-config git dependency to run its `prepare` build
+# (esbuild index.ts -> index.js) during install. pnpm blocks git-dep build
+# scripts by default (ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED).
+allowBuilds:
+  '@janosh/vite-config': true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,0 @@
-# Allow the shared lint-config git dependency to run its `prepare` build
-# (esbuild index.ts -> index.js) during install. pnpm blocks git-dep build
-# scripts by default (ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED).
-allowBuilds:
-  '@janosh/vite-config': true

--- a/scripts/package-dist-assets.ts
+++ b/scripts/package-dist-assets.ts
@@ -1,9 +1,8 @@
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { dirname, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { resolve } from 'node:path'
 import { gunzipSync } from 'node:zlib'
 
-const root_dir = resolve(dirname(fileURLToPath(import.meta.url)), `..`)
+const root_dir = resolve(import.meta.dirname, `..`)
 const gz_path = resolve(root_dir, `src/lib/element/data.json.gz`)
 const out_dir = resolve(root_dir, `dist/element`)
 const out_path = resolve(out_dir, `data.js`)

--- a/src/lib/MillerIndexInput.svelte
+++ b/src/lib/MillerIndexInput.svelte
@@ -19,7 +19,7 @@
       if (nums.every((num) => !isNaN(num))) return nums as Vec3
     }
     // Fall back to compact single-digit format: "001", "-101"
-    const compact = input.replace(/\s+/g, ``)
+    const compact = input.replaceAll(/\s+/g, ``)
     const match = compact.match(/^(-?\d)(-?\d)(-?\d)$/)
     if (match) return [Number(match[1]), Number(match[2]), Number(match[3])] as Vec3
     return null

--- a/src/lib/api/optimade.ts
+++ b/src/lib/api/optimade.ts
@@ -153,7 +153,7 @@ export async function fetch_optimade_providers(): Promise<OptimadeProvider[]> {
 
 // URL encode/decode utilities for structure IDs with special characters
 export const encode_structure_id = (id: string) =>
-  encodeURIComponent(id).replace(/\./g, `%2E`).replace(/\//g, `%2F`)
+  encodeURIComponent(id).replaceAll('.', `%2E`).replaceAll('/', `%2F`)
 
 export const decode_structure_id = (encoded_id: string) => decodeURIComponent(encoded_id)
 

--- a/src/lib/brillouin/BrillouinZone.svelte
+++ b/src/lib/brillouin/BrillouinZone.svelte
@@ -29,6 +29,7 @@
     extract_point_group_from_operations,
     reciprocal_lattice,
   } from './compute'
+  import { to_error } from '$lib/utils'
   import type {
     BrillouinZoneData,
     BZHoverData,
@@ -192,7 +193,7 @@
       parse_structure(content, filename)
     } catch (err) {
       error_msg = `Failed to parse ${filename}: ${
-        err instanceof Error ? err.message : err
+        to_error(err).message
       }`
       on_error?.({ error_msg, filename })
     }
@@ -214,7 +215,7 @@
       const valid_order = Math.min(Math.max(1, bz_order), 3) as 1 | 2 | 3
       bz_data = compute_brillouin_zone(k_lattice, valid_order)
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
+      const msg = to_error(err).message
       error_msg = `BZ computation failed: ${msg}`
       bz_data = undefined
       untrack(() => on_error?.({ error_msg, structure, bz_order }))
@@ -253,7 +254,7 @@
   // Load structure from URL or string
   $effect(() => {
     const handle_error = (err: unknown, source: string) => {
-      error_msg = err instanceof Error ? err.message : String(err)
+      error_msg = to_error(err).message
       on_error?.({ error_msg, filename: source })
     }
 

--- a/src/lib/chempot-diagram/ChemPotDiagram.svelte
+++ b/src/lib/chempot-diagram/ChemPotDiagram.svelte
@@ -1,20 +1,21 @@
 <script lang="ts">
-  import { get_electro_neg_formula } from '$lib/composition/format';
-  import type { PhaseData } from '$lib/convex-hull/types';
-  import Spinner from '$lib/feedback/Spinner.svelte';
-  import { format_num } from '$lib/labels';
-  import { constrain_tooltip_position } from '$lib/plot/layout';
-  import { sanitize_html } from '$lib/sanitize';
-  import { compute_chempot_async } from './async-compute.svelte';
-  import ChemPotDiagram2D from './ChemPotDiagram2D.svelte';
-  import ChemPotDiagram3D from './ChemPotDiagram3D.svelte';
-  import { get_ternary_combinations } from './compute';
+  import { get_electro_neg_formula } from '$lib/composition/format'
+  import type { PhaseData } from '$lib/convex-hull/types'
+  import Spinner from '$lib/feedback/Spinner.svelte'
+  import { format_num } from '$lib/labels'
+  import { constrain_tooltip_position } from '$lib/plot/layout'
+  import { sanitize_html } from '$lib/sanitize'
+  import { compute_chempot_async } from './async-compute.svelte'
+  import ChemPotDiagram2D from './ChemPotDiagram2D.svelte'
+  import ChemPotDiagram3D from './ChemPotDiagram3D.svelte'
+  import { get_ternary_combinations } from './compute'
   import type {
       ChemPotDiagramConfig,
       ChemPotHoverInfo,
       ChemPotHoverInfo3D,
-  } from './types';
-  import { CHEMPOT_DEFAULTS } from './types';
+  } from './types'
+  import { CHEMPOT_DEFAULTS } from './types'
+  import { to_error } from '$lib/utils'
 
   let {
     entries = [],
@@ -84,7 +85,7 @@
       .catch((err) => {
         if (cancelled) return
         console.error(`Grid precompute failed:`, err)
-        grid_error = err instanceof Error ? err.message : String(err)
+        grid_error = to_error(err).message
       })
     return () => { cancelled = true }
   })

--- a/src/lib/chempot-diagram/ChemPotDiagram3D.svelte
+++ b/src/lib/chempot-diagram/ChemPotDiagram3D.svelte
@@ -14,7 +14,7 @@
     convex_hull_2d,
     cross_3d,
     merge_coplanar_triangles,
-    normalize_vec3,
+    normalize_vec,
   } from '$lib/math'
   import DraggablePane from '$lib/overlays/DraggablePane.svelte'
   import { ColorBar, ScatterPlot3DControls } from '$lib/plot'
@@ -953,7 +953,7 @@
           pos.getY(base + 2) - pos.getY(base),
           pos.getZ(base + 2) - pos.getZ(base),
         ]
-        normals.push(normalize_vec3(cross_3d(e1, e2)))
+        normals.push(normalize_vec(cross_3d(e1, e2)))
       }
       // Build edge → face adjacency
       const edge_faces = new SvelteMap<string, number[]>()

--- a/src/lib/chempot-diagram/async-compute.svelte.ts
+++ b/src/lib/chempot-diagram/async-compute.svelte.ts
@@ -3,6 +3,7 @@
 import { compute_chempot_diagram, formula_key_from_composition } from './compute'
 import type { ChemPotDiagramConfig, ChemPotDiagramData } from './types'
 import type { PhaseData } from '$lib/convex-hull/types'
+import { to_error } from '$lib/utils'
 
 let worker: Worker | null = null
 let next_id = 0
@@ -44,6 +45,7 @@ function track_pending(
 function get_worker(): Worker | null {
   if (typeof Worker === `undefined`) return null
   if (!worker) {
+    // oxlint-disable-next-line eslint-plugin-unicorn/relative-url-style -- Vite worker detection requires the `./` prefix
     worker = new Worker(new URL(`./chempot-worker.js`, import.meta.url), { type: `module` })
     worker.addEventListener(`message`, ({ data: { id, result, error } }) => {
       const req = pending.get(id)
@@ -87,7 +89,7 @@ export function compute_chempot_async(
       wkr.postMessage($state.snapshot({ id, entries, config }))
     } catch (err) {
       pending.delete(id)
-      reject(err instanceof Error ? err : new Error(String(err)))
+      reject(to_error(err))
     }
   })
   return track_pending(request_key, promise)

--- a/src/lib/chempot-diagram/chempot-worker.ts
+++ b/src/lib/chempot-diagram/chempot-worker.ts
@@ -1,4 +1,5 @@
 import { compute_chempot_diagram } from './compute'
+import { to_error } from '$lib/utils'
 
 self.addEventListener(`message`, (event: MessageEvent) => {
   const { id, entries, config } = event.data
@@ -6,6 +7,6 @@ self.addEventListener(`message`, (event: MessageEvent) => {
     const result = compute_chempot_diagram(entries, config)
     postMessage({ id, result, error: null })
   } catch (err) {
-    postMessage({ id, result: null, error: err instanceof Error ? err.message : String(err) })
+    postMessage({ id, result: null, error: to_error(err).message })
   }
 })

--- a/src/lib/chempot-diagram/compute.ts
+++ b/src/lib/chempot-diagram/compute.ts
@@ -988,7 +988,7 @@ export function compute_chempot_diagram(
   if (is_projection) {
     const col_indices = display_elements.map((element) => {
       const idx = compute_elements.indexOf(element)
-      if (idx < 0) {
+      if (idx === -1) {
         throw new Error(`Display element ${element} not present in compute element set`)
       }
       return idx

--- a/src/lib/composition/FormulaFilter.svelte
+++ b/src/lib/composition/FormulaFilter.svelte
@@ -341,7 +341,7 @@
       .replaceAll(`·`, ``)
       .replaceAll(`⋅`, ``)
       .replaceAll(`−`, `-`)
-      .replace(/\s+/g, ``)
+      .replaceAll(/\s+/g, ``)
   }
 
   function normalize_exact_formula(input: string): string {
@@ -361,7 +361,7 @@
       const wildcard_tokens = tokens.filter((token) => token.element === null)
 
       // Merge explicit element counts before sorting.
-      const merged_explicit: Array<{ element: string; count: number }> = []
+      const merged_explicit: { element: string; count: number }[] = []
       for (const token of explicit) {
         const existing = merged_explicit.find((item) =>
           item.element === token.element
@@ -609,14 +609,20 @@
     const reformatted = format_for_mode(elements, next_mode)
 
     search_mode = next_mode
-    last_synced = value = input_value = reformatted // update last_synced to prevent effect re-inference
+    // set last_synced too to prevent effect re-inference
+    last_synced = reformatted
+    value = reformatted
+    input_value = reformatted
     run_validation(reformatted, next_mode)
     onchange?.(reformatted, next_mode)
   }
 
   function set_value(new_value: string, forced_mode?: FormulaSearchMode): void {
     const mode = forced_mode ?? (mode_locked ? search_mode : infer_mode(new_value))
-    last_synced = value = input_value = new_value // update last_synced to prevent effect re-inference
+    // set last_synced too to prevent effect re-inference
+    last_synced = new_value
+    value = new_value
+    input_value = new_value
     search_mode = mode
     if (new_value.trim()) add_to_history(new_value)
     close_history()

--- a/src/lib/composition/PieChart.svelte
+++ b/src/lib/composition/PieChart.svelte
@@ -151,11 +151,9 @@
         } else if (is_medium_slice) {
           // Medium slices: place closer to outer edge, proportional to chart size
           label_radius = outer_radius - outer_radius * 0.3
-          is_outside_slice = false
         } else {
           // Large slices: place in middle of ring
           label_radius = (outer_radius + inner_radius_adjusted) / 2
-          is_outside_slice = false
         }
 
         // Calculate font scale based on slice size and smart text fitting

--- a/src/lib/composition/parse.ts
+++ b/src/lib/composition/parse.ts
@@ -80,11 +80,11 @@ export const atomic_symbol_to_num = (
 // Expand parentheses in chemical formulas
 const expand_parentheses = (formula: string): string => {
   while (formula.includes(`(`)) {
-    formula = formula.replace(
+    formula = formula.replaceAll(
       /\(([^()]+)\)(\d+(?:\.\d+)?|\.\d+)?/g,
       (_match, group, multiplier) => {
         const mult = parse_count(multiplier)
-        return group.replace(
+        return group.replaceAll(
           /([A-Z][a-z]?)(\d+(?:\.\d+)?|\.\d+)?/g,
           (_m: string, element: string, count: string) => {
             const count_str = format_count(parse_count(count) * mult)
@@ -100,7 +100,7 @@ const expand_parentheses = (formula: string): string => {
 // Parse chemical formula string into composition object
 export const parse_formula = (formula: string): CompositionType => {
   const composition: CompositionType = {}
-  const cleaned_formula = expand_parentheses(formula.replace(/\s/g, ``))
+  const cleaned_formula = expand_parentheses(formula.replaceAll(/\s/g, ``))
 
   for (const match of cleaned_formula.matchAll(/([A-Z][a-z]?)(\d+(?:\.\d+)?|\.\d+)?/g)) {
     const element = match[1]
@@ -275,7 +275,7 @@ export const parse_formula_with_oxidation = (
   strict = false,
 ): ElementWithOxidation[] => {
   const elements: ElementWithOxidation[] = []
-  const cleaned_formula = expand_parentheses(formula.replace(/\s/g, ``))
+  const cleaned_formula = expand_parentheses(formula.replaceAll(/\s/g, ``))
 
   // Regex to match: Element, optional oxidation state and/or count in either order
   // Pattern: ([A-Z][a-z]?)  - element symbol
@@ -410,7 +410,7 @@ export function normalize_element_symbols<T extends string>(csv: string, all_sym
 export function normalize_element_symbols<T extends string>(
   csv: string,
   all_symbols?: T[],
-): Array<ElementSymbol | T> {
+): (ElementSymbol | T)[] {
   const input_set = new Set(
     csv
       .split(`,`)
@@ -444,7 +444,7 @@ export const has_wildcards = (input: string): boolean => input.includes(`*`)
 // Throws if any non-wildcard token is not a valid element symbol.
 export function parse_chemsys_with_wildcards(input: string): ChemsysWithWildcards {
   const tokens = input
-    .replace(/-/g, `,`)
+    .replaceAll('-', `,`)
     .split(`,`)
     .map((tok) => tok.trim())
     .filter(Boolean)
@@ -484,7 +484,7 @@ export function parse_formula_with_wildcards(formula: string): WildcardFormulaTo
   const tokens: WildcardFormulaToken[] = []
 
   // Expand parentheses, treating * as a pseudo-element (temporarily replace to protect it)
-  let cleaned = formula.replace(/\s/g, ``)
+  let cleaned = formula.replaceAll(/\s/g, ``)
 
   // Protect wildcards from parentheses expansion by replacing * with placeholder
   cleaned = cleaned.replace(ELEM_WILDCARD.to_placeholder, ELEM_WILDCARD.placeholder)
@@ -556,7 +556,7 @@ export function matches_formula_wildcard(
     const composition = parse_formula(formula)
 
     // Separate explicit elements and wildcards from pattern
-    const explicit_requirements: Array<{ element: ElementSymbol; count: number }> = []
+    const explicit_requirements: { element: ElementSymbol; count: number }[] = []
     const wildcard_counts: number[] = []
 
     for (const token of pattern) {

--- a/src/lib/convex-hull/ConvexHull2D.svelte
+++ b/src/lib/convex-hull/ConvexHull2D.svelte
@@ -391,7 +391,7 @@
           ? base_radius * hl.size_multiplier
           : base_radius,
         symbol_type: marker_to_d3_symbol(entry.marker),
-        is_highlighted: !!hl,
+        is_highlighted: Boolean(hl),
         highlight_effect: hl?.effect,
         highlight_color: hl?.color,
       }
@@ -437,7 +437,7 @@
     const entry = selected_entry
     if (!entry) return null
     const idx = visible_entries.findIndex((vis_entry) => vis_entry === entry)
-    return idx >= 0 ? { series_idx: 0, point_idx: idx } : null
+    return idx !== -1 ? { series_idx: 0, point_idx: idx } : null
   })
 
   // Convex hull statistics - compute internally and expose via bindable prop

--- a/src/lib/convex-hull/ConvexHull3D.svelte
+++ b/src/lib/convex-hull/ConvexHull3D.svelte
@@ -963,7 +963,7 @@
 
   // Formation energy color bar helpers
   const e_form_range = $derived.by((): [number, number] => {
-    const min_fe = plot_entries.length ? energy_range.min : -1
+    const min_fe = plot_entries.length > 0 ? energy_range.min : -1
     return [min_fe, 0]
   })
 

--- a/src/lib/convex-hull/ConvexHull4D.svelte
+++ b/src/lib/convex-hull/ConvexHull4D.svelte
@@ -394,12 +394,11 @@
     const total_entries = effective_entries.length
     if (total_entries > label_threshold) {
       show_stable_labels = false
-      show_unstable_labels = false
     } else {
       // For smaller datasets, show stable labels by default
       show_stable_labels = true
-      show_unstable_labels = false
     }
+    show_unstable_labels = false
   })
 
   // Function to extract structure data from a convex hull entry

--- a/src/lib/convex-hull/ConvexHullStats.svelte
+++ b/src/lib/convex-hull/ConvexHullStats.svelte
@@ -254,20 +254,20 @@
   // Escape HTML special chars to prevent XSS when rendering user-supplied strings via {@html}
   const escape_html = (str: string): string =>
     str
-      .replace(/&/g, `&amp;`)
-      .replace(/</g, `&lt;`)
-      .replace(/>/g, `&gt;`)
-      .replace(/"/g, `&quot;`)
-      .replace(/'/g, `&#39;`)
+      .replaceAll('&', `&amp;`)
+      .replaceAll('<', `&lt;`)
+      .replaceAll('>', `&gt;`)
+      .replaceAll('"', `&quot;`)
+      .replaceAll('\'', `&#39;`)
   const unescape_html = (str: string, max_rounds = 5): string => {
     let decoded = str
     for (let round_idx = 0; round_idx < max_rounds; round_idx++) {
       const next_decoded = decoded
-        .replace(/&amp;/g, `&`)
-        .replace(/&lt;/g, `<`)
-        .replace(/&gt;/g, `>`)
-        .replace(/&quot;/g, `"`)
-        .replace(/&#39;/g, `'`)
+        .replaceAll('&amp;', `&`)
+        .replaceAll('&lt;', `<`)
+        .replaceAll('&gt;', `>`)
+        .replaceAll('&quot;', `"`)
+        .replaceAll('&#39;', `'`)
       if (next_decoded === decoded) break
       decoded = next_decoded
     }
@@ -336,7 +336,7 @@
       // Match by entry_id or common data fields (mat_id, structure_id)
       // since entry_id may be wrapped in HTML (e.g. <a> tags)
       const entry_data = entry.data as Record<string, unknown> | undefined
-      const is_highlighted = !!(highlighted_entry_id && (
+      const is_highlighted = Boolean(highlighted_entry_id && (
         entry.entry_id === highlighted_entry_id ||
         entry_data?.mat_id === highlighted_entry_id ||
         entry_data?.structure_id === highlighted_entry_id

--- a/src/lib/convex-hull/GasPressureControls.svelte
+++ b/src/lib/convex-hull/GasPressureControls.svelte
@@ -64,7 +64,7 @@
 
   // Convert slider position (0-100) to pressure
   const slider_to_pressure = (value: number): number =>
-    Math.pow(10, LOG_P_MIN + (value / 100) * LOG_P_RANGE)
+    10 ** (LOG_P_MIN + (value / 100) * LOG_P_RANGE)
 
   // Format gas name for display (subscript numbers)
   const format_gas_name = (gas: GasSpecies): string =>
@@ -94,7 +94,7 @@
     gas: GasSpecies,
     event: Event & { currentTarget: HTMLInputElement },
   ): void {
-    const P = slider_to_pressure(+event.currentTarget.value)
+    const P = slider_to_pressure(Number(event.currentTarget.value))
     pressures = { ...pressures, [gas]: P }
     // Clear only this gas's preview (don't reset other sliders being dragged simultaneously)
     const { [gas]: _removed_preview, ...remaining_previews } = preview_pressures
@@ -103,8 +103,8 @@
 
   function set_pressure_direct(gas: GasSpecies, value: number): void {
     const clamped = Math.max(
-      Math.pow(10, LOG_P_MIN),
-      Math.min(Math.pow(10, LOG_P_MAX), value),
+      10 ** LOG_P_MIN,
+      Math.min(10 ** LOG_P_MAX, value),
     )
     pressures = { ...pressures, [gas]: clamped }
   }

--- a/src/lib/convex-hull/TemperatureSlider.svelte
+++ b/src/lib/convex-hull/TemperatureSlider.svelte
@@ -25,7 +25,7 @@
   function handle_slider_input(
     event: Event & { currentTarget: HTMLInputElement },
   ): void {
-    const new_index = +event.currentTarget.value
+    const new_index = Number(event.currentTarget.value)
     preview_index = new_index
     // Throttle parent updates during drag to prevent scene flashing
     const now = Date.now()
@@ -38,7 +38,7 @@
   function handle_slider_end(
     event: Event & { currentTarget: HTMLInputElement },
   ): void {
-    const new_temp = available_temperatures[+event.currentTarget.value]
+    const new_temp = available_temperatures[Number(event.currentTarget.value)]
     if (new_temp !== undefined) temperature = new_temp
     preview_index = null
   }

--- a/src/lib/convex-hull/gas-thermodynamics.ts
+++ b/src/lib/convex-hull/gas-thermodynamics.ts
@@ -307,7 +307,7 @@ export function compute_gas_correction(
     ...DEFAULT_ELEMENT_TO_GAS,
     ...config.element_to_gas,
   }
-  const enabled_gases = new Set(config.enabled_gases ?? [])
+  const enabled_gases = new Set(config.enabled_gases)
 
   let correction = 0
   const n_atoms = count_atoms_in_composition(entry.composition)

--- a/src/lib/convex-hull/helpers.ts
+++ b/src/lib/convex-hull/helpers.ts
@@ -18,6 +18,7 @@ import type {
   PhaseData,
 } from './types'
 import { DEFAULT_GAS_TEMP } from './types'
+
 export { DEFAULT_GAS_TEMP }
 
 // Tolerance for classifying a phase as on the convex hull (eV/atom)
@@ -97,7 +98,7 @@ export function get_point_color_for_entry(
 ): string {
   const is_stable = entry_is_stable(entry)
   if (color_mode === `stability`) {
-    return is_stable ? colors?.stable || `#0072B2` : colors?.unstable || `#E69F00`
+    return is_stable ? (colors?.stable ?? `#0072B2`) : (colors?.unstable ?? `#E69F00`)
   }
   return energy_scale && typeof entry.e_above_hull === `number`
     ? energy_scale(entry.e_above_hull)
@@ -184,7 +185,7 @@ export function build_entry_tooltip_text(entry: PhaseData): string {
 
   let text = is_element
     ? `${elem_symbol}${elem_name ? ` (${elem_name})` : ``}\n`
-    : `${entry.name || entry.reduced_formula || ``}\n`
+    : `${entry.name ?? entry.reduced_formula ?? ``}\n`
 
   if (!is_element) {
     const total = Object.values(entry.composition).reduce((sum, amt) => sum + amt, 0)
@@ -352,7 +353,7 @@ export function is_entry_highlighted<T extends { entry_id?: string; structure_id
   entry: T,
   highlighted_list: (string | T)[],
 ): boolean {
-  if (!highlighted_list.length) return false
+  if (highlighted_list.length === 0) return false
   const { entry_id, structure_id } = entry
   if (!entry_id && !structure_id) return false
 

--- a/src/lib/convex-hull/index.ts
+++ b/src/lib/convex-hull/index.ts
@@ -1,4 +1,5 @@
 import type { D3InterpolateName } from '$lib/colors'
+import type { TooltipConfig } from '$lib/tooltip'
 import type { Snippet } from 'svelte'
 import type { HTMLAttributes } from 'svelte/elements'
 import type {
@@ -45,7 +46,6 @@ export interface TooltipSnippetProps<AnyDimEntry = PhaseData> {
 }
 
 // ConvexHull-specific tooltip types
-import type { TooltipConfig } from '$lib/tooltip'
 export type ConvexHullTooltipConfig<AnyDimEntry = PhaseData> = TooltipConfig<AnyDimEntry>
 export type ConvexHullTooltipProp<AnyDimEntry = PhaseData> =
   | Snippet<[TooltipSnippetProps<AnyDimEntry>]>

--- a/src/lib/convex-hull/thermodynamics.ts
+++ b/src/lib/convex-hull/thermodynamics.ts
@@ -548,10 +548,10 @@ export function process_hull_for_stats(
   entries: PhaseData[],
   elements?: ElementSymbol[],
 ): HighDimHullResult | null {
-  if (!entries.length) return null
+  if (entries.length === 0) return null
 
   const processed = process_hull_entries(entries)
-  if (!processed.entries.length) return null
+  if (processed.entries.length === 0) return null
   const hull_elements = elements ?? processed.elements
 
   // Compute formation energies

--- a/src/lib/coordination/CoordinationBarPlot.svelte
+++ b/src/lib/coordination/CoordinationBarPlot.svelte
@@ -180,30 +180,29 @@
         }
       })
     }
-      // split_mode === 'none': combine all into single series
-      const combined_histogram = new SvelteMap<number, number>()
+    // split_mode === 'none': combine all into single series
+    const combined_histogram = new SvelteMap<number, number>()
 
-      for (const entry of entries_with_data) {
-        for (const [cn, count] of entry.data.cn_histogram) {
-          combined_histogram.set(cn, (combined_histogram.get(cn) ?? 0) + count)
-        }
+    for (const entry of entries_with_data) {
+      for (const [cn, count] of entry.data.cn_histogram) {
+        combined_histogram.set(cn, (combined_histogram.get(cn) ?? 0) + count)
       }
+    }
 
-      const x_vals = Array.from(combined_histogram.keys()).sort((a, b) => a - b)
-      const y_vals = x_vals.map((cn) => combined_histogram.get(cn) ?? 0)
+    const x_vals = Array.from(combined_histogram.keys()).sort((a, b) => a - b)
+    const y_vals = x_vals.map((cn) => combined_histogram.get(cn) ?? 0)
 
-      return [
-        {
-          x: x_vals,
-          y: y_vals,
-          label: `All Sites`,
-          color: PLOT_COLORS[0],
-          bar_width: 0.8,
-          visible: true,
-          metadata: {},
-        },
-      ]
-
+    return [
+      {
+        x: x_vals,
+        y: y_vals,
+        label: `All Sites`,
+        color: PLOT_COLORS[0],
+        bar_width: 0.8,
+        visible: true,
+        metadata: {},
+      },
+    ]
   })
 
   const compute_and_add = (content: string | ArrayBuffer, filename: string) => {

--- a/src/lib/coordination/CoordinationBarPlot.svelte
+++ b/src/lib/coordination/CoordinationBarPlot.svelte
@@ -18,6 +18,7 @@
   import { SvelteMap, SvelteSet } from 'svelte/reactivity'
   import { calc_coordination_nums, type CoordinationData } from './calc-coordination'
   import type { SplitMode } from './index'
+  import { to_error } from '$lib/utils'
 
   type CoordinationMetadata = {
     element?: string
@@ -178,7 +179,7 @@
           metadata: { structure_label: entry.label },
         }
       })
-    } else {
+    }
       // split_mode === 'none': combine all into single series
       const combined_histogram = new SvelteMap<number, number>()
 
@@ -202,7 +203,7 @@
           metadata: {},
         },
       ]
-    }
+
   })
 
   const compute_and_add = (content: string | ArrayBuffer, filename: string) => {
@@ -221,7 +222,7 @@
       }
     } catch (exc) {
       error_msg = `Failed to process structure: ${
-        exc instanceof Error ? exc.message : String(exc)
+        to_error(exc).message
       }`
     }
   }

--- a/src/lib/fermi-surface/FermiSlice.svelte
+++ b/src/lib/fermi-surface/FermiSlice.svelte
@@ -8,6 +8,7 @@
   import { compute_fermi_slice } from './compute'
   import { BAND_COLORS } from './constants'
   import type { FermiSliceData, FermiSurfaceData } from './types'
+  import { to_error } from '$lib/utils'
 
   let {
     fermi_data,
@@ -60,7 +61,7 @@
       slice_data = compute_fermi_slice(fermi_data, { miller_indices, distance })
     } catch (err) {
       slice_data = null
-      on_error?.(err instanceof Error ? err : new Error(String(err)))
+      on_error?.(to_error(err))
     }
   })
 
@@ -114,7 +115,7 @@
     const band = slice_data?.isolines[series_idx]?.band_index
     if (band === undefined) return
     const all_bands = [
-      ...new Set(slice_data?.isolines.map((iso) => iso.band_index) ?? []),
+      ...new Set(slice_data?.isolines.map((iso) => iso.band_index)),
     ]
     const is_solo = all_bands.every((bid) => bid === band || hidden_bands.has(bid))
     hidden_bands.clear()

--- a/src/lib/fermi-surface/FermiSurface.svelte
+++ b/src/lib/fermi-surface/FermiSurface.svelte
@@ -24,6 +24,7 @@
   import FermiSurfaceScene from './FermiSurfaceScene.svelte'
   import FermiSurfaceTooltip from './FermiSurfaceTooltip.svelte'
   import { parse_fermi_file } from './parse'
+  import { to_error } from '$lib/utils'
   import type {
     BandGridData,
     ColorProperty,
@@ -202,7 +203,7 @@
       await parse_fermi_content(content, filename)
     } catch (err) {
       error_msg = `Failed to parse ${filename}: ${
-        err instanceof Error ? err.message : err
+        to_error(err).message
       }`
       on_error?.({ error_msg, filename })
     }
@@ -263,7 +264,7 @@
       await export_scene(scene, format, current_filename || `fermi-surface`)
     } catch (err) {
       console.error(`Export failed:`, err)
-      error_msg = `Export failed: ${err instanceof Error ? err.message : err}`
+      error_msg = `Export failed: ${to_error(err).message}`
     }
   }
 
@@ -284,7 +285,7 @@
     try {
       bz_data = compute_brillouin_zone(k_lattice, 1)
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
+      const msg = to_error(err).message
       console.warn(`BZ computation failed:`, msg)
       bz_data = undefined
       // Only report error for structure-derived lattice (user-provided data)
@@ -313,7 +314,7 @@
       load_from_url(data_url, safe_parse)
         .catch((err) => {
           if (current_load_id !== load_id) return // stale request
-          error_msg = err instanceof Error ? err.message : String(err)
+          error_msg = to_error(err).message
           on_error?.({ error_msg, filename: data_url })
         })
         .finally(() => {

--- a/src/lib/fermi-surface/FermiSurfaceControls.svelte
+++ b/src/lib/fermi-surface/FermiSurfaceControls.svelte
@@ -111,7 +111,7 @@
       return
     }
     const idx = selected_bands.indexOf(band_idx)
-    if (idx >= 0) {
+    if (idx !== -1) {
       selected_bands = selected_bands.filter((band) => band !== band_idx)
     } else {
       selected_bands = [...selected_bands, band_idx].toSorted((a, b) => a - b)

--- a/src/lib/fermi-surface/compute.ts
+++ b/src/lib/fermi-surface/compute.ts
@@ -400,10 +400,9 @@ function analyze_surface_topology(
     const orientation: Vec3 = [0, 0, 0]
     orientation[axis_idx] = 1
     return { dimensionality: `1D`, orientation }
-  } else {
-    // Spans all 3 directions - complex warped network
-    return { dimensionality: `quasi-2D`, orientation: null }
   }
+  // Spans all 3 directions - complex warped network
+  return { dimensionality: `quasi-2D`, orientation: null }
 }
 
 // Compute 2D Fermi slice along a specified plane
@@ -538,10 +537,10 @@ function slice_surface_with_plane(
     if (face.length < 3) continue
 
     // Find which edges of this face cross the plane
-    const crossing_edges: Array<{
+    const crossing_edges: {
       edge_key: string
       intersection: { point: Vec3; property?: number }
-    }> = []
+    }[] = []
 
     for (let edge_idx = 0; edge_idx < face.length; edge_idx++) {
       const v0_idx = face[edge_idx]

--- a/src/lib/fermi-surface/compute.ts
+++ b/src/lib/fermi-surface/compute.ts
@@ -436,7 +436,7 @@ export function compute_fermi_slice(
       )}]`,
     )
   }
-  const unit_normal = math.normalize_vec3(plane_normal)
+  const unit_normal = math.normalize_vec(plane_normal)
 
   // Compute in-plane basis vectors
   const [in_plane_u, in_plane_v] = math.compute_in_plane_basis(unit_normal)

--- a/src/lib/fermi-surface/export.ts
+++ b/src/lib/fermi-surface/export.ts
@@ -8,7 +8,7 @@ function download_file(content: string | ArrayBuffer, filename: string, mime_typ
   const link = document.createElement(`a`)
   link.href = url
   link.download = filename
-  document.body.appendChild(link)
+  document.body.append(link)
   link.click()
   document.body.removeChild(link)
   URL.revokeObjectURL(url)
@@ -45,7 +45,7 @@ export async function export_to_gltf(scene: Scene, filename: string): Promise<vo
         download_file(output, `${filename}.gltf`, `application/json`)
         resolve()
       },
-      (error) => reject(error),
+      (error) => reject(error instanceof Error ? error : new Error(error.message)),
       { binary: false },
     )
   })

--- a/src/lib/fermi-surface/export.ts
+++ b/src/lib/fermi-surface/export.ts
@@ -1,5 +1,6 @@
 // Export Fermi surface to various 3D formats
 import type { Scene } from 'three'
+import { to_error } from '$lib/utils'
 
 // Helper to trigger file download
 function download_file(content: string | ArrayBuffer, filename: string, mime_type: string) {
@@ -45,7 +46,7 @@ export async function export_to_gltf(scene: Scene, filename: string): Promise<vo
         download_file(output, `${filename}.gltf`, `application/json`)
         resolve()
       },
-      (error) => reject(error instanceof Error ? error : new Error(error.message)),
+      (error) => reject(to_error(error)),
       { binary: false },
     )
   })

--- a/src/lib/fermi-surface/parse.ts
+++ b/src/lib/fermi-surface/parse.ts
@@ -14,7 +14,7 @@ import type {
 const parse_number_tokens = (line: string): string[] => line.split(/\s+/).filter(Boolean)
 
 // Parse whitespace-separated floats from a line (optimized with unary +)
-const parse_floats = (line: string): number[] => parse_number_tokens(line).map((part) => +part)
+const parse_floats = (line: string): number[] => parse_number_tokens(line).map(Number)
 
 // Parse whitespace-separated integers from a line
 const parse_ints = (line: string): number[] =>
@@ -358,8 +358,10 @@ function parse_fermi_json(content: string): FermiSurfaceData | BandGridData {
       k_grid: bs.k_grid ?? bs.kgrid,
       k_lattice: bs.k_lattice ?? bs.reciprocal_lattice,
       fermi_energy: bs.fermi_energy ?? bs.efermi ?? 0,
-      n_bands: bs.n_bands || bs.nbands || bs.energies[0]?.length || 0,
-      n_spins: bs.n_spins || bs.nspins || bs.energies.length || 1,
+      // oxlint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- numeric fallback chain (0 falls through)
+      n_bands: (bs.n_bands ?? bs.nbands) || bs.energies[0]?.length || 0,
+      // oxlint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- numeric fallback chain (0 falls through)
+      n_spins: (bs.n_spins ?? bs.nspins) || bs.energies.length || 1,
     } as BandGridData
   }
 
@@ -507,7 +509,7 @@ export function parse_fermi_file(
   content: string,
   filename?: string,
 ): BandGridData | FermiSurfaceData | null {
-  const lower_name = filename?.toLowerCase() || ``
+  const lower_name = filename?.toLowerCase() ?? ``
 
   // Detect by filename extension
   if (lower_name.endsWith(`.bxsf`) || lower_name.endsWith(`.bxsf.gz`)) {

--- a/src/lib/heatmap-matrix/HeatmapMatrix.svelte
+++ b/src/lib/heatmap-matrix/HeatmapMatrix.svelte
@@ -334,7 +334,7 @@
   }
 
   function get_quantile(sorted_values: number[], quantile: number): number {
-    if (!sorted_values.length) return 0
+    if (sorted_values.length === 0) return 0
     const clipped_quantile = Math.max(0, Math.min(1, quantile))
     const float_idx = (sorted_values.length - 1) * clipped_quantile
     const low_idx = Math.floor(float_idx)
@@ -369,7 +369,7 @@
   })
 
   let [robust_min, robust_max] = $derived.by(() => {
-    if (!valid_numeric_values.length) return [0, 1] as const
+    if (valid_numeric_values.length === 0) return [0, 1] as const
     const sorted_values = valid_numeric_values.toSorted((value_a, value_b) =>
       value_a - value_b
     )
@@ -460,7 +460,7 @@
     return colors
   })
 
-  const to_contrast_colors = (bg_values: Array<string | null>): Array<string | null> =>
+  const to_contrast_colors = (bg_values: (string | null)[]): (string | null)[] =>
     bg_values.map((bg_color) =>
       bg_color ? pick_contrast_color({ bg_color }) : null
     )
@@ -775,7 +775,7 @@
       cell_pos_key(pos.x_idx, pos.y_idx) === clicked_key
     )
     const toggle_mode = selection_mode === `multi` && (event.metaKey || event.ctrlKey)
-    if (existing_idx >= 0 && toggle_mode) next_cells.splice(existing_idx, 1)
+    if (existing_idx !== -1 && toggle_mode) next_cells.splice(existing_idx, 1)
     else if (selection_mode === `multi` && toggle_mode) next_cells.push(clicked_cell)
     else next_cells.splice(0, next_cells.length, clicked_cell)
     selected_cells = next_cells
@@ -1010,7 +1010,7 @@
   }
 
   function compute_summary(summary_values: number[]): number | null {
-    if (!summary_values.length) return null
+    if (summary_values.length === 0) return null
     if (summary_fn) return summary_fn(summary_values)
     const total = summary_values.reduce((sum, value) => sum + value, 0)
     return total / summary_values.length

--- a/src/lib/heatmap-matrix/index.ts
+++ b/src/lib/heatmap-matrix/index.ts
@@ -1,6 +1,7 @@
 import type { ChemicalElement, ElementSymbol } from '$lib/element'
 import { element_data } from '$lib/element'
 import type { Snippet } from 'svelte'
+
 export { COLOR_OVERRIDE_KEY_SEPARATOR, make_color_override_key } from './shared'
 
 // === Types ===
@@ -102,7 +103,7 @@ function escape_csv_field(value: number | string | null | undefined): string {
 }
 
 export function rows_to_csv(rows: Record<string, number | string | null>[]): string {
-  if (!rows.length) return ``
+  if (rows.length === 0) return ``
   const headers = Object.keys(rows[0])
   const lines = [
     headers.map((header) => escape_csv_field(header)).join(`,`),

--- a/src/lib/io/decompress.ts
+++ b/src/lib/io/decompress.ts
@@ -1,5 +1,6 @@
 import type { COMPRESSION_EXTENSIONS } from '$lib/constants'
 import { COMPRESSION_EXTENSIONS_REGEX, COMPRESSION_FORMATS } from '$lib/constants'
+import { to_error } from '$lib/utils'
 
 export type CompressionFormat = keyof typeof COMPRESSION_FORMATS
 export type CompressionExtension = (typeof COMPRESSION_EXTENSIONS)[number]
@@ -77,7 +78,7 @@ export function decompress_file(file: File): Promise<{ content: string; filename
             resolve({ content: result, filename: file.name })
           }
         } catch (error) {
-          reject(error)
+          reject(to_error(error))
         }
       },
       { once: true },

--- a/src/lib/io/export.ts
+++ b/src/lib/io/export.ts
@@ -1,6 +1,7 @@
 import { download } from '$lib/io/fetch'
 import type { AnyStructure } from '$lib/structure'
 import { create_structure_filename } from '$lib/structure/export'
+import { to_error } from '$lib/utils'
 import { type Camera, type Scene, Vector2, type WebGLRenderer } from 'three'
 
 function is_webgl_renderer_like(value: unknown): value is WebGLRenderer {
@@ -16,7 +17,8 @@ function is_webgl_renderer_like(value: unknown): value is WebGLRenderer {
 }
 
 function get_canvas_renderer(canvas: HTMLCanvasElement): WebGLRenderer | undefined {
-  const renderer_val = (canvas as unknown as Record<string, unknown>)[`__renderer`]
+  // oxlint-disable-next-line no-underscore-dangle -- three.js stores its renderer here
+  const renderer_val = (canvas as unknown as Record<string, unknown>).__renderer
   return is_webgl_renderer_like(renderer_val) ? renderer_val : undefined
 }
 
@@ -43,7 +45,7 @@ export function canvas_to_png_blob(
           else reject(new Error(`Failed to generate PNG - canvas may be empty`))
         }, `image/png`)
       } catch (error) {
-        reject(error)
+        reject(to_error(error))
       }
     })
   }
@@ -69,7 +71,7 @@ export function canvas_to_png_blob(
       }, `image/png`)
     } catch (error) {
       restore()
-      reject(error)
+      reject(to_error(error))
     }
   })
 }
@@ -106,7 +108,7 @@ export function export_canvas_as_png(
 
 // Helper to ensure font-family is set on SVG root
 function set_svg_font_family(svg: SVGElement) {
-  const style = svg.getAttribute(`style`) || ``
+  const style = svg.getAttribute(`style`) ?? ``
   if (!style.includes(`font-family`)) {
     svg.setAttribute(`style`, `${style}${style ? `;` : ``}font-family:sans-serif;`)
   }
@@ -198,7 +200,7 @@ export function svg_to_png_blob(svg_element: SVGElement, png_dpi = 150): Promise
           1,
         )
       } catch (error) {
-        reject(error)
+        reject(to_error(error))
       } finally {
         URL.revokeObjectURL(svg_data_url)
       }
@@ -351,7 +353,7 @@ export async function export_trajectory_video(
         on_progress?.(100)
         resolve()
       } catch (error) {
-        reject(error)
+        reject(to_error(error))
       }
     })
 
@@ -378,7 +380,7 @@ export async function export_trajectory_video(
     } catch (error) {
       if (!is_resolved) {
         is_resolved = true
-        reject(error)
+        reject(to_error(error))
       }
     }
   })

--- a/src/lib/io/fetch.ts
+++ b/src/lib/io/fetch.ts
@@ -27,7 +27,7 @@ function default_download(data: string | Blob, filename: string, type: string) {
   link.style.display = `none`
   link.href = url
   link.download = filename
-  document.body.appendChild(link)
+  document.body.append(link)
   link.click()
   link.remove()
   URL.revokeObjectURL(url)

--- a/src/lib/io/file-drop.ts
+++ b/src/lib/io/file-drop.ts
@@ -1,6 +1,7 @@
 // Shared file-drop handler composable for drag-and-drop file loading.
 import { decompress_file } from './decompress'
 import { handle_url_drop } from './url-drop'
+import { to_error } from '$lib/utils'
 
 export interface FileDropOptions {
   allow: () => boolean
@@ -23,7 +24,7 @@ export const create_file_drop_handler =
     try {
       let url_error: string | undefined
       const handled = await handle_url_drop(event, opts.on_drop).catch((exc) => {
-        url_error = exc instanceof Error ? exc.message : String(exc)
+        url_error = to_error(exc).message
         return false
       })
       if (handled) return
@@ -38,7 +39,7 @@ export const create_file_drop_handler =
       const { content, filename } = await decompress_file(file)
       if (content) await opts.on_drop(content, filename)
     } catch (exc) {
-      const detail = exc instanceof Error ? exc.message : String(exc)
+      const detail = to_error(exc).message
       const msg = drop_filename
         ? `Failed to load file ${drop_filename}: ${detail}`
         : `Failed to load file: ${detail}`

--- a/src/lib/io/url-drop.ts
+++ b/src/lib/io/url-drop.ts
@@ -17,7 +17,7 @@ function extract_filename(headers: Headers | undefined, fallback: string): strin
   if (!content_disposition_str) return fallback
   const star_match = /filename\*=(?:UTF-8''|)([^;]+)/i.exec(content_disposition_str)
   if (star_match?.[1]) {
-    const raw = star_match[1].trim().replace(/^"|"$/g, ``)
+    const raw = star_match[1].trim().replaceAll(/^"|"$/g, ``)
     try {
       return decodeURIComponent(raw)
     } catch {
@@ -25,7 +25,7 @@ function extract_filename(headers: Headers | undefined, fallback: string): strin
     }
   }
   const plain_match = /filename\s*=\s*"?([^";]+)"?/i.exec(content_disposition_str)
-  return plain_match?.[1]?.trim() || fallback
+  return plain_match?.[1]?.trim() ?? fallback
 }
 
 // Handle URL-based file drop data by fetching content lazily
@@ -52,8 +52,8 @@ export async function load_from_url(
   url: string,
   callback: (content: string | ArrayBuffer, filename: string) => Promise<void> | void,
 ): Promise<void> {
-  const url_basename = url.split(`/`).pop() || url
-  const ext = url_basename.split(`.`).pop()?.toLowerCase() || ``
+  const url_basename = url.split(`/`).pop() ?? url
+  const ext = url_basename.split(`.`).pop()?.toLowerCase() ?? ``
 
   if (BINARY_EXTENSIONS.has(ext)) {
     // Force binary mode for known binary files to handle GitHub Pages content-type issues
@@ -66,13 +66,12 @@ export async function load_from_url(
       if (resp.headers.get(`content-encoding`) === `gzip`) {
         // Browser automatically decompressed it, so it's text
         return callback(await resp.text(), filename)
-      } else {
-        // Need to decompress manually
-        const buffer = await resp.arrayBuffer()
-        const content = await decompress_data(buffer, `gzip`)
-        // Remove .gz extension when manually decompressing
-        return callback(content, filename.replace(/\.gz$/, ``))
       }
+      // Need to decompress manually
+      const buffer = await resp.arrayBuffer()
+      const content = await decompress_data(buffer, `gzip`)
+      // Remove .gz extension when manually decompressing
+      return callback(content, filename.replace(/\.gz$/, ``))
     }
 
     // For H5 files, always load as binary regardless of signature

--- a/src/lib/io/url-drop.ts
+++ b/src/lib/io/url-drop.ts
@@ -25,7 +25,10 @@ function extract_filename(headers: Headers | undefined, fallback: string): strin
     }
   }
   const plain_match = /filename\s*=\s*"?([^";]+)"?/i.exec(content_disposition_str)
-  return plain_match?.[1]?.trim() ?? fallback
+  // truthiness check (not ??) so whitespace-only `filename=` values fall back too
+  const name = plain_match?.[1]?.trim()
+  if (!name) return fallback
+  return name
 }
 
 // Handle URL-based file drop data by fetching content lazily

--- a/src/lib/isosurface/parse.ts
+++ b/src/lib/isosurface/parse.ts
@@ -57,7 +57,7 @@ function parse_float_block(
     while (pos < len && text.charCodeAt(pos) > 32) pos++
 
     // Parse number using unary + (handles scientific notation)
-    const num = +text.substring(start, pos)
+    const num = Number(text.slice(start, pos))
     if (!Number.isNaN(num)) {
       data[idx++] = num
     }
@@ -81,7 +81,7 @@ function find_line_offset(text: string, target_line: number): number {
 function read_line(text: string, pos: number): { line: string; next: number } {
   let end = pos
   while (end < text.length && text.charCodeAt(end) !== 10 && text.charCodeAt(end) !== 13) end++
-  const line = text.substring(pos, end)
+  const line = text.slice(pos, end)
   let next = end
   if (next < text.length && text.charCodeAt(next) === 13) next++ // skip \r
   if (next < text.length && text.charCodeAt(next) === 10) next++ // skip \n
@@ -237,7 +237,7 @@ export function parse_chgcar(content: string): VolumetricFileData | null {
 
   // Detect VASP 5+ format (has element symbols before counts)
   const first_token = cur.line.trim().split(/\s+/)[0]
-  const has_element_symbols = isNaN(parseInt(first_token))
+  const has_element_symbols = isNaN(parseInt(first_token, 10))
 
   if (has_element_symbols) {
     element_symbols = cur.line.trim().split(/\s+/)
@@ -248,15 +248,14 @@ export function parse_chgcar(content: string): VolumetricFileData | null {
       return null
     }
     atom_counts = cur.line.trim().split(/\s+/).map(Number)
-    pos = cur.next
   } else {
     atom_counts = cur.line.trim().split(/\s+/).map(Number)
     const fallback_elements = [`H`, `He`, `Li`, `Be`, `B`, `C`, `N`, `O`, `F`, `Ne`]
     element_symbols = atom_counts.map(
       (_count, idx) => fallback_elements[idx % fallback_elements.length],
     )
-    pos = cur.next
   }
+  pos = cur.next
 
   if (pos >= content.length) {
     console.error(`CHGCAR: file ends before coordinate mode line`)
@@ -617,7 +616,7 @@ export function parse_volumetric_file(
   // Content-based detection (only parse first few lines, not the whole file)
   // Find enough lines for detection without splitting the entire string
   const detection_end = find_line_offset(content, 10)
-  const detection_text = content.substring(0, detection_end)
+  const detection_text = content.slice(0, detection_end)
   const lines = detection_text.split(/\r?\n/)
 
   // .cube detection: line 3 has 4 numbers (n_atoms + origin), line 4 has 4 numbers (grid dim + voxel)

--- a/src/lib/isosurface/parse.ts
+++ b/src/lib/isosurface/parse.ts
@@ -56,7 +56,7 @@ function parse_float_block(
     const start = pos
     while (pos < len && text.charCodeAt(pos) > 32) pos++
 
-    // Parse number using unary + (handles scientific notation)
+    // Parse number (handles scientific notation)
     const num = Number(text.slice(start, pos))
     if (!Number.isNaN(num)) {
       data[idx++] = num

--- a/src/lib/isosurface/slice.ts
+++ b/src/lib/isosurface/slice.ts
@@ -102,7 +102,7 @@ export function sample_hkl_slice(
     h_idx * recip[0][2] + k_idx * recip[1][2] + l_idx * recip[2][2],
   ]
   if (Math.hypot(...plane_normal) < 1e-12) return null // degenerate normal
-  const unit_normal = math.normalize_vec3(plane_normal)
+  const unit_normal = math.normalize_vec(plane_normal)
 
   // In-plane basis vectors
   const [u_vec, v_vec] = math.compute_in_plane_basis(unit_normal)

--- a/src/lib/isosurface/types.ts
+++ b/src/lib/isosurface/types.ts
@@ -72,7 +72,7 @@ export const LAYER_COLORS = [
 // Compute min/max/abs_max/mean of a 3D grid.
 // Prefer using the precomputed `data_range` field on VolumetricData when available.
 export function grid_data_range(grid: number[][][]): DataRange {
-  if (!grid.length || !grid[0]?.length || !grid[0][0]?.length) {
+  if (grid.length === 0 || !grid[0]?.length || !grid[0][0]?.length) {
     return { min: 0, max: 0, abs_max: 0, mean: 0 }
   }
   let [min_val, max_val] = [Infinity, -Infinity]

--- a/src/lib/labels.ts
+++ b/src/lib/labels.ts
@@ -15,7 +15,7 @@ const is_d3_symbol_name = (name: string): name is D3SymbolName =>
 function name_for_symbol(sym: unknown): D3SymbolName | null {
   for (const [key, symbol] of Object.entries(d3_symbols)) {
     if (symbol === sym && /^symbol[A-Z]/.test(key)) {
-      const name = key.substring(6)
+      const name = key.slice(6)
       if (is_d3_symbol_name(name)) return name
     }
   }
@@ -44,7 +44,7 @@ export function format_value(value: number, formatter?: string): string {
   if (Number.isNaN(value)) return `NaN`
 
   // Format and normalize unicode minus
-  const formatted = format(formatter)(value).replace(/−/g, `-`)
+  const formatted = format(formatter)(value).replaceAll('−', `-`)
 
   // Handle percentage formatting - remove trailing zeros
   if (formatter.includes(`%`)) {
@@ -112,7 +112,7 @@ export const ELEM_HEATMAP_LABELS: Partial<Record<string, keyof ChemicalElement>>
 export const DEFAULT_FMT: [string, string] = [`,.3~s`, `.3~g`]
 
 // Unicode glyphs for common fractions used by format_fractional()
-export const FRACTION_GLYPHS: ReadonlyArray<readonly [number, string]> = [
+export const FRACTION_GLYPHS: readonly (readonly [number, string])[] = [
   [0, `0`],
   [1 / 12, `¹⁄₁₂`],
   [1 / 8, `⅛`],
@@ -184,7 +184,7 @@ export function parse_si_float<T extends string | number | null | undefined>(
   // if not string, return as is
   if (typeof value !== `string`) return value
   // Remove whitespace and commas
-  const cleaned = value.trim().replace(/(\d),(\d)/g, `$1$2`)
+  const cleaned = value.trim().replaceAll(/(\d),(\d)/g, `$1$2`)
 
   // Check if the value is a SI-formatted number (e.g. "1.23k", "4.56M", "789µ", "12n")
   const match = /^([-+]?\d*\.?\d+)\s*([yzafpnµmkMGTPEZY])?$/i.exec(cleaned)
@@ -195,7 +195,7 @@ export function parse_si_float<T extends string | number | null | undefined>(
       const suffixes = `yzafpnµm kMGTPEZY`
       const index = suffixes.indexOf(suffix)
       if (index !== -1) {
-        multiplier = Math.pow(1000, index - 8)
+        multiplier = 1000 ** (index - 8)
       }
     }
     return parseFloat(num_part) * multiplier
@@ -268,7 +268,7 @@ export const SUBSCRIPT_MAP = {
 
 // replaces all signs and digits with their unicode superscript equivalent
 export const superscript_digits = (input: string): string =>
-  input.replace(/[\d+-]/g, (match) =>
+  input.replaceAll(/[\d+-]/g, (match) =>
     is_superscript_key(match) ? SUPERSCRIPT_MAP[match] : match,
   )
 

--- a/src/lib/layout/PropertyFilter.svelte
+++ b/src/lib/layout/PropertyFilter.svelte
@@ -46,7 +46,7 @@
 
   // Active when either bound is set (undefined = unbounded)
   let active = $derived(min_value !== undefined || max_value !== undefined)
-  let plain_label = $derived(label.replace(/<[^>]*>/g, ``))
+  let plain_label = $derived(label.replaceAll(/<[^>]*>/g, ``))
 
   let filtered_data = $derived.by(() => {
     if (!histogram_data) return []
@@ -69,7 +69,8 @@
   }
 
   function clear_filter(): void {
-    min_value = max_value = undefined
+    min_value = undefined
+    max_value = undefined
     onclear?.()
     onchange?.(undefined, undefined)
   }

--- a/src/lib/layout/SettingsSection.svelte
+++ b/src/lib/layout/SettingsSection.svelte
@@ -26,7 +26,7 @@
   // Create a deep copy of current_values on mount to use as reference values
   function deep_copy(obj: unknown): unknown {
     if (obj === null || typeof obj !== `object`) return obj
-    if (obj instanceof Date) return new Date(obj.getTime())
+    if (obj instanceof Date) return new Date(obj)
     if (obj instanceof RegExp) return new RegExp(obj)
     if (Array.isArray(obj)) {
       return obj.map((item) =>

--- a/src/lib/layout/json-tree/JsonNode.svelte
+++ b/src/lib/layout/json-tree/JsonNode.svelte
@@ -118,7 +118,7 @@
   }
 
   // Get children based on value type
-  function get_children(): Array<{ key: string | number; value: unknown }> {
+  function get_children(): { key: string | number; value: unknown }[] {
     if (!expandable) return []
 
     if (value_type === `array`) {

--- a/src/lib/layout/json-tree/JsonTree.svelte
+++ b/src/lib/layout/json-tree/JsonTree.svelte
@@ -252,8 +252,8 @@
     const all_paths = collect_all_paths(value, root_path)
     const descendants = target_path === `` ? all_paths : all_paths.filter(
       (entry) =>
-        entry === target_path || entry.startsWith(target_path + `.`) ||
-        entry.startsWith(target_path + `[`),
+        entry === target_path || entry.startsWith(`${target_path  }.`) ||
+        entry.startsWith(`${target_path  }[`),
     )
     return descendants.includes(target_path)
       ? descendants

--- a/src/lib/layout/json-tree/JsonTree.svelte
+++ b/src/lib/layout/json-tree/JsonTree.svelte
@@ -252,8 +252,8 @@
     const all_paths = collect_all_paths(value, root_path)
     const descendants = target_path === `` ? all_paths : all_paths.filter(
       (entry) =>
-        entry === target_path || entry.startsWith(`${target_path  }.`) ||
-        entry.startsWith(`${target_path  }[`),
+        entry === target_path || entry.startsWith(`${target_path}.`) ||
+        entry.startsWith(`${target_path}[`),
     )
     return descendants.includes(target_path)
       ? descendants

--- a/src/lib/layout/json-tree/utils.ts
+++ b/src/lib/layout/json-tree/utils.ts
@@ -16,6 +16,7 @@ function safe_stringify(val: unknown): string {
       }
       if (typeof inner === `bigint`) return `${inner}n`
       if (typeof inner === `symbol`) return inner.toString()
+      // oxlint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- anonymous fns have name ``
       if (typeof inner === `function`) return `[Function: ${inner.name || `anonymous`}]`
       return inner
     },
@@ -92,7 +93,7 @@ function format_path_segment(segment: string | number, is_first: boolean = false
     return is_first ? segment : `.${segment}`
   }
   // Use bracket notation for keys with special characters
-  return `["${segment.replace(/"/g, `\\"`)}"]`
+  return `["${segment.replaceAll('"', `\\"`)}"]`
 }
 
 // Format a full path from segments
@@ -240,7 +241,7 @@ export function collect_all_paths(
   current_path: string = ``,
   max_depth: number = Infinity,
   current_depth: number = 0,
-  seen: WeakSet<object> = new WeakSet(),
+  seen = new WeakSet<object>(),
 ): string[] {
   if (current_depth >= max_depth) return []
   const type = get_value_type(value)
@@ -266,7 +267,7 @@ export function find_matching_paths(
   query: string,
   current_path: string = ``,
   current_key: string | number | null = null,
-  seen: WeakSet<object> = new WeakSet(),
+  seen = new WeakSet<object>(),
 ): Set<string> {
   const matches = new Set<string>()
   if (!query) return matches
@@ -340,7 +341,7 @@ export function parse_path(path: string): (string | number)[] {
         const num = Number(current)
         if (Number.isNaN(num)) {
           // Remove surrounding quotes and unescape internal quotes
-          const unquoted = current.replace(/^"|"$/g, ``).replace(/\\"/g, `"`)
+          const unquoted = current.replaceAll(/^"|"$/g, ``).replaceAll('\\"', `"`)
           segments.push(unquoted)
         } else segments.push(num)
       }
@@ -355,7 +356,7 @@ export function parse_path(path: string): (string | number)[] {
       // Apply same numeric/quoted-string logic as inside brackets
       const num = Number(current)
       if (Number.isNaN(num)) {
-        const unquoted = current.replace(/^"|"$/g, ``).replace(/\\"/g, `"`)
+        const unquoted = current.replaceAll(/^"|"$/g, ``).replaceAll('\\"', `"`)
         segments.push(unquoted)
       } else segments.push(num)
     } else segments.push(current)
@@ -433,8 +434,8 @@ export function set_at_path(
   const segments = parse_path(path_str)
   const start = root_label && segments[0] === root_label ? 1 : 0
   if (start >= segments.length) return new_value
-  const cloned = JSON.parse(JSON.stringify(root))
-  let current: Record<string | number, unknown> = cloned
+  const cloned = structuredClone(root)
+  let current = cloned as Record<string | number, unknown>
   for (let idx = start; idx < segments.length - 1; idx++) {
     const next = current[segments[idx]]
     if (next === undefined || next === null) return root // bail — path no longer valid
@@ -549,8 +550,8 @@ export function compute_diff(
   old_val: unknown,
   new_val: unknown,
   current_path: string = ``,
-  result: Map<string, DiffEntry> = new Map(),
-  seen: WeakSet<object> = new WeakSet(),
+  result = new Map<string, DiffEntry>(),
+  seen = new WeakSet<object>(),
 ): Map<string, DiffEntry> {
   const old_type = get_value_type(old_val)
   const new_type = get_value_type(new_val)

--- a/src/lib/math.ts
+++ b/src/lib/math.ts
@@ -585,8 +585,8 @@ export const centered_frac = (val: number): number => {
 // Returns true if both are the same reference, or both are defined with equal components.
 export const vecs_equal = (vec_a?: Vec3, vec_b?: Vec3): boolean =>
   vec_a === vec_b ||
-  (!!vec_a &&
-    !!vec_b &&
+  (vec_a !== undefined &&
+    vec_b !== undefined &&
     vec_a[0] === vec_b[0] &&
     vec_a[1] === vec_b[1] &&
     vec_a[2] === vec_b[2])

--- a/src/lib/math.ts
+++ b/src/lib/math.ts
@@ -585,17 +585,25 @@ export const centered_frac = (val: number): number => {
 // Returns true if both are the same reference, or both are defined with equal components.
 export const vecs_equal = (vec_a?: Vec3, vec_b?: Vec3): boolean =>
   vec_a === vec_b ||
-  (vec_a !== undefined &&
-    vec_b !== undefined &&
+  (vec_a != null &&
+    vec_b != null &&
     vec_a[0] === vec_b[0] &&
     vec_a[1] === vec_b[1] &&
     vec_a[2] === vec_b[2])
 
-// Normalize a Vec3 to unit length, returns zero vector if input is zero
-export function normalize_vec3(vec: Vec3, fallback?: Vec3): Vec3 {
-  const len = Math.hypot(vec[0], vec[1], vec[2])
-  if (len < EPS) return fallback ?? [0, 0, 0]
-  return [vec[0] / len, vec[1] / len, vec[2] / len]
+// Vec3 -> Vec3, number[] -> number[] (same length, mutable)
+type Normalized<T extends readonly number[]> = { -readonly [K in keyof T]: number }
+
+// Normalize a vector of any length to unit length; returns `fallback` (or zeros) when ~zero.
+export function normalize_vec<T extends readonly number[]>(
+  vec: T,
+  fallback?: NoInfer<T>,
+): Normalized<T> {
+  let sum_sq = 0
+  for (const coord of vec) sum_sq += coord * coord
+  const len = Math.sqrt(sum_sq)
+  const unit = len < EPS ? (fallback ?? vec.map(() => 0)) : vec.map((coord) => coord / len)
+  return unit as Normalized<T>
 }
 
 // Compute orthonormal basis vectors in a plane perpendicular to `normal`.
@@ -610,7 +618,7 @@ export function compute_in_plane_basis(normal: Vec3): [Vec3, Vec3] {
     ref_vec[1] - dot_nr * normal[1],
     ref_vec[2] - dot_nr * normal[2],
   ]
-  const u_vec = normalize_vec3(u_raw, [0, 1, 0])
+  const u_vec = normalize_vec(u_raw, [0, 1, 0])
   const v_vec = cross_3d(normal, u_vec)
   return [u_vec, v_vec] // u, v basis vectors
 }

--- a/src/lib/periodic-table/PeriodicTable.svelte
+++ b/src/lib/periodic-table/PeriodicTable.svelte
@@ -30,7 +30,7 @@
     active_elements = $bindable([]),
     gap = `0.3cqw`,
     inner_transition_metal_offset = 0.5,
-    lanth_act_tiles = tile_props?.show_symbol == false
+    lanth_act_tiles = tile_props?.show_symbol === false
       ? []
       : [...default_f_block_inset_tiles],
     lanth_act_style = ``,
@@ -115,8 +115,8 @@
             `each element possibly omitting elements at the end, got ${heatmap_values.length}`,
         )
         return []
-      } else return heatmap_values
-    } else if (typeof heatmap_values == `object`) {
+      }return heatmap_values
+    } else if (typeof heatmap_values === `object`) {
       const bad_keys = Object.keys(heatmap_values).filter(
         (key) => !ELEM_SYMBOLS.includes(key as ElementSymbol),
       )
@@ -143,7 +143,7 @@
 
   function handle_key(event: KeyboardEvent) {
     if (disabled || !active_element) return
-    if (event.key == `Enter`) onenter?.(active_element)
+    if (event.key === `Enter`) onenter?.(active_element)
 
     const arrow_keys = [`ArrowUp`, `ArrowDown`, `ArrowLeft`, `ArrowRight`]
     if (!arrow_keys.includes(event.key)) return
@@ -186,12 +186,12 @@
   }
 
   let color_scale_fn = $derived(
-    typeof color_scale == `string` ? d3_sc[color_scale] : color_scale,
+    typeof color_scale === `string` ? d3_sc[color_scale] : color_scale,
   )
 
   let cs_min = $derived(
     color_scale_range[0] ??
-      (heat_values.length
+      (heat_values.length > 0
         ? Math.min(
           ...heat_values.flat().filter((v): v is number => typeof v === `number`),
         )
@@ -199,7 +199,7 @@
   )
   let cs_max = $derived(
     color_scale_range[1] ??
-      (heat_values.length
+      (heat_values.length > 0
         ? Math.max(
           ...heat_values.flat().filter((v): v is number => typeof v === `number`),
         )

--- a/src/lib/phase-diagram/PhaseDiagramEditorPane.svelte
+++ b/src/lib/phase-diagram/PhaseDiagramEditorPane.svelte
@@ -6,6 +6,7 @@
   import { build_diagram } from './build-diagram'
   import type { DiagramInput } from './diagram-input'
   import type { PhaseDiagramData } from './types'
+  import { to_error } from '$lib/utils'
 
   let {
     editor_open = $bindable(false),
@@ -54,7 +55,7 @@
         build_diagram(updated as DiagramInput)
         diagram_input = updated as DiagramInput
       } catch (error) {
-        const msg = error instanceof Error ? error.message : String(error)
+        const msg = to_error(error).message
         show_rejection(msg)
       }
       return

--- a/src/lib/phase-diagram/PhaseDiagramTooltip.svelte
+++ b/src/lib/phase-diagram/PhaseDiagramTooltip.svelte
@@ -106,7 +106,7 @@
 
   // Calculate distance to nearest phase boundary (liquidus/solidus)
   const boundary_distance = $derived.by(() => {
-    if (!boundaries.length) return null
+    if (boundaries.length === 0) return null
     const { composition, temperature } = hover_info
     let min_dist: { type: string; delta_t: number } | null = null
 

--- a/src/lib/phase-diagram/build-diagram.ts
+++ b/src/lib/phase-diagram/build-diagram.ts
@@ -36,8 +36,8 @@ export function parse_curve_ref(ref: string): CurveRef {
   const slice_match = /^(.+)\[(-?\d*):(-?\d*)\]$/.exec(name)
   if (slice_match) {
     name = slice_match[1]
-    start = slice_match[2] ? parseInt(slice_match[2]) : null
-    end = slice_match[3] ? parseInt(slice_match[3]) : null
+    start = slice_match[2] ? parseInt(slice_match[2], 10) : null
+    end = slice_match[3] ? parseInt(slice_match[3], 10) : null
   }
 
   return { name, reverse, start, end }

--- a/src/lib/phase-diagram/parse.ts
+++ b/src/lib/phase-diagram/parse.ts
@@ -2,6 +2,7 @@
 // Parses CALPHAD TDB files to extract metadata about elements, phases, and parameters
 
 import { ELEM_SYMBOLS } from '$lib/labels'
+import { to_error } from '$lib/utils'
 
 // Default temperature bounds for TDB parsing (in Kelvin)
 export const TDB_TEMP_DEFAULTS = {
@@ -73,20 +74,20 @@ export function parse_tdb(content: string): TdbParseResult {
 
     // Normalize line endings and join continuation lines
     const normalized = content
-      .replace(/\r\n/g, `\n`)
-      .replace(/\r/g, `\n`)
+      .replaceAll('\r\n', `\n`)
+      .replaceAll('\r', `\n`)
       // Join lines that don't end with ! (continuation)
       .split(`\n`)
       .reduce((acc: string[], line) => {
         const trimmed = line.trim()
         if (trimmed.startsWith(`$`)) {
-          data.comments.push(trimmed.substring(1).trim())
+          data.comments.push(trimmed.slice(1).trim())
           return acc
         }
         if (acc.length === 0 || acc[acc.length - 1].endsWith(`!`)) {
           acc.push(trimmed)
         } else {
-          acc[acc.length - 1] += ` ` + trimmed
+          acc[acc.length - 1] += ` ${trimmed}`
         }
         return acc
       }, [])
@@ -129,7 +130,7 @@ export function parse_tdb(content: string): TdbParseResult {
     return {
       success: false,
       data: null,
-      error: exc instanceof Error ? exc.message : String(exc),
+      error: to_error(exc).message,
     }
   }
 }

--- a/src/lib/plot/BarPlot.svelte
+++ b/src/lib/plot/BarPlot.svelte
@@ -271,7 +271,7 @@
   })
 
   let category_indices = $derived(
-    category_list.length ? category_list.map((_, idx) => idx) : null,
+    category_list.length > 0 ? category_list.map((_, idx) => idx) : null,
   )
 
   let internal_series = $derived.by<NumericBarSeries[]>(() => {
@@ -365,7 +365,7 @@
         ]
       }
 
-      if (!points.length) return [0, 1]
+      if (points.length === 0) return [0, 1]
 
       let computed_y_range = get_nice_data_range(
         points,
@@ -396,13 +396,13 @@
     // Get x values split by axis for range calculation
     // For categorical data, use fixed range centered on integer indices
     let x_auto_range: number[]
-    if (category_list.length) {
+    if (category_list.length > 0) {
       x_auto_range = [-0.5, category_list.length - 0.5]
     } else {
       const x1_x_points = visible_series
         .filter((srs) => (srs.x_axis ?? `x1`) === `x1`)
         .flatMap((srs) => srs.x.map((x_val) => ({ x: x_val, y: 0 })))
-      x_auto_range = x1_x_points.length
+      x_auto_range = x1_x_points.length > 0
         ? get_nice_data_range(
           x1_x_points,
           (pt) => pt.x,
@@ -418,7 +418,7 @@
       srs.x.map((x_val) => ({ x: x_val, y: 0 }))
     )
     const x2_scale_type = x2_axis.scale_type ?? `linear`
-    const x2_auto_range = x2_x_points.length
+    const x2_auto_range = x2_x_points.length > 0
       ? get_nice_data_range(
         x2_x_points,
         (pt) => pt.x,
@@ -494,7 +494,7 @@
 
   // Update padding when format or ticks change
   $effect(() => {
-    const new_pad = width && height && ticks.y.length
+    const new_pad = width && height && ticks.y.length > 0
       ? calc_auto_padding({
         padding,
         default_padding,
@@ -505,7 +505,7 @@
       : filter_padding(padding, default_padding)
     // Expand right padding if y2 ticks are shown (only for vertical orientation)
     if (
-      width && height && y2_series.length && ticks.y2.length &&
+      width && height && y2_series.length > 0 && ticks.y2.length > 0 &&
       orientation === `vertical`
     ) {
       // Need space for: tick shift + tick width + gap (30px) + label space (20px if present)
@@ -521,7 +521,7 @@
     }
     // Expand top padding if x2 ticks are shown (only for vertical orientation)
     if (
-      width && height && x2_series.length && ticks.x2.length &&
+      width && height && x2_series.length > 0 && ticks.x2.length > 0 &&
       orientation === `vertical`
     ) {
       const inside = x2_axis.tick?.label?.inside ?? false
@@ -546,7 +546,7 @@
   // from baseline to its tip so the legend can't hide inside a tall bar. Built from internal_series
   // (pad-independent) + ranges so the crowding decision can't see its own reservation.
   const obstacles_norm = $derived.by(() => {
-    if (!width || !height || !visible_series.length) return []
+    if (!width || !height || visible_series.length === 0) return []
     const base_w = width - base_pad.l - base_pad.r
     const base_h = height - base_pad.t - base_pad.b
     if (base_w <= 0 || base_h <= 0) return []
@@ -661,7 +661,7 @@
   // In vertical mode categories are on x-axis; in horizontal mode on y-axis
   let cat_axis = $derived(orientation === `horizontal` ? `y` : `x`)
   let effective_cat_ticks = $derived.by(() => {
-    if (!category_list.length) return undefined
+    if (category_list.length === 0) return undefined
     // Only respect user ticks when they're a Record (custom label mapping),
     // not a number (tick count) or array (tick positions)
     const user_ticks = cat_axis === `x` ? x_axis.ticks : y_axis.ticks
@@ -1103,7 +1103,7 @@
 
   // Collect bar and line positions for legend placement
   let bar_points_for_placement = $derived.by(() => {
-    if (!width || !height || !visible_series.length) return []
+    if (!width || !height || visible_series.length === 0) return []
 
     return internal_series.flatMap((srs, series_idx) => {
       if (!(srs?.visible ?? true)) return []

--- a/src/lib/plot/BinnedScatterPlot.svelte
+++ b/src/lib/plot/BinnedScatterPlot.svelte
@@ -574,7 +574,7 @@
   })
 
   let point_label_positions = $derived.by(() => {
-    if (!point_label_payloads.length) return {}
+    if (point_label_payloads.length === 0) return {}
 
     const filtered_data: InternalPoint<Metadata>[] = point_label_payloads.map(
       (payload) => ({
@@ -623,7 +623,7 @@
   }
 
   $effect(() => {
-    if (!label_measure_root || !point_label_payloads.length) return
+    if (!label_measure_root || point_label_payloads.length === 0) return
     void measure_point_labels()
   })
 

--- a/src/lib/plot/ColorBar.svelte
+++ b/src/lib/plot/ColorBar.svelte
@@ -226,23 +226,22 @@
 
         return power_of_10_ticks
       }
-        // Generate exactly n_ticks manually for log scale if not snapping
-        const log_min = Math.log10(scale_min)
-        const log_max = Math.log10(scale_max)
-        return [...Array(n_ticks).keys()].map((idx) => {
-          const fraction = idx / (n_ticks - 1)
-          const log_val = log_min + fraction * (log_max - log_min)
-          return 10 ** log_val
-        })
-
-    }
-      // Use D3's default nice ticks for linear scale
-      if (snap_ticks) return scale.ticks(n_ticks)
-      // Generate exactly n_ticks evenly spaced linear ticks
+      // Generate exactly n_ticks manually for log scale if not snapping
+      const log_min = Math.log10(scale_min)
+      const log_max = Math.log10(scale_max)
       return [...Array(n_ticks).keys()].map((idx) => {
         const fraction = idx / (n_ticks - 1)
-        return scale_min + fraction * (scale_max - scale_min)
+        const log_val = log_min + fraction * (log_max - log_min)
+        return 10 ** log_val
       })
+    }
+    // Use D3's default nice ticks for linear scale
+    if (snap_ticks) return scale.ticks(n_ticks)
+    // Generate exactly n_ticks evenly spaced linear ticks
+    return [...Array(n_ticks).keys()].map((idx) => {
+      const fraction = idx / (n_ticks - 1)
+      return scale_min + fraction * (scale_max - scale_min)
+    })
 
   })
 

--- a/src/lib/plot/ColorBar.svelte
+++ b/src/lib/plot/ColorBar.svelte
@@ -103,11 +103,11 @@
     // If ticks are secondary (top), default label to bottom
     if (orientation === `horizontal`) {
       return tick_side === `primary` ? `top` : `bottom`
-    } else { // orientation === `vertical`
+    } // orientation === `vertical`
       // If ticks are primary (right), default label to left
       // If ticks are secondary (left), default label to right
       return tick_side === `primary` ? `left` : `right`
-    }
+
   })
 
   // Number of ticks to generate
@@ -200,7 +200,7 @@
 
         const power_of_10_ticks: number[] = []
         for (let exp = start_exp; exp <= end_exp; exp++) {
-          power_of_10_ticks.push(Math.pow(10, exp))
+          power_of_10_ticks.push(10 ** exp)
         }
 
         // Ensure domain endpoints are included if they are powers of 10 and missed by loop
@@ -225,27 +225,25 @@
         }
 
         return power_of_10_ticks
-      } else {
+      }
         // Generate exactly n_ticks manually for log scale if not snapping
         const log_min = Math.log10(scale_min)
         const log_max = Math.log10(scale_max)
         return [...Array(n_ticks).keys()].map((idx) => {
           const fraction = idx / (n_ticks - 1)
           const log_val = log_min + fraction * (log_max - log_min)
-          return Math.pow(10, log_val)
+          return 10 ** log_val
         })
-      }
-    } else {
+
+    }
       // Use D3's default nice ticks for linear scale
       if (snap_ticks) return scale.ticks(n_ticks)
-      else {
-        // Generate exactly n_ticks evenly spaced linear ticks
-        return [...Array(n_ticks).keys()].map((idx) => {
-          const fraction = idx / (n_ticks - 1)
-          return scale_min + fraction * (scale_max - scale_min)
-        })
-      }
-    }
+      // Generate exactly n_ticks evenly spaced linear ticks
+      return [...Array(n_ticks).keys()].map((idx) => {
+        const fraction = idx / (n_ticks - 1)
+        return scale_min + fraction * (scale_max - scale_min)
+      })
+
   })
 
   // Update nice_range binding when snapping ticks
@@ -380,7 +378,7 @@
       if (use_log_interp) {
         data_value = log_span === 0
           ? adjusted_min_ramp
-          : Math.pow(10, log_min + fraction * log_span)
+          : 10 ** (log_min + fraction * log_span)
       } else if (type_name === `arcsinh`) {
         data_value = asinh_span === 0
           ? min_ramp_domain

--- a/src/lib/plot/Histogram.svelte
+++ b/src/lib/plot/Histogram.svelte
@@ -299,7 +299,7 @@
       scale_type: ScaleType,
     ): Vec2 => {
       const type_name = get_scale_type_name(scale_type)
-      if (!series_list.length) {
+      if (series_list.length === 0) {
         const fallback = type_name === `log` ? 1 : 0
         return [fallback, 1]
       }
@@ -416,7 +416,7 @@
     const current_ticks_y = untrack(() => ticks.y)
     const current_ticks_y2 = untrack(() => ticks.y2)
 
-    const new_pad = width && height && current_ticks_y.length
+    const new_pad = width && height && current_ticks_y.length > 0
       ? calc_auto_padding({
         padding,
         default_padding,
@@ -428,7 +428,7 @@
 
     // Add y2 axis label space (calc_auto_padding only accounts for tick labels)
     if (
-      width && height && y2_series.length && current_ticks_y2.length &&
+      width && height && y2_series.length > 0 && current_ticks_y2.length > 0 &&
       final_y2_axis.label
     ) {
       const inside = final_y2_axis.tick?.label?.inside ?? false
@@ -444,7 +444,7 @@
 
     // Add x2 axis label space (mirroring y2 logic for top padding)
     if (
-      width && height && x2_series.length && current_ticks_x2.length &&
+      width && height && x2_series.length > 0 && current_ticks_x2.length > 0 &&
       final_x2_axis.label
     ) {
       const inside = final_x2_axis.tick?.label?.inside ?? false
@@ -472,7 +472,7 @@
   // vertical segment (top -> baseline) so the legend can't hide inside a tall bar. Built from
   // histogram_bins (pad-independent) + ranges so the crowding decision can't see its own reservation.
   const obstacles_norm = $derived.by(() => {
-    if (!width || !height || !histogram_bins.length) return []
+    if (!width || !height || histogram_bins.length === 0) return []
     const base_w = width - base_pad.l - base_pad.r
     const base_h = height - base_pad.t - base_pad.b
     if (base_w <= 0 || base_h <= 0) return []
@@ -540,7 +540,7 @@
 
   // Pad-independent binning (no pixel scales) so the auto-place obstacle field can reuse it
   let histogram_bins = $derived.by(() => {
-    if (!selected_series.length || !width || !height) return []
+    if (selected_series.length === 0 || !width || !height) return []
     const hist_generator = bin()
       .domain([ranges.current.x[0], ranges.current.x[1]])
       .thresholds(bins)
@@ -625,7 +625,7 @@
 
   // Collect histogram bar positions for legend placement
   let hist_points_for_placement = $derived.by(() => {
-    if (!width || !height || !histogram_data.length) return []
+    if (!width || !height || histogram_data.length === 0) return []
 
     const points: { x: number; y: number }[] = []
 

--- a/src/lib/plot/InteractiveAxisLabel.svelte
+++ b/src/lib/plot/InteractiveAxisLabel.svelte
@@ -24,7 +24,7 @@
     [key: string]: unknown
   } = $props()
 
-  let is_interactive = $derived(Boolean(options?.length > 0))
+  let is_interactive = $derived(Boolean(options?.length))
 
   const stop = (evt: Event) => evt.stopPropagation()
   // Only stop propagation for keys the dropdown handles, allow Tab/Escape for navigation

--- a/src/lib/plot/InteractiveAxisLabel.svelte
+++ b/src/lib/plot/InteractiveAxisLabel.svelte
@@ -24,7 +24,7 @@
     [key: string]: unknown
   } = $props()
 
-  let is_interactive = $derived(Boolean(options?.length))
+  let is_interactive = $derived(Boolean(options?.length > 0))
 
   const stop = (evt: Event) => evt.stopPropagation()
   // Only stop propagation for keys the dropdown handles, allow Tab/Escape for navigation

--- a/src/lib/plot/PlotControls.svelte
+++ b/src/lib/plot/PlotControls.svelte
@@ -81,9 +81,8 @@
         timeFormat(format_string)(new Date())
         return true
       }
-        format(format_string)(123.456)
-        return true
-
+      format(format_string)(123.456)
+      return true
     } catch {
       return false
     }

--- a/src/lib/plot/PlotControls.svelte
+++ b/src/lib/plot/PlotControls.svelte
@@ -80,10 +80,10 @@
       if (format_string.startsWith(`%`)) {
         timeFormat(format_string)(new Date())
         return true
-      } else {
+      }
         format(format_string)(123.456)
         return true
-      }
+
     } catch {
       return false
     }

--- a/src/lib/plot/PortalSelect.svelte
+++ b/src/lib/plot/PortalSelect.svelte
@@ -115,12 +115,12 @@
         btn.setAttribute(`aria-selected`, `true`)
         selected_btn = btn
       }
-      li.appendChild(btn)
-      ul.appendChild(li)
+      li.append(btn)
+      ul.append(li)
     }
 
-    portal_el.appendChild(ul)
-    document.body.appendChild(portal_el)
+    portal_el.append(ul)
+    document.body.append(portal_el)
     update_position()
     dropdown_open = true
     active_close_fn = close_dropdown
@@ -181,8 +181,8 @@
       buttons[(idx + 1) % len]?.focus()
     } else if (evt.key === `ArrowUp`) {
       evt.preventDefault()
-      buttons[idx < 0 ? len - 1 : (idx - 1 + len) % len]?.focus()
-    } else if (evt.key === `Enter` && idx >= 0) {
+      buttons[idx === -1 ? len - 1 : (idx - 1 + len) % len]?.focus()
+    } else if (evt.key === `Enter` && idx !== -1) {
       evt.preventDefault()
       buttons[idx].click()
     }

--- a/src/lib/plot/ReferenceLine3D.svelte
+++ b/src/lib/plot/ReferenceLine3D.svelte
@@ -102,7 +102,7 @@
     color: ref_line.style?.color ?? `white`,
     opacity: ref_line.style?.opacity ?? 1,
     width: ref_line.style?.width ?? 2,
-    dashed: !!ref_line.style?.dash,
+    dashed: Boolean(ref_line.style?.dash),
   })
 
   // Create Line2 with LineGeometry and LineMaterial for proper variable-width lines

--- a/src/lib/plot/ReferencePlane.svelte
+++ b/src/lib/plot/ReferencePlane.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   // ReferencePlane: 3D reference planes (axis-aligned, normal-defined, or point-defined)
   import type { Vec3 } from '$lib/math'
-  import { cross_3d, normalize_vec3 } from '$lib/math'
+  import { cross_3d, normalize_vec } from '$lib/math'
   import { T } from '@threlte/core'
   import * as THREE from 'three'
   import { create_to_threejs, span_or } from './reference-line'
@@ -82,7 +82,7 @@
       const v2: Vec3 = [p3[0] - p1[0], p3[1] - p1[1], p3[2] - p1[2]]
       const cross = cross_3d(v1, v2)
       if (Math.hypot(...cross) < 1e-9) return null // collinear points
-      return create_plane_from_normal(normalize_vec3(cross), p1)
+      return create_plane_from_normal(normalize_vec(cross), p1)
     }
     return null
   }
@@ -111,9 +111,9 @@
 
   // Create plane from normal and point, scaled to cover bounding box
   function create_plane_from_normal(normal: Vec3, point: Vec3): THREE.BufferGeometry {
-    const normalized = normalize_vec3(normal)
+    const normalized = normalize_vec(normal)
     // Pick u perpendicular to normal (use axis least aligned with normal)
-    const u_dir = normalize_vec3(
+    const u_dir = normalize_vec(
       cross_3d(normalized, Math.abs(normalized[0]) < 0.9 ? [1, 0, 0] : [0, 1, 0]),
     )
     const v_dir = cross_3d(normalized, u_dir)

--- a/src/lib/plot/ScatterPlot.svelte
+++ b/src/lib/plot/ScatterPlot.svelte
@@ -791,7 +791,7 @@
       .filter((
         srs,
       ): srs is DataSeries<Metadata> & { filtered_data: InternalPoint<Metadata>[] } =>
-        Boolean(srs.filtered_data) && srs.filtered_data.length > 0
+        (srs.filtered_data?.length ?? 0) > 0
       ),
   )
 

--- a/src/lib/plot/ScatterPlot.svelte
+++ b/src/lib/plot/ScatterPlot.svelte
@@ -429,7 +429,7 @@
   // Update padding when format or ticks change
   $effect(() => {
     const new_pad = width && height &&
-        (y_tick_values.length || y2_tick_values.length || x2_tick_values.length)
+        (y_tick_values.length > 0 || y2_tick_values.length > 0 || x2_tick_values.length > 0)
       ? calc_auto_padding({
         padding,
         default_padding,
@@ -791,7 +791,7 @@
       .filter((
         srs,
       ): srs is DataSeries<Metadata> & { filtered_data: InternalPoint<Metadata>[] } =>
-        !!srs.filtered_data && srs.filtered_data.length > 0
+        Boolean(srs.filtered_data) && srs.filtered_data.length > 0
       ),
   )
 
@@ -1161,7 +1161,7 @@
 
   // Calculate color bar placement (coordinates with legend to avoid overlap)
   let color_bar_placement = $derived.by(() => {
-    if (!color_bar || !all_color_values.length || !width || !height) return null
+    if (!color_bar || all_color_values.length === 0 || !width || !height) return null
 
     const plot_width = width - pad.l - pad.r
     const plot_height = height - pad.t - pad.b

--- a/src/lib/plot/ScatterPlot3DScene.svelte
+++ b/src/lib/plot/ScatterPlot3DScene.svelte
@@ -216,7 +216,7 @@
   ): Vec2 {
     if (range?.[0] != null && range?.[1] != null) return range as Vec2
     const valid = values.filter(isFinite)
-    if (!valid.length) return [0, 1]
+    if (valid.length === 0) return [0, 1]
     let [min, max] = [Math.min(...valid), Math.max(...valid)]
     const pad = min === max
       ? (min === 0 ? 1 : Math.abs(min * 0.1))
@@ -257,7 +257,7 @@
     all_points.map((pt) => pt.color_value).filter((val): val is number => val != null),
   )
   let auto_color_range: [number, number] = $derived.by(() => {
-    if (!all_color_values.length) return [0, 1]
+    if (all_color_values.length === 0) return [0, 1]
     let min = all_color_values[0]
     let max = all_color_values[0]
     for (const val of all_color_values) {

--- a/src/lib/plot/ScatterPoint.svelte
+++ b/src/lib/plot/ScatterPoint.svelte
@@ -44,7 +44,7 @@
   function get_symbol_path(): string {
     const symbol_key: D3SymbolName = style.symbol_type ?? DEFAULTS.scatter.symbol_type
     const symbol_type = symbol_map[symbol_key] ?? d3_symbols.symbolCircle
-    const size = style.symbol_size ?? Math.PI * Math.pow(style.radius ?? 2, 2)
+    const size = style.symbol_size ?? Math.PI * (style.radius ?? 2) ** 2
     return symbol().type(symbol_type).size(size)() || ``
   }
 

--- a/src/lib/plot/auto-place.ts
+++ b/src/lib/plot/auto-place.ts
@@ -85,7 +85,7 @@ function is_crowded(
   base_h: number,
   clearance: number,
 ): boolean {
-  if (!obstacles.length || base_w <= 0 || base_h <= 0) return false
+  if (obstacles.length === 0 || base_w <= 0 || base_h <= 0) return false
   const fw = footprint.width / base_w
   const fh = footprint.height / base_h
   if (fw >= 1 || fh >= 1) return true // too big to fit inside -> outside

--- a/src/lib/plot/axis-utils.ts
+++ b/src/lib/plot/axis-utils.ts
@@ -1,5 +1,6 @@
 // Shared utilities for interactive axis functionality
 
+import { to_error } from '$lib/utils'
 import type {
   AxisConfig,
   AxisLoadError,
@@ -105,7 +106,7 @@ export const create_axis_change_handler =
       // Revert selection
       state.set_axis(axis, { ...state.get_axis(axis), selected_key: prev_key })
 
-      const message = err instanceof Error ? err.message : String(err)
+      const message = to_error(err).message
       on_error?.({ axis, key, message })
     } finally {
       state.set_loading(null)

--- a/src/lib/plot/data-cleaning.ts
+++ b/src/lib/plot/data-cleaning.ts
@@ -318,7 +318,7 @@ function compute_savgol_coefficients(window: number, order: number): number[] {
   for (let idx = -half; idx <= half; idx++) {
     const row: number[] = []
     for (let power = 0; power <= order; power++) {
-      row.push(Math.pow(idx, power))
+      row.push(idx ** power)
     }
     vandermonde.push(row)
   }

--- a/src/lib/plot/data-transform.ts
+++ b/src/lib/plot/data-transform.ts
@@ -14,10 +14,10 @@ export const get_series_symbol = (series_idx: number): D3SymbolName =>
 // Extract the primary color from a series data object.
 // Checks line stroke, then point fill (handling arrays), with fallback to default blue.
 export const extract_series_color = (series_data: DataSeries): string =>
-  series_data.line_style?.stroke ||
-  (Array.isArray(series_data.point_style)
-    ? series_data.point_style[0]?.fill
-    : series_data.point_style?.fill) ||
+  (series_data.line_style?.stroke ??
+    (Array.isArray(series_data.point_style)
+      ? series_data.point_style[0]?.fill
+      : series_data.point_style?.fill)) || // oxlint-disable-line @typescript-eslint/prefer-nullish-coalescing -- empty fill should use default color
   `#4A9EFF`
 
 // Prepare legend data from series array

--- a/src/lib/plot/reference-line.ts
+++ b/src/lib/plot/reference-line.ts
@@ -332,22 +332,20 @@ export function calculate_annotation_position(
     // Perpendicular vector (normalized)
     const nx = -dy / len
     const ny = dx / len
+    let sign: number
     if (side === `above` || side === `below`) {
       // In SVG, y increases downward. Flip sign if 'above' and perpendicular points down (ny > 0),
       // or if 'below' and perpendicular points up (ny <= 0), to ensure offset is in correct direction
-      const sign = (side === `above`) === ny > 0 ? -1 : 1
-      perp_x = sign * nx * gap
-      perp_y = sign * ny * gap
+      sign = (side === `above`) === ny > 0 ? -1 : 1
     } else {
       // left/right offset to the side of the line in screen space (right -> +x, left -> -x), stable
       // regardless of endpoint order — vertical ref lines are stored bottom->top, which flips the
       // perpendicular. Horizontal lines (nx == 0) fall back to right = up (-y), left = down (+y).
       const want_right = side === `right`
-      const sign =
-        Math.abs(nx) > 1e-9 ? (want_right ? 1 : -1) * Math.sign(nx) : want_right ? -1 : 1
-      perp_x = sign * nx * gap
-      perp_y = sign * ny * gap
+      sign = Math.abs(nx) > 1e-9 ? (want_right ? 1 : -1) * Math.sign(nx) : want_right ? -1 : 1
     }
+    perp_x = sign * nx * gap
+    perp_y = sign * ny * gap
   }
 
   const final_x = base_x + perp_x + offset_x

--- a/src/lib/plot/scales.ts
+++ b/src/lib/plot/scales.ts
@@ -215,14 +215,14 @@ function generate_positive_arcsinh_ticks(
   const max_power = Math.ceil(Math.log10(max))
 
   for (let power = min_power; power <= max_power; power++) {
-    const val = Math.pow(10, power)
+    const val = 10 ** power
     if (val >= min && val <= max) ticks.push(val)
   }
 
   // Add intermediate values (2x, 5x) for sparser regions
   if (ticks.length < count) {
     for (let power = min_power; power < max_power; power++) {
-      const base = Math.pow(10, power)
+      const base = 10 ** power
       for (const mult of [2, 5]) {
         const val = base * mult
         if (val >= min && val <= max) ticks.push(val)
@@ -388,14 +388,14 @@ export function get_nice_data_range(
       const span = data_max - data_min
       if (is_time) {
         const padding_ms = span * padding_factor
-        data_min = data_min - padding_ms
-        data_max = data_max + padding_ms
+        data_min -= padding_ms
+        data_max += padding_ms
       } else if (type_name === `log`) {
         const log_min = Math.log10(Math.max(data_min, math.LOG_EPS))
         const log_max = Math.log10(Math.max(data_max, math.LOG_EPS))
         const log_span = log_max - log_min
-        data_min = Math.pow(10, log_min - log_span * padding_factor)
-        data_max = Math.pow(10, log_max + log_span * padding_factor)
+        data_min = 10 ** (log_min - log_span * padding_factor)
+        data_max = 10 ** (log_max + log_span * padding_factor)
       } else if (type_name === `arcsinh`) {
         // Arcsinh: apply padding in arcsinh-transformed space
         // Guard against extremely small thresholds that could cause precision issues
@@ -408,31 +408,29 @@ export function get_nice_data_range(
       } else {
         // Linear scale
         const padding_abs = span * padding_factor
-        data_min = data_min - padding_abs
-        data_max = data_max + padding_abs
+        data_min -= padding_abs
+        data_max += padding_abs
       }
-    } else {
       // Handle single data point case with fixed relative padding
-      if (is_time) {
-        const one_day = 86_400_000 // milliseconds in a day
-        data_min = data_min - one_day
-        data_max = data_max + one_day
-      } else if (type_name === `log`) {
-        data_min = Math.max(math.LOG_EPS, data_min / 1.1) // 10% multiplicative padding
-        data_max = data_max * 1.1
-      } else if (type_name === `arcsinh`) {
-        // Arcsinh: 10% padding in transformed space
-        // Guard against extremely small thresholds that could cause precision issues
-        const threshold = Math.max(get_arcsinh_threshold(scale_type), Number.EPSILON)
-        const asinh_val = Math.asinh(data_min / threshold)
-        const padding = Math.abs(asinh_val) * 0.1 || 0.1 // Use 0.1 if transformed value is 0 (i.e. data_min = 0)
-        data_min = Math.sinh(asinh_val - padding) * threshold
-        data_max = Math.sinh(asinh_val + padding) * threshold
-      } else {
-        const padding_abs = data_min === 0 ? 1 : Math.abs(data_min * 0.1) // 10% additive padding, or 1 if value is 0
-        data_min = data_min - padding_abs
-        data_max = data_max + padding_abs
-      }
+    } else if (is_time) {
+      const one_day = 86_400_000 // milliseconds in a day
+      data_min -= one_day
+      data_max += one_day
+    } else if (type_name === `log`) {
+      data_min = Math.max(math.LOG_EPS, data_min / 1.1) // 10% multiplicative padding
+      data_max *= 1.1
+    } else if (type_name === `arcsinh`) {
+      // Arcsinh: 10% padding in transformed space
+      // Guard against extremely small thresholds that could cause precision issues
+      const threshold = Math.max(get_arcsinh_threshold(scale_type), Number.EPSILON)
+      const asinh_val = Math.asinh(data_min / threshold)
+      const padding = Math.abs(asinh_val) * 0.1 || 0.1 // Use 0.1 if transformed value is 0 (i.e. data_min = 0)
+      data_min = Math.sinh(asinh_val - padding) * threshold
+      data_max = Math.sinh(asinh_val + padding) * threshold
+    } else {
+      const padding_abs = data_min === 0 ? 1 : Math.abs(data_min * 0.1) // 10% additive padding, or 1 if value is 0
+      data_min -= padding_abs
+      data_max += padding_abs
     }
   }
 
@@ -480,8 +478,8 @@ export function generate_log_ticks(
     range_size <= 2 ? min_power - 1 : min_power - Math.max(1, Math.floor(range_size / 4))
   const extended_max_power = range_size <= 2 ? max_power + 1 : max_power
 
-  const powers = range(extended_min_power, extended_max_power + 1).map((power: number) =>
-    Math.pow(10, power),
+  const powers = range(extended_min_power, extended_max_power + 1).map(
+    (power: number) => 10 ** power,
   )
 
   // For narrow ranges, include intermediate values
@@ -489,8 +487,8 @@ export function generate_log_ticks(
     const detailed_ticks: number[] = []
     powers.forEach((power: number) => {
       detailed_ticks.push(power)
-      if (power * 2 <= Math.pow(10, extended_max_power)) detailed_ticks.push(power * 2)
-      if (power * 5 <= Math.pow(10, extended_max_power)) detailed_ticks.push(power * 5)
+      if (power * 2 <= 10 ** extended_max_power) detailed_ticks.push(power * 2)
+      if (power * 5 <= 10 ** extended_max_power) detailed_ticks.push(power * 5)
     })
     return detailed_ticks.filter((tick) => tick >= min && tick <= max)
   }

--- a/src/lib/plot/types.ts
+++ b/src/lib/plot/types.ts
@@ -4,10 +4,11 @@ import type DraggablePane from '$lib/overlays/DraggablePane.svelte'
 import type { ComponentProps, Snippet } from 'svelte'
 import type { HTMLAttributes } from 'svelte/elements'
 import type { TweenOptions } from 'svelte/motion'
-export type { TweenOptions } from 'svelte/motion'
 import type { Sides } from './layout'
 import type PlotLegend from './PlotLegend.svelte'
 import type { TicksOption } from './scales'
+
+export type { TweenOptions } from 'svelte/motion'
 
 export type XyShift = { x?: number; y?: number } // For optional shift/offset values
 

--- a/src/lib/rdf/RdfPlot.svelte
+++ b/src/lib/rdf/RdfPlot.svelte
@@ -10,6 +10,7 @@
   import { is_crystal } from '$lib/structure/validation'
   import type { ComponentProps, Snippet } from 'svelte'
   import { calculate_all_pair_rdfs, calculate_rdf, type RdfEntry } from './index'
+  import { to_error } from '$lib/utils'
 
   let {
     patterns,
@@ -66,7 +67,7 @@
       }
     } catch (exc) {
       error_msg = `Failed to process structure: ${
-        exc instanceof Error ? exc.message : String(exc)
+        to_error(exc).message
       }`
     }
   }

--- a/src/lib/rdf/calc-rdf.ts
+++ b/src/lib/rdf/calc-rdf.ts
@@ -78,7 +78,7 @@ export function calculate_rdf(structure: Crystal, options: RdfOptions = {}): Rdf
   }
 
   // Calculate distances and bin them with occupancy weighting
-  const use_pbc = pbc.some((flag) => flag)
+  const use_pbc = pbc.some(Boolean)
   const converters = use_pbc ? create_lattice_converters(lattice) : undefined
 
   for (const center of centers) {

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -58,7 +58,7 @@ function sanitize_svg_content(
   })
   const open_end = wrapped.indexOf(`>`)
   const close_start = wrapped.lastIndexOf(`</svg>`)
-  if (open_end < 0 || close_start < 0) return wrapped
+  if (open_end === -1 || close_start === -1) return wrapped
   return wrapped.slice(open_end + 1, close_start)
 }
 

--- a/src/lib/spectral/Bands.svelte
+++ b/src/lib/spectral/Bands.svelte
@@ -590,9 +590,9 @@
     const display_values = detected_band_type === `phonon`
       ? convert_band_values(all_freqs)
       : all_freqs
-    if (!display_values.length) return undefined
+    if (display_values.length === 0) return undefined
     const finite = display_values.filter(Number.isFinite)
-    if (!finite.length) return undefined
+    if (finite.length === 0) return undefined
     let min_val = Math.min(...finite), max_val = Math.max(...finite)
     if (
       // clamp phonon min to 0 if negatives are noise
@@ -622,7 +622,7 @@
   })
 
   let has_series = $derived(series_data.length > 0)
-  let is_strict_path_error = $derived(path_mode === `strict` && !!strict_path_error)
+  let is_strict_path_error = $derived(path_mode === `strict` && Boolean(strict_path_error))
 
   let imaginary_mode_region = $derived.by((): FillRegion[] => {
     if (
@@ -675,7 +675,7 @@
     )
     const occupied = all_energies.filter((energy) => energy <= effective_fermi_level)
     const unoccupied = all_energies.filter((energy) => energy > effective_fermi_level)
-    if (!occupied.length || !unoccupied.length) return null
+    if (occupied.length === 0 || unoccupied.length === 0) return null
     const vbm = Math.max(...occupied)
     const cbm = Math.min(...unoccupied)
     const gap = cbm - vbm

--- a/src/lib/spectral/Dos.svelte
+++ b/src/lib/spectral/Dos.svelte
@@ -308,7 +308,7 @@
   )
 
   let x_range = $derived.by((): [number, number] | undefined => {
-    if (!series_data.length) return undefined
+    if (series_data.length === 0) return undefined
     const all_x = series_data.flatMap((srs) => srs.x)
     const min_x = Math.min(...all_x), max_x = Math.max(...all_x)
     // For horizontal orientation with mirror mode, allow negative values (mirrored densities)
@@ -318,7 +318,7 @@
   })
 
   let y_range = $derived.by((): [number, number] | undefined => {
-    if (!series_data.length) return undefined
+    if (series_data.length === 0) return undefined
     const all_y = series_data.flatMap((srs) => srs.y)
     const min_y = Math.min(...all_y), max_y = Math.max(...all_y)
     // For vertical orientation with mirror mode, allow negative values (mirrored densities)
@@ -379,7 +379,7 @@
   // Auto-detect sigma range based on frequency/energy range
   let effective_sigma_range = $derived.by((): [number, number] => {
     if (sigma_range) return sigma_range
-    if (!all_freqs.length) return [0, 1]
+    if (all_freqs.length === 0) return [0, 1]
     const freq_range = Math.max(...all_freqs) - Math.min(...all_freqs)
     // Reasonable sigma range: 0 to ~5% of total range
     const max_sigma = Math.max(0.1, freq_range * 0.05)

--- a/src/lib/spectral/helpers.ts
+++ b/src/lib/spectral/helpers.ts
@@ -119,12 +119,12 @@ export function pretty_sym_point(symbol: string): string {
   // Handle subscripts: convert S0 to S₀, K1 to K₁, Γ1 to Γ₁, etc.
   // Use \p{L} to match any Unicode letter (not just ASCII A-Z)
   return symbol
-    .replace(/_/g, ``)
-    .replace(/\\?GAMMA/gi, `Γ`)
-    .replace(/\\?DELTA/gi, `Δ`)
-    .replace(/\\?SIGMA/gi, `Σ`)
-    .replace(/\\?LAMBDA/gi, `Λ`)
-    .replace(
+    .replaceAll('_', ``)
+    .replaceAll(/\\?GAMMA/gi, `Γ`)
+    .replaceAll(/\\?DELTA/gi, `Δ`)
+    .replaceAll(/\\?SIGMA/gi, `Σ`)
+    .replaceAll(/\\?LAMBDA/gi, `Λ`)
+    .replaceAll(
       /(\p{L})(\d+)/gu,
       (_, letter, num) =>
         letter +
@@ -217,7 +217,7 @@ export function get_band_xaxis_ticks(
 ): [number[], string[]] {
   const ticks_x_pos: number[] = []
   const tick_labels: string[] = []
-  let prev_label = band_struct.qpoints[0]?.label || null
+  let prev_label = band_struct.qpoints[0]?.label ?? null
   let prev_branch = band_struct.branches[0]?.name || null
 
   // Convert branches to Set for consistent handling
@@ -235,7 +235,7 @@ export function get_band_xaxis_ticks(
 
     if (point.label !== prev_label && prev_branch !== this_branch) {
       // Branch transition - combine labels
-      tick_labels[tick_labels.length - 1] = `${prev_label || ``}|${point.label}`
+      tick_labels[tick_labels.length - 1] = `${prev_label ?? ``}|${point.label}`
       ticks_x_pos[ticks_x_pos.length - 1] = band_struct.distance[idx]
     } else if (branches_set.size === 0 || (this_branch && branches_set.has(this_branch))) {
       tick_labels.push(point.label)
@@ -318,6 +318,7 @@ function fnv1a_hash(arr: number[]): number {
     hash ^= int_view[1]
     hash = Math.imul(hash, 16777619)
   }
+  // oxlint-disable-next-line eslint-plugin-unicorn/prefer-math-trunc -- `>>> 0` is unsigned 32-bit coercion, not truncation
   return hash >>> 0 // Ensure unsigned
 }
 
@@ -418,7 +419,7 @@ interface PymatgenKpoint {
   label?: string | null
 }
 const is_kpoint = (val: unknown): val is PymatgenKpoint =>
-  !!val && typeof val === `object` && `frac_coords` in val && is_vec3(val.frac_coords)
+  val !== null && typeof val === `object` && `frac_coords` in val && is_vec3(val.frac_coords)
 
 const is_pymatgen_format = (obj: Record<string, unknown>): boolean => {
   // Check for explicit pymatgen markers
@@ -446,10 +447,10 @@ const parse_qpoint = (
   if (!frac_coords) return null
 
   const label =
-    (is_kpoint(qpt) && typeof qpt.label === `string` && qpt.label) ||
-    Object.entries(labels_dict ?? {}).find(
-      ([, c]) => euclidean_dist(frac_coords, c) < 1e-4,
-    )?.[0] ||
+    ((is_kpoint(qpt) && typeof qpt.label === `string` && qpt.label) ||
+      Object.entries(labels_dict ?? {}).find(
+        ([, c]) => euclidean_dist(frac_coords, c) < 1e-4,
+      )?.[0]) ??
     null
   return { label, frac_coords }
 }
@@ -534,15 +535,15 @@ function convert_pymatgen_band_structure(
   if (
     !Array.isArray(raw_qpts) ||
     !Array.isArray(raw_bands) ||
-    !raw_qpts.length ||
-    !raw_bands.length
+    raw_qpts.length === 0 ||
+    raw_bands.length === 0
   )
     return null
 
   const qpoints = raw_qpts
     .map((qpoint) => parse_qpoint(qpoint, labels_dict))
     .filter((qpoint): qpoint is types.QPoint => qpoint !== null)
-  if (!qpoints.length) return null
+  if (qpoints.length === 0) return null
 
   // Step distances and discontinuity detection (5x median threshold)
   const steps = qpoints
@@ -605,7 +606,7 @@ function convert_pymatgen_band_structure(
       .filter((branch) => branch.start_index <= branch.end_index)
   }
 
-  if (!branches.length) {
+  if (branches.length === 0) {
     branches.push({ start_index: 0, end_index: qpoints.length - 1, name: `path` })
   }
 
@@ -1306,7 +1307,7 @@ export function format_dos_tooltip(
         format_tooltip_line(
           y_parsed.name || freq_defaults.name,
           y_formatted,
-          y_parsed.unit || freq_defaults.unit,
+          y_parsed.unit ?? freq_defaults.unit,
         ),
         format_tooltip_line(x_parsed.name || `Density`, x_formatted),
       ]
@@ -1315,7 +1316,7 @@ export function format_dos_tooltip(
         format_tooltip_line(
           x_parsed.name || freq_defaults.name,
           x_formatted,
-          x_parsed.unit || freq_defaults.unit,
+          x_parsed.unit ?? freq_defaults.unit,
         ),
       ]
 

--- a/src/lib/structure/AtomLegend.svelte
+++ b/src/lib/structure/AtomLegend.svelte
@@ -128,8 +128,8 @@
       // Use unique_values instead of values to avoid undefined colors from duplicates
       property_colors?.unique_values?.flatMap((val) => {
         const idx = property_colors.values.indexOf(val)
-        return idx >= 0 ? [[val, property_colors.colors[idx]]] : []
-      }) ?? [],
+        return idx !== -1 ? [[val, property_colors.colors[idx]]] : []
+      }),
     ),
   )
 

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -65,6 +65,7 @@
   import StructureExportPane from './StructureExportPane.svelte'
   import StructureInfoPane from './StructureInfoPane.svelte'
   import StructureScene from './StructureScene.svelte'
+  import { to_error } from '$lib/utils'
 
   // Type alias for event handlers to reduce verbosity
   type EventHandler = (data: StructureHandlerData) => void
@@ -303,7 +304,7 @@
             emit_file_load_event(parsed, filename, content)
           } catch (error) {
             error_msg = `Failed to parse structure: ${
-              error instanceof Error ? error.message : String(error)
+              to_error(error).message
             }`
             on_error?.({ error_msg, filename })
           }
@@ -334,7 +335,7 @@
       }
     } catch (err) {
       error_msg = `Failed to parse structure from string: ${
-        err instanceof Error ? err.message : String(err)
+        to_error(err).message
       }`
       untrack(() => on_error?.({ error_msg, filename: `string` }))
     } finally {
@@ -823,7 +824,7 @@
   let supercell_structure = $state(structure)
   let supercell_loading = $state(false)
   let has_supercell = $derived(
-    !!supercell_scaling && ![``, `1x1x1`, `1`].includes(supercell_scaling),
+    Boolean(supercell_scaling) && ![``, `1x1x1`, `1`].includes(supercell_scaling),
   )
   let bond_edits_enabled = $derived(
     cell_type === `original` && !has_supercell && !supercell_loading,
@@ -866,8 +867,8 @@
       // For large supercells, show loading state and use async generation
       const sites_count = base_structure.sites?.length || 0
       const [nx_str, ny_str, nz_str] = supercell_scaling.split(/[x×]/)
-      const scaling_mult = (parseInt(nx_str) || 1) * (parseInt(ny_str) || 1) *
-        (parseInt(nz_str) || 1)
+      const scaling_mult = (parseInt(nx_str, 10) || 1) * (parseInt(ny_str, 10) || 1) *
+        (parseInt(nz_str, 10) || 1)
       const estimated_sites = sites_count * scaling_mult
 
       // Show spinner for supercells with >1000 estimated sites or scaling >8
@@ -1125,7 +1126,7 @@
         emit_file_load_event(parsed, filename, content)
       } catch (err) {
         error_msg = `Failed to parse structure: ${
-          err instanceof Error ? err.message : String(err)
+          to_error(err).message
         }`
         on_error?.({ error_msg, filename })
       }

--- a/src/lib/structure/StructureInfoPane.svelte
+++ b/src/lib/structure/StructureInfoPane.svelte
@@ -231,7 +231,7 @@
         // Only display scalar values (skip arrays and objects)
         if (value == null || typeof value === `object`) continue
         structure_items.push({
-          label: key.replace(/_/g, ` `).replace(/\b\w/g, (char) => char.toUpperCase()),
+          label: key.replaceAll('_', ` `).replaceAll(/\b\w/g, (char) => char.toUpperCase()),
           value: String(value),
           key: `structure-prop-${key}`,
         })
@@ -280,7 +280,7 @@
         international_short?: string
       }).international_short
       const space_group_symbol = (sym_data.hm_symbol ?? international_symbol)
-        ?.replace(
+        ?.replaceAll(
           /\s+/g,
           ``,
         )
@@ -379,7 +379,7 @@
     const selected_site_idx = selected_sites[0]
     if (!pane_open || selected_site_idx === undefined) return
     const visible_idx = visible_site_cards.findIndex(({ idx }) => idx === selected_site_idx)
-    if (visible_idx < 0) return
+    if (visible_idx === -1) return
     const selected_window_start = Math.floor(visible_idx / SITE_WINDOW_SIZE) *
       SITE_WINDOW_SIZE
     if (selected_window_start !== site_window_start) {

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -1089,7 +1089,7 @@
 
     const bond_directions_by_site = new SvelteMap<number, Vec3[]>()
     const add_bond_direction = (site_idx: number, pos_1: Vec3, pos_2: Vec3) => {
-      const direction = math.normalize_vec3(
+      const direction = math.normalize_vec(
         math.subtract(pos_2, pos_1),
         [0, 0, 0],
       )
@@ -1252,9 +1252,9 @@
         let mean: Vec3 = [0, 0, 0]
         for (const key of site_keys) {
           const vec = vec_map.get(key)
-          if (vec) mean = math.add(mean, math.normalize_vec3(vec)) as Vec3
+          if (vec) mean = math.add(mean, math.normalize_vec(vec)) as Vec3
         }
-        const mean_dir = math.normalize_vec3(mean, [0, 1, 0] as Vec3)
+        const mean_dir = math.normalize_vec(mean, [0, 1, 0] as Vec3)
         const [u_vec, v_vec] = math.compute_in_plane_basis(mean_dir)
         const offsets = new SvelteMap<string, Vec3>()
         for (const [idx, key] of site_keys.entries()) {
@@ -1316,7 +1316,7 @@
 
           const offset = site_offsets?.[site_idx]?.get(key)
           const position = offset ? math.add(site.xyz, offset) as Vec3 : site.xyz
-          const arrow_vec = vector_normalize ? math.normalize_vec3(vec) : vec
+          const arrow_vec = vector_normalize ? math.normalize_vec(vec) : vec
 
           return {
             site_idx,

--- a/src/lib/structure/atom-properties.ts
+++ b/src/lib/structure/atom-properties.ts
@@ -111,7 +111,7 @@ export function apply_color_scale(
   scale = DEFAULT_COLOR_SCALE,
   type: ColorScaleType = `continuous`,
 ): { colors: string[]; unique_values?: number[] } {
-  if (!vals.length) return { colors: [] }
+  if (vals.length === 0) return { colors: [] }
   if (type === `categorical`) {
     const result = make_categorical(vals, scale, (val_a, val_b) => val_a - val_b)
     return { colors: result.colors, unique_values: result.unique_values }
@@ -135,7 +135,7 @@ export const apply_categorical_color_scale = (
   vals: string[],
   scale = DEFAULT_COLOR_SCALE,
 ): { colors: string[]; unique_values: string[] } =>
-  vals.length ? make_categorical(vals, scale) : { colors: [], unique_values: [] }
+  vals.length > 0 ? make_categorical(vals, scale) : { colors: [], unique_values: [] }
 
 // Get original site index for property color lookup.
 // Supercell atoms use orig_unit_cell_idx, image atoms use orig_site_idx, otherwise use site_idx.
@@ -148,7 +148,7 @@ export const get_orig_site_idx = (site: Site | undefined, site_idx: number): num
 
 // Expand structure with PBC images - use minimal expansion based on atom positions
 function expand_structure_for_pbc(structure: AnyStructure): AnyStructure {
-  if (!(`lattice` in structure) || !structure.lattice || !structure.sites.length) {
+  if (!(`lattice` in structure) || !structure.lattice || structure.sites.length === 0) {
     return structure
   }
 
@@ -158,7 +158,7 @@ function expand_structure_for_pbc(structure: AnyStructure): AnyStructure {
   const all_offsets = get_all_offsets(pbc)
 
   // Small structures: expand all atoms
-  if (sites.length < 20 || !pbc.some((periodic) => periodic)) {
+  if (sites.length < 20 || !pbc.some(Boolean)) {
     const image_sites = sites.flatMap((site, orig_idx) =>
       all_offsets.map((offset) => build_image_site(site, frac_to_cart, offset, orig_idx)),
     )
@@ -195,7 +195,7 @@ export function get_coordination_colors(
   // Check if structure has periodic boundary conditions
   const has_lattice = `lattice` in structure && structure.lattice !== undefined
   const pbc = has_lattice ? structure.lattice.pbc : undefined
-  const has_pbc = has_lattice && (pbc === undefined || pbc.some((is_periodic) => is_periodic))
+  const has_pbc = has_lattice && (pbc === undefined || pbc.some(Boolean))
 
   // For PBC structures, expand with images from neighboring cells for accurate coordination
   const coord_structure = has_pbc ? expand_structure_for_pbc(structure) : structure
@@ -312,5 +312,5 @@ export function get_property_colors(
 ): AtomPropertyColors | null {
   if (!structure || config.mode === `element`) return null
   const result = get_atom_colors(structure, config, bonding_strategy, sym_data)
-  return result.colors.length ? result : null
+  return result.colors.length > 0 ? result : null
 }

--- a/src/lib/structure/bond-order-perception.ts
+++ b/src/lib/structure/bond-order-perception.ts
@@ -90,7 +90,7 @@ function split_fragments(n_atoms: number, edges: [number, number][]): number[][]
     const stack = [start]
     const frag: number[] = []
     seen.add(start)
-    while (stack.length) {
+    while (stack.length > 0) {
       const node = stack.pop()
       if (node === undefined) break
       frag.push(node)

--- a/src/lib/structure/bonding.ts
+++ b/src/lib/structure/bonding.ts
@@ -8,7 +8,7 @@ import type { AnyStructure, BondOrder, BondPair, Site, StructureBond } from '$li
 type SpatialGrid = Map<string, number[]>
 
 const element_lookup = new Map(element_data.map((el) => [el.symbol, el]))
-const covalent_radii: Map<string, number> = new Map(
+const covalent_radii = new Map<string, number>(
   element_data.flatMap((el) =>
     el.covalent_radius === null ? [] : [[el.symbol, el.covalent_radius]],
   ),

--- a/src/lib/structure/export.ts
+++ b/src/lib/structure/export.ts
@@ -126,6 +126,7 @@ export function generate_mtl_content(scene: Scene): string {
     const materials = Array.isArray(object.material) ? object.material : [object.material]
     for (const mat of materials) {
       // Skip if already processed or no name
+      // oxlint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- empty name should use default
       const mat_name = mat.name || `default_material`
       if (processed_materials.has(mat_name)) continue
       processed_materials.add(mat_name)
@@ -347,10 +348,10 @@ function convert_instanced_meshes_to_regular(scene: Scene): Scene {
 // Sanitize string for use in filenames by removing problematic characters.
 const sanitize_filename_part = (text: string): string =>
   text
-    .replace(/<\/?[^>]+>/g, ``) // strip HTML tags
-    .replace(/[/\\:*?"<>|]/g, `_`) // replace filesystem-invalid chars
-    .replace(/_+/g, `_`) // condense consecutive underscores
-    .replace(/^_|_$/g, ``) // remove leading/trailing underscores
+    .replaceAll(/<\/?[^>]+>/g, ``) // strip HTML tags
+    .replaceAll(/[/\\:*?"<>|]/g, `_`) // replace filesystem-invalid chars
+    .replaceAll(/_+/g, `_`) // condense consecutive underscores
+    .replaceAll(/^_|_$/g, ``) // remove leading/trailing underscores
 
 export function create_structure_filename(
   structure: AnyStructure | undefined,
@@ -501,7 +502,7 @@ function get_cif_block_name(structure: AnyStructure): string {
     if (structure.id) {
       // Remove invalid CIF characters (keep alphanumerics and underscores)
       // and condense consecutive underscores for cleaner block names
-      return structure.id.replace(/[^a-zA-Z0-9_]/g, `_`).replace(/_+/g, `_`)
+      return structure.id.replaceAll(/[^a-zA-Z0-9_]/g, `_`).replaceAll(/_+/g, `_`)
     }
     return `structure`
   }
@@ -616,8 +617,8 @@ export function structure_to_poscar_str(structure?: AnyStructure): string {
   // Use plain text formula for POSCAR title to avoid HTML tags
   const formula = get_electro_neg_formula(structure, true)
   const title =
-    structure.id ||
-    (formula && formula !== `Unknown` ? formula : null) ||
+    structure.id || // oxlint-disable-line @typescript-eslint/prefer-nullish-coalescing -- first non-empty string
+    (formula && formula !== `Unknown` ? formula : null) || // oxlint-disable-line @typescript-eslint/prefer-nullish-coalescing -- first non-empty string
     `Generated from structure`
   lines.push(title)
   lines.push(`1.0`) // Scale factor (1.0 for direct coordinates)

--- a/src/lib/structure/index.ts
+++ b/src/lib/structure/index.ts
@@ -42,7 +42,7 @@ export type Site = {
 }
 
 export const LATTICE_PARAM_KEYS = [`a`, `b`, `c`, `alpha`, `beta`, `gamma`] as const
-export type LatticeParams = { [key in (typeof LATTICE_PARAM_KEYS)[number]]: number }
+export type LatticeParams = Record<(typeof LATTICE_PARAM_KEYS)[number], number>
 
 export type LatticeType = {
   matrix: math.Matrix3x3

--- a/src/lib/structure/label-placement.ts
+++ b/src/lib/structure/label-placement.ts
@@ -41,8 +41,8 @@ export const choose_site_label_offset = (bond_directions: Vec3[], base_offset: V
     return base_offset
   }
 
-  const preferred_direction = math.normalize_vec3(base_offset, [0, 1, 0])
-  const repulsion_direction = math.normalize_vec3(
+  const preferred_direction = math.normalize_vec(base_offset, [0, 1, 0])
+  const repulsion_direction = math.normalize_vec(
     bond_directions.reduce<Vec3>(
       (offset_sum, bond_direction) => math.subtract(offset_sum, bond_direction),
       [0, 0, 0],
@@ -57,7 +57,7 @@ export const choose_site_label_offset = (bond_directions: Vec3[], base_offset: V
     repulsion_direction,
     ...LABEL_OFFSET_DIRECTIONS,
   ]) {
-    const direction = math.normalize_vec3(candidate_direction, preferred_direction)
+    const direction = math.normalize_vec(candidate_direction, preferred_direction)
     const score = label_direction_score(direction, bond_directions, preferred_direction)
     if (score <= best_score + LABEL_OFFSET_EPS) continue
     best_score = score
@@ -98,7 +98,7 @@ export const label_screen_position = (
   const direction_x = offset_length > LABEL_OFFSET_EPS ? offset_x / offset_length : 0
   const direction_y =
     offset_length > LABEL_OFFSET_EPS ? offset_y / offset_length : label_offset[1] >= 0 ? -1 : 1
-  const radius_direction = math.normalize_vec3(label_offset, [0, 1, 0])
+  const radius_direction = math.normalize_vec(label_offset, [0, 1, 0])
   const radius_edge = math.add(atom_position, math.scale(radius_direction, visual_radius))
   const radius_screen = project_to_screen(radius_edge, label_camera, size)
   const atom_screen_radius = Math.hypot(

--- a/src/lib/structure/parse.ts
+++ b/src/lib/structure/parse.ts
@@ -708,12 +708,10 @@ const parse_cif_atom_data = (
       : 1.0
 
   const from_symbol = symbol >= 0 ? /^([A-Z][a-z]*)/.exec(raw_data[symbol])?.[1] : undefined
-  const element_symbol =
-    from_symbol ??
-    raw_data[label]?.match(/([A-Z][a-z]*)/g)?.[0] ??
-    (() => {
-      throw new Error(`Could not extract element symbol from: ${raw_data.join(` `)}`)
-    })()
+  const element_symbol = from_symbol ?? raw_data[label]?.match(/([A-Z][a-z]*)/g)?.[0]
+  if (!element_symbol) {
+    throw new Error(`Could not extract element symbol from: ${raw_data.join(` `)}`)
+  }
 
   return {
     id: raw_data[label],

--- a/src/lib/structure/parse.ts
+++ b/src/lib/structure/parse.ts
@@ -113,9 +113,9 @@ function parse_coordinate_line(line: string): number[] {
     const sanitized = line
       .trim()
       // Add space when '-' follows a digit and precedes a digit or dot
-      .replace(/(\d)-(?=[\d.])/g, `$1 -`)
+      .replaceAll(/(\d)-(?=[\d.])/g, `$1 -`)
       // Revert accidental spaces after exponent markers
-      .replace(/([eE])\s-\s/g, `$1-`)
+      .replaceAll(/([eE])\s-\s/g, `$1-`)
     tokens = sanitized.split(/\s+/)
   }
 
@@ -185,7 +185,7 @@ export function parse_poscar(content: string): ParsedStructure | null {
     // Handle negative scale factor (volume-based scaling)
     if (scale_factor < 0) {
       const volume = Math.abs(math.det_3x3(lattice_vecs))
-      scale_factor = Math.pow(-scale_factor / volume, 1 / 3)
+      scale_factor = (-scale_factor / volume) ** (1 / 3)
     }
 
     // Scale lattice vectors
@@ -203,7 +203,7 @@ export function parse_poscar(content: string): ParsedStructure | null {
     // Detect if this is VASP 5+ format (has element symbols)
     // Try to parse the first token as a number - if it succeeds, it's VASP 4 format
     const first_token = lines[line_index].trim().split(/\s+/)[0]
-    const first_token_as_number = parseInt(first_token)
+    const first_token_as_number = parseInt(first_token, 10)
     const has_element_symbols = isNaN(first_token_as_number)
 
     if (has_element_symbols) {
@@ -214,7 +214,7 @@ export function parse_poscar(content: string): ParsedStructure | null {
       for (let lookahead_idx = 1; lookahead_idx < 10; lookahead_idx++) {
         if (line_index + lookahead_idx >= lines.length) break
         const next_line_first_token = lines[line_index + lookahead_idx].trim().split(/\s+/)[0]
-        const next_token_as_number = parseInt(next_line_first_token)
+        const next_token_as_number = parseInt(next_line_first_token, 10)
         if (!isNaN(next_token_as_number)) {
           symbol_lines = lookahead_idx
           break
@@ -339,7 +339,7 @@ export function parse_poscar(content: string): ParsedStructure | null {
             abc,
             xyz,
             label: `${element}${atom_index + atom_count_idx + 1}`,
-            properties: selective_dynamics ? { selective_dynamics: selective_dynamics } : {},
+            properties: selective_dynamics ? { selective_dynamics } : {},
           }
 
           sites.push(site)
@@ -355,10 +355,9 @@ export function parse_poscar(content: string): ParsedStructure | null {
       }
 
       return structure
-    } else {
-      console.error(`Missing coordinate mode line in POSCAR`)
-      return null
     }
+    console.error(`Missing coordinate mode line in POSCAR`)
+    return null
   } catch (error) {
     console.error(`Error parsing POSCAR file:`, error)
     return null
@@ -405,7 +404,7 @@ export function parse_xyz(content: string): ParsedStructure | null {
     }
 
     // Parse number of atoms (line 1)
-    const num_atoms = parseInt(lines[0].trim())
+    const num_atoms = parseInt(lines[0].trim(), 10)
     if (isNaN(num_atoms) || num_atoms <= 0) {
       console.error(`Invalid number of atoms in XYZ file`)
       return null
@@ -502,7 +501,7 @@ const parse_symmetry_expression = (
   let translation = 0
 
   // Remove all whitespace
-  const expr = expr_input.replace(/\s+/g, ``)
+  const expr = expr_input.replaceAll(/\s+/g, ``)
   if (!expr) return { coefficients, translation }
 
   // Tokenize: split into terms while preserving signs
@@ -708,9 +707,10 @@ const parse_cif_atom_data = (
       ? parseFloat(raw_data[occupancy].split(`(`)[0]) || 1.0
       : 1.0
 
+  const from_symbol = symbol >= 0 ? /^([A-Z][a-z]*)/.exec(raw_data[symbol])?.[1] : undefined
   const element_symbol =
-    (symbol >= 0 && /^([A-Z][a-z]*)/.exec(raw_data[symbol])?.[1]) ||
-    raw_data[label]?.match(/([A-Z][a-z]*)/g)?.[0] ||
+    from_symbol ??
+    raw_data[label]?.match(/([A-Z][a-z]*)/g)?.[0] ??
     (() => {
       throw new Error(`Could not extract element symbol from: ${raw_data.join(` `)}`)
     })()
@@ -802,7 +802,7 @@ export function parse_cif(
           if (line.startsWith(`;`)) {
             let multi_line_data = ``
             while (jj < lines.length && !lines[jj].trim().endsWith(`;`)) {
-              multi_line_data += lines[jj] + `\n`
+              multi_line_data += `${lines[jj]}\n`
               jj++
             }
             multi_line_data += lines[jj]
@@ -816,7 +816,7 @@ export function parse_cif(
       if (atom_data_lines.length > 0) break
     }
 
-    if (!atom_headers.length || !atom_data_lines.length) {
+    if (atom_headers.length === 0 || atom_data_lines.length === 0) {
       console.error(`No valid atom site loop found in CIF file`)
       return null
     }
@@ -851,8 +851,8 @@ export function parse_cif(
       .map((line) => {
         // Handle quoted multi-word values by splitting only on whitespace
         // that is not inside quotes.
-        const tokens = line.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) || []
-        return tokens.map((token) => token.replace(/['"]/g, ``))
+        const tokens = line.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) ?? []
+        return tokens.map((token) => token.replaceAll(/['"]/g, ``))
       })
       .filter((tokens) => {
         const { disorder } = header_indices
@@ -872,7 +872,7 @@ export function parse_cif(
       })
       .filter((atom): atom is NonNullable<typeof atom> => atom !== null)
 
-    if (!atoms.length) {
+    if (atoms.length === 0) {
       console.error(`No valid atoms found in CIF file`)
       return null
     }
@@ -902,8 +902,8 @@ export function parse_cif(
 
     // Normalize symmetry operations (trim/strip quotes) but preserve duplicates; we deduplicate positions later
     const normalized_ops = symmetry_ops
-      .map((op) => /['"]([^'"]+)['"]/.exec(op)?.[1] || op.trim())
-      .map((op) => op.replace(/\s+/g, ``))
+      .map((op) => /['"]([^'"]+)['"]/.exec(op)?.[1] ?? op.trim())
+      .map((op) => op.replaceAll(/\s+/g, ``))
 
     // Rely on symmetry operations list for all centering/translations to avoid double-counting
     // TODO: Support conventional cells with centering by discovering centering from space group metadata
@@ -934,14 +934,14 @@ export function parse_cif(
               lj++
               continue
             }
-            const toks = (line.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) || []).map((tok) =>
-              tok.replace(/['"]/g, ``),
+            const toks = (line.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) ?? []).map((tok) =>
+              tok.replaceAll(/['"]/g, ``),
             )
             if (toks.length > Math.max(sym_idx, num_idx)) {
               // Normalize type symbol to bare element (e.g. 'Sn2+' -> 'Sn')
               const match = /^([A-Z][a-z]*)/.exec(toks[sym_idx])
               const sym = match ? match[1] : toks[sym_idx]
-              const num = parseInt(toks[num_idx])
+              const num = parseInt(toks[num_idx], 10)
               if (sym && !Number.isNaN(num)) map[sym] = num
             }
             lj++
@@ -1125,10 +1125,9 @@ export function parse_phonopy_yaml(
     if (cell_type && cell_type !== `auto`) {
       const cell = get_phonopy_cell(data, cell_type)
       if (cell) return convert_phonopy_cell(cell)
-      else {
-        console.error(`Requested cell type '${cell_type}' not found in phonopy YAML`)
-        return null
-      }
+
+      console.error(`Requested cell type '${cell_type}' not found in phonopy YAML`)
+      return null
     }
 
     // Auto mode: return preferred structure in order of preference
@@ -1306,7 +1305,7 @@ export function parse_structure_file(
   }
 
   // XYZ format detection: first line should be a number, second line is comment
-  const first_line_number = parseInt(lines[0].trim())
+  const first_line_number = parseInt(lines[0].trim(), 10)
   if (!isNaN(first_line_number) && first_line_number > 0) {
     // Check if this looks like XYZ format
     if (lines.length >= first_line_number + 2) {
@@ -1321,7 +1320,7 @@ export function parse_structure_file(
 
           // Check if first token looks like an element symbol (not a number)
           // and the next 3 tokens look like coordinates (numbers)
-          const is_element_symbol = isNaN(parseInt(first_token)) && first_token.length <= 3
+          const is_element_symbol = isNaN(parseInt(first_token, 10)) && first_token.length <= 3
           const are_coordinates = coords.every((coord) => !isNaN(parseFloat(coord)))
 
           if (is_element_symbol && are_coordinates) {

--- a/src/lib/symmetry/SymmetryStats.svelte
+++ b/src/lib/symmetry/SymmetryStats.svelte
@@ -32,7 +32,7 @@
   const wyckoff_count = $derived(
     sym_data ? wyckoff_positions_from_moyo(sym_data).length : 0,
   )
-  const display_hm_symbol = $derived(sym_data?.hm_symbol?.replace(/\s+/g, ``) ?? `?`)
+  const display_hm_symbol = $derived(sym_data?.hm_symbol?.replaceAll(/\s+/g, ``) ?? `?`)
 
   const sym_ops_counts = $derived.by(() => {
     const EPS = 1e-10
@@ -83,7 +83,7 @@
   function get_step_from_order_of_magnitude(value: number): number {
     if (!Number.isFinite(value) || value <= 0) return 1e-5
     const exponent = Math.floor(Math.log10(value))
-    return Math.pow(10, exponent)
+    return 10 ** exponent
   }
 
   const symprec_step = $derived(get_step_from_order_of_magnitude(settings.symprec))

--- a/src/lib/symmetry/index.ts
+++ b/src/lib/symmetry/index.ts
@@ -271,7 +271,7 @@ export function wyckoff_positions_from_moyo(sym_data: SymmetryDataset | null): W
   )
 
   rows.sort((w1, w2) => {
-    const [w1_mult, w2_mult] = [parseInt(w1.wyckoff), parseInt(w2.wyckoff)]
+    const [w1_mult, w2_mult] = [parseInt(w1.wyckoff, 10), parseInt(w2.wyckoff, 10)]
     if (w1_mult !== w2_mult) return w1_mult - w2_mult
     return w1.wyckoff.localeCompare(w2.wyckoff)
   })
@@ -320,7 +320,7 @@ export function map_wyckoff_to_all_atoms(
   }
 
   return wyckoff_positions.map((wyckoff_pos) => {
-    const indices = (wyckoff_pos.site_indices || [])
+    const indices = (wyckoff_pos.site_indices ?? [])
       .filter((idx) => idx < orig_structure.sites.length)
       .flatMap((orig_idx) => {
         const { abc: orig_abc, species } = orig_structure.sites[orig_idx]

--- a/src/lib/table/HeatmapTable.svelte
+++ b/src/lib/table/HeatmapTable.svelte
@@ -484,7 +484,7 @@
 
         // Push invalid values to bottom
         if (is_invalid(val1) || is_invalid(val2)) {
-          return +is_invalid(val1) - +is_invalid(val2)
+          return Number(is_invalid(val1)) - Number(is_invalid(val2))
         }
 
         const sort_val1 = get_sort_val(val1)
@@ -497,10 +497,8 @@
             sensitivity: `base`,
           })
           if (cmp !== 0) return cmp * modifier
-        } else {
-          if (sort_val1 !== sort_val2) {
-            return (sort_val1 ?? 0) < (sort_val2 ?? 0) ? -modifier : modifier
-          }
+        } else if (sort_val1 !== sort_val2) {
+          return (sort_val1 ?? 0) < (sort_val2 ?? 0) ? -modifier : modifier
         }
       }
       return 0
@@ -558,7 +556,7 @@
     // Shift+click for multi-column sort
     if (event.shiftKey) {
       const existing_idx = multi_sort.findIndex((sort_entry) => sort_entry.column === col_id)
-      if (existing_idx >= 0) {
+      if (existing_idx !== -1) {
         // Toggle direction or remove if clicked again
         const existing = multi_sort[existing_idx]
         if (existing.ascending === (col.better === `lower`)) {
@@ -684,7 +682,7 @@
 
     // Check multi-sort first
     const multi_idx = multi_sort.findIndex((sort_entry) => sort_entry.column === col_id)
-    if (multi_idx >= 0) {
+    if (multi_idx !== -1) {
       const arrow = multi_sort[multi_idx].ascending ? `↓` : `↑`
       const badge = multi_sort.length > 1 ? `<sup>${multi_idx + 1}</sup>` : ``
       return `<span style="font-size: 0.8em;">${arrow}${badge}</span>`
@@ -716,7 +714,7 @@
   function toggle_row_select(row: RowData) {
     const row_id = get_row_id(row)
     const idx = selected_rows.findIndex((selected_row) => get_row_id(selected_row) === row_id)
-    if (idx >= 0) {
+    if (idx !== -1) {
       selected_rows = selected_rows.filter((_, i) => i !== idx)
     } else {
       selected_rows = [...selected_rows, row]
@@ -755,7 +753,7 @@
     const quote = (str: string) => {
       if (!csv_quote) return str
       if (str.includes(`,`) || str.includes(`"`) || str.includes(`\n`)) {
-        return `"${str.replace(/"/g, `""`)}"`
+        return `"${str.replaceAll('"', `""`)}"`
       }
       return str
     }
@@ -799,7 +797,7 @@
     const link = document.createElement(`a`)
     link.href = url
     link.download = filename
-    document.body.appendChild(link)
+    document.body.append(link)
     link.click()
     document.body.removeChild(link)
     URL.revokeObjectURL(url)

--- a/src/lib/table/index.ts
+++ b/src/lib/table/index.ts
@@ -15,7 +15,7 @@ export type CellVal =
   | undefined
   | null
   | Record<string, unknown>
-  | { [key: string]: string | number | null | undefined | boolean }[]
+  | Record<string, string | number | null | undefined | boolean>[]
 
 // Row data for table entries
 export type RowData = { style?: string; class?: string; [key: string]: CellVal }
@@ -91,7 +91,7 @@ export type ExportData = boolean | { formats?: (`csv` | `json`)[]; filename?: st
 export type OnSortCallback = (column: string, dir: `asc` | `desc`) => Promise<RowData[]>
 
 // Strip HTML tags from a string (for search, export, etc.)
-export const strip_html = (str: string): string => str.replace(/<[^>]*>/g, ``)
+export const strip_html = (str: string): string => str.replaceAll(/<[^>]*>/g, ``)
 
 // Calculate table cell background color based on its value and column config
 export function calc_cell_color(

--- a/src/lib/theme/index.ts
+++ b/src/lib/theme/index.ts
@@ -56,7 +56,7 @@ export const get_theme_preference = (): ThemeMode => {
   if (!is_browser) return AUTO_THEME
   try {
     const saved = localStorage[storage_key]
-    return is_valid_theme_mode(saved || ``) ? (saved as ThemeMode) : AUTO_THEME
+    return is_valid_theme_mode(saved ?? ``) ? (saved as ThemeMode) : AUTO_THEME
   } catch {
     return AUTO_THEME
   }
@@ -82,8 +82,8 @@ export const apply_theme_to_dom = (mode: ThemeMode): void => {
   if (!resolved || !(resolved in THEME_TYPE)) {
     throw new Error(`Invalid theme mode: ${resolved}`)
   }
-  const theme = globalThis.MATTERVIZ_THEMES?.[resolved] || {}
-  const css_vars = globalThis.MATTERVIZ_CSS_MAP || {}
+  const theme = globalThis.MATTERVIZ_THEMES?.[resolved] ?? {}
+  const css_vars = globalThis.MATTERVIZ_CSS_MAP ?? {}
 
   const root = document.documentElement
   Object.entries(theme).forEach(([key, value]) => {
@@ -100,8 +100,8 @@ export const apply_theme_to_dom = (mode: ThemeMode): void => {
 }
 
 // Theme getters
-export const light_theme = () => globalThis.MATTERVIZ_THEMES?.[COLOR_THEMES.light] || {}
-export const dark_theme = () => globalThis.MATTERVIZ_THEMES?.[COLOR_THEMES.dark] || {}
-export const white_theme = () => globalThis.MATTERVIZ_THEMES?.[COLOR_THEMES.white] || {}
-export const black_theme = () => globalThis.MATTERVIZ_THEMES?.[COLOR_THEMES.black] || {}
-export const get_theme_by_name = (name: ThemeName) => globalThis.MATTERVIZ_THEMES?.[name] || {}
+export const light_theme = () => globalThis.MATTERVIZ_THEMES?.[COLOR_THEMES.light] ?? {}
+export const dark_theme = () => globalThis.MATTERVIZ_THEMES?.[COLOR_THEMES.dark] ?? {}
+export const white_theme = () => globalThis.MATTERVIZ_THEMES?.[COLOR_THEMES.white] ?? {}
+export const black_theme = () => globalThis.MATTERVIZ_THEMES?.[COLOR_THEMES.black] ?? {}
+export const get_theme_by_name = (name: ThemeName) => globalThis.MATTERVIZ_THEMES?.[name] ?? {}

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -367,7 +367,7 @@
 
   // Update visible_properties binding when user toggles series visibility in legend
   $effect(() => {
-    if (!plot_series.length) return
+    if (plot_series.length === 0) return
 
     // Extract property keys from visible series metadata
     const visible_keys = plot_series.flatMap((srs) => {
@@ -509,7 +509,7 @@
     is_playing = false
     if (trajectory) {
       on_pause?.({
-        trajectory: trajectory,
+        trajectory,
         step_idx: current_step_idx,
         frame_count: total_frames,
       })
@@ -520,9 +520,10 @@
     const playing = is_playing
     const rate_ms = 1000 / fps
 
+    // Read current interval once (untrack to avoid circular dependency)
+    const current_interval = untrack(() => play_interval)
     if (playing) {
-      // Clear existing interval if it exists - use untrack to avoid circular dependency
-      const current_interval = untrack(() => play_interval)
+      // Clear existing interval if it exists
       if (current_interval !== undefined) clearInterval(current_interval)
 
       // Create new interval with current frame rate
@@ -542,13 +543,10 @@
           }
         } else next_step()
       }, rate_ms)
-    } else {
-      // Clear interval when not playing - use untrack to avoid circular dependency
-      const current_interval = untrack(() => play_interval)
-      if (current_interval !== undefined) {
-        clearInterval(current_interval)
-        play_interval = undefined
-      }
+    } else if (current_interval !== undefined) {
+      // Clear interval when not playing
+      clearInterval(current_interval)
+      play_interval = undefined
     }
   })
 
@@ -634,7 +632,6 @@
       if (text_data) {
         file_size = new Blob([text_data]).size // Calculate byte size of text data
         await load_trajectory_data(text_data, `trajectory.json`)
-        return
       }
     } catch (error) {
       console.error(`File drop failed:`, error)
@@ -677,7 +674,7 @@
 
   // Watch for frame rate changes
   $effect(() => {
-    on_frame_rate_change?.({ trajectory, fps: fps })
+    on_frame_rate_change?.({ trajectory, fps })
   })
 
   async function load_trajectory_data(data: string | ArrayBuffer, filename: string) {
@@ -840,10 +837,10 @@
     // Playback speed shortcuts (only when playing)
     else if ((event.key === `=` || event.key === `+`) && is_playing) {
       fps = Math.min(fps_range[1], fps + 0.2)
-      on_frame_rate_change?.({ trajectory, fps: fps })
+      on_frame_rate_change?.({ trajectory, fps })
     } else if (event.key === `-` && is_playing) {
       fps = Math.max(fps_range[0], fps - 0.2)
-      on_frame_rate_change?.({ trajectory, fps: fps })
+      on_frame_rate_change?.({ trajectory, fps })
     } // System shortcuts
     else if (event.key === `Escape`) {
       if (document.fullscreenElement) document.exitFullscreen()

--- a/src/lib/trajectory/TrajectoryExportPane.svelte
+++ b/src/lib/trajectory/TrajectoryExportPane.svelte
@@ -8,6 +8,7 @@
   import type { TrajectoryType } from '$lib/trajectory'
   import type { ComponentProps } from 'svelte'
   import { tooltip } from 'svelte-multiselect/attachments'
+  import { to_error } from '$lib/utils'
 
   let {
     export_pane_open = $bindable(false),
@@ -123,7 +124,7 @@
       }, 1000)
     } catch (error) {
       console.error(`Export failed:`, error)
-      export_error = error instanceof Error ? error.message : String(error)
+      export_error = to_error(error).message
       is_exporting = false
       export_progress = 0
     }

--- a/src/lib/trajectory/TrajectoryInfoPane.svelte
+++ b/src/lib/trajectory/TrajectoryInfoPane.svelte
@@ -45,7 +45,7 @@
     frames.map((frame) => frame.metadata?.[prop]).filter(is_valid_number)
 
   const format_range = (values: number[], unit = ``, decimals = `.2~f`) => {
-    if (!values.length) return null
+    if (values.length === 0) return null
     if (values.length === 1) {
       return `${format_num(values[0], decimals)} ${unit}`.trim()
     }
@@ -61,6 +61,7 @@
     tooltip?: string,
   ): InfoItem | null => value ? { label, value, key, tooltip } : null
 
+  // oxlint-disable-next-line eslint-plugin-unicorn/prefer-native-coercion-functions -- type predicate needed for narrowing
   const is_info_item = (item: unknown): item is InfoItem => Boolean(item)
 
   const safe_formula = (structure: AnyStructure) => {

--- a/src/lib/trajectory/format-detect.ts
+++ b/src/lib/trajectory/format-detect.ts
@@ -42,7 +42,7 @@ export const FORMAT_PATTERNS = {
   },
 
   vasp: (data: string, filename?: string) => {
-    const basename = filename?.toLowerCase().split(`/`).pop() || ``
+    const basename = filename?.toLowerCase().split(`/`).pop() ?? ``
     if (basename === `xdatcar` || basename.startsWith(`xdatcar`)) return true
     const lines = data.trim().split(/\r?\n/)
     return (

--- a/src/lib/trajectory/frame-reader.ts
+++ b/src/lib/trajectory/frame-reader.ts
@@ -401,7 +401,7 @@ export class TrajFrameReader implements FrameLoader {
     })
 
     const step_match = /(?:step|frame)\s*[=:]?\s*(\d+)/i.exec(comment)
-    const step = step_match ? parseInt(step_match[1]) : frame_number
+    const step = step_match ? parseInt(step_match[1], 10) : frame_number
 
     return { frame_number, step, properties }
   }

--- a/src/lib/trajectory/helpers.ts
+++ b/src/lib/trajectory/helpers.ts
@@ -200,7 +200,7 @@ export function count_xyz_frames(data: string): number {
     let valid_coords = 0
     for (let idx = 0; idx < Math.min(num_atoms, 3); idx++) {
       const parts = lines[line_idx + 2 + idx]?.trim().split(/\s+/)
-      if (parts?.length >= 4 && isNaN(parseInt(parts[0])) && parts[0].length <= 3) {
+      if (parts?.length >= 4 && isNaN(parseInt(parts[0], 10)) && parts[0].length <= 3) {
         if (parts.slice(1, 4).every((coord) => !isNaN(parseFloat(coord)))) valid_coords++
       }
     }

--- a/src/lib/trajectory/index.ts
+++ b/src/lib/trajectory/index.ts
@@ -169,7 +169,7 @@ export function validate_trajectory(trajectory: TrajectoryType): string[] {
 
 export function get_trajectory_stats(trajectory: TrajectoryType): Record<string, unknown> {
   const { frames, total_frames, indexed_frames, plot_metadata } = trajectory
-  const frame_count = total_frames || frames.length
+  const frame_count = total_frames ?? frames.length
   const stats: Record<string, unknown> = {
     frame_count,
     is_indexed: trajectory.is_indexed ?? false,

--- a/src/lib/trajectory/parse/hdf5.ts
+++ b/src/lib/trajectory/parse/hdf5.ts
@@ -25,7 +25,7 @@ export async function parse_torch_sim_hdf5(
     filename
       ?.split(`/`)
       .at(-1)
-      ?.replace(/[^\w.-]/g, `_`) || `temp`
+      ?.replaceAll(/[^\w.-]/g, `_`) ?? `temp`
   const unique_suffix = `${Date.now()}-${Math.random().toString(36).slice(2)}`
   const temp_filename = `${file_basename}-${unique_suffix}.h5`
 

--- a/src/lib/trajectory/parse/index.ts
+++ b/src/lib/trajectory/parse/index.ts
@@ -98,7 +98,7 @@ export async function parse_trajectory_data(
       const frame_obj = frame_data as Record<string, unknown>
       const frame_step = frame_obj.step
       return {
-        structure: (frame_obj.structure || frame_obj) as AnyStructure,
+        structure: (frame_obj.structure ?? frame_obj) as AnyStructure,
         step: typeof frame_step === `number` ? frame_step : idx,
         metadata: (frame_obj.metadata as Record<string, unknown>) || {},
       }

--- a/src/lib/trajectory/parse/vasp.ts
+++ b/src/lib/trajectory/parse/vasp.ts
@@ -65,7 +65,7 @@ export function parse_vasp_xdatcar(content: string, filename?: string): Trajecto
     const config_line = lines[config_idx]
     line_idx = config_idx + 1
     const step_match = /configuration=\s*(\d+)/.exec(config_line)
-    const step = step_match ? parseInt(step_match[1]) : frames.length + 1
+    const step = step_match ? parseInt(step_match[1], 10) : frames.length + 1
 
     const positions = []
     for (let idx = 0; idx < elements.length && line_idx < lines.length; idx++) {

--- a/src/lib/trajectory/parse/xyz.ts
+++ b/src/lib/trajectory/parse/xyz.ts
@@ -36,7 +36,7 @@ export function parse_xyz_trajectory(content: string): TrajectoryType {
     }
 
     const step_match = extractors.step.exec(comment)
-    const step = step_match?.[1] ? parseInt(step_match[1]) : frames.length
+    const step = step_match?.[1] ? parseInt(step_match[1], 10) : frames.length
     Object.entries(extractors).forEach(([key, pattern]) => {
       if (key === `step`) return
       const match = pattern.exec(comment)

--- a/src/lib/trajectory/plotting.ts
+++ b/src/lib/trajectory/plotting.ts
@@ -187,7 +187,7 @@ function group_and_assign_series(
   // Group by unit
   const unit_map = new Map<string, DataSeries[]>()
   for (const srs of series) {
-    const unit = srs.unit || `dimensionless`
+    const unit = srs.unit ?? `dimensionless`
     const group = unit_map.get(unit) ?? []
     group.push(srs)
     unit_map.set(unit, group)
@@ -199,7 +199,7 @@ function group_and_assign_series(
       const priority = calculate_priority(unit, group_series)
       const has_default_visible = group_series.some((srs) => {
         const metadata = Array.isArray(srs.metadata) ? srs.metadata[0] : srs.metadata
-        const property_key = (metadata?.property_key as string) || srs.label || ``
+        const property_key = ((metadata?.property_key as string) || srs.label) ?? ``
         return is_default_visible(property_key, default_visible_properties)
       })
 
@@ -252,7 +252,7 @@ function extract_label_and_unit(
   const config = property_config[key] || property_config[key.toLowerCase()]
   if (config) return { clean_label: config.label, unit: config.unit }
   return {
-    clean_label: key.charAt(0).toUpperCase() + key.slice(1).replace(/_/g, ` `),
+    clean_label: key.charAt(0).toUpperCase() + key.slice(1).replaceAll('_', ` `),
     unit: ``,
   }
 }
@@ -264,14 +264,14 @@ function calculate_priority(unit: string, group_series: DataSeries[]): number {
 
   // Energy properties get high priority
   const has_energy = group_series.some((srs) => {
-    const label = srs.label?.toLowerCase() || ``
+    const label = srs.label?.toLowerCase() ?? ``
     return ENERGY_PROPERTIES.some((prop) => label.includes(prop))
   })
   if (has_energy) return 10
 
   // Force properties get medium priority
   const has_force = group_series.some((srs) => {
-    const label = srs.label?.toLowerCase() || ``
+    const label = srs.label?.toLowerCase() ?? ``
     return FORCE_PROPERTIES.some((prop) => label.includes(prop))
   })
   if (has_force) return 100
@@ -283,8 +283,8 @@ function calculate_priority(unit: string, group_series: DataSeries[]): number {
 const normalize_property_key = (key: string): string => {
   const normalized = key
     .toLowerCase()
-    .replace(/<[^>]*>/g, ``)
-    .replace(/_/g, ` `)
+    .replaceAll(/<[^>]*>/g, ``)
+    .replaceAll('_', ` `)
     .trim()
   // Map common force property aliases to canonical form
   return [`fmax`, `f`, `force maximum`].includes(normalized) ? `force max` : normalized
@@ -354,7 +354,7 @@ export function toggle_series_visibility(
 function create_unit_groups_from_series(series: DataSeries[]): UnitGroup[] {
   const unit_map = new Map<string, DataSeries[]>()
   for (const srs of series) {
-    const unit = srs.unit || `dimensionless`
+    const unit = srs.unit ?? `dimensionless`
     const group = unit_map.get(unit) ?? []
     group.push(srs)
     unit_map.set(unit, group)
@@ -401,7 +401,7 @@ function update_group_visibility_and_axes(
     .sort((g1, g2) => g1.priority - g2.priority)
 
   const axis_map = new Map<UnitGroup, `y1` | `y2`>()
-  if (final_visible.length >= 1) axis_map.set(final_visible[0], `y1`)
+  if (final_visible.length > 0) axis_map.set(final_visible[0], `y1`)
   if (final_visible.length === 2) axis_map.set(final_visible[1], `y2`)
 
   // Apply to series
@@ -447,19 +447,19 @@ export function should_hide_plot(
 
 function get_axis_label(axis_series: DataSeries[]): string {
   const visible_series = axis_series.filter((srs) => srs.visible)
-  if (!visible_series.length) return `Value`
+  if (visible_series.length === 0) return `Value`
 
   const unit_groups = new Map<string, string[]>()
   visible_series.forEach((srs) => {
-    const unit = srs.unit || ``
-    const label = srs.label || `Value`
+    const unit = srs.unit ?? ``
+    const label = srs.label ?? `Value`
     if (!unit_groups.has(unit)) unit_groups.set(unit, [])
     const group = unit_groups.get(unit)
     if (group) group.push(label)
   })
 
   const unit_entries = Array.from(unit_groups.entries())
-  if (!unit_entries.length) return `Value`
+  if (unit_entries.length === 0) return `Value`
 
   const [unit, labels] = unit_entries[0]
   const unique_labels = [...new Set(labels)].sort().join(` / `)
@@ -470,7 +470,7 @@ export function generate_axis_labels(plot_series: DataSeries[]): {
   y1: string
   y2: string
 } {
-  if (!plot_series.length) return { y1: `Value`, y2: `Value` }
+  if (plot_series.length === 0) return { y1: `Value`, y2: `Value` }
 
   return {
     y1: get_axis_label(plot_series.filter((srs) => (srs.y_axis ?? `y1`) === `y1`)),
@@ -490,7 +490,7 @@ export function generate_streaming_plot_series(
   metadata_list: TrajectoryMetadata[],
   options: StreamingPlotOptions = {},
 ): DataSeries[] {
-  if (!metadata_list.length) return []
+  if (metadata_list.length === 0) return []
 
   const {
     property_config = trajectory_property_config,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -26,14 +26,18 @@ export const escape_html = (unsafe_string: string): string =>
     .replaceAll(`'`, `&#39;`)
 
 // Normalize unicode minus (U+2212) to ASCII hyphen-minus.
-export const normalize_unicode_minus = (value: string): string => value.replace(/−/g, `-`)
+export const normalize_unicode_minus = (value: string): string => value.replaceAll('−', `-`)
 
 // Normalize scientific notation variants (d/D exponent, Mathematica *^).
 export const normalize_scientific_notation = (value: string): string =>
-  normalize_unicode_minus(value).toLowerCase().replace(/d/g, `e`).replace(/\*\^/g, `e`)
+  normalize_unicode_minus(value).toLowerCase().replaceAll('d', `e`).replaceAll('*^', `e`)
+
+// Coerce an unknown thrown value into an Error (for typed Promise rejections / error callbacks).
+export const to_error = (value: unknown): Error =>
+  value instanceof Error ? value : new Error(String(value))
 
 export function make_change_detector(): (value: unknown) => boolean {
-  const unset = Symbol()
+  const unset = Symbol(`unset`)
   let prev: unknown = unset
   return (value: unknown) => {
     const changed = prev !== unset && value !== prev
@@ -46,7 +50,7 @@ export function make_change_detector(): (value: unknown) => boolean {
 // Converts `-` → `+`, `_` → `/`, restores padding, then decodes.
 // Returns undefined if decoding fails.
 export function decode_url_safe_base64(encoded: string): string | undefined {
-  const std_b64 = encoded.replace(/-/g, `+`).replace(/_/g, `/`)
+  const std_b64 = encoded.replaceAll('-', `+`).replaceAll('_', `/`)
   const padded = std_b64 + `=`.repeat((4 - (std_b64.length % 4)) % 4)
   try {
     return atob(padded)

--- a/src/lib/xrd/XrdPlot.svelte
+++ b/src/lib/xrd/XrdPlot.svelte
@@ -26,6 +26,7 @@
   import type { BroadeningParams } from './broadening'
   import { compute_broadened_pattern, DEFAULT_BROADENING } from './broadening'
   import type { Hkl, HklFormat, PatternEntry, XrdPattern } from './index'
+  import { to_error } from '$lib/utils'
 
   function is_xrd_pattern(obj: unknown): obj is XrdPattern {
     if (!obj || typeof obj !== `object`) return false
@@ -352,7 +353,7 @@
           }
         } catch (exc) {
           error_msg = `Failed to load file ${file.name}: ${
-            exc instanceof Error ? exc.message : String(exc)
+            to_error(exc).message
           }`
         }
       }

--- a/src/lib/xrd/calc-xrd.ts
+++ b/src/lib/xrd/calc-xrd.ts
@@ -362,7 +362,9 @@ export async function add_xrd_pattern(
       }
       // Get base extension (strip .gz if present) for error message
       const base_name = filename.toLowerCase().replace(/\.gz$/, ``)
-      const ext = base_name.split(`.`).pop()?.toUpperCase() ?? `XRD`
+      // truthiness (not ??) so an empty extension (filename ending in `.`) falls back to XRD
+      const last_part = base_name.split(`.`).pop()
+      const ext = last_part ? last_part.toUpperCase() : `XRD`
       const format_hints: Record<string, string> = {
         XY: `Expected 2-column format: "2theta intensity" (space/tab/comma separated)`,
         XYE: `Expected 3-column format: "2theta intensity error" (space/tab/comma separated)`,

--- a/src/lib/xrd/calc-xrd.ts
+++ b/src/lib/xrd/calc-xrd.ts
@@ -9,6 +9,7 @@ import { is_crystal } from '$lib/structure/validation'
 import ATOMIC_SCATTERING_PARAMS from './atomic_scattering_params.json' with { type: 'json' }
 import type { Hkl, HklObj, PatternEntry, RecipPoint, XrdOptions, XrdPattern } from './index'
 import { is_xrd_data_file, parse_xrd_file } from './parse'
+import { to_error } from '$lib/utils'
 
 // JSON import yields Record<string, number[][]>; type for element-keyed scattering params
 type ScatteringParamsRecord = Partial<
@@ -361,7 +362,7 @@ export async function add_xrd_pattern(
       }
       // Get base extension (strip .gz if present) for error message
       const base_name = filename.toLowerCase().replace(/\.gz$/, ``)
-      const ext = base_name.split(`.`).pop()?.toUpperCase() || `XRD`
+      const ext = base_name.split(`.`).pop()?.toUpperCase() ?? `XRD`
       const format_hints: Record<string, string> = {
         XY: `Expected 2-column format: "2theta intensity" (space/tab/comma separated)`,
         XYE: `Expected 3-column format: "2theta intensity error" (space/tab/comma separated)`,
@@ -389,7 +390,7 @@ export async function add_xrd_pattern(
     }
   } catch (exc) {
     return {
-      error: `Failed to compute XRD pattern: ${exc instanceof Error ? exc.message : String(exc)}`,
+      error: `Failed to compute XRD pattern: ${to_error(exc).message}`,
     }
   }
 }

--- a/src/lib/xrd/index.ts
+++ b/src/lib/xrd/index.ts
@@ -1,6 +1,7 @@
 import type { CompositionType } from '$lib/composition'
 import type { Vec3 } from '$lib/math'
 import type { RadiationKey } from './calc-xrd'
+
 export * from './broadening'
 export * from './calc-xrd'
 export * from './parse'

--- a/src/lib/xrd/parse.ts
+++ b/src/lib/xrd/parse.ts
@@ -407,7 +407,7 @@ function parse_bruker_raw_v1(view: DataView, bytes: Uint8Array): XrdPattern | nu
     // Find where binary data starts (after header)
     let data_offset = 512
     if (count_match) {
-      const expected_count = parseInt(count_match[1])
+      const expected_count = parseInt(count_match[1], 10)
       // Binary data is typically 4 bytes per intensity (float32)
       data_offset = bytes.length - expected_count * 4
     }
@@ -478,7 +478,7 @@ function parse_rigaku_raw_file(data: ArrayBuffer): XrdPattern | null {
 
     const start = start_match ? parseFloat(start_match[1]) : 0
     const step = step_match ? parseFloat(step_match[1]) : DEFAULT_STEP_SIZE
-    const expected_count = count_match ? parseInt(count_match[1]) : 0
+    const expected_count = count_match ? parseInt(count_match[1], 10) : 0
 
     // Find binary data section
     // Rigaku typically stores intensities as 32-bit floats or integers

--- a/src/routes/(demos)/convex-hull/chempot-diagram/+page.svelte
+++ b/src/routes/(demos)/convex-hull/chempot-diagram/+page.svelte
@@ -5,6 +5,7 @@
   import Spinner from '$lib/feedback/Spinner.svelte'
   import { onMount } from 'svelte'
   import { SvelteSet } from 'svelte/reactivity'
+  import { to_error } from '$lib/utils'
 
   // vite-plugin-json-gz decompresses each .json.gz at build time.
   // Lazy chunks are code-split and loaded on demand.
@@ -73,7 +74,7 @@
       all_entries = (await quaternary_files[li_co_ni_o_path]()).default
     } catch (error) {
       quaternary_error = `Failed to load data: ${
-        error instanceof Error ? error.message : String(error)
+        to_error(error).message
       }`
     } finally {
       quaternary_loading = false

--- a/src/routes/(demos)/phase-diagram/+page.svelte
+++ b/src/routes/(demos)/phase-diagram/+page.svelte
@@ -15,6 +15,7 @@
     parse_phase_diagram_svg,
     TdbInfoPanel,
   } from '$lib/phase-diagram'
+  import { to_error } from '$lib/utils'
   import {
     all_phase_diagram_files,
     find_precomputed_url,
@@ -45,7 +46,7 @@
 
   // Helper for consistent error formatting
   const format_error = (context: string, exc: unknown) =>
-    `${context}: ${exc instanceof Error ? exc.message : String(exc)}`
+    `${context}: ${to_error(exc).message}`
 
   // Token for race condition protection - each load gets a unique Symbol
   let active_load: symbol | null = null
@@ -82,7 +83,7 @@
     update_url_param: boolean = true,
     preserve_tdb: boolean = false,
   ): Promise<boolean> {
-    const token = Symbol()
+    const token = Symbol(`load-token`)
     active_load = token
     loading = true
     error_message = null
@@ -120,7 +121,7 @@
         current_file = filename
         if (update_url_param) update_url(filename)
         return true
-      } else {
+      }
         // JSON files: load directly
         const data = await load_binary_phase_diagram(url)
         if (is_stale(token)) return false
@@ -132,7 +133,7 @@
         current_file = filename
         if (update_url_param) update_url(filename)
         return true
-      }
+
     } catch (exc) {
       if (is_stale(token)) return false
       error_message = format_error(`Failed to load`, exc)

--- a/src/routes/(demos)/plot/data-cleaning/+page.svelte
+++ b/src/routes/(demos)/plot/data-cleaning/+page.svelte
@@ -162,7 +162,7 @@
       return { x: x_vals, y: add_nan_values(base, nan_probability) }
     } else if (data_type === `jumpy`) {
       return { x: x_vals, y: generate_jumpy(data_length, 4) }
-    } else {
+    }
       // combined
       let y_vals = generate_smooth(data_length)
       y_vals = add_noise(y_vals, noise_level * 0.5)
@@ -173,7 +173,7 @@
       )
       y_vals = add_nan_values(y_vals, nan_probability * 0.5)
       return { x: x_vals, y: y_vals }
-    }
+
   })
 
   // Derived: cleaned data

--- a/src/routes/(demos)/structure/coordination/+page.svelte
+++ b/src/routes/(demos)/structure/coordination/+page.svelte
@@ -52,7 +52,8 @@
     Object.fromEntries(
       selected_ids
         .map((id) => structures_by_id[id])
-        .filter((struct): struct is Crystal => !!struct)
+        // oxlint-disable-next-line eslint-plugin-unicorn/prefer-native-coercion-functions -- type predicate needed for narrowing
+        .filter((struct): struct is Crystal => Boolean(struct))
         .map((struct) => [
           `${struct.id} ${formula_for(struct.id ?? ``)}`,
           struct,

--- a/src/routes/(demos)/structure/isosurface/+page.svelte
+++ b/src/routes/(demos)/structure/isosurface/+page.svelte
@@ -20,6 +20,7 @@
     Structure,
   } from 'matterviz'
   import { onMount } from 'svelte'
+  import { to_error } from '$lib/utils'
 
   let structure = $state<AnyStructure | undefined>()
   let volumetric_data = $state<VolumetricData[] | undefined>()
@@ -116,7 +117,7 @@
       })
       parse_time_ms = Math.round(performance.now() - parse_start)
     } catch (error) {
-      error_msg = error instanceof Error ? error.message : String(error)
+      error_msg = to_error(error).message
     } finally {
       loading = false
     }

--- a/src/routes/(demos)/structure/xrd/+page.svelte
+++ b/src/routes/(demos)/structure/xrd/+page.svelte
@@ -9,6 +9,7 @@
   import { compute_xrd_pattern, XrdPlot } from '$lib/xrd'
   import { structures } from '$site/structures'
   import { SvelteMap } from 'svelte/reactivity'
+  import { to_error } from '$lib/utils'
 
   // Auto-discover XRD data files from static/xrd/ using Vite's import.meta.glob
   // Files are picked up at build time; restart dev server to see new files
@@ -102,7 +103,7 @@
         computed_pattern = result
       }
     } catch (exc) {
-      compute_error = exc instanceof Error ? exc.message : String(exc)
+      compute_error = to_error(exc).message
       computed_pattern = null
     }
   })

--- a/src/routes/test/brillouin-zone/+page.svelte
+++ b/src/routes/test/brillouin-zone/+page.svelte
@@ -45,7 +45,7 @@
     }
 
     if (params.has(`bz_order`)) {
-      const order = parseInt(params.get(`bz_order`) || `1`)
+      const order = parseInt(params.get(`bz_order`) || `1`, 10)
       if (!isNaN(order)) bz_order = order
     }
 

--- a/src/routes/test/convex-hull-performance/+page.svelte
+++ b/src/routes/test/convex-hull-performance/+page.svelte
@@ -107,7 +107,7 @@
     const params = new URLSearchParams(globalThis.location.search)
     const dim = params.get(`dim`)
     if (dim && [`2d`, `3d`, `4d`].includes(dim)) dimension = dim as Dimension
-    const cnt = parseInt(params.get(`count`) ?? ``)
+    const cnt = parseInt(params.get(`count`) ?? ``, 10)
     if (!isNaN(cnt) && cnt >= 10 && cnt <= 50000) entry_count = cnt
     const hull = parseFloat(params.get(`hull_dist`) ?? ``)
     if (!isNaN(hull) && hull >= 0) max_hull_dist = hull

--- a/src/routes/test/histogram/+page.svelte
+++ b/src/routes/test/histogram/+page.svelte
@@ -77,7 +77,7 @@
       { length: 1000 },
       () => Math.exp(Math.random() * 2 + 1),
     )
-    const power_law = Array.from({ length: 1000 }, () => Math.pow(Math.random(), -2))
+    const power_law = Array.from({ length: 1000 }, () => Math.random() ** -2)
 
     return [
       {
@@ -104,7 +104,7 @@
     if (distribution_type === `bimodal`) {
       values = [...generate_normal(300, 20, 3), ...generate_normal(300, 50, 4)]
     } else if (distribution_type === `skewed`) {
-      values = Array.from({ length: 500 }, () => Math.pow(Math.random(), 3) * 100)
+      values = Array.from({ length: 500 }, () => Math.random() ** 3 * 100)
     } else if (distribution_type === `discrete`) {
       values = Array.from({ length: 200 }, () => Math.floor(Math.random() * 6) + 1)
     } else if (distribution_type === `age`) {
@@ -141,9 +141,9 @@
         { ...base_series, label: `${bin_count_30} bins` },
         { ...base_series, label: `${bin_count_100} bins` },
       ] as DataSeries[]
-    } else {
-      return [{ ...base_series, label: `${single_bin_count} bins` }] as DataSeries[]
     }
+      return [{ ...base_series, label: `${single_bin_count} bins` }] as DataSeries[]
+
   })
 
   let tick_test_data = $derived.by(() => {

--- a/src/routes/test/scatter-plot/+page.svelte
+++ b/src/routes/test/scatter-plot/+page.svelte
@@ -151,7 +151,7 @@
     y: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
     color_values: Array(10)
       .fill(0)
-      .map((_, idx) => Math.pow(2, idx)),
+      .map((_, idx) => 2 ** idx),
     point_style: { radius: 10, stroke: `black`, stroke_width: 1 },
   }
 
@@ -194,7 +194,7 @@
       points.point_style.push({ fill: `purple`, radius: 5 })
       points.point_label.push({
         text: `${label_prefix}-${data_idx + 1}`,
-        auto_placement: auto_placement,
+        auto_placement,
         font_size: `10px`,
       })
     }

--- a/src/routes/test/structure-performance/+page.svelte
+++ b/src/routes/test/structure-performance/+page.svelte
@@ -70,9 +70,9 @@
 
     let random_idx = 0
     for (let idx = 0; idx < count; idx++) {
-      const grid_z = (idx / sites_per_layer) | 0
+      const grid_z = Math.trunc((idx / sites_per_layer))
       const remainder = idx - grid_z * sites_per_layer
-      const grid_y = (remainder / sites_per_edge) | 0
+      const grid_y = Math.trunc((remainder / sites_per_edge))
       const grid_x = remainder - grid_y * sites_per_edge
 
       const frac_x = (grid_x + 1) * spacing + randoms[random_idx++]
@@ -112,7 +112,7 @@
     const parse_int = (key: string, min: number, max: number, fallback: number) => {
       const val = params.get(key)
       if (!val) return fallback
-      const parsed = parseInt(val)
+      const parsed = parseInt(val, 10)
       return !isNaN(parsed) && parsed >= min && parsed <= max ? parsed : fallback
     }
 

--- a/src/routes/test/structure/+page.svelte
+++ b/src/routes/test/structure/+page.svelte
@@ -86,7 +86,7 @@
       if (!isNaN(opacity)) lattice_props.cell_surface_opacity = opacity
     }
     if (url_params.has(`cell_edge_width`)) {
-      const line_width = parseInt(url_params.get(`cell_edge_width`) || `1`)
+      const line_width = parseInt(url_params.get(`cell_edge_width`) || `1`, 10)
       if (!isNaN(line_width)) lattice_props.cell_edge_width = line_width
     }
 

--- a/src/site/electronic/bands/index.ts
+++ b/src/site/electronic/bands/index.ts
@@ -10,7 +10,7 @@ const imports = import.meta.glob<BaseBandStructure>([`./*-bands.json`, `./*-band
 // Export with IDs extracted from filenames (e.g. ./cao-2605-bands.json -> cao_2605)
 export const electronic_bands = Object.fromEntries(
   Object.entries(imports).map(([path, data]) => [
-    /\/([^/]+)-bands\.json(?:\.gz)?$/.exec(path)?.[1]?.replace(/-/g, `_`) ?? path,
+    /\/([^/]+)-bands\.json(?:\.gz)?$/.exec(path)?.[1]?.replaceAll('-', `_`) ?? path,
     data,
   ]),
 ) as Record<string, BaseBandStructure>

--- a/src/site/fermi-surfaces/index.ts
+++ b/src/site/fermi-surfaces/index.ts
@@ -21,10 +21,10 @@ const FRMSF_COLOR_DATA_FILES = new Set([
 // Convert glob results to FileInfo array with categories
 export const fermi_surface_files: FileInfo[] = Object.entries(fermi_file_modules)
   .map(([path, url]) => {
-    const name = path.split(`/`).pop() || path
+    const name = path.split(`/`).pop() ?? path
     // Remove .gz extension to get base format
     const base_name = name.replace(/\.gz$/i, ``)
-    const ext = base_name.split(`.`).pop()?.toLowerCase() || ``
+    const ext = base_name.split(`.`).pop()?.toLowerCase() ?? ``
 
     // Determine category and icon based on format and filename
     let category = `Unknown`

--- a/src/site/isosurfaces/index.ts
+++ b/src/site/isosurfaces/index.ts
@@ -86,7 +86,7 @@ const file_metadata: Record<string, { type: string; label: string; description: 
 
 export const volumetric_files: VolumetricFileInfo[] = Object.entries(volumetric_file_modules)
   .map(([path, url]) => {
-    const name = path.split(`/`).pop() || path
+    const name = path.split(`/`).pop() ?? path
     const meta = file_metadata[name] ?? {
       type: `unknown`,
       label: name,

--- a/src/site/molecules/index.ts
+++ b/src/site/molecules/index.ts
@@ -23,7 +23,7 @@ export const molecule_files: FileInfo[] = Object.entries(
     import: `default`,
   }),
 ).map(([path]) => {
-  const filename = path.split(`/`).pop() || path
+  const filename = path.split(`/`).pop() ?? path
   const type = path.split(`.`).pop()?.toUpperCase() ?? `FILE`
   const url = path.replace(`/src/site`, ``)
   return { name: filename, url, type, category: `molecule`, category_icon: `🧬` }

--- a/src/site/phase-diagrams/index.ts
+++ b/src/site/phase-diagrams/index.ts
@@ -20,7 +20,7 @@ const tdb_modules = import.meta.glob<string>(`./tdb/*.tdb`, {
 // Build all diagrams from JSON data
 const built_diagrams = new Map<string, PhaseDiagramData>()
 for (const [path, input] of Object.entries(diagram_modules)) {
-  const name = path.split(`/`).pop()?.replace(`.json`, ``) || path
+  const name = path.split(`/`).pop()?.replace(`.json`, ``) ?? path
   built_diagrams.set(name, build_diagram(input))
 }
 
@@ -38,7 +38,7 @@ export const binary_phase_diagram_files: FileInfo[] = Array.from(built_diagrams.
 
 // Convert glob results to FileInfo array for TDB files
 export const tdb_files: FileInfo[] = Object.entries(tdb_modules).map(([path, url]) => {
-  const name = path.split(`/`).pop() || path
+  const name = path.split(`/`).pop() ?? path
   return { name, url, type: `tdb`, category: `TDB`, category_icon: `📄` }
 })
 

--- a/src/site/plot-utils.ts
+++ b/src/site/plot-utils.ts
@@ -41,14 +41,14 @@ export const generate_log_normal = (count: number, mu: number, sigma: number) =>
 export const generate_power_law = (count: number, alpha: number, x_min = 1) =>
   Array.from({ length: count }, () => {
     const rand_val = Math.random()
-    return x_min * Math.pow(1 - rand_val, -1 / (alpha - 1))
+    return x_min * (1 - rand_val) ** (-1 / (alpha - 1))
   })
 
 // Generate Pareto distribution data
 export const generate_pareto = (count: number, x_min: number, alpha: number) =>
   Array.from({ length: count }, () => {
     const rand_val = Math.random()
-    return x_min * Math.pow(rand_val, -1 / alpha)
+    return x_min * rand_val ** (-1 / alpha)
   })
 
 // Generate gamma distribution data (approximation)
@@ -75,8 +75,7 @@ export function generate_gamma(count: number, alpha: number, beta: number): numb
       const u1 = Math.max(Math.random(), Number.EPSILON)
       const u2 = Math.max(Math.random(), Number.EPSILON)
       const beta_sample =
-        Math.pow(u1, 1 / frac_alpha) /
-        (Math.pow(u1, 1 / frac_alpha) + Math.pow(u2, 1 / (1 - frac_alpha)))
+        u1 ** (1 / frac_alpha) / (u1 ** (1 / frac_alpha) + u2 ** (1 / (1 - frac_alpha)))
       sum += (-Math.log(Math.max(Math.random(), Number.EPSILON)) * beta_sample) / beta
     }
 
@@ -100,7 +99,7 @@ export const generate_large_dataset = (count: number, type: `normal` | `uniform`
 
   if (type === `normal`) return generate_normal(count, 50, 15)
   else if (type === `uniform`) return generate_uniform(count, 0, 100)
-  else return generate_normal(count, 50, 15)
+  return generate_normal(count, 50, 15)
 }
 
 // Generate sparse data with many zeros

--- a/src/site/structures/index.ts
+++ b/src/site/structures/index.ts
@@ -48,7 +48,7 @@ export const structure_files: FileInfo[] = Object.entries(
 )
   .filter(([, content]) => typeof content === `string`)
   .map(([path, content]) => {
-    const filename = path.split(`/`).pop() || path
+    const filename = path.split(`/`).pop() ?? path
     const type = path.split(`.`).pop()?.toUpperCase() ?? `FILE`
     const url = path.replace(`/src/site`, ``)
 

--- a/tests/playwright/brillouin-zone.test.ts
+++ b/tests/playwright/brillouin-zone.test.ts
@@ -226,7 +226,7 @@ test.describe(`BrillouinZone IBZ (Irreducible Brillouin Zone) Tests`, () => {
     // Should have vertices
     await expect(async () => {
       const count = await vertices_count.textContent()
-      expect(parseInt(count || `0`)).toBeGreaterThan(0)
+      expect(parseInt(count ?? `0`, 10)).toBeGreaterThan(0)
     }).toPass({ timeout: 5000 })
   })
 

--- a/tests/playwright/convex-hull/convex-hull-2d.test.ts
+++ b/tests/playwright/convex-hull/convex-hull-2d.test.ts
@@ -89,7 +89,7 @@ test.describe(`ConvexHull2D (Binary)`, () => {
       const text = await info.getByTestId(`hull-visible-unstable`).textContent()
       // Format: Visible unstable: X / Y
       const match = text?.match(/(\d+)\s*\/\s*(\d+)/)
-      return match ? { x: parseInt(match[1]), y: parseInt(match[2]) } : { x: 0, y: 0 }
+      return match ? { x: parseInt(match[1], 10), y: parseInt(match[2], 10) } : { x: 0, y: 0 }
     }
 
     const before = await get_visible_unstable()
@@ -141,7 +141,7 @@ test.describe(`ConvexHull2D (Binary)`, () => {
     const get_visible_unstable = async () => {
       const text = await info.getByTestId(`hull-visible-unstable`).textContent()
       const match = text?.match(/(\d+)\s*\/\s*(\d+)/)
-      return match ? parseInt(match[1]) : 0
+      return match ? parseInt(match[1], 10) : 0
     }
     const before = await get_visible_unstable()
     // Toggle 'Above hull' off

--- a/tests/playwright/element-data.ts
+++ b/tests/playwright/element-data.ts
@@ -1,13 +1,9 @@
 import type { ChemicalElement } from '$lib/element/types'
 import { readFileSync } from 'node:fs'
-import { dirname, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { resolve } from 'node:path'
 import { gunzipSync } from 'node:zlib'
 
-const data_gz_path = resolve(
-  dirname(fileURLToPath(import.meta.url)),
-  `../../src/lib/element/data.json.gz`,
-)
+const data_gz_path = resolve(import.meta.dirname, `../../src/lib/element/data.json.gz`)
 
 export default JSON.parse(
   gunzipSync(readFileSync(data_gz_path)).toString(`utf8`),

--- a/tests/playwright/periodic-table.test.ts
+++ b/tests/playwright/periodic-table.test.ts
@@ -312,7 +312,7 @@ test.describe(`Periodic Table`, () => {
           const heatmap_val = format_num(heatmap_value)
 
           // make sure heatmap value is displayed correctly (use regex for flexible whitespace)
-          const escaped_val = heatmap_val.replace(/[.*+?^${}()|[\]\\]/g, `\\$&`)
+          const escaped_val = heatmap_val.replaceAll(/[.*+?^${}()|[\]\\]/g, `\\$&`)
           const tiles_with_text = await tiles
             .filter({
               hasText: new RegExp(

--- a/tests/playwright/phase-diagram/isobaric-binary.test.ts
+++ b/tests/playwright/phase-diagram/isobaric-binary.test.ts
@@ -151,8 +151,8 @@ test.describe(`IsobaricBinaryPhaseDiagram`, () => {
 
     // X-axis: composition 0-100
     const x_ticks = svg.locator(`g.x-axis > g text`)
-    expect(parseFloat((await x_ticks.first().textContent()) || ``)).toBe(0)
-    expect(parseFloat((await x_ticks.last().textContent()) || ``)).toBeGreaterThanOrEqual(80)
+    expect(parseFloat((await x_ticks.first().textContent()) ?? ``)).toBe(0)
+    expect(parseFloat((await x_ticks.last().textContent()) ?? ``)).toBeGreaterThanOrEqual(80)
 
     // Y-axis: temperature label
     await expect(

--- a/tests/playwright/plot/histogram.test.ts
+++ b/tests/playwright/plot/histogram.test.ts
@@ -51,7 +51,7 @@ const get_histogram_tick_range = async (axis_locator: Locator) => {
   const tick_elements = await axis_locator.locator(`.tick text`).all()
   const tick_texts = await Promise.all(tick_elements.map((tick) => tick.textContent()))
   const ticks = tick_texts
-    .map((text) => (text ? Number(text.replace(/[^\deE.+-]/g, ``)) : NaN))
+    .map((text) => (text ? Number(text.replaceAll(/[^\deE.+-]/g, ``)) : NaN))
     .filter((num) => !isNaN(num))
 
   if (ticks.length < 2) return { ticks, range: 0 }
@@ -168,7 +168,7 @@ test.describe(`Histogram Component Tests`, () => {
     expect(series_bars.length).toBeGreaterThan(0)
 
     const stroke_width = await series_bars[0].getAttribute(`stroke-width`)
-    expect(parseFloat(stroke_width || `0`)).toBeGreaterThan(0)
+    expect(parseFloat(stroke_width ?? `0`)).toBeGreaterThan(0)
 
     // Verify histogram remains functional after initial render
     await expect(histogram.locator(`g.x-axis`)).toBeVisible()

--- a/tests/playwright/plot/scatter-plot.test.ts
+++ b/tests/playwright/plot/scatter-plot.test.ts
@@ -36,7 +36,7 @@ const get_legend_position = async (
 
   return legend_wrapper.evaluate((el) => {
     const rect = el.getBoundingClientRect()
-    const parent_rect = (el as HTMLElement).offsetParent?.getBoundingClientRect() || {
+    const parent_rect = (el as HTMLElement).offsetParent?.getBoundingClientRect() ?? {
       x: 0,
       y: 0,
     }

--- a/tests/playwright/plot/spacegroup-bar-plot.test.ts
+++ b/tests/playwright/plot/spacegroup-bar-plot.test.ts
@@ -210,7 +210,7 @@ test.describe(`SpacegroupBarPlot Component Tests`, () => {
 
     // All should have some opacity for background effect
     const opacities = await system_rects.evaluateAll((rects) =>
-      rects.map((rect) => parseFloat(rect.getAttribute(`opacity`) || `1`)),
+      rects.map((rect) => parseFloat(rect.getAttribute(`opacity`) ?? `1`)),
     )
 
     // Background rectangles should have low opacity

--- a/tests/playwright/rdf/rdf-plot.test.ts
+++ b/tests/playwright/rdf/rdf-plot.test.ts
@@ -75,8 +75,8 @@ test.describe(`RdfPlot Component Tests`, () => {
     await expect(tooltip).toBeVisible({ timeout: 3000 })
     const text = await tooltip.textContent()
     // Default ScatterPlot tooltip shows "x: <number>" and "y: <number>"
-    expect(text || ``).toMatch(/x:\s*-?\d+\.?\d*/)
-    expect(text || ``).toMatch(/y:\s*-?\d+\.?\d*/)
+    expect(text ?? ``).toMatch(/x:\s*-?\d+\.?\d*/)
+    expect(text ?? ``).toMatch(/y:\s*-?\d+\.?\d*/)
   })
 
   // Test reference line

--- a/tests/playwright/spectral/dos.test.ts
+++ b/tests/playwright/spectral/dos.test.ts
@@ -47,7 +47,7 @@ test.describe(`DOS Component Tests`, () => {
     ).toBeVisible()
     const y_ticks = await max_plot.locator(`g.y-axis text`).allTextContents()
     const nums = y_ticks
-      .map((tick) => Number.parseFloat(tick.replace(/[^\d.\-+eE]/g, ``)))
+      .map((tick) => Number.parseFloat(tick.replaceAll(/[^\d.\-+eE]/g, ``)))
       .filter(Number.isFinite)
     const max_val = Math.max(...nums)
     expect(max_val).toBeLessThanOrEqual(1.01) // Small margin for tick rounding
@@ -280,7 +280,7 @@ test.describe(`DOS Component Tests`, () => {
           tooltip_text.indexOf(`Frequency`),
           tooltip_text.indexOf(`Energy`),
         ].filter((idx) => idx >= 0)
-        const freq_idx = freq_candidates.length ? Math.min(...freq_candidates) : -1
+        const freq_idx = freq_candidates.length > 0 ? Math.min(...freq_candidates) : -1
         const density_idx = tooltip_text.indexOf(`Density`)
 
         // Both should be present
@@ -341,7 +341,7 @@ test.describe(`DOS Component Tests`, () => {
           tooltip_text.indexOf(`Frequency`),
           tooltip_text.indexOf(`Energy`),
         ].filter((idx) => idx >= 0)
-        const freq_idx = freq_candidates.length ? Math.min(...freq_candidates) : -1
+        const freq_idx = freq_candidates.length > 0 ? Math.min(...freq_candidates) : -1
         const density_idx = tooltip_text.indexOf(`Density`)
 
         // Both should be present

--- a/tests/playwright/structure/structure.test.ts
+++ b/tests/playwright/structure/structure.test.ts
@@ -283,7 +283,7 @@ test.describe(`Structure Component Tests`, () => {
     await page.keyboard.press(`i`)
 
     // Should not be in fullscreen mode after 'f' key
-    const is_fullscreen = await page.evaluate(() => !!document.fullscreenElement)
+    const is_fullscreen = await page.evaluate(() => Boolean(document.fullscreenElement))
     expect(is_fullscreen).toBe(false)
 
     // Test that modifier key combinations can be dispatched without errors
@@ -560,22 +560,22 @@ test.describe(`Structure Component Tests`, () => {
 
     // Check initial value
     const initial_value = await padding_number_input.inputValue()
-    expect(parseInt(initial_value)).toBeGreaterThanOrEqual(0)
+    expect(parseInt(initial_value, 10)).toBeGreaterThanOrEqual(0)
 
     // Test number input
     await padding_number_input.fill(`5`)
     const number_value = await padding_number_input.inputValue()
-    expect(parseInt(number_value)).toBe(5)
+    expect(parseInt(number_value, 10)).toBe(5)
 
     // Test range input
     await padding_range_input.fill(`8`)
     const range_value = await padding_range_input.inputValue()
-    expect(parseInt(range_value)).toBe(8)
+    expect(parseInt(range_value, 10)).toBe(8)
 
     // Verify inputs are synchronized
     const final_number_value = await padding_number_input.inputValue()
     const final_range_value = await padding_range_input.inputValue()
-    expect(parseInt(final_number_value)).toBe(parseInt(final_range_value))
+    expect(parseInt(final_number_value, 10)).toBe(parseInt(final_range_value, 10))
   })
 
   test(`label offset X control works correctly`, async ({ page }) => {
@@ -1668,7 +1668,7 @@ test.describe(`Export Button Tests`, () => {
 
     // Test changing DPI value
     const initial_value = await dpi_input.inputValue()
-    expect(parseInt(initial_value)).toBeGreaterThanOrEqual(72)
+    expect(parseInt(initial_value, 10)).toBeGreaterThanOrEqual(72)
 
     await dpi_input.fill(`200`)
     expect(await dpi_input.inputValue()).toBe(`200`)
@@ -2629,7 +2629,7 @@ test.describe(`Structure Rotation Controls Tests`, () => {
       await expect(y_range_input).toHaveValue(expected)
 
       // For valid values, number input should match
-      if (parseInt(input) <= 360) {
+      if (parseInt(input, 10) <= 360) {
         await expect(y_number_input).toHaveValue(expected)
       }
     }

--- a/tests/playwright/trajectory-performance.test.ts
+++ b/tests/playwright/trajectory-performance.test.ts
@@ -54,7 +54,7 @@ test.describe(`Trajectory Performance Tests`, () => {
 
     const step_text = await step_info.textContent()
     const max_step_match = step_text?.match(/\/ (\d+)/)
-    const max_step = max_step_match ? parseInt(max_step_match[1]) : 0
+    const max_step = max_step_match ? parseInt(max_step_match[1], 10) : 0
 
     expect(max_step).toBeGreaterThanOrEqual(200)
 
@@ -99,7 +99,7 @@ test.describe(`Trajectory Performance Tests`, () => {
       (target) => {
         const step_input_el = document.querySelector(`.step-input`) as HTMLInputElement
         if (!step_input_el) return false
-        const current_step = parseInt(step_input_el.value)
+        const current_step = parseInt(step_input_el.value, 10)
         return current_step >= target
       },
       target_step,
@@ -235,7 +235,7 @@ test.describe(`Trajectory Performance Tests`, () => {
 
     // Wait for playback to start and progress a few steps
     const initial_step = await step_input.inputValue()
-    const start_step = parseInt(initial_step)
+    const start_step = parseInt(initial_step, 10)
     expect(start_step).toBeGreaterThanOrEqual(0)
 
     // Wait for progression observing step change
@@ -243,14 +243,14 @@ test.describe(`Trajectory Performance Tests`, () => {
     await page.waitForFunction(
       (start_step_value) => {
         const step_input_el = document.querySelector(`.step-input`) as HTMLInputElement
-        return step_input_el && parseInt(step_input_el.value) > start_step_value
+        return step_input_el && parseInt(step_input_el.value, 10) > start_step_value
       },
       start_step,
       { timeout: 30000 },
     )
 
     const current_step = await step_input.inputValue()
-    const progressed_step = parseInt(current_step)
+    const progressed_step = parseInt(current_step, 10)
     expect(progressed_step).toBeGreaterThan(start_step)
 
     await play_button.click() // Stop playback

--- a/tests/playwright/xrd-plot.test.ts
+++ b/tests/playwright/xrd-plot.test.ts
@@ -34,7 +34,7 @@ test.describe(`XrdPlot Component Tests`, () => {
     const tooltip = plot.locator(`.plot-tooltip`)
     await expect(tooltip).toBeVisible({ timeout: 3000 })
     const text = await tooltip.textContent()
-    expect(text || ``).toContain(`2θ:`)
+    expect(text ?? ``).toContain(`2θ:`)
     // hkl and d are conditional; ensure tooltip structure exists
   })
 

--- a/tests/vitest/FilePicker.test.ts
+++ b/tests/vitest/FilePicker.test.ts
@@ -55,9 +55,9 @@ describe(`FilePicker`, () => {
 
         if (is_active_test) {
           const active_elements = document.querySelectorAll(`.file-item.active`)
-          expect(active_elements.length).toBe(expected_count)
+          expect(active_elements).toHaveLength(expected_count)
         } else {
-          expect(carousel.children.length).toBe(expected_count)
+          expect(carousel.children).toHaveLength(expected_count)
         }
       },
     )
@@ -69,7 +69,7 @@ describe(`FilePicker`, () => {
       ]
       mount(FilePicker, { target: document.body, props: { files: labeled } })
       const badges = document.querySelectorAll(`.file-type-badge`)
-      expect(badges.length).toBe(1)
+      expect(badges).toHaveLength(1)
       expect(badges[0].textContent).toBe(`CHGCAR`)
     })
   })
@@ -174,7 +174,7 @@ describe(`FilePicker`, () => {
       })
 
       // Should only show crystal files, not uncategorized or molecule files
-      expect(filtered.length).toBe(2)
+      expect(filtered).toHaveLength(2)
       expect(filtered[0].name).toBe(`structure1.cif`)
       expect(filtered[1].name).toBe(`another.cif`)
     })
@@ -192,7 +192,7 @@ describe(`FilePicker`, () => {
       const get_base_file_type = (file: FileInfo): string => {
         let base_name = file.name.toLowerCase()
         if (base_name.endsWith(`.gz`)) base_name = base_name.slice(0, -3)
-        return base_name.split(`.`).pop() || `file`
+        return base_name.split(`.`).pop() ?? `file`
       }
 
       const active_type_filter = `xyz`
@@ -205,7 +205,7 @@ describe(`FilePicker`, () => {
       })
 
       // Should only show XYZ files
-      expect(filtered.length).toBe(2)
+      expect(filtered).toHaveLength(2)
       expect(filtered[0].name).toBe(`molecule.xyz`)
       expect(filtered[1].name).toBe(`another.xyz`)
     })
@@ -218,14 +218,14 @@ describe(`FilePicker`, () => {
       // Clear filters
       active_category_filter = null
       active_type_filter = null
-      expect(active_category_filter).toBe(null)
-      expect(active_type_filter).toBe(null)
+      expect(active_category_filter).toBeNull()
+      expect(active_type_filter).toBeNull()
 
       // Test mutual exclusion
       active_category_filter = `crystal`
       active_type_filter = `xyz`
       active_category_filter = null
-      expect(active_category_filter).toBe(null)
+      expect(active_category_filter).toBeNull()
       expect(active_type_filter).toBe(`xyz`)
     })
   })
@@ -247,7 +247,7 @@ describe(`FilePicker`, () => {
         if (should_exist) {
           expect(elements.length).toBeGreaterThan(0)
         } else {
-          expect(elements.length).toBe(0)
+          expect(elements).toHaveLength(0)
         }
       },
     )
@@ -330,7 +330,7 @@ describe(`FilePicker`, () => {
 
       const carousel = doc_query(`.file-picker`)
       expect(carousel).toBeInstanceOf(HTMLElement)
-      expect(carousel.children.length).toBe(1) // Only legend
+      expect(carousel.children).toHaveLength(1) // Only legend
     })
 
     it(`handles with empty active_files correctly`, () => {
@@ -340,7 +340,7 @@ describe(`FilePicker`, () => {
       })
 
       const active_elements = document.querySelectorAll(`.file-item.active`)
-      expect(active_elements.length).toBe(0)
+      expect(active_elements).toHaveLength(0)
     })
 
     it(`handles with show_category_filters disabled correctly`, () => {

--- a/tests/vitest/brillouin-compute.test.ts
+++ b/tests/vitest/brillouin-compute.test.ts
@@ -105,9 +105,9 @@ describe(`compute_brillouin_zone`, () => {
 
   test(`cubic BZ: 8 vertices, 12 triangulated faces, 12 edges`, () => {
     const bz = compute_brillouin_zone(reference_data.cubic.reciprocal_lattice as Matrix3x3, 1)
-    expect(bz.vertices.length).toBe(8)
-    expect(bz.faces.length).toBe(12)
-    expect(bz.edges.length).toBe(12)
+    expect(bz.vertices).toHaveLength(8)
+    expect(bz.faces).toHaveLength(12)
+    expect(bz.edges).toHaveLength(12)
   })
 
   test(`inversion symmetry`, () => {
@@ -128,7 +128,7 @@ describe(`BZ edge filtering`, () => {
     [`hexagonal`, 18],
   ] as [keyof typeof reference_data, number][])(`%s has %d edges`, (name, expected_count) => {
     const bz = compute_brillouin_zone(reference_data[name].reciprocal_lattice as Matrix3x3, 1)
-    expect(bz.edges.length).toBe(expected_count)
+    expect(bz.edges).toHaveLength(expected_count)
   })
 
   test(`valid edge topology: no duplicates, edges shared by 2 faces`, () => {
@@ -189,7 +189,7 @@ describe(`generate_bz_vertices`, () => {
 
   test(`cubic BZ: 8 vertices at corners`, () => {
     const vertices = generate_bz_vertices(k_lattice, 1)
-    expect(vertices.length).toBe(8)
+    expect(vertices).toHaveLength(8)
     const k_max = Math.PI / 5
     vertices.forEach((v) => v.forEach((c) => expect(Math.abs(c)).toBeCloseTo(k_max, 5)))
   })
@@ -244,9 +244,9 @@ describe(`compute_convex_hull`, () => {
     `%s: %d vertices, %d faces, %d edges`,
     (_, vertices, v_count, f_count, e_count) => {
       const hull = compute_convex_hull(vertices)
-      expect(hull.vertices.length).toBe(v_count)
-      expect(hull.faces.length).toBe(f_count)
-      expect(hull.edges.length).toBe(e_count)
+      expect(hull.vertices).toHaveLength(v_count)
+      expect(hull.faces).toHaveLength(f_count)
+      expect(hull.edges).toHaveLength(e_count)
     },
   )
 

--- a/tests/vitest/chempot-diagram/compute.test.ts
+++ b/tests/vitest/chempot-diagram/compute.test.ts
@@ -34,12 +34,10 @@ import type { PhaseData } from '$lib/convex-hull/types'
 import type { Vec2 } from '$lib/math'
 import { convex_hull_2d, polygon_centroid, solve_linear_system } from '$lib/math'
 import { readFileSync } from 'node:fs'
-import { dirname } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { gunzipSync } from 'node:zlib'
 import { describe, expect, test } from 'vitest'
 
-const test_dir = dirname(fileURLToPath(import.meta.url))
+const test_dir = import.meta.dirname
 
 function load_gzip_json(filename: string): PhaseData[] {
   const compressed_bytes = readFileSync(`${test_dir}/${filename}`)
@@ -121,9 +119,9 @@ function dedup_vertices(pts: number[][], tol: number = 1e-4): number[][] {
 
 describe(`pymatgen parity: ChemicalPotentialDiagram`, () => {
   test(`dim`, () => {
-    expect(cpd_binary.elements.length).toBe(2)
-    expect(cpd_ternary.elements.length).toBe(3)
-    expect(cpd_ternary_formal.elements.length).toBe(3)
+    expect(cpd_binary.elements).toHaveLength(2)
+    expect(cpd_ternary.elements).toHaveLength(3)
+    expect(cpd_ternary_formal.elements).toHaveLength(3)
   })
 
   test(`elements sorted alphabetically`, () => {
@@ -131,9 +129,9 @@ describe(`pymatgen parity: ChemicalPotentialDiagram`, () => {
   })
 
   test(`el_refs (absolute)`, () => {
-    expect(cpd_ternary.el_refs[`Li`].energy).toBeCloseTo(-1.91301487, 5)
-    expect(cpd_ternary.el_refs[`Fe`].energy).toBeCloseTo(-6.5961471, 5)
-    expect(cpd_ternary.el_refs[`O`].energy).toBeCloseTo(-25.54966885, 5)
+    expect(cpd_ternary.el_refs.Li.energy).toBeCloseTo(-1.91301487, 5)
+    expect(cpd_ternary.el_refs.Fe.energy).toBeCloseTo(-6.5961471, 5)
+    expect(cpd_ternary.el_refs.O.energy).toBeCloseTo(-25.54966885, 5)
   })
 
   test(`el_refs (formal) are zero`, () => {
@@ -259,7 +257,7 @@ describe(`pymatgen parity: ChemicalPotentialDiagram`, () => {
     expect(actual_pts, `Domain missing for ${our_key}`).toBeDefined()
     const sorted_actual = sort_rows(dedup_vertices(actual_pts))
     const sorted_expected = sort_rows(reorder_cols(pmg_vertices))
-    expect(sorted_actual.length).toBe(sorted_expected.length)
+    expect(sorted_actual).toHaveLength(sorted_expected.length)
     for (let idx = 0; idx < sorted_expected.length; idx++) {
       for (let jdx = 0; jdx < sorted_expected[idx].length; jdx++) {
         expect(sorted_actual[idx][jdx]).toBeCloseTo(sorted_expected[idx][jdx], 4)
@@ -307,8 +305,8 @@ describe(`physical invariants`, () => {
   test(`elemental domains touch the el_ref energy axis`, () => {
     // For absolute chempots: the Fe domain should have vertices where
     // mu_Fe = E_ref(Fe) (the elemental reference energy per atom)
-    const fe_ref_e = cpd_ternary.el_refs[`Fe`].energy
-    const fe_domain = dedup_vertices(cpd_ternary.domains[`Fe`])
+    const fe_ref_e = cpd_ternary.el_refs.Fe.energy
+    const fe_domain = dedup_vertices(cpd_ternary.domains.Fe)
     // Fe column is index 0 (alphabetical: Fe, Li, O)
     const fe_vals = fe_domain.map((pt) => pt[0])
     expect(fe_vals.some((val) => Math.abs(val - fe_ref_e) < 0.01)).toBe(true)
@@ -375,12 +373,12 @@ describe(`binary system (2 elements)`, () => {
   })
 
   test(`elemental ref energies match input`, () => {
-    expect(binary_simple.el_refs[`A`].energy_per_atom).toBe(-2.0)
-    expect(binary_simple.el_refs[`B`].energy_per_atom).toBe(-3.0)
+    expect(binary_simple.el_refs.A.energy_per_atom).toBe(-2.0)
+    expect(binary_simple.el_refs.B.energy_per_atom).toBe(-3.0)
   })
 
   test(`compound domain vertices lie between element refs`, () => {
-    const ab_domain = dedup_vertices(binary_simple.domains[`AB`])
+    const ab_domain = dedup_vertices(binary_simple.domains.AB)
     // AB domain should not extend beyond the elemental reference energies
     for (const pt of ab_domain) {
       expect(pt[0]).toBeLessThanOrEqual(-2.0 + 1e-4) // mu_A <= E_A
@@ -398,8 +396,8 @@ describe(`binary system (2 elements)`, () => {
       { default_min_limit: -20, formal_chempots: true },
     )
 
-    expect(formal.el_refs[`A`].energy_per_atom).toBeCloseTo(0, 8)
-    expect(formal.el_refs[`B`].energy_per_atom).toBeCloseTo(0, 8)
+    expect(formal.el_refs.A.energy_per_atom).toBeCloseTo(0, 8)
+    expect(formal.el_refs.B.energy_per_atom).toBeCloseTo(0, 8)
   })
 
   test(`tighter limits produce vertices within bounds`, () => {
@@ -475,7 +473,7 @@ describe(`get_min_entries_and_el_refs`, () => {
       make_entry({ A: 1 }, -2.0), // lower energy
       make_entry({ A: 1 }, -0.5),
     ])
-    expect(min_entries.length).toBe(1)
+    expect(min_entries).toHaveLength(1)
     expect(min_entries[0].energy_per_atom).toBe(-2.0)
   })
 
@@ -485,9 +483,9 @@ describe(`get_min_entries_and_el_refs`, () => {
       make_entry({ B: 1 }, -2.0),
       make_entry({ A: 1, B: 1 }, -3.0),
     ])
-    expect(min_entries.length).toBe(3)
-    expect(el_refs[`A`].energy_per_atom).toBe(-1.0)
-    expect(el_refs[`B`].energy_per_atom).toBe(-2.0)
+    expect(min_entries).toHaveLength(3)
+    expect(el_refs.A.energy_per_atom).toBe(-1.0)
+    expect(el_refs.B.energy_per_atom).toBe(-2.0)
   })
 
   test(`handles multiple polymorphs of same composition`, () => {
@@ -497,8 +495,8 @@ describe(`get_min_entries_and_el_refs`, () => {
       make_entry({ Fe: 1 }, -6.2),
       make_entry({ O: 2 }, -8.0),
     ])
-    expect(min_entries.length).toBe(2)
-    expect(el_refs[`Fe`].energy_per_atom).toBe(-6.5)
+    expect(min_entries).toHaveLength(2)
+    expect(el_refs.Fe.energy_per_atom).toBe(-6.5)
   })
 })
 
@@ -545,7 +543,7 @@ describe(`build_hyperplanes`, () => {
   }
   const ab_entry = make_entry({ A: 1, B: 1 }, -6.0)
   const { hyperplanes, hyperplane_entries } = build_hyperplanes(
-    [el_refs[`A`], el_refs[`B`], ab_entry],
+    [el_refs.A, el_refs.B, ab_entry],
     el_refs,
     [`A`, `B`],
   )
@@ -556,7 +554,7 @@ describe(`build_hyperplanes`, () => {
 
   test(`rows have dim+1 columns and atomic fractions sum to 1`, () => {
     for (const row of hyperplanes) {
-      expect(row.length).toBe(3) // [x_A, x_B, -E]
+      expect(row).toHaveLength(3) // [x_A, x_B, -E]
       expect(row[0] + row[1]).toBeCloseTo(1.0, 8)
     }
   })
@@ -822,7 +820,7 @@ describe(`convex_hull_2d`, () => {
   ] as { pts: Vec2[]; n: number; label: string }[])(
     `$label → $n hull vertices`,
     ({ pts, n }) => {
-      expect(convex_hull_2d(pts).length).toBe(n)
+      expect(convex_hull_2d(pts)).toHaveLength(n)
     },
   )
 
@@ -1065,7 +1063,7 @@ describe(`config.elements projection vs subsystem`, () => {
     })
     expect(result.elements).toEqual([`Fe`, `Li`, `O`])
     // Same domain count as cpd_ternary (computed without config.elements)
-    expect(Object.keys(result.domains).length).toBe(Object.keys(cpd_ternary.domains).length)
+    expect(Object.keys(result.domains)).toHaveLength(Object.keys(cpd_ternary.domains).length)
   })
 
   // === Stability: configuration sensitivity ===
@@ -1085,14 +1083,14 @@ describe(`config.elements projection vs subsystem`, () => {
       const is_interior = (pt: number[], min_lim: number) =>
         pt.every((val) => Math.abs(val - min_lim) > 1 && Math.abs(val) > 1)
 
-      const feo_tight_interior = dedup_vertices(tight.domains[`FeO`] ?? []).filter((pt) =>
+      const feo_tight_interior = dedup_vertices(tight.domains.FeO ?? []).filter((pt) =>
         is_interior(pt, -15),
       )
-      const feo_wide_interior = dedup_vertices(wide.domains[`FeO`] ?? []).filter((pt) =>
+      const feo_wide_interior = dedup_vertices(wide.domains.FeO ?? []).filter((pt) =>
         is_interior(pt, -50),
       )
 
-      expect(feo_tight_interior.length).toBe(feo_wide_interior.length)
+      expect(feo_tight_interior).toHaveLength(feo_wide_interior.length)
       const sorted_t = sort_rows(feo_tight_interior)
       const sorted_w = sort_rows(feo_wide_interior)
       for (let idx = 0; idx < sorted_t.length; idx++) {
@@ -1167,14 +1165,14 @@ describe(`YTOS quaternary system (projection mode)`, () => {
   test(`projected vertices have 3 columns`, () => {
     for (const pts of Object.values(ytos_y_ti_o.domains)) {
       for (const pt of pts) {
-        expect(pt.length).toBe(3)
+        expect(pt).toHaveLength(3)
       }
     }
   })
 
   test(`projected lims have 3 entries`, () => {
-    expect(ytos_y_ti_o.lims.length).toBe(3)
-    expect(ytos_ti_o_s.lims.length).toBe(3)
+    expect(ytos_y_ti_o.lims).toHaveLength(3)
+    expect(ytos_ti_o_s.lims).toHaveLength(3)
   })
 
   test(`formal chempots are non-positive in projected coordinates`, () => {
@@ -1260,7 +1258,7 @@ describe(`build_axis_ranges`, () => {
 
   test(`elements longer than point dimensions produces Infinity`, () => {
     const result = build_axis_ranges([[1, 2]], [`A`, `B`, `C`])
-    expect(result.length).toBe(3)
+    expect(result).toHaveLength(3)
     // axis 2 reads undefined from points → loop finds no finite values
     expect(result[2].min_val).toBe(Infinity)
     expect(result[2].max_val).toBe(-Infinity)
@@ -1336,7 +1334,7 @@ describe(`dedup_points`, () => {
     },
   ])(`$label → $n_unique unique`, ({ pts, tol, n_unique, indices }) => {
     const result = dedup_points(pts, tol)
-    expect(result.unique.length).toBe(n_unique)
+    expect(result.unique).toHaveLength(n_unique)
     expect(result.orig_indices).toEqual(indices)
     // unique points should match the points at orig_indices
     for (let idx = 0; idx < result.unique.length; idx++) {
@@ -1462,7 +1460,7 @@ describe(`get_3d_domain_simplexes_and_ann_loc`, () => {
     },
   ])(`$label → $n_edges edges`, ({ pts, n_edges, ann_loc }) => {
     const result = get_3d_domain_simplexes_and_ann_loc(pts)
-    expect(result.simplex_indices.length).toBe(n_edges)
+    expect(result.simplex_indices).toHaveLength(n_edges)
     if (ann_loc) expect(result.ann_loc).toEqual(ann_loc)
     if (n_edges > 0) assert_valid_edges(result, pts.length)
   })
@@ -1488,7 +1486,7 @@ describe(`get_3d_domain_simplexes_and_ann_loc`, () => {
       [10, 0, 0],
     ]
     const result = get_3d_domain_simplexes_and_ann_loc(pts)
-    expect(result.simplex_indices.length).toBe(3)
+    expect(result.simplex_indices).toHaveLength(3)
     expect(result.simplex_indices.flat().every((idx) => idx <= 2)).toBe(true)
     assert_valid_edges(result, pts.length)
   })
@@ -1587,7 +1585,7 @@ describe(`compute_domains`, () => {
   test(`unstable compound → no domain for AB`, () => {
     // AB with E_per_atom = -2.0 is above hull → no stability domain
     const { domains } = make_ab_domains(-2.0)
-    expect(domains[`AB`]).toBeUndefined()
+    expect(domains.AB).toBeUndefined()
   })
 })
 
@@ -1625,11 +1623,11 @@ describe(`compute_chempot_diagram edge cases`, () => {
     )
     // Verify axes actually swapped: Fe domain's O-axis range (col 0 in reordered)
     // should match its col 2 range in default [Fe,Li,O] order
-    const fe_reordered = dedup_vertices(reordered.domains[`Fe`])
-    const fe_default = dedup_vertices(cpd_ternary.domains[`Fe`])
+    const fe_reordered = dedup_vertices(reordered.domains.Fe)
+    const fe_default = dedup_vertices(cpd_ternary.domains.Fe)
     const re_o_vals = fe_reordered.map((pt) => pt[0]).sort((val_a, val_b) => val_a - val_b)
     const def_o_vals = fe_default.map((pt) => pt[2]).sort((val_a, val_b) => val_a - val_b) // O is axis 2 in default
-    expect(re_o_vals.length).toBe(def_o_vals.length)
+    expect(re_o_vals).toHaveLength(def_o_vals.length)
     for (let idx = 0; idx < re_o_vals.length; idx++) {
       expect(re_o_vals[idx]).toBeCloseTo(def_o_vals[idx], 4)
     }
@@ -1661,9 +1659,9 @@ describe(`compute_chempot_diagram edge cases`, () => {
       formal_chempots: true,
     })
     expect(result.elements).toEqual(elements)
-    expect(result.lims.length).toBe(n_axes)
+    expect(result.lims).toHaveLength(n_axes)
     for (const pts of Object.values(result.domains)) {
-      for (const pt of pts) expect(pt.length).toBe(n_axes)
+      for (const pt of pts) expect(pt).toHaveLength(n_axes)
     }
   })
 
@@ -1678,7 +1676,7 @@ describe(`compute_chempot_diagram edge cases`, () => {
     expect(domain_keys.length).toBeGreaterThan(0)
     for (const pts of Object.values(projected.domains)) {
       for (const pt of pts) {
-        expect(pt.length).toBe(3)
+        expect(pt).toHaveLength(3)
         for (const coord of pt) expect(Number.isFinite(coord)).toBe(true)
       }
     }
@@ -1768,8 +1766,8 @@ describe(`formation energy from elemental refs`, () => {
     const renormed = renormalize_entries(all_entries, raw_refs, [`A`, `B`])
     const { el_refs: renorm_refs } = get_min_entries_and_el_refs(renormed)
     // Renormalized refs have epa=0, so compute_e_form degenerates to just epa
-    expect(get_energy_per_atom(renorm_refs[`A`])).toBeCloseTo(0, 8)
-    expect(get_energy_per_atom(renorm_refs[`B`])).toBeCloseTo(0, 8)
+    expect(get_energy_per_atom(renorm_refs.A)).toBeCloseTo(0, 8)
+    expect(get_energy_per_atom(renorm_refs.B)).toBeCloseTo(0, 8)
     // Using renormalized refs, e_form equals raw epa (not true formation energy!)
     const ab = make_entry({ A: 1, B: 1 }, -3.5)
     expect(compute_e_form(ab, renorm_refs)).toBeCloseTo(-3.5, 8)
@@ -1902,7 +1900,7 @@ describe(`temperature filtering integration behavior`, () => {
       default_min_limit: -20,
       formal_chempots: false,
     })
-    expect(result.elements.length).toBe(2)
+    expect(result.elements).toHaveLength(2)
     expect(Object.keys(result.domains)).toEqual(expect.arrayContaining([`Li`, `O`]))
   })
 })
@@ -2043,7 +2041,7 @@ describe(`N-D projection cache consistency`, () => {
       elements: [`O`, `Ti`, `Y`],
     })
     // Formal chempots shifts coordinates by elemental refs → values differ
-    expect(formal.domains[`O2Ti`][0][0]).not.toBeCloseTo(absolute.domains[`O2Ti`][0][0], 1)
+    expect(formal.domains.O2Ti[0][0]).not.toBeCloseTo(absolute.domains.O2Ti[0][0], 1)
   })
 })
 

--- a/tests/vitest/chempot-diagram/performance.test.ts
+++ b/tests/vitest/chempot-diagram/performance.test.ts
@@ -8,13 +8,11 @@ import {
 import { count_atoms_in_composition } from '$lib/composition/parse'
 import type { PhaseData } from '$lib/convex-hull/types'
 import { readFileSync } from 'node:fs'
-import { dirname } from 'node:path'
 import process from 'node:process'
-import { fileURLToPath } from 'node:url'
 import { gunzipSync } from 'node:zlib'
 import { describe, expect, test } from 'vitest'
 
-const test_dir = dirname(fileURLToPath(import.meta.url))
+const test_dir = import.meta.dirname
 const min_speedup_ratio = Number(
   process.env.CHEMPOT_MIN_SPEEDUP_RATIO ?? (process.env.CI ? 1.5 : 2),
 )

--- a/tests/vitest/composition/BarChart.test.ts
+++ b/tests/vitest/composition/BarChart.test.ts
@@ -87,7 +87,7 @@ describe(`BarChart component`, () => {
     })
 
     const segments = document.querySelectorAll(`rect.bar-segment`)
-    expect(segments.length).toBe(2) // H and O segments
+    expect(segments).toHaveLength(2) // H and O segments
   })
 
   test(`external label positioning balances above and below`, () => {
@@ -101,11 +101,11 @@ describe(`BarChart component`, () => {
     // Check that external labels exist by looking at their y-coordinates
     const all_labels = document.querySelectorAll(`text.external-label`)
     const above_labels = Array.from(all_labels).filter((label) => {
-      const y = parseFloat(label.getAttribute(`y`) || `0`)
+      const y = parseFloat(label.getAttribute(`y`) ?? `0`)
       return y < 20 // Above the bar
     })
     const below_labels = Array.from(all_labels).filter((label) => {
-      const y = parseFloat(label.getAttribute(`y`) || `0`)
+      const y = parseFloat(label.getAttribute(`y`) ?? `0`)
       return y > 60 // Below the bar
     })
 
@@ -152,7 +152,7 @@ describe(`BarChart component`, () => {
     })
 
     const segments = document.querySelectorAll(`rect.bar-segment`)
-    expect(segments.length).toBe(0)
+    expect(segments).toHaveLength(0)
   })
 
   test(`shows labels and percentages when enabled`, () => {

--- a/tests/vitest/composition/BarChart.test.ts
+++ b/tests/vitest/composition/BarChart.test.ts
@@ -101,11 +101,11 @@ describe(`BarChart component`, () => {
     // Check that external labels exist by looking at their y-coordinates
     const all_labels = document.querySelectorAll(`text.external-label`)
     const above_labels = Array.from(all_labels).filter((label) => {
-      const y = parseFloat(label.getAttribute(`y`) ?? `0`)
+      const y = Number(label.getAttribute(`y`)) || 0
       return y < 20 // Above the bar
     })
     const below_labels = Array.from(all_labels).filter((label) => {
-      const y = parseFloat(label.getAttribute(`y`) ?? `0`)
+      const y = Number(label.getAttribute(`y`)) || 0
       return y > 60 // Below the bar
     })
 

--- a/tests/vitest/composition/Composition.svelte.test.ts
+++ b/tests/vitest/composition/Composition.svelte.test.ts
@@ -130,7 +130,7 @@ describe(`Composition component`, () => {
     const export_options = Array.from(
       document.querySelectorAll(`.context-menu button`),
     ).filter((opt) => opt.textContent?.includes(`Export`) || opt.textContent?.includes(`Copy`))
-    expect(export_options.length).toBe(4)
+    expect(export_options).toHaveLength(4)
 
     const option_texts = export_options.map((opt) => opt.textContent?.trim())
     expect(option_texts).toContain(`Copy Formula`)

--- a/tests/vitest/composition/Formula.test.ts
+++ b/tests/vitest/composition/Formula.test.ts
@@ -221,7 +221,7 @@ test.each([
     props: { formula: `H2O`, color_scheme: scheme },
   })
   const symbols = document.querySelectorAll(`.element-symbol`)
-  expect(symbols.length).toBe(2)
+  expect(symbols).toHaveLength(2)
 
   // Check that elements have color styles applied
   const has_color = Array.from(symbols).some((symbol) => (symbol as HTMLElement).style.color)
@@ -275,7 +275,7 @@ test(`Formula component renders subscripts for amounts > 1`, () => {
   // Mounting to document.body
   mount(Formula, { target: document.body, props: { formula: `H2O` } })
   const subscripts = document.querySelectorAll(`sub`)
-  expect(subscripts.length).toBe(1)
+  expect(subscripts).toHaveLength(1)
   expect(subscripts[0].textContent).toBe(`2`)
 })
 
@@ -283,14 +283,14 @@ test(`Formula component does not render subscripts for amount = 1`, () => {
   // Mounting to document.body
   mount(Formula, { target: document.body, props: { formula: `HO` } })
   const subscripts = document.querySelectorAll(`sub`)
-  expect(subscripts.length).toBe(0)
+  expect(subscripts).toHaveLength(0)
 })
 
 test(`Formula component renders superscripts for oxidation states`, () => {
   // Mounting to document.body
   mount(Formula, { target: document.body, props: { formula: `Fe^2+O^2-` } })
   const superscripts = document.querySelectorAll(`sup`)
-  expect(superscripts.length).toBe(2)
+  expect(superscripts).toHaveLength(2)
 
   const oxidation_values = Array.from(superscripts as NodeListOf<Element>).map(
     (sup) => sup.textContent,
@@ -307,7 +307,7 @@ test(`Formula component does not render superscripts for zero oxidation`, () => 
   // Mounting to document.body
   mount(Formula, { target: document.body, props: { formula: composition } })
   const superscripts = document.querySelectorAll(`sup`)
-  expect(superscripts.length).toBe(0)
+  expect(superscripts).toHaveLength(0)
 })
 
 test(`Formula component accepts OxiComposition input`, () => {
@@ -392,7 +392,7 @@ test.each([
 
     // Check correct number of oxidation state superscripts
     const superscripts = element?.querySelectorAll(`sup`) ?? []
-    expect(superscripts.length).toBe(expected_superscripts)
+    expect(superscripts).toHaveLength(expected_superscripts)
   },
 )
 
@@ -402,7 +402,7 @@ function normalize_to_hex(color: string): string {
   const match = /rgb\((\d+),\s*(\d+),\s*(\d+)\)/.exec(color)
   if (!match) return color
   const [, r, g, b] = match
-  const to_hex = (n: string) => parseInt(n).toString(16).padStart(2, `0`)
+  const to_hex = (n: string) => parseInt(n, 10).toString(16).padStart(2, `0`)
   return `#${to_hex(r)}${to_hex(g)}${to_hex(b)}`
 }
 
@@ -431,7 +431,7 @@ test.each([`Vesta`, `Jmol`] as const)(
     expect(tile).toBeInstanceOf(HTMLElement)
 
     // The tile background should match the color scheme for Fe
-    const expected_hex = ELEMENT_COLOR_SCHEMES[color_scheme]?.[`Fe`]
+    const expected_hex = ELEMENT_COLOR_SCHEMES[color_scheme]?.Fe
     if (!expected_hex) throw new Error(`Missing color for Fe in ${color_scheme}`)
     const actual_hex = normalize_to_hex(tile.style.backgroundColor)
     expect(actual_hex).toBe(expected_hex.toLowerCase())

--- a/tests/vitest/composition/FormulaFilter.svelte.test.ts
+++ b/tests/vitest/composition/FormulaFilter.svelte.test.ts
@@ -160,7 +160,7 @@ describe(`FormulaFilter`, () => {
     { value: `Fe`, show_clear_button: true, disabled: true, expected: false },
   ])(`clear button visible=$expected`, (params) => {
     mount(FormulaFilter, { target: document.body, props: params })
-    expect(!!document.querySelector(`.clear-btn`)).toBe(params.expected)
+    expect(Boolean(document.querySelector(`.clear-btn`))).toBe(params.expected)
   })
 
   test(`clears value on click or Escape`, () => {
@@ -380,7 +380,7 @@ describe(`FormulaFilter`, () => {
       { show_examples: true, disabled: true, expected: false },
     ])(`help button visible=$expected`, (params) => {
       mount(FormulaFilter, { target: document.body, props: { value: ``, ...params } })
-      expect(!!document.querySelector(`.help-btn`)).toBe(params.expected)
+      expect(Boolean(document.querySelector(`.help-btn`))).toBe(params.expected)
     })
 
     test(`toggles, displays content, and applies example on click`, () => {
@@ -395,8 +395,8 @@ describe(`FormulaFilter`, () => {
       flushSync()
       expect(document.querySelector(`.examples-dropdown`)).toBeInstanceOf(HTMLElement)
       expect(help_btn.getAttribute(`aria-expanded`)).toBe(`true`)
-      expect(document.querySelectorAll(`.example-category`).length).toBe(3)
-      expect(document.querySelectorAll(`.example-tag`).length).toBe(9)
+      expect(document.querySelectorAll(`.example-category`)).toHaveLength(3)
+      expect(document.querySelectorAll(`.example-tag`)).toHaveLength(9)
 
       // Apply example
       Array.from(document.querySelectorAll<HTMLButtonElement>(`.example-tag`))
@@ -733,7 +733,7 @@ describe(`FormulaFilter`, () => {
       expect(history_dropdown()?.getAttribute(`aria-label`)).toBe(`Recent searches`)
       // Items rendered in order with correct roles
       const items = history_values()
-      expect(items.length).toBe(3)
+      expect(items).toHaveLength(3)
       expect(items[0].textContent?.trim()).toBe(`Fe,O`)
       expect(items[1].textContent?.trim()).toBe(`Li-Fe-O`)
       expect(items[2].textContent?.trim()).toBe(`LiFePO4`)
@@ -774,7 +774,7 @@ describe(`FormulaFilter`, () => {
 
     test(`excludes current value from visible history`, () => {
       seed_mount_focus([`Fe,O`, `Li,Na`], { value: `Fe,O` })
-      expect(history_values().length).toBe(1)
+      expect(history_values()).toHaveLength(1)
       expect(history_values()[0].textContent?.trim()).toBe(`Li,Na`)
     })
 
@@ -798,10 +798,10 @@ describe(`FormulaFilter`, () => {
 
     test(`remove button removes entry and updates localStorage`, () => {
       seed_mount_focus([`Fe,O`, `Li,Na`, `Si,O`])
-      expect(history_items().length).toBe(3)
+      expect(history_items()).toHaveLength(3)
       remove_btns()[1].dispatchEvent(new MouseEvent(`mousedown`, { bubbles: true }))
       flushSync()
-      expect(history_values().length).toBe(2)
+      expect(history_values()).toHaveLength(2)
       expect(history_values()[0].textContent?.trim()).toBe(`Fe,O`)
       expect(history_values()[1].textContent?.trim()).toBe(`Si,O`)
       expect(get_stored()).toEqual([`Fe,O`, `Si,O`])
@@ -909,7 +909,7 @@ describe(`FormulaFilter`, () => {
       })
       focus_input()
       flushSync()
-      expect(history_values().length).toBe(1)
+      expect(history_values()).toHaveLength(1)
       expect(history_values()[0].textContent?.trim()).toBe(`Fe,O`)
       localStorage.removeItem(key_a)
       localStorage.removeItem(key_b)
@@ -1123,21 +1123,21 @@ describe(`FormulaFilter`, () => {
       mount_filter({ value: `+Li,-O` })
       flushSync()
       const chips = document.querySelectorAll(`.token-chip`)
-      expect(chips.length).toBe(2)
+      expect(chips).toHaveLength(2)
       ;(chips[0] as HTMLButtonElement).click()
       flushSync()
-      expect(document.querySelectorAll(`.token-chip`).length).toBe(1)
+      expect(document.querySelectorAll(`.token-chip`)).toHaveLength(1)
     })
 
     test(`removing one duplicate token chip only removes one instance`, () => {
       mount_filter({ value: `Li,Li` })
       flushSync()
       let chips = document.querySelectorAll(`.token-chip`)
-      expect(chips.length).toBe(2)
+      expect(chips).toHaveLength(2)
       ;(chips[0] as HTMLButtonElement).click()
       flushSync()
       chips = document.querySelectorAll(`.token-chip`)
-      expect(chips.length).toBe(1)
+      expect(chips).toHaveLength(1)
       expect(chips[0].textContent).toContain(`+Li`)
     })
 

--- a/tests/vitest/composition/parse.test.ts
+++ b/tests/vitest/composition/parse.test.ts
@@ -425,7 +425,7 @@ describe(`generate_chem_sys_subspaces`, () => {
   ] as [[number, ElementSymbol[]], string][])(
     `generates 2^n-1 subspaces for %j (%s)`,
     ([expected_num, elements], _desc) => {
-      expect(generate_chem_sys_subspaces(elements).length).toBe(2 ** expected_num - 1)
+      expect(generate_chem_sys_subspaces(elements)).toHaveLength(2 ** expected_num - 1)
     },
   )
 

--- a/tests/vitest/convex-hull/ConvexHullStats.test.ts
+++ b/tests/vitest/convex-hull/ConvexHullStats.test.ts
@@ -83,7 +83,7 @@ const set_select_value = (select_element: HTMLSelectElement, value: string) => {
   const option_idx = Array.from(select_element.options).findIndex(
     (option_element) => option_element.value === value,
   )
-  if (option_idx >= 0) select_element.selectedIndex = option_idx
+  if (option_idx !== -1) select_element.selectedIndex = option_idx
   select_element.value = value
   select_element.dispatchEvent(new Event(`change`, { bubbles: true }))
   flushSync()
@@ -171,13 +171,13 @@ describe(`ConvexHullStats`, () => {
     mount_stats()
     trigger(doc_query(`[data-testid="pd-total-entries"]`))
     flushSync()
-    expect(navigator.clipboard[`writeText`]).toHaveBeenCalled()
+    expect(navigator.clipboard.writeText).toHaveBeenCalled()
   })
 
   test(`renders both histograms when entries have energy and hull data`, () => {
     // mock_entry has both e_form_per_atom and e_above_hull by default
     mount_stats({ stable_entries: [mock_entry()] })
-    expect(document.querySelectorAll(`.histogram`).length).toBe(2)
+    expect(document.querySelectorAll(`.histogram`)).toHaveLength(2)
   })
 
   test.each([
@@ -216,7 +216,7 @@ describe(`ConvexHullStats`, () => {
 
   test(`renders empty stat items when phase_stats is null`, () => {
     mount_stats({ phase_stats: null })
-    expect(doc_query(`.convex-hull-stats`).querySelectorAll(`.stat-item`).length).toBe(0)
+    expect(doc_query(`.convex-hull-stats`).querySelectorAll(`.stat-item`)).toHaveLength(0)
   })
 
   test(`energy_per_atom fallback renders both histograms`, () => {
@@ -229,7 +229,7 @@ describe(`ConvexHullStats`, () => {
         }),
       ],
     })
-    expect(document.querySelectorAll(`.histogram`).length).toBe(2)
+    expect(document.querySelectorAll(`.histogram`)).toHaveLength(2)
   })
 
   test(`zero totals does not produce NaN in percentages`, () => {
@@ -249,7 +249,7 @@ describe(`ConvexHullStats`, () => {
       ],
     })
     // NaN/Infinity are filtered out → no histogram data → 0 histograms
-    expect(document.querySelectorAll(`.histogram`).length).toBe(0)
+    expect(document.querySelectorAll(`.histogram`)).toHaveLength(0)
   })
 
   test(`missing energy fields render without errors`, () => {

--- a/tests/vitest/convex-hull/barycentric-coords.test.ts
+++ b/tests/vitest/convex-hull/barycentric-coords.test.ts
@@ -21,7 +21,7 @@ import { describe, expect, test } from 'vitest'
 
 describe(`ternary: constants and projections`, () => {
   test(`triangle vertices are equilateral base`, () => {
-    expect(TRIANGLE_VERTICES.length).toBe(3)
+    expect(TRIANGLE_VERTICES).toHaveLength(3)
     // side lengths: (0)-(1) and (1)-(2) should match
     const d01 = Math.hypot(
       TRIANGLE_VERTICES[0][0] - TRIANGLE_VERTICES[1][0],
@@ -102,7 +102,7 @@ describe(`ternary: composition and plotting`, () => {
       }, // out-of-system
     ]
     const out = get_ternary_3d_coordinates(entries, elements)
-    expect(out.length).toBe(2)
+    expect(out).toHaveLength(2)
     expect(out[0]).toHaveProperty(`x`)
     expect(out[0]).toHaveProperty(`y`)
     expect(out[0]).toHaveProperty(`z`)
@@ -111,9 +111,9 @@ describe(`ternary: composition and plotting`, () => {
 
   test(`edges and vertical edges are generated with correct counts`, () => {
     const edges = get_triangle_edges()
-    expect(edges.length).toBe(3)
+    expect(edges).toHaveLength(3)
     const v_edges = get_triangle_vertical_edges(-2, 1)
-    expect(v_edges.length).toBe(3)
+    expect(v_edges).toHaveLength(3)
     for (const [lo, hi] of v_edges) {
       expect(lo.z).toBe(-2)
       expect(hi.z).toBe(1)
@@ -153,7 +153,7 @@ describe(`ternary: geometry helpers`, () => {
 
 describe(`quaternary: barycentric and projection`, () => {
   test(`tetrahedron vertex count and non-degenerate`, () => {
-    expect(TETRAHEDRON_VERTICES.length).toBe(4)
+    expect(TETRAHEDRON_VERTICES).toHaveLength(4)
     // distances from vertex 3 (origin) are non-zero
     for (let idx = 0; idx < 3; idx++) {
       const d = Math.hypot(
@@ -196,7 +196,7 @@ describe(`quaternary: compute_4d_coords`, () => {
       { composition: { A: 1, E: 1 } as unknown as CompositionType, energy: 0 },
     ]
     const out = compute_4d_coords(entries, elems)
-    expect(out.length).toBe(2)
+    expect(out).toHaveLength(2)
     expect(out[0]).toHaveProperty(`x`)
     expect(out[0]).toHaveProperty(`y`)
     expect(out[0]).toHaveProperty(`z`)

--- a/tests/vitest/convex-hull/helpers.test.ts
+++ b/tests/vitest/convex-hull/helpers.test.ts
@@ -348,7 +348,7 @@ describe(`helpers: fractional composition`, () => {
 
   test(`get_fractional_composition handles empty composition`, () => {
     const frac = helpers.get_fractional_composition({})
-    expect(Object.keys(frac).length).toBe(0)
+    expect(Object.keys(frac)).toHaveLength(0)
   })
 
   test(`get_fractional_composition ignores zero amounts`, () => {

--- a/tests/vitest/convex-hull/pymatgen-validation.test.ts
+++ b/tests/vitest/convex-hull/pymatgen-validation.test.ts
@@ -51,7 +51,7 @@ describe(`Pymatgen cross-validation for quinary (5-element) system`, () => {
 
   test(`reference data has expected structure`, () => {
     expect(reference.elements).toEqual([`Li`, `Na`, `K`, `Rb`, `Cs`])
-    expect(reference.entries.length).toBe(12)
+    expect(reference.entries).toHaveLength(12)
     expect(reference.n_stable).toBe(6)
     expect(reference.n_unstable).toBe(6)
   })

--- a/tests/vitest/convex-hull/thermodynamics.test.ts
+++ b/tests/vitest/convex-hull/thermodynamics.test.ts
@@ -116,8 +116,8 @@ describe(`find_lowest_energy_unary_refs`, () => {
       make_phase({ O: 1 }, -2.5),
     ]
     const refs = find_lowest_energy_unary_refs(entries)
-    expect(refs[`Fe`].energy_per_atom).toBe(-4.0)
-    expect(refs[`O`].energy_per_atom).toBe(-2.5)
+    expect(refs.Fe.energy_per_atom).toBe(-4.0)
+    expect(refs.O.energy_per_atom).toBe(-2.5)
   })
 
   test(`ignores non-unary entries`, () => {

--- a/tests/vitest/coordination/calc-coordination.test.ts
+++ b/tests/vitest/coordination/calc-coordination.test.ts
@@ -14,7 +14,7 @@ describe(`calc_coordination_nums`, () => {
   test(`should calculate coordination numbers`, () => {
     const result = calc_coordination_nums(simple_cubic, `electroneg_ratio`)
 
-    expect(result.sites.length).toBe(4)
+    expect(result.sites).toHaveLength(4)
     expect(result.cn_histogram.size).toBeGreaterThan(0)
     expect(result.cn_by_element.size).toBe(2) // Na and Cl
   })
@@ -31,7 +31,7 @@ describe(`calc_coordination_nums`, () => {
   test(`should work with solid_angle strategy`, () => {
     const result = calc_coordination_nums(simple_cubic, `solid_angle`)
 
-    expect(result.sites.length).toBe(4)
+    expect(result.sites).toHaveLength(4)
     expect(result.cn_histogram.size).toBeGreaterThan(0)
   })
 
@@ -48,7 +48,7 @@ describe(`calc_coordination_nums`, () => {
     // With atoms 50 Å apart, no bonds should form with default electroneg_ratio strategy
     const result = calc_coordination_nums(isolated_atoms, `electroneg_ratio`)
 
-    expect(result.sites.length).toBe(2)
+    expect(result.sites).toHaveLength(2)
     // Both atoms should have CN = 0 since they are too far apart for bonding
     const cn_values = result.sites.map((site) => site.coordination_num)
     expect(cn_values.every((cn) => cn === 0)).toBe(true)

--- a/tests/vitest/element/BohrAtom.test.ts
+++ b/tests/vitest/element/BohrAtom.test.ts
@@ -36,6 +36,6 @@ describe(`BohrAtom`, () => {
     expect(svg.getAttribute(`style`)).toBe(`width: 300px;`)
 
     const electron = document.querySelectorAll(`.electron`)
-    expect(electron.length).toBe(shells.reduce((a, b) => a + b, 0))
+    expect(electron).toHaveLength(shells.reduce((a, b) => a + b, 0))
   })
 })

--- a/tests/vitest/element/data.test.ts
+++ b/tests/vitest/element/data.test.ts
@@ -32,7 +32,7 @@ const EQUAL_MASS_PAIRS = [
 ] as const
 
 test(`element data basics`, () => {
-  expect(element_data.length).toBe(118)
+  expect(element_data).toHaveLength(118)
   expect(element_data[0].name).toBe(`Hydrogen`)
   expect(element_data[0].category).toBe(`diatomic nonmetal`)
   expect(element_data[0].number).toBe(1)

--- a/tests/vitest/fermi-surface/FermiSurfaceTooltip.test.ts
+++ b/tests/vitest/fermi-surface/FermiSurfaceTooltip.test.ts
@@ -66,7 +66,7 @@ describe(`FermiSurfaceTooltip`, () => {
       expect(text).toContain(`k (frac):`)
       expect(text).toMatch(/1\.234/)
       expect(text).toMatch(/0\.25/)
-      expect(document.querySelectorAll(`.k-coord-row`).length).toBe(2)
+      expect(document.querySelectorAll(`.k-coord-row`)).toHaveLength(2)
     })
 
     test(`hides fractional row when position_fractional is null`, () => {
@@ -76,7 +76,7 @@ describe(`FermiSurfaceTooltip`, () => {
       const text = document.body.textContent ?? ``
       expect(text).toContain(`k (Å⁻¹):`)
       expect(text).not.toContain(`k (frac):`)
-      expect(document.querySelectorAll(`.k-coord-row`).length).toBe(1)
+      expect(document.querySelectorAll(`.k-coord-row`)).toHaveLength(1)
     })
   })
 

--- a/tests/vitest/fermi-surface/compute.test.ts
+++ b/tests/vitest/fermi-surface/compute.test.ts
@@ -51,7 +51,7 @@ describe(`extract_fermi_surface`, () => {
     const band_data = create_spherical_band_data(10, 9) // Fermi level at radius^2 = 9
     const result = extract_fermi_surface(band_data)
 
-    expect(result.isosurfaces.length).toBe(1)
+    expect(result.isosurfaces).toHaveLength(1)
     expect(result.fermi_energy).toBe(9)
     expect(result.reciprocal_cell).toBe(`wigner_seitz`)
   })
@@ -73,7 +73,7 @@ describe(`extract_fermi_surface`, () => {
     const band_data = create_spherical_band_data(10, 100) // Fermi level too high
     const result = extract_fermi_surface(band_data)
 
-    expect(result.isosurfaces.length).toBe(0)
+    expect(result.isosurfaces).toHaveLength(0)
     expect(result.metadata.total_area).toBe(0)
   })
 

--- a/tests/vitest/fermi-surface/export.test.ts
+++ b/tests/vitest/fermi-surface/export.test.ts
@@ -104,7 +104,7 @@ describe(`export_scene`, () => {
       expect(captured_blobs[0].type).toBe(mime)
       expect(mock_link.download).toBe(filename)
       expect(call_order).toEqual([`appendChild`, `click`, `removeChild`])
-      expect(URL[`revokeObjectURL`]).toHaveBeenCalledWith(`blob:mock`)
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith(`blob:mock`)
     },
   )
 })

--- a/tests/vitest/fermi-surface/marching-cubes.test.ts
+++ b/tests/vitest/fermi-surface/marching-cubes.test.ts
@@ -101,7 +101,7 @@ describe(`marching_cubes (fermi-surface re-export)`, () => {
     const result = marching_cubes(grid, 1.0, identity_lattice)
 
     expect(result.normals.length).toBeGreaterThan(0)
-    expect(result.normals.length).toBe(result.vertices.length)
+    expect(result.normals).toHaveLength(result.vertices.length)
     for (const normal of result.normals) {
       expect(Math.hypot(...normal)).toBeCloseTo(1.0, 3)
     }

--- a/tests/vitest/fermi-surface/parse.test.ts
+++ b/tests/vitest/fermi-surface/parse.test.ts
@@ -46,11 +46,11 @@ END_BLOCK_BANDGRID_3D
       expect(result).not.toBeNull()
 
       const band_data = result as { energies: number[][][][][] }
-      expect(band_data.energies.length).toBe(1) // 1 spin
-      expect(band_data.energies[0].length).toBe(1) // 1 band
-      expect(band_data.energies[0][0].length).toBe(3) // kx
-      expect(band_data.energies[0][0][0].length).toBe(3) // ky
-      expect(band_data.energies[0][0][0][0].length).toBe(3) // kz
+      expect(band_data.energies).toHaveLength(1) // 1 spin
+      expect(band_data.energies[0]).toHaveLength(1) // 1 band
+      expect(band_data.energies[0][0]).toHaveLength(3) // kx
+      expect(band_data.energies[0][0][0]).toHaveLength(3) // ky
+      expect(band_data.energies[0][0][0][0]).toHaveLength(3) // kz
     })
 
     test(`parses energy values correctly`, () => {
@@ -290,13 +290,13 @@ END_BLOCK_BANDGRID_3D`
 
       // Type assertion for FermiSurfaceData
       const fermi_data = result as {
-        isosurfaces: Array<{
+        isosurfaces: {
           vertices: number[][]
           faces: number[][]
           band_index: number
           spin: string
           dimensionality?: string
-        }>
+        }[]
         k_lattice: number[][]
         fermi_energy: number
         metadata: { n_bands: number; n_surfaces: number; has_spin: boolean }
@@ -363,7 +363,7 @@ END_BLOCK_BANDGRID_3D`
       expect(result).not.toBeNull()
       expect(`isosurfaces` in (result ?? {})).toBe(true)
 
-      const fermi_data = result as { isosurfaces: Array<{ area?: number }> }
+      const fermi_data = result as { isosurfaces: { area?: number }[] }
 
       // Area should be computed only from valid faces, not NaN
       expect(fermi_data.isosurfaces).toHaveLength(1)

--- a/tests/vitest/fixtures/xrd/index.ts
+++ b/tests/vitest/fixtures/xrd/index.ts
@@ -4,7 +4,7 @@ import type { XrdPattern } from '$lib/xrd'
 export const xrd_patterns = Object.fromEntries(
   Object.entries(import.meta.glob(`./*.json`, { eager: true, import: `default` })).map(
     ([path, data]) => {
-      const id = path.split(`/`).at(-1)?.replace(`.json`, ``) || path
+      const id = path.split(`/`).at(-1)?.replace(`.json`, ``) ?? path
       return [id, data as XrdPattern]
     },
   ),

--- a/tests/vitest/index.test.ts
+++ b/tests/vitest/index.test.ts
@@ -45,16 +45,15 @@ test(`is_binary function detects binary content`, () => {
   expect(lib.is_binary(`\0\0\0\0`)).toBe(true)
 
   // Content with many control characters should be binary
-  const control_chars = `\x00\x01\x02\x03\x04\x05\x06\x07\x08\x0E\x0F\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1A\x1B\x1C\x1D\x1E\x1F`
-  expect(lib.is_binary(control_chars + `some text`)).toBe(true)
+  const control_chars = `\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F`
+  expect(lib.is_binary(`${control_chars}some text`)).toBe(true)
 
   // Content with mostly non-printable characters should be binary
-  const mostly_non_printable = `\x80\x81\x82\x83\x84\x85\x86\x87\x88\x89` + `a`.repeat(5)
+  const mostly_non_printable = `\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089${`a`.repeat(5)}`
   expect(lib.is_binary(mostly_non_printable)).toBe(true)
 
   // Content with mostly printable characters should not be binary
-  const mostly_printable =
-    `abcdefghijklmnopqrstuvwxyz\x80\x81\x82` + `abcdefghijklmnopqrstuvwxyz`.repeat(10)
+  const mostly_printable = `abcdefghijklmnopqrstuvwxyz\u0080\u0081\u0082${`abcdefghijklmnopqrstuvwxyz`.repeat(10)}`
   expect(lib.is_binary(mostly_printable)).toBe(false)
 })
 
@@ -70,7 +69,10 @@ describe(`Utility Functions`, () => {
 
   test.each([
     [`Hello\0World`, true],
-    [`Hello\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0FWorld`, true],
+    [
+      `Hello\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008\u0009\u000A\u000B\u000C\u000D\u000E\u000FWorld`,
+      true,
+    ],
     [`Hello World`, false],
     [``, false],
   ])(`is_binary: %s → %s`, (input, expected) => {
@@ -83,7 +85,7 @@ describe(`Utility Functions`, () => {
 
     beforeEach(() => {
       mock_wrapper = document.createElement(`div`)
-      document.body.appendChild(mock_wrapper) // Must be connected to DOM
+      document.body.append(mock_wrapper) // Must be connected to DOM
       orig_fullscreen_element = document.fullscreenElement
       mock_wrapper.requestFullscreen = vi.fn().mockResolvedValue(undefined)
       document.exitFullscreen = vi.fn().mockResolvedValue(undefined)
@@ -116,8 +118,8 @@ describe(`Utility Functions`, () => {
 
       await lib.toggle_fullscreen(mock_wrapper)
 
-      expect(mock_wrapper[`requestFullscreen`]).toHaveBeenCalledTimes(should_enter ? 1 : 0)
-      expect(document[`exitFullscreen`]).toHaveBeenCalledTimes(should_exit ? 1 : 0)
+      expect(mock_wrapper.requestFullscreen).toHaveBeenCalledTimes(should_enter ? 1 : 0)
+      expect(document.exitFullscreen).toHaveBeenCalledTimes(should_exit ? 1 : 0)
     })
 
     test(`switches when different element is fullscreen`, async () => {
@@ -126,9 +128,9 @@ describe(`Utility Functions`, () => {
 
       await lib.toggle_fullscreen(mock_wrapper)
 
-      expect(document[`exitFullscreen`]).toHaveBeenCalledOnce()
+      expect(document.exitFullscreen).toHaveBeenCalledOnce()
       await new Promise((r) => setTimeout(r, 0))
-      expect(mock_wrapper[`requestFullscreen`]).toHaveBeenCalledOnce()
+      expect(mock_wrapper.requestFullscreen).toHaveBeenCalledOnce()
     })
 
     test.each([
@@ -149,8 +151,8 @@ describe(`Utility Functions`, () => {
 
     test(`returns early when no wrapper provided`, async () => {
       await lib.toggle_fullscreen(undefined)
-      expect(mock_wrapper[`requestFullscreen`]).not.toHaveBeenCalled()
-      expect(document[`exitFullscreen`]).not.toHaveBeenCalled()
+      expect(mock_wrapper.requestFullscreen).not.toHaveBeenCalled()
+      expect(document.exitFullscreen).not.toHaveBeenCalled()
     })
 
     test(`returns early when wrapper not connected to DOM`, async () => {

--- a/tests/vitest/instanced-mesh-limit.test.ts
+++ b/tests/vitest/instanced-mesh-limit.test.ts
@@ -9,7 +9,7 @@ const get_tags = (source: string): string[] =>
 function get_attr(tag: string, attr: `limit` | `range` | `key`): string {
   const match = new RegExp(`\\b${attr}\\s*=\\s*(?:"([^"]+)"|\\{\\s*([^}]+?)\\s*\\})`).exec(tag)
   if (!match) throw new Error(`InstancedMesh tag is missing ${attr}: ${tag}`)
-  return (match[1] ?? match[2]).replace(/\s+/g, ``)
+  return (match[1] ?? match[2]).replaceAll(/\s+/g, ``)
 }
 
 describe(`InstancedMesh limits`, () => {

--- a/tests/vitest/io/export.test.ts
+++ b/tests/vitest/io/export.test.ts
@@ -151,7 +151,7 @@ describe(`svg_to_svg_string`, () => {
     const svg = make_svg(`0 0 100 100`)
     const original_attrs = svg.attributes.length
     svg_to_svg_string(svg)
-    expect(svg.attributes.length).toBe(original_attrs)
+    expect(svg.attributes).toHaveLength(original_attrs)
   })
 
   test(`preserves xmlns if already set`, () => {
@@ -180,8 +180,8 @@ describe(`svg_to_png_blob`, () => {
   let orig_revokeObjectURL: typeof URL.revokeObjectURL
 
   beforeEach(() => {
-    orig_createObjectURL = globalThis.URL[`createObjectURL`]
-    orig_revokeObjectURL = globalThis.URL[`revokeObjectURL`]
+    orig_createObjectURL = globalThis.URL.createObjectURL
+    orig_revokeObjectURL = globalThis.URL.revokeObjectURL
 
     mock_canvas_element = {
       getContext: vi.fn().mockReturnValue({ clearRect: vi.fn(), drawImage: vi.fn() }),
@@ -263,7 +263,7 @@ describe(`svg_to_png_blob`, () => {
   test(`serializes cloned SVG as blob for image loading`, () => {
     const svg = make_svg(`0 0 100 100`)
     void svg_to_png_blob(svg, 72)
-    expect(URL[`createObjectURL`]).toHaveBeenCalledWith(
+    expect(URL.createObjectURL).toHaveBeenCalledWith(
       expect.objectContaining({ type: `image/svg+xml;charset=utf-8` }),
     )
   })
@@ -283,7 +283,7 @@ describe(`svg_to_png_blob`, () => {
     try {
       const svg = make_svg(`0 0 100 100`)
       await svg_to_png_blob(svg, 72)
-      expect(URL[`revokeObjectURL`]).toHaveBeenCalled()
+      expect(URL.revokeObjectURL).toHaveBeenCalled()
     } finally {
       globalThis.Image = orig_image
     }

--- a/tests/vitest/io/file-drop.test.ts
+++ b/tests/vitest/io/file-drop.test.ts
@@ -1,12 +1,11 @@
 import type { FileDropOptions } from '$lib/io/file-drop'
 import { create_file_drop_handler } from '$lib/io/file-drop'
+import { decompress_file } from '$lib/io/decompress'
+import { handle_url_drop } from '$lib/io/url-drop'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 vi.mock(`$lib/io/decompress`, () => ({ decompress_file: vi.fn() }))
 vi.mock(`$lib/io/url-drop`, () => ({ handle_url_drop: vi.fn() }))
-
-import { decompress_file } from '$lib/io/decompress'
-import { handle_url_drop } from '$lib/io/url-drop'
 
 const make_event = (files: File[] = []) =>
   ({
@@ -41,7 +40,7 @@ describe(`create_file_drop_handler`, () => {
 
   test(`blocks drop when allow returns false`, async () => {
     const event = await run({ allow: () => false })
-    expect(event[`preventDefault`]).toHaveBeenCalled()
+    expect(event.preventDefault).toHaveBeenCalled()
     expect(on_drop).not.toHaveBeenCalled()
     expect(handle_url_drop).not.toHaveBeenCalled()
     expect(set_loading).not.toHaveBeenCalled()
@@ -49,7 +48,7 @@ describe(`create_file_drop_handler`, () => {
 
   test(`calls preventDefault and sets loading true then false`, async () => {
     const event = await run()
-    expect(event[`preventDefault`]).toHaveBeenCalled()
+    expect(event.preventDefault).toHaveBeenCalled()
     expect(set_loading).toHaveBeenCalledWith(true)
     expect(set_loading).toHaveBeenLastCalledWith(false)
   })

--- a/tests/vitest/isosurface/IsosurfaceControls.test.ts
+++ b/tests/vitest/isosurface/IsosurfaceControls.test.ts
@@ -69,13 +69,13 @@ describe(`IsosurfaceControls`, () => {
   test(`shows negative color picker only when show_negative is true`, () => {
     mount_controls({ settings: { ...DEFAULT_ISOSURFACE_SETTINGS, show_negative: false } })
     const color_inputs = document.querySelectorAll<HTMLInputElement>(`input[type="color"]`)
-    expect(color_inputs.length).toBe(1) // only positive color
+    expect(color_inputs).toHaveLength(1) // only positive color
 
     document.body.innerHTML = ``
     mount_controls({ settings: { ...DEFAULT_ISOSURFACE_SETTINGS, show_negative: true } })
     const color_inputs_with_neg =
       document.querySelectorAll<HTMLInputElement>(`input[type="color"]`)
-    expect(color_inputs_with_neg.length).toBe(2) // positive + negative
+    expect(color_inputs_with_neg).toHaveLength(2) // positive + negative
   })
 
   test(`renders wireframe checkbox unchecked by default`, () => {
@@ -159,11 +159,11 @@ describe(`IsosurfaceControls`, () => {
 
     // Layer rows with correct controls
     const layer_rows = document.querySelectorAll(`.layer-row`)
-    expect(layer_rows.length).toBe(2)
+    expect(layer_rows).toHaveLength(2)
     for (const row of Array.from(layer_rows)) {
       expect(row.querySelector(`input[type="checkbox"]`)).toBeInstanceOf(HTMLElement)
       expect(row.querySelector(`input[type="color"]`)).toBeInstanceOf(HTMLElement)
-      expect(row.querySelectorAll(`input[type="range"]`).length).toBe(2)
+      expect(row.querySelectorAll(`input[type="range"]`)).toHaveLength(2)
     }
 
     // Single-layer controls should be hidden

--- a/tests/vitest/isosurface/parse.test.ts
+++ b/tests/vitest/isosurface/parse.test.ts
@@ -341,7 +341,7 @@ function make_cube({
   }
   if (orbital_header) lines.push(orbital_header as string)
   lines.push(data as string)
-  return lines.join(`\n`) + `\n`
+  return `${lines.join(`\n`)}\n`
 }
 
 describe(`parse_cube`, () => {
@@ -425,7 +425,7 @@ describe(`parse_cube`, () => {
 
   test(`handles non-zero grid origin`, () => {
     const result = parse_cube(make_cube({ origin: [1.0, 2.0, 3.0] }))
-    expect(result?.volumes[0].origin[0]).toBeCloseTo(1.0 * bohr, 5)
+    expect(result?.volumes[0].origin[0]).toBeCloseTo(bohr, 5)
     expect(result?.volumes[0].origin[1]).toBeCloseTo(2.0 * bohr, 5)
     expect(result?.volumes[0].origin[2]).toBeCloseTo(3.0 * bohr, 5)
   })
@@ -516,18 +516,17 @@ describe(`parse_cube`, () => {
 
   test(`returns null for malformed header (NaN tokens)`, () => {
     // Corrupt line 3 (n_atoms line) with non-numeric tokens
-    const bad_cube =
-      [
-        `title`,
-        `comment`,
-        `    abc   0.000000   0.000000   0.000000`, // "abc" instead of number
-        `   2   1.889726   0.000000   0.000000`,
-        `   2   0.000000   1.889726   0.000000`,
-        `   2   0.000000   0.000000   1.889726`,
-        `    1   0.000000   0.000000   0.000000   0.000000`,
-        `    1   0.000000   0.000000   0.000000   1.400000`,
-        `0.001  0.002  0.003  0.004  0.005  0.006  0.007  0.008`,
-      ].join(`\n`) + `\n`
+    const bad_cube = `${[
+      `title`,
+      `comment`,
+      `    abc   0.000000   0.000000   0.000000`, // "abc" instead of number
+      `   2   1.889726   0.000000   0.000000`,
+      `   2   0.000000   1.889726   0.000000`,
+      `   2   0.000000   0.000000   1.889726`,
+      `    1   0.000000   0.000000   0.000000   0.000000`,
+      `    1   0.000000   0.000000   0.000000   1.400000`,
+      `0.001  0.002  0.003  0.004  0.005  0.006  0.007  0.008`,
+    ].join(`\n`)}\n`
     expect(parse_cube(bad_cube)).toBeNull()
   })
 

--- a/tests/vitest/isosurface/slice.test.ts
+++ b/tests/vitest/isosurface/slice.test.ts
@@ -93,7 +93,7 @@ describe(`sample_hkl_slice`, () => {
     const result = expect_slice(sample_hkl_slice(z_gradient, [0, 0, 1], 0.5))
     expect(result.width).toBeGreaterThan(0)
     expect(result.height).toBeGreaterThan(0)
-    expect(result.data.length).toBe(result.width * result.height)
+    expect(result.data).toHaveLength(result.width * result.height)
   })
 
   test(`(001) slice at d=0.2 has lower values than d=0.8 for z-gradient`, () => {
@@ -146,7 +146,7 @@ describe(`sample_hkl_slice`, () => {
       hex_lattice,
     )
     const result = expect_slice(sample_hkl_slice(vol, [0, 0, 1], 0.5))
-    expect(result.data.length).toBe(result.width * result.height)
+    expect(result.data).toHaveLength(result.width * result.height)
   })
 
   test(`non-periodic volume with out-of-bounds plane returns zeros at edges`, () => {

--- a/tests/vitest/isosurface/types.test.ts
+++ b/tests/vitest/isosurface/types.test.ts
@@ -276,9 +276,9 @@ describe(`downsample_grid`, () => {
     const result = downsample_grid(grid, dims)
     const [rnx, rny, rnz] = result.dims
     expect(rnx * rny * rnz).toBeLessThanOrEqual(500_000)
-    expect(result.grid.length).toBe(rnx)
-    expect(result.grid[0].length).toBe(rny)
-    expect(result.grid[0][0].length).toBe(rnz)
+    expect(result.grid).toHaveLength(rnx)
+    expect(result.grid[0]).toHaveLength(rny)
+    expect(result.grid[0][0]).toHaveLength(rnz)
   })
 
   test(`respects custom max_points budget`, () => {
@@ -315,9 +315,9 @@ describe(`pad_periodic_grid`, () => {
     const result = pad_periodic_grid(grid, [10, 10, 10], 0.3)
     // pad = ceil(10 * 0.3) = 3 per axis → dims 10+6=16
     expect(result.dims).toEqual([16, 16, 16])
-    expect(result.grid.length).toBe(16)
-    expect(result.grid[0].length).toBe(16)
-    expect(result.grid[0][0].length).toBe(16)
+    expect(result.grid).toHaveLength(16)
+    expect(result.grid[0]).toHaveLength(16)
+    expect(result.grid[0][0]).toHaveLength(16)
     // offset = -3/10 = -0.3
     expect(result.offset[0]).toBeCloseTo(-0.3)
     expect(result.offset[1]).toBeCloseTo(-0.3)
@@ -434,9 +434,9 @@ describe(`tile_volumetric_data`, () => {
     const vol = make_volume(4, 5, 6)
     const tiled = tile_volumetric_data(vol, scaling)
     expect(tiled.grid_dims).toEqual([4 * scaling[0], 5 * scaling[1], 6 * scaling[2]])
-    expect(tiled.grid.length).toBe(tiled.grid_dims[0])
-    expect(tiled.grid[0].length).toBe(tiled.grid_dims[1])
-    expect(tiled.grid[0][0].length).toBe(tiled.grid_dims[2])
+    expect(tiled.grid).toHaveLength(tiled.grid_dims[0])
+    expect(tiled.grid[0]).toHaveLength(tiled.grid_dims[1])
+    expect(tiled.grid[0][0]).toHaveLength(tiled.grid_dims[2])
   })
 
   test(`grid values repeat via modulo at boundary wrap points`, () => {
@@ -531,9 +531,9 @@ describe(`tile_volumetric_data`, () => {
     const tiled = tile_volumetric_data(vol, scaling)
     const [tnx, tny, tnz] = tiled.grid_dims
     // Grid shape matches dims
-    expect(tiled.grid.length).toBe(tnx)
-    expect(tiled.grid[0].length).toBe(tny)
-    expect(tiled.grid[0][0].length).toBe(tnz)
+    expect(tiled.grid).toHaveLength(tnx)
+    expect(tiled.grid[0]).toHaveLength(tny)
+    expect(tiled.grid[0][0]).toHaveLength(tnz)
     // Lattice diagonal scaled by supercell factors
     for (let idx = 0; idx < 3; idx++) {
       expect(tiled.lattice[idx][idx]).toBe(vol.lattice[idx][idx] * scaling[idx])

--- a/tests/vitest/layout/InfoTag.test.ts
+++ b/tests/vitest/layout/InfoTag.test.ts
@@ -137,7 +137,7 @@ describe(`InfoTag`, () => {
         target: document.body,
         props: { label: `Test`, value: 1, ...params },
       })
-      expect(!!document.querySelector(`[aria-label="Remove"]`)).toBe(params.expected)
+      expect(Boolean(document.querySelector(`[aria-label="Remove"]`))).toBe(params.expected)
     },
   )
 

--- a/tests/vitest/layout/PropertyFilter.test.ts
+++ b/tests/vitest/layout/PropertyFilter.test.ts
@@ -14,7 +14,7 @@ describe(`PropertyFilter`, () => {
     mount(PropertyFilter, { target: document.body, props: { label: `E<sub>hull</sub>` } })
     expect(get_container()).toBeInstanceOf(HTMLDivElement)
     expect(doc_query(`.filter-label sub`).textContent).toBe(`hull`)
-    expect(get_inputs().length).toBe(2)
+    expect(get_inputs()).toHaveLength(2)
     expect(get_min_input().type).toBe(`number`)
     expect(get_min_input().step).toBe(`any`)
   })
@@ -65,7 +65,7 @@ describe(`PropertyFilter`, () => {
   ])(`unit label visible=$expected when unit=$unit`, ({ unit, expected }) => {
     mount(PropertyFilter, { target: document.body, props: { label: `Energy`, unit } })
     const unit_label = document.querySelector(`.unit-label`)
-    expect(!!unit_label).toBe(expected)
+    expect(Boolean(unit_label)).toBe(expected)
     if (expected) expect(unit_label?.textContent).toBe(unit)
   })
 
@@ -76,7 +76,7 @@ describe(`PropertyFilter`, () => {
     { min_value: 10, show_clear_button: true, disabled: true, expected: false },
   ])(`clear button visible=$expected`, (params) => {
     mount(PropertyFilter, { target: document.body, props: { label: `Test`, ...params } })
-    expect(!!document.querySelector(`.clear-btn`)).toBe(params.expected)
+    expect(Boolean(document.querySelector(`.clear-btn`))).toBe(params.expected)
   })
 
   test(`clear button and Escape key clear values and fire callbacks`, () => {
@@ -146,7 +146,7 @@ describe(`PropertyFilter`, () => {
         target: document.body,
         props: { label: `Test`, histogram_data },
       })
-      expect(!!document.querySelector(`svg`)).toBe(expected)
+      expect(Boolean(document.querySelector(`svg`))).toBe(expected)
     },
   )
 
@@ -160,7 +160,7 @@ describe(`PropertyFilter`, () => {
       props: { label: `Test`, histogram_data: [1, 2, 3], histogram_position: position },
     })
     const svg = document.querySelector(`svg`)
-    expect(!!svg).toBe(visible)
+    expect(Boolean(svg)).toBe(visible)
     if (visible) {
       const container = get_container()
       const row = doc_query(`.filter-row`)
@@ -176,7 +176,7 @@ describe(`PropertyFilter`, () => {
       target: document.body,
       props: { label: `Test`, histogram_data: [1, 2, 3], log },
     })
-    expect(!!document.querySelector(`.log-label`)).toBe(log)
+    expect(Boolean(document.querySelector(`.log-label`))).toBe(log)
   })
 
   test(`clear button accessibility and onchange on blur`, () => {

--- a/tests/vitest/layout/json-tree.test.ts
+++ b/tests/vitest/layout/json-tree.test.ts
@@ -159,8 +159,8 @@ describe(`JsonTree`, () => {
       expect(bracket_text).toContain(`{`)
       expect(bracket_text).toContain(`}`)
       // Count: outer object { }, inner array [ ], inner object { } = 3 pairs each
-      expect(bracket_text.filter((text) => text === `[`).length).toBe(1) // Only arr uses [
-      expect(bracket_text.filter((text) => text === `{`).length).toBe(2) // outer obj + inner obj
+      expect(bracket_text.filter((text) => text === `[`)).toHaveLength(1) // Only arr uses [
+      expect(bracket_text.filter((text) => text === `{`)).toHaveLength(2) // outer obj + inner obj
     })
 
     it.each([
@@ -177,7 +177,7 @@ describe(`JsonTree`, () => {
         },
       })
       const indices = document.querySelectorAll(`.array-index .index`)
-      expect(indices.length).toBe(expected_count)
+      expect(indices).toHaveLength(expected_count)
     })
 
     it(`sorts object keys when sort_keys=true`, () => {
@@ -191,7 +191,7 @@ describe(`JsonTree`, () => {
         },
       })
       const keys = Array.from(document.querySelectorAll(`.node-key`)).map((el) =>
-        el.textContent?.replace(/"/g, ``).trim(),
+        el.textContent?.replaceAll('"', ``).trim(),
       )
       expect(keys).toEqual([`apple`, `mango`, `zebra`])
     })
@@ -378,9 +378,9 @@ describe(`JsonTree`, () => {
       mount(JsonTree, { target: document.body, props: { value: { name: `test` } } })
       const btns = document.querySelectorAll(`.controls button`)
       // 2 toggles (T, #) + 5 expand/collapse (expand, collapse, 1, 2, 3) + 2 copy/download
-      expect(btns.length).toBe(9)
+      expect(btns).toHaveLength(9)
       const dividers = document.querySelectorAll(`.divider`)
-      expect(dividers.length).toBe(2) // separators between 3 button groups
+      expect(dividers).toHaveLength(2) // separators between 3 button groups
     })
 
     it(`has toggle buttons for data types and array indices`, () => {
@@ -397,7 +397,7 @@ describe(`JsonTree`, () => {
       const control_groups = document.querySelectorAll(`.controls`)
       const last_group = control_groups[control_groups.length - 1]
       const btns = last_group.querySelectorAll(`button`)
-      expect(btns.length).toBe(2)
+      expect(btns).toHaveLength(2)
       // Both should have SVG icons
       expect(btns[0].querySelector(`svg`)).toBeInstanceOf(SVGSVGElement)
       expect(btns[1].querySelector(`svg`)).toBeInstanceOf(SVGSVGElement)
@@ -633,7 +633,7 @@ describe(`JsonTree`, () => {
       })
 
       // Initially no type annotations
-      expect(document.querySelectorAll(`.type-annotation`).length).toBe(0)
+      expect(document.querySelectorAll(`.type-annotation`)).toHaveLength(0)
 
       const type_toggle = get_toggle_btns()[0]
       expect(type_toggle.textContent).toBe(`T`)
@@ -652,7 +652,7 @@ describe(`JsonTree`, () => {
       flushSync()
       await tick()
 
-      expect(document.querySelectorAll(`.type-annotation`).length).toBe(0)
+      expect(document.querySelectorAll(`.type-annotation`)).toHaveLength(0)
       expect(type_toggle.classList.contains(`active`)).toBe(false)
     })
 
@@ -667,7 +667,7 @@ describe(`JsonTree`, () => {
       })
 
       // Initially indices are shown
-      expect(document.querySelectorAll(`.array-index .index`).length).toBe(3)
+      expect(document.querySelectorAll(`.array-index .index`)).toHaveLength(3)
 
       const index_toggle = get_toggle_btns()[1]
       expect(index_toggle.textContent).toBe(`#`)
@@ -678,7 +678,7 @@ describe(`JsonTree`, () => {
       await tick()
 
       // Now indices should be hidden
-      expect(document.querySelectorAll(`.array-index .index`).length).toBe(0)
+      expect(document.querySelectorAll(`.array-index .index`)).toHaveLength(0)
       expect(index_toggle.classList.contains(`active`)).toBe(false)
 
       // Toggle on again
@@ -686,7 +686,7 @@ describe(`JsonTree`, () => {
       flushSync()
       await tick()
 
-      expect(document.querySelectorAll(`.array-index .index`).length).toBe(3)
+      expect(document.querySelectorAll(`.array-index .index`)).toHaveLength(3)
       expect(index_toggle.classList.contains(`active`)).toBe(true)
     })
 
@@ -975,7 +975,7 @@ describe(`search navigation`, () => {
     await type_search(`ba`)
 
     expect(get_match_nav()).toBeInstanceOf(HTMLElement)
-    expect(get_nav_btns().length).toBe(2) // prev and next
+    expect(get_nav_btns()).toHaveLength(2) // prev and next
   })
 
   it(`shows "X of Y" match count format`, async () => {
@@ -1832,10 +1832,10 @@ describe(`diff mode`, () => {
         default_fold_level: 5,
       },
     })
-    expect(document.querySelectorAll(`.diff-added`).length).toBe(0)
-    expect(document.querySelectorAll(`.diff-changed`).length).toBe(0)
-    expect(document.querySelectorAll(`.diff-removed`).length).toBe(0)
-    expect(document.querySelectorAll(`.ghost`).length).toBe(0)
+    expect(document.querySelectorAll(`.diff-added`)).toHaveLength(0)
+    expect(document.querySelectorAll(`.diff-changed`)).toHaveLength(0)
+    expect(document.querySelectorAll(`.diff-removed`)).toHaveLength(0)
+    expect(document.querySelectorAll(`.ghost`)).toHaveLength(0)
   })
 })
 
@@ -1851,7 +1851,7 @@ describe(`sticky headers`, () => {
     })
     const sticky_nodes = document.querySelectorAll(`.sticky-header`)
     // root (depth 0), a (depth 1), b (depth 2) should all be sticky
-    expect(sticky_nodes.length).toBe(3)
+    expect(sticky_nodes).toHaveLength(3)
   })
 
   it(`does not add sticky-header to collapsed or leaf nodes`, () => {
@@ -1865,7 +1865,7 @@ describe(`sticky headers`, () => {
     })
     // Only the root node should be sticky (depth 0, expanded)
     const sticky = document.querySelectorAll(`.sticky-header`)
-    expect(sticky.length).toBe(1)
+    expect(sticky).toHaveLength(1)
   })
 })
 

--- a/tests/vitest/marching-cubes.test.ts
+++ b/tests/vitest/marching-cubes.test.ts
@@ -87,7 +87,7 @@ describe(`marching_cubes`, () => {
     })
     const uncentered = marching_cubes(grid, 0.5, IDENTITY, NON_PERIODIC)
 
-    expect(centered.faces.length).toBe(uncentered.faces.length)
+    expect(centered.faces).toHaveLength(uncentered.faces.length)
     // Centered vertices have lower mean position (shifted by -0.5)
     const mean_x = (verts: Vec3[]) => verts.reduce((s, v) => s + v[0], 0) / verts.length
     expect(mean_x(centered.vertices)).toBeLessThan(mean_x(uncentered.vertices))
@@ -120,7 +120,7 @@ describe(`marching_cubes`, () => {
       interpolate: false,
     })
     expect(no_interp.vertices.length).toBeGreaterThan(0)
-    expect(no_interp.faces.length).toBe(interp.faces.length)
+    expect(no_interp.faces).toHaveLength(interp.faces.length)
     // Non-linear gradient means interpolated positions differ from midpoints
     const any_different = no_interp.vertices.some(
       (vert, idx) => Math.abs(vert[0] - interp.vertices[idx][0]) > 1e-6,
@@ -138,7 +138,7 @@ describe(`marching_cubes`, () => {
     const unit = marching_cubes(grid, 0.5, IDENTITY, NON_PERIODIC)
     const scaled = marching_cubes(grid, 0.5, scaled_lattice, NON_PERIODIC)
 
-    expect(scaled.vertices.length).toBe(unit.vertices.length)
+    expect(scaled.vertices).toHaveLength(unit.vertices.length)
     // Guard: unit result has non-zero y-coordinates
     expect(unit.vertices.some((v) => Math.abs(v[1]) > 1e-6)).toBe(true)
     // Scaled vertices should be 10x unit vertices

--- a/tests/vitest/math.test.ts
+++ b/tests/vitest/math.test.ts
@@ -2154,14 +2154,14 @@ describe(`lerp_vec3`, () => {
   })
 })
 
-describe(`normalize_vec3`, () => {
+describe(`normalize_vec`, () => {
   it(`normalizes unit vector along x-axis`, () => {
-    const result = math.normalize_vec3([5, 0, 0])
+    const result = math.normalize_vec([5, 0, 0])
     expect(result).toEqual([1, 0, 0])
   })
 
   it(`normalizes diagonal vector`, () => {
-    const result = math.normalize_vec3([1, 1, 1])
+    const result = math.normalize_vec([1, 1, 1])
     const expected_component = 1 / Math.sqrt(3)
     expect(result[0]).toBeCloseTo(expected_component)
     expect(result[1]).toBeCloseTo(expected_component)
@@ -2169,18 +2169,18 @@ describe(`normalize_vec3`, () => {
   })
 
   it(`returns zero vector for zero input`, () => {
-    const result = math.normalize_vec3([0, 0, 0])
+    const result = math.normalize_vec([0, 0, 0])
     expect(result).toEqual([0, 0, 0])
   })
 
   it(`uses fallback for zero input when provided`, () => {
     const fallback: Vec3 = [0, 1, 0]
-    const result = math.normalize_vec3([0, 0, 0], fallback)
+    const result = math.normalize_vec([0, 0, 0], fallback)
     expect(result).toEqual([0, 1, 0])
   })
 
   it(`preserves unit vectors`, () => {
-    const result = math.normalize_vec3([0, 1, 0])
+    const result = math.normalize_vec([0, 1, 0])
     expect(result).toEqual([0, 1, 0])
   })
 })

--- a/tests/vitest/math.test.ts
+++ b/tests/vitest/math.test.ts
@@ -167,7 +167,7 @@ test.each([
   ],
 ])(`add vectors`, (vec1, vec2, expected) => {
   expect(math.add(vec1, vec2)).toEqual(expected)
-  expect(Math.hypot(...math.subtract(math.add(vec1, vec2), expected))).toEqual(0)
+  expect(Math.hypot(...math.subtract(math.add(vec1, vec2), expected))).toBe(0)
 })
 
 test(`add function comprehensive`, () => {
@@ -2440,7 +2440,7 @@ describe(`convex_hull_2d`, () => {
       [2.5, 2], // interior
     ]
     const hull = math.convex_hull_2d(pts)
-    expect(hull.length).toBe(5) // interior excluded
+    expect(hull).toHaveLength(5) // interior excluded
   })
 
   test(`duplicate points`, () => {
@@ -2452,7 +2452,7 @@ describe(`convex_hull_2d`, () => {
       [0, 1],
     ]
     const hull = math.convex_hull_2d(pts)
-    expect(hull.length).toBe(3)
+    expect(hull).toHaveLength(3)
   })
 
   test(`all same point`, () => {
@@ -2612,14 +2612,14 @@ describe(`merge_coplanar_triangles`, () => {
   test(`empty input returns empty Float32Array`, () => {
     const result = math.merge_coplanar_triangles(new Float32Array(0))
     expect(result).toBeInstanceOf(Float32Array)
-    expect(result.length).toBe(0)
+    expect(result).toHaveLength(0)
   })
 
   test(`single triangle passes through unchanged`, () => {
     // Triangle on xy-plane
     const input = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0])
     const result = math.merge_coplanar_triangles(input)
-    expect(result.length).toBe(9)
+    expect(result).toHaveLength(9)
     // Vertices should match (order may differ within fan)
     const verts_in = extract_triangle_verts(input)
     const verts_out = extract_triangle_verts(result)
@@ -2652,7 +2652,7 @@ describe(`merge_coplanar_triangles`, () => {
       0, // tri2: C-D-A  (starts with C)
     ])
     const result = math.merge_coplanar_triangles(input)
-    expect(result.length).toBe(18)
+    expect(result).toHaveLength(18)
     const out_verts = extract_triangle_verts(result)
     const expected_verts: Vec3[] = [
       [0, 0, 0],
@@ -2693,7 +2693,7 @@ describe(`merge_coplanar_triangles`, () => {
       1, // xz-plane
     ])
     const result = math.merge_coplanar_triangles(input)
-    expect(result.length).toBe(18)
+    expect(result).toHaveLength(18)
     expect(
       same_vertex_set(extract_triangle_verts(input), extract_triangle_verts(result)),
     ).toBe(true)
@@ -2727,7 +2727,7 @@ describe(`merge_coplanar_triangles`, () => {
     ])
     const result = math.merge_coplanar_triangles(input)
     // Should merge to 4 fan triangles from 6 hull vertices
-    expect(result.length).toBe(4 * 9)
+    expect(result).toHaveLength(4 * 9)
     // All 6 hex vertices should appear in output
     const out_verts = extract_triangle_verts(result)
     for (const hv of hex_verts) {
@@ -2767,14 +2767,14 @@ describe(`merge_coplanar_triangles`, () => {
       1, // separate triangle on z=1
     ])
     const result = math.merge_coplanar_triangles(input)
-    expect(result.length).toBe(3 * 9)
+    expect(result).toHaveLength(3 * 9)
   })
 
   test(`degenerate zero-area triangle passes through`, () => {
     // All 3 vertices are the same point
     const input = new Float32Array([1, 1, 1, 1, 1, 1, 1, 1, 1])
     const result = math.merge_coplanar_triangles(input)
-    expect(result.length).toBe(9)
+    expect(result).toHaveLength(9)
   })
 
   test(`coplanar triangles on axis-aligned plane merge despite winding differences`, () => {
@@ -2800,7 +2800,7 @@ describe(`merge_coplanar_triangles`, () => {
       1, // tri2 (opposite winding)
     ])
     const result = math.merge_coplanar_triangles(input)
-    expect(result.length).toBe(18)
+    expect(result).toHaveLength(18)
     const out_verts = extract_triangle_verts(result)
     for (const ev of [
       [5, 0, 0],
@@ -2844,7 +2844,7 @@ describe(`merge_coplanar_triangles`, () => {
       0, // A-D-E
     ])
     const result = math.merge_coplanar_triangles(input)
-    expect(result.length).toBe(3 * 9)
+    expect(result).toHaveLength(3 * 9)
     const out_verts = extract_triangle_verts(result)
     for (const ev of [
       [0, 0, 0],
@@ -2881,7 +2881,7 @@ function same_vertex_set(set_a: Vec3[], set_b: Vec3[]): boolean {
   const used = new Set<number>()
   for (const va of set_a) {
     const match_idx = set_b.findIndex((vb, idx) => !used.has(idx) && vec3_close(va, vb))
-    if (match_idx < 0) return false
+    if (match_idx === -1) return false
     used.add(match_idx)
   }
   return true

--- a/tests/vitest/package-exports.test.ts
+++ b/tests/vitest/package-exports.test.ts
@@ -1,9 +1,8 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs'
-import { dirname, join, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join, resolve } from 'node:path'
 import { describe, expect, test } from 'vitest'
 
-const repo_root = resolve(dirname(fileURLToPath(import.meta.url)), `../..`)
+const repo_root = resolve(import.meta.dirname, `../..`)
 const lib_dir = join(repo_root, `src/lib`)
 const pkg = JSON.parse(readFileSync(join(repo_root, `package.json`), `utf8`)) as {
   exports: Record<string, string | Record<string, string>>

--- a/tests/vitest/periodic-table/ElementTile.test.ts
+++ b/tests/vitest/periodic-table/ElementTile.test.ts
@@ -261,8 +261,8 @@ describe(`ElementTile`, () => {
       })
 
       const node = doc_query(`.element-tile`)
-      expect(node.getAttribute(`tabindex`)).toBe(null)
-      expect(node.getAttribute(`role`)).toBe(null)
+      expect(node.getAttribute(`tabindex`)).toBeNull()
+      expect(node.getAttribute(`role`)).toBeNull()
     })
   })
 
@@ -274,8 +274,8 @@ describe(`ElementTile`, () => {
       })
 
       const node = doc_query(`.element-tile`)
-      expect(node.getAttribute(`role`)).toBe(null)
-      expect(node.getAttribute(`tabindex`)).toBe(null)
+      expect(node.getAttribute(`role`)).toBeNull()
+      expect(node.getAttribute(`tabindex`)).toBeNull()
     })
   })
 
@@ -484,7 +484,7 @@ describe(`ElementTile`, () => {
           target: document.body,
           props: { element: rand_element, ...props },
         })
-        expect(!!document.querySelector(`.number`)).toBe(should_show)
+        expect(Boolean(document.querySelector(`.number`))).toBe(should_show)
       }
 
       test_show_number({ value: 42 }, true) // Single value - show by default
@@ -524,10 +524,10 @@ describe(`ElementTile`, () => {
 
       expect(document.querySelector(`.element-tile`)).toBeInstanceOf(HTMLElement)
       if (expected_count !== undefined) {
-        expect(document.querySelectorAll(`.multi-value`).length).toBe(expected_count)
+        expect(document.querySelectorAll(`.multi-value`)).toHaveLength(expected_count)
       }
       if (expected_segments !== undefined) {
-        expect(document.querySelectorAll(`.segment`).length).toBe(expected_segments)
+        expect(document.querySelectorAll(`.segment`)).toHaveLength(expected_segments)
       }
     })
   })
@@ -550,8 +550,8 @@ describe(`ElementTile`, () => {
 
       const tile = doc_query(`.element-tile`)
       expect(tile.style.backgroundColor).toBe(color_value)
-      expect(!!document.querySelector(`.value`)).toBe(!is_detected)
-      expect(!!document.querySelector(`.name`)).toBe(is_detected)
+      expect(Boolean(document.querySelector(`.value`))).toBe(!is_detected)
+      expect(Boolean(document.querySelector(`.name`))).toBe(is_detected)
     })
 
     test.each([
@@ -568,8 +568,8 @@ describe(`ElementTile`, () => {
         },
       })
 
-      const has_value = !!document.querySelector(`.value`)
-      const has_name = !!document.querySelector(`.name`)
+      const has_value = Boolean(document.querySelector(`.value`))
+      const has_name = Boolean(document.querySelector(`.name`))
       expect(has_value).toBe(show_values)
       expect(has_name).toBe(!show_values)
     })
@@ -584,7 +584,7 @@ describe(`ElementTile`, () => {
         props: { element: rand_element, value: colors, bg_colors: colors },
       })
 
-      expect(document.querySelectorAll(`.segment`).length).toBe(segments)
+      expect(document.querySelectorAll(`.segment`)).toHaveLength(segments)
       expect(doc_query(`.element-tile`).style.backgroundColor).toBe(`transparent`)
       expect(document.querySelector(`.value`)).toBeNull()
     })
@@ -602,8 +602,8 @@ describe(`ElementTile`, () => {
         },
       })
 
-      expect(document.querySelectorAll(`.multi-value`).length).toBe(expected_spans)
-      expect(!!document.querySelector(`.name`)).toBe(!should_show)
+      expect(document.querySelectorAll(`.multi-value`)).toHaveLength(expected_spans)
+      expect(Boolean(document.querySelector(`.name`))).toBe(!should_show)
     })
   })
 
@@ -673,7 +673,7 @@ describe(`ElementTile`, () => {
       })
 
       const segments = document.querySelectorAll(`.segment`)
-      expect(segments.length).toBe(expected_segments)
+      expect(segments).toHaveLength(expected_segments)
 
       if (expected_segments === 0) {
         const fallback_value = document.querySelector(`.value`)

--- a/tests/vitest/periodic-table/PeriodicTable.test.svelte.ts
+++ b/tests/vitest/periodic-table/PeriodicTable.test.svelte.ts
@@ -20,12 +20,12 @@ describe(`PeriodicTable`, () => {
   ] as const)(`renders lanth_act_tiles=%s -> %s tiles`, (show_lanth_act, expected_tiles) => {
     const props = show_lanth_act ? {} : { lanth_act_tiles: [] }
     mount(PeriodicTable, { target: document.body, props })
-    expect(document.querySelectorAll(`.element-tile`).length).toBe(expected_tiles)
+    expect(document.querySelectorAll(`.element-tile`)).toHaveLength(expected_tiles)
   })
 
   test(`empty tiles are rendered`, () => {
     mount(PeriodicTable, { target: document.body })
-    expect(document.querySelectorAll(`.element-tile`).length).toBe(120)
+    expect(document.querySelectorAll(`.element-tile`)).toHaveLength(120)
   })
 
   test(`hovering element tile toggles CSS class 'active'`, async () => {
@@ -138,7 +138,7 @@ describe(`PeriodicTable`, () => {
         target: document.body,
         props: { active_category },
       })
-      expect(document.querySelectorAll(`.element-tile.active`).length).toBe(expected_active)
+      expect(document.querySelectorAll(`.element-tile.active`)).toHaveLength(expected_active)
     },
   )
 
@@ -155,7 +155,7 @@ describe(`PeriodicTable`, () => {
         props: { active_elements: [...active_elements] },
       })
       const active_tiles = document.querySelectorAll(`.element-tile.active`)
-      expect(active_tiles.length).toBe(expected_active)
+      expect(active_tiles).toHaveLength(expected_active)
     },
   )
 
@@ -294,7 +294,7 @@ describe(`PeriodicTable`, () => {
     await tick()
 
     const tooltip_el = document.querySelector(`.tooltip`)
-    expect(!!tooltip_el).toBe(should_show)
+    expect(Boolean(tooltip_el)).toBe(should_show)
 
     if (should_show) {
       expect(tooltip_el?.textContent).toContain(`Hydrogen`)
@@ -533,7 +533,7 @@ describe(`PeriodicTable`, () => {
   describe(`automatic ColorBar integration`, () => {
     // Helper to get numeric tick values from colorbar
     const get_tick_values = (colorbar: Element | null) =>
-      Array.from(colorbar?.querySelectorAll(`.tick-label`) || [])
+      Array.from(colorbar?.querySelectorAll(`.tick-label`) ?? [])
         .map((tick_label) => parseFloat((tick_label as HTMLElement).textContent?.trim() || ``))
         .filter((val) => !isNaN(val))
 
@@ -641,7 +641,7 @@ describe(`PeriodicTable`, () => {
         },
       })
 
-      expect(document.querySelectorAll(`.tick-label.tick-secondary`).length).toBe(3)
+      expect(document.querySelectorAll(`.tick-label.tick-secondary`)).toHaveLength(3)
     })
 
     test.each([

--- a/tests/vitest/phase-diagram/PhaseDiagramExportPane.test.ts
+++ b/tests/vitest/phase-diagram/PhaseDiagramExportPane.test.ts
@@ -128,7 +128,7 @@ describe(`PhaseDiagramExportPane`, () => {
       copy_btn.dispatchEvent(new Event(`click`, { bubbles: true }))
 
       await vi.waitFor(() => {
-        expect(navigator.clipboard[`writeText`]).toHaveBeenCalledWith(expected_clipboard)
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith(expected_clipboard)
       })
 
       vi.advanceTimersByTime(1500)
@@ -270,7 +270,7 @@ describe(`PhaseDiagramExportPane`, () => {
 
     // Flush microtasks then verify clipboard was not called
     await new Promise<void>((resolve) => queueMicrotask(resolve))
-    expect(navigator.clipboard[`writeText`]).not.toHaveBeenCalled()
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled()
   })
 
   test(`JSON download creates blob URL and triggers download`, async () => {
@@ -303,13 +303,13 @@ describe(`PhaseDiagramExportPane`, () => {
     })
 
     // The button is disabled, but let's also verify click doesn't trigger copy
-    vi.mocked(navigator.clipboard[`writeText`]).mockClear()
+    vi.mocked(navigator.clipboard.writeText).mockClear()
 
     const copy_btn = get_button(`Copy JSON`)
     copy_btn.dispatchEvent(new Event(`click`, { bubbles: true }))
 
     // Flush microtasks then verify clipboard was not called
     await new Promise<void>((resolve) => queueMicrotask(resolve))
-    expect(navigator.clipboard[`writeText`]).not.toHaveBeenCalled()
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled()
   })
 })

--- a/tests/vitest/phase-diagram/parse.test.ts
+++ b/tests/vitest/phase-diagram/parse.test.ts
@@ -40,7 +40,7 @@ describe(`parse_tdb`, () => {
 PHASE FCC_A1 %A 2 1 1 !`
     const result = parse_tdb(content)
     const phases = result.data?.phases ?? []
-    expect(phases.length).toBe(2)
+    expect(phases).toHaveLength(2)
     const liquid = phases.find((phase) => phase.name === `LIQUID`)
     expect(liquid?.sublattice_count).toBe(1)
     expect(liquid?.sublattice_sites).toEqual([1.0])

--- a/tests/vitest/phase-diagram/utils.test.ts
+++ b/tests/vitest/phase-diagram/utils.test.ts
@@ -911,7 +911,7 @@ describe(`convert_temp`, () => {
 describe(`word boundary regex for component matching`, () => {
   // Tests the \b regex pattern used in IsobaricBinaryPhaseDiagram's x_domain
   function matches_component(region_name: string, component: string): boolean {
-    const escaped = component.replace(/[.*+?^${}()|[\]\\]/g, `\\$&`)
+    const escaped = component.replaceAll(/[.*+?^${}()|[\]\\]/g, `\\$&`)
     return new RegExp(`\\b${escaped}\\b`).test(region_name)
   }
 

--- a/tests/vitest/plot/BarPlot.test.ts
+++ b/tests/vitest/plot/BarPlot.test.ts
@@ -353,7 +353,7 @@ describe(`BarPlot`, () => {
         },
       })
       await tick()
-      expect(document.querySelectorAll(`path[role="button"]`).length).toBe(3)
+      expect(document.querySelectorAll(`path[role="button"]`)).toHaveLength(3)
     })
 
     test(`hover provides category_label and preserves metadata`, async () => {

--- a/tests/vitest/plot/ColorBar.test.ts
+++ b/tests/vitest/plot/ColorBar.test.ts
@@ -36,7 +36,7 @@ describe(`ColorBar Horizontal (Default)`, () => {
     expect(cbar_div.style.height).toBe(`20px`)
 
     const tick_label_spans = document.querySelectorAll(`.colorbar > div.bar > span.tick-label`)
-    expect(tick_label_spans.length).toBe(6)
+    expect(tick_label_spans).toHaveLength(6)
     const first_tick = tick_label_spans[0] as HTMLElement
     expect(first_tick.style.left).toBe(`0%`)
     expect(first_tick.classList).toContain(`horizontal`)
@@ -87,7 +87,7 @@ describe(`ColorBar Vertical`, () => {
     expect(computed_style.height).not.toBe(`10px`)
 
     const tick_label_spans = document.querySelectorAll(`.colorbar > div.bar > span.tick-label`)
-    expect(tick_label_spans.length).toBe(6)
+    expect(tick_label_spans).toHaveLength(6)
 
     const first_tick = tick_label_spans[0] as HTMLElement
     expect(first_tick.style.top).toBe(`100%`) // 0 value is at the bottom
@@ -125,7 +125,7 @@ describe(`ColorBar Vertical`, () => {
     expect(cbar_div.style.height).toBe(`300px`)
 
     const tick_label_spans = document.querySelectorAll(`.colorbar > div.bar > span.tick-label`)
-    expect(tick_label_spans.length).toBe(7)
+    expect(tick_label_spans).toHaveLength(7)
 
     const middle_tick = tick_label_spans[3] as HTMLElement // Tick '0'
     expect(middle_tick.textContent).toBe(`0`)
@@ -149,7 +149,7 @@ describe(`ColorBar tick_side='inside'`, () => {
     })
 
     const tick_label_spans = document.querySelectorAll(`.colorbar > div.bar > span.tick-label`)
-    expect(tick_label_spans.length).toBe(4)
+    expect(tick_label_spans).toHaveLength(4)
 
     const first_visible_tick = tick_label_spans[0] as HTMLElement
     expect(first_visible_tick.textContent).toBe(`20`)
@@ -175,7 +175,7 @@ describe(`ColorBar tick_side='inside'`, () => {
     })
 
     const tick_label_spans = document.querySelectorAll(`.colorbar > div.bar > span.tick-label`)
-    expect(tick_label_spans.length).toBe(7)
+    expect(tick_label_spans).toHaveLength(7)
 
     const first_visible_tick = tick_label_spans[0] as HTMLElement
     expect(first_visible_tick.textContent).toBe(`20`) // Range [10, 90], 9 ticks total
@@ -212,7 +212,7 @@ describe(`ColorBar tick_side='inside'`, () => {
     const tick_label_spans = document.querySelectorAll(`.colorbar > div.bar > span.tick-label`)
 
     // Inside ticks hide first/last, so we check ticks at 0.25, 0.5, 0.75
-    expect(tick_label_spans.length).toBe(3)
+    expect(tick_label_spans).toHaveLength(3)
 
     // Tick at 0.25 (Greenish - should be moderately light -> black text)
     const tick1 = tick_label_spans[0] as HTMLElement
@@ -276,7 +276,7 @@ describe(`ColorBar Date/Time Formatting`, () => {
     })
 
     const tick_label_spans = document.querySelectorAll(`.colorbar > div.bar > span.tick-label`)
-    expect(tick_label_spans.length).toBe(3)
+    expect(tick_label_spans).toHaveLength(3)
     expect(tick_label_spans[0].textContent).toBe(`2024-01-01`) // Start date
     expect(tick_label_spans[1].textContent).toBe(`2024-07-01`) // Mid-point (approx)
     expect(tick_label_spans[2].textContent).toBe(`2024-12-31`) // End date
@@ -301,7 +301,7 @@ describe(`ColorBar Date/Time Formatting`, () => {
     const tick_label_spans_date_fmt = document.querySelectorAll(
       `.colorbar > div.bar > span.tick-label`,
     )
-    expect(tick_label_spans_date_fmt.length).toBe(5)
+    expect(tick_label_spans_date_fmt).toHaveLength(5)
     expect(tick_label_spans_date_fmt[0].textContent).toBe(`00:00`)
     expect([`11:59`, `12:00`]).toContain(tick_label_spans_date_fmt[2].textContent)
     expect(tick_label_spans_date_fmt[4].textContent).toBe(`23:59`) // Near end of day
@@ -321,7 +321,7 @@ describe(`ColorBar Numeric Formatting`, () => {
     })
 
     const tick_label_spans = document.querySelectorAll(`.colorbar > div.bar > span.tick-label`)
-    expect(tick_label_spans.length).toBe(6)
+    expect(tick_label_spans).toHaveLength(6)
     expect(tick_label_spans[0].textContent).toBe(`0`)
     expect(tick_label_spans[1].textContent).toBe(`2`)
     expect(tick_label_spans[2].textContent).toBe(`4`)
@@ -342,7 +342,7 @@ describe(`ColorBar Numeric Formatting`, () => {
     })
 
     const tick_label_spans = document.querySelectorAll(`.colorbar > div.bar > span.tick-label`)
-    expect(tick_label_spans.length).toBe(5)
+    expect(tick_label_spans).toHaveLength(5)
     expect(tick_label_spans[0].textContent).toBe(`0%`)
     expect(tick_label_spans[1].textContent).toBe(`25%`)
     expect(tick_label_spans[2].textContent).toBe(`50%`)
@@ -367,7 +367,7 @@ describe(`ColorBar Numeric Formatting`, () => {
       })
 
       const ticks = document.querySelectorAll(`.colorbar > div.bar > span.tick-label`)
-      expect(ticks.length).toBe(expected.length)
+      expect(ticks).toHaveLength(expected.length)
       expected.forEach((text, idx) => expect(ticks[idx].textContent).toBe(text))
     },
   )
@@ -386,7 +386,7 @@ describe(`ColorBar Other Features`, () => {
     })
 
     const tick_label_spans = document.querySelectorAll(`.colorbar > div.bar > span.tick-label`)
-    expect(tick_label_spans.length).toBe(explicit_ticks.length)
+    expect(tick_label_spans).toHaveLength(explicit_ticks.length)
     explicit_ticks.forEach((tick_value, idx) => {
       expect(tick_label_spans[idx].textContent).toBe(tick_value.toString())
     })
@@ -399,7 +399,7 @@ describe(`ColorBar Other Features`, () => {
     })
 
     const tick_label_spans = document.querySelectorAll(`.colorbar > div.bar > span.tick-label`)
-    expect(tick_label_spans.length).toBe(4)
+    expect(tick_label_spans).toHaveLength(4)
     expect(tick_label_spans[0].textContent).toBe(`0`)
     expect(tick_label_spans[1].textContent).toBe(`33`)
     expect(tick_label_spans[2].textContent).toBe(`66`)

--- a/tests/vitest/plot/FillArea.test.ts
+++ b/tests/vitest/plot/FillArea.test.ts
@@ -72,7 +72,7 @@ describe(`FillArea`, () => {
     })
     const grad = doc_query(`linearGradient`)
     expect(grad.getAttribute(`gradientTransform`)).toBe(`rotate(45, 0.5, 0.5)`)
-    expect(grad.querySelectorAll(`stop`).length).toBe(2)
+    expect(grad.querySelectorAll(`stop`)).toHaveLength(2)
   })
 
   test(`renders radial gradient with correct center and stops`, () => {
@@ -91,7 +91,7 @@ describe(`FillArea`, () => {
     })
     const grad = doc_query(`radialGradient`)
     expect(grad.getAttribute(`cx`)).toBe(`0.3`)
-    expect(grad.querySelectorAll(`stop`).length).toBe(3)
+    expect(grad.querySelectorAll(`stop`)).toHaveLength(3)
   })
 
   test(`on_click handler receives correct FillHandlerEvent`, async () => {

--- a/tests/vitest/plot/Line.test.ts
+++ b/tests/vitest/plot/Line.test.ts
@@ -91,7 +91,7 @@ describe(`Line`, () => {
     mount(Line, { target: document.body, props: { points, origin, ...props } })
 
     const paths = document.querySelectorAll(`path`)
-    expect(paths.length).toBe(2)
+    expect(paths).toHaveLength(2)
 
     const line_path = paths[0]
     const area_path = paths[1]
@@ -171,7 +171,7 @@ describe(`Line`, () => {
         props: { points, origin: [0, 100], area_color, line_tween: { duration: 0 } },
       })
       const paths = document.querySelectorAll(`path`)
-      expect(paths.length).toBe(2)
+      expect(paths).toHaveLength(2)
       expect(paths[0].getAttribute(`d`)).toMatch(/^M0,50L100,0$/)
       expect(paths[1].getAttribute(`d`)).toBe(``)
     },
@@ -187,7 +187,7 @@ describe(`Line`, () => {
     })
 
     const paths = document.querySelectorAll(`path`)
-    expect(paths.length).toBe(2)
+    expect(paths).toHaveLength(2)
     expect(paths[0].getAttribute(`d`)).toBe(``)
     expect(paths[1].getAttribute(`d`)).toBe(``)
   })
@@ -202,7 +202,7 @@ describe(`Line`, () => {
     })
 
     const paths = document.querySelectorAll(`path`)
-    expect(paths.length).toBe(2)
+    expect(paths).toHaveLength(2)
     expect(paths[0].getAttribute(`d`)).toMatch(/^M50,50Z?$/)
     expect(paths[1].getAttribute(`d`)).toMatch(/^M50,50Z?L50,100L50,100Z$/)
   })
@@ -226,7 +226,7 @@ describe(`Line`, () => {
     })
 
     const paths = document.querySelectorAll(`path`)
-    expect(paths.length).toBe(2)
+    expect(paths).toHaveLength(2)
     // Further checks on internal tween state are difficult in unit tests,
     // but mounting confirms the props were accepted.
   })
@@ -248,7 +248,7 @@ describe(`Line`, () => {
     })
 
     const paths = document.querySelectorAll(`path`)
-    expect(paths.length).toBe(2)
+    expect(paths).toHaveLength(2)
 
     // Check that both paths received the rest props
     paths.forEach((path_element) => {

--- a/tests/vitest/plot/PlotControls.test.svelte.ts
+++ b/tests/vitest/plot/PlotControls.test.svelte.ts
@@ -71,7 +71,7 @@ describe(`PlotControls`, () => {
       const inputs = Array.from(
         document.querySelectorAll<HTMLInputElement>(`input.range-input`),
       )
-      expect(inputs.length).toBe(6) // 2 per axis
+      expect(inputs).toHaveLength(6) // 2 per axis
 
       // Test input updates work
       inputs[0].value = `10`
@@ -81,7 +81,7 @@ describe(`PlotControls`, () => {
 
     test(`hides y2 inputs when has_y2_points is false`, () => {
       mount_controls({ has_y2_points: false })
-      expect(document.querySelectorAll(`input.range-input`).length).toBe(4)
+      expect(document.querySelectorAll(`input.range-input`)).toHaveLength(4)
     })
   })
 
@@ -131,7 +131,7 @@ describe(`PlotControls`, () => {
     test(`renders correct number of grid controls`, () => {
       mount_controls({ has_y2_points: true })
       const grids = get_checkboxes_in_group(`grid`)
-      expect(grids.length).toBe(3)
+      expect(grids).toHaveLength(3)
     })
 
     test.each([
@@ -143,7 +143,7 @@ describe(`PlotControls`, () => {
     ])(`shows $expected zero line controls for ranges`, ({ x_range, y_range, expected }) => {
       mount_controls({ x_range, y_range, auto_x_range: x_range, auto_y_range: y_range })
       const zero_lines = get_checkboxes_in_group(`zero line`)
-      expect(zero_lines.length).toBe(expected)
+      expect(zero_lines).toHaveLength(expected)
     })
   })
 

--- a/tests/vitest/plot/PlotLegend.test.ts
+++ b/tests/vitest/plot/PlotLegend.test.ts
@@ -77,7 +77,7 @@ describe(`PlotLegend`, () => {
     expect(wrapper.style.gridTemplateRows).toBe(`repeat(1, auto)`)
 
     const items = document.querySelectorAll(`.legend-item`)
-    expect(items.length).toBe(default_series_data.length)
+    expect(items).toHaveLength(default_series_data.length)
 
     // Check first item details (visible)
     const first_item = items[0]
@@ -88,7 +88,7 @@ describe(`PlotLegend`, () => {
     expect(first_item.getAttribute(`aria-label`)).toBe(`Toggle visibility for Series 1`)
     expect(first_item.querySelector(`.legend-label`)?.textContent).toBe(`Series 1`)
     const first_marker_svgs = first_item.querySelectorAll(`.legend-marker > svg`)
-    expect(first_marker_svgs.length).toBe(2) // line + marker
+    expect(first_marker_svgs).toHaveLength(2) // line + marker
     expect(first_marker_svgs[0].querySelector(`line`)?.getAttribute(`stroke`)).toBe(`red`)
     expect(first_marker_svgs[0].querySelector(`line`)?.getAttribute(`stroke-dasharray`)).toBe(
       `solid`,
@@ -104,7 +104,7 @@ describe(`PlotLegend`, () => {
     expect(second_item.getAttribute(`aria-label`)).toBe(`Toggle visibility for Series 2`)
     expect(second_item.querySelector(`.legend-label`)?.textContent).toBe(`Series 2`)
     const second_marker_svgs = second_item.querySelectorAll(`.legend-marker > svg`)
-    expect(second_marker_svgs.length).toBe(2) // line + marker
+    expect(second_marker_svgs).toHaveLength(2) // line + marker
     expect(second_marker_svgs[0].querySelector(`line`)?.getAttribute(`stroke`)).toBe(`blue`)
     expect(second_marker_svgs[0].querySelector(`line`)?.getAttribute(`stroke-dasharray`)).toBe(
       `dashed`,
@@ -115,7 +115,7 @@ describe(`PlotLegend`, () => {
     const third_item = items[2]
     expect(third_item.getAttribute(`aria-pressed`)).toBe(`true`)
     const third_marker_svgs = third_item.querySelectorAll(`.legend-marker > svg`)
-    expect(third_marker_svgs.length).toBe(1) // Only marker shape svg
+    expect(third_marker_svgs).toHaveLength(1) // Only marker shape svg
     expect(third_marker_svgs[0].querySelector(`polygon`)).toBeInstanceOf(SVGPolygonElement) // triangle
     expect(third_marker_svgs[0].querySelector(`polygon`)?.getAttribute(`fill`)).toBe(`green`)
 
@@ -123,7 +123,7 @@ describe(`PlotLegend`, () => {
     const fourth_item = items[3]
     expect(fourth_item.getAttribute(`aria-pressed`)).toBe(`true`)
     const fourth_marker_svgs = fourth_item.querySelectorAll(`.legend-marker > svg`)
-    expect(fourth_marker_svgs.length).toBe(1) // Only line svg
+    expect(fourth_marker_svgs).toHaveLength(1) // Only line svg
     expect(fourth_marker_svgs[0].querySelector(`line`)).toBeInstanceOf(SVGLineElement) // line
     expect(fourth_marker_svgs[0].querySelector(`line`)?.getAttribute(`stroke`)).toBe(`purple`)
     expect(fourth_marker_svgs[0].querySelector(`line`)?.getAttribute(`stroke-dasharray`)).toBe(
@@ -302,11 +302,11 @@ describe(`PlotLegend`, () => {
     })
 
     const items = document.querySelectorAll(`.legend-item`)
-    expect(items.length).toBe(5)
+    expect(items).toHaveLength(5)
 
     // Circle/Solid
     const item1_marker_svgs = items[0].querySelectorAll(`.legend-marker > svg`)
-    expect(item1_marker_svgs.length).toBe(2) // Line + Marker
+    expect(item1_marker_svgs).toHaveLength(2) // Line + Marker
     expect(item1_marker_svgs[0].querySelector(`line`)?.getAttribute(`stroke-dasharray`)).toBe(
       `solid`,
     )
@@ -317,7 +317,7 @@ describe(`PlotLegend`, () => {
 
     // Square/Dashed
     const item2_marker_svgs = items[1].querySelectorAll(`.legend-marker > svg`)
-    expect(item2_marker_svgs.length).toBe(2)
+    expect(item2_marker_svgs).toHaveLength(2)
     expect(item2_marker_svgs[0].querySelector(`line`)?.getAttribute(`stroke-dasharray`)).toBe(
       `dashed`,
     )
@@ -328,7 +328,7 @@ describe(`PlotLegend`, () => {
 
     // Triangle/Dotted
     const item3_marker_svgs = items[2].querySelectorAll(`.legend-marker > svg`)
-    expect(item3_marker_svgs.length).toBe(2)
+    expect(item3_marker_svgs).toHaveLength(2)
     expect(item3_marker_svgs[0].querySelector(`line`)?.getAttribute(`stroke-dasharray`)).toBe(
       `dotted`,
     )
@@ -339,14 +339,14 @@ describe(`PlotLegend`, () => {
 
     // Cross (only marker) - rendered as filled polygon matching D3's symbolCross
     const item4_marker_svgs = items[3].querySelectorAll(`.legend-marker > svg`)
-    expect(item4_marker_svgs.length).toBe(1)
+    expect(item4_marker_svgs).toHaveLength(1)
     const cross_polygon = item4_marker_svgs[0].querySelector(`polygon`)
     expect(cross_polygon).toBeInstanceOf(SVGPolygonElement) // cross as filled polygon (plus shape)
     expect(cross_polygon?.getAttribute(`fill`)).toBe(`orange`)
 
     // Star (only marker)
     const item5_marker_svgs = items[4].querySelectorAll(`.legend-marker > svg`)
-    expect(item5_marker_svgs.length).toBe(1)
+    expect(item5_marker_svgs).toHaveLength(1)
     const star_polygon = item5_marker_svgs[0].querySelector(`polygon`)
     expect(star_polygon).toBeInstanceOf(SVGPolygonElement) // star polygon
     expect(star_polygon?.getAttribute(`fill`)).toBe(`magenta`)
@@ -430,18 +430,18 @@ describe(`PlotLegend`, () => {
 
     // Red
     const item1_marker_svgs = items[0].querySelectorAll(`.legend-marker > svg`)
-    expect(item1_marker_svgs.length).toBe(2)
+    expect(item1_marker_svgs).toHaveLength(2)
     expect(item1_marker_svgs[0].querySelector(`line`)?.getAttribute(`stroke`)).toBe(`red`)
     expect(item1_marker_svgs[1].querySelector(`circle`)?.getAttribute(`fill`)).toBe(`red`)
 
     // Blue Marker Only
     const item2_marker_svgs = items[1].querySelectorAll(`.legend-marker > svg`)
-    expect(item2_marker_svgs.length).toBe(1) // Only marker SVG rendered
+    expect(item2_marker_svgs).toHaveLength(1) // Only marker SVG rendered
     expect(item2_marker_svgs[0].querySelector(`rect`)?.getAttribute(`fill`)).toBe(`blue`)
 
     // Green Line Only
     const item3_marker_svgs = items[2].querySelectorAll(`.legend-marker > svg`)
-    expect(item3_marker_svgs.length).toBe(1) // Only line SVG rendered
+    expect(item3_marker_svgs).toHaveLength(1) // Only line SVG rendered
     expect(item3_marker_svgs[0].querySelector(`line`)?.getAttribute(`stroke`)).toBe(`green`)
   })
 
@@ -521,7 +521,7 @@ describe(`PlotLegend`, () => {
     const wrapper = doc_query(`.legend`)
     expect(wrapper).toBeInstanceOf(HTMLElement)
     const items = document.querySelectorAll(`.legend-item`)
-    expect(items.length).toBe(1)
+    expect(items).toHaveLength(1)
     expect(items[0].querySelector(`.legend-label`)?.textContent).toBe(`Series 1`)
     // Check ARIA attributes for single item
     expect(items[0].getAttribute(`role`)).toBe(`button`)
@@ -587,9 +587,9 @@ describe(`PlotLegend`, () => {
       })
 
       expect(doc_query(`.legend`).classList.contains(`grouped`)).toBe(expects.grouped_class)
-      expect(document.querySelectorAll(`.legend-group-header`).length).toBe(expects.headers)
-      expect(document.querySelectorAll(`.legend-item`).length).toBe(expects.items)
-      expect(document.querySelectorAll(`.legend-item.indented`).length).toBe(expects.indented)
+      expect(document.querySelectorAll(`.legend-group-header`)).toHaveLength(expects.headers)
+      expect(document.querySelectorAll(`.legend-item`)).toHaveLength(expects.items)
+      expect(document.querySelectorAll(`.legend-item.indented`)).toHaveLength(expects.indented)
 
       const group_labels = Array.from(document.querySelectorAll(`.legend-group-header`)).map(
         (h) => h.querySelector(`.group-label`)?.textContent,
@@ -689,19 +689,19 @@ describe(`PlotLegend`, () => {
 
       const chevron = doc_query(`.group-chevron`)
       expect(chevron.classList.contains(`collapsed`)).toBe(false)
-      expect(document.querySelectorAll(`.legend-item`).length).toBe(6)
+      expect(document.querySelectorAll(`.legend-item`)).toHaveLength(6)
 
       // Click to collapse
       chevron.dispatchEvent(new MouseEvent(`click`, { bubbles: true }))
       await tick()
       expect(chevron.classList.contains(`collapsed`)).toBe(true)
-      expect(document.querySelectorAll(`.legend-item`).length).toBe(3) // 6 - 3 Li₂O items
+      expect(document.querySelectorAll(`.legend-item`)).toHaveLength(3) // 6 - 3 Li₂O items
 
       // Keyboard (Enter) to expand
       chevron.dispatchEvent(new KeyboardEvent(`keydown`, { key: `Enter`, bubbles: true }))
       await tick()
       expect(chevron.classList.contains(`collapsed`)).toBe(false)
-      expect(document.querySelectorAll(`.legend-item`).length).toBe(6)
+      expect(document.querySelectorAll(`.legend-item`)).toHaveLength(6)
     })
 
     test(`collapsed_groups prop controls initial collapse state`, async () => {
@@ -718,13 +718,13 @@ describe(`PlotLegend`, () => {
       // NaCl (second group) should be expanded
       expect(chevrons[1].classList.contains(`collapsed`)).toBe(false)
       // Only 3 items visible (NaCl: 2 + Ungrouped: 1)
-      expect(document.querySelectorAll(`.legend-item`).length).toBe(3)
+      expect(document.querySelectorAll(`.legend-item`)).toHaveLength(3)
 
       // Clicking chevron updates the bound set
       chevrons[0].dispatchEvent(new MouseEvent(`click`, { bubbles: true }))
       await tick()
       expect(collapsed.has(`Li₂O`)).toBe(false) // Removed from set
-      expect(document.querySelectorAll(`.legend-item`).length).toBe(6)
+      expect(document.querySelectorAll(`.legend-item`)).toHaveLength(6)
     })
 
     test(`no grouping when legend_group not set`, () => {
@@ -734,8 +734,8 @@ describe(`PlotLegend`, () => {
       })
 
       expect(doc_query(`.legend`).classList.contains(`grouped`)).toBe(false)
-      expect(document.querySelectorAll(`.legend-group-header`).length).toBe(0)
-      expect(document.querySelectorAll(`.legend-item.indented`).length).toBe(0)
+      expect(document.querySelectorAll(`.legend-group-header`)).toHaveLength(0)
+      expect(document.querySelectorAll(`.legend-item.indented`)).toHaveLength(0)
     })
 
     test.each([
@@ -784,14 +784,14 @@ describe(`PlotLegend`, () => {
         props: { series_data: make_grouped_data() },
       })
 
-      expect(document.querySelectorAll(`.legend-item`).length).toBe(6)
+      expect(document.querySelectorAll(`.legend-item`)).toHaveLength(6)
 
       // Collapse first group (Li₂O)
       const chevrons = document.querySelectorAll(`.group-chevron`)
       chevrons[0].dispatchEvent(new MouseEvent(`click`, { bubbles: true }))
       await tick()
 
-      expect(document.querySelectorAll(`.legend-item`).length).toBe(3) // 6 - 3 Li₂O
+      expect(document.querySelectorAll(`.legend-item`)).toHaveLength(3) // 6 - 3 Li₂O
       expect(chevrons[1].classList.contains(`collapsed`)).toBe(false)
     })
 

--- a/tests/vitest/plot/ReferenceLine.test.ts
+++ b/tests/vitest/plot/ReferenceLine.test.ts
@@ -23,8 +23,8 @@ describe(`ReferenceLine`, () => {
     const svg = document.createElementNS(`http://www.w3.org/2000/svg`, `svg`)
     svg.setAttribute(`width`, `800`)
     svg.setAttribute(`height`, `600`)
-    container.appendChild(svg)
-    document.body.appendChild(container)
+    container.append(svg)
+    document.body.append(container)
   })
 
   test(`renders horizontal line correctly`, () => {
@@ -47,7 +47,7 @@ describe(`ReferenceLine`, () => {
     expect(group).toBeInstanceOf(SVGGElement)
 
     const lines = query_all(`line`)
-    expect(lines.length).toBe(2) // Hit area + visible line
+    expect(lines).toHaveLength(2) // Hit area + visible line
 
     // Verify the visible line is at correct y position
     const visible_line = Array.from(lines).find(
@@ -75,7 +75,7 @@ describe(`ReferenceLine`, () => {
     })
 
     const lines = query_all(`line`)
-    expect(lines.length).toBe(2) // Hit area + visible line
+    expect(lines).toHaveLength(2) // Hit area + visible line
 
     // Get the visible line (not transparent)
     const visible_line = Array.from(lines).find(
@@ -328,7 +328,7 @@ describe(`ReferenceLine`, () => {
 
     const lines = query_all(`line`)
     // Should have hit area + visible line
-    expect(lines.length).toBe(2)
+    expect(lines).toHaveLength(2)
   })
 
   test(`has correct aria-label`, () => {

--- a/tests/vitest/plot/ScatterPlot.test.svelte.ts
+++ b/tests/vitest/plot/ScatterPlot.test.svelte.ts
@@ -610,7 +610,7 @@ describe(`ScatterPlot`, () => {
       )
 
     // fill renders and has a legend item
-    expect(document.querySelectorAll(`.fill-region`).length).toBe(1)
+    expect(document.querySelectorAll(`.fill-region`)).toHaveLength(1)
     expect(fill_item()).toBeDefined()
 
     // hide it (what clicking the legend fill item does via the fill_regions binding)
@@ -619,7 +619,7 @@ describe(`ScatterPlot`, () => {
     await tick()
 
     // fill no longer drawn, but the legend item persists (greyed) so it can be toggled back
-    expect(document.querySelectorAll(`.fill-region`).length).toBe(0)
+    expect(document.querySelectorAll(`.fill-region`)).toHaveLength(0)
     expect(fill_item()?.classList.contains(`hidden`)).toBe(true)
 
     // hovering the hidden fill's legend item must not mark it active (nothing renders to highlight)

--- a/tests/vitest/plot/ScatterPlot3D.test.ts
+++ b/tests/vitest/plot/ScatterPlot3D.test.ts
@@ -56,7 +56,7 @@ describe(`ScatterPlot3D smoke tests`, () => {
 
   beforeEach(() => {
     container = document.createElement(`div`)
-    document.body.appendChild(container)
+    document.body.append(container)
     // Suppress WebGL warnings in jsdom environment
     vi.spyOn(console, `warn`).mockImplementation(() => {})
     vi.spyOn(console, `error`).mockImplementation(() => {})
@@ -251,9 +251,9 @@ describe(`ScatterPlot3D data processing`, () => {
 
     // Verify no valid point has undefined coordinates
     for (const pt of valid_points) {
-      expect(pt.x).not.toBeUndefined()
-      expect(pt.y).not.toBeUndefined()
-      expect(pt.z).not.toBeUndefined()
+      expect(pt.x).toBeDefined()
+      expect(pt.y).toBeDefined()
+      expect(pt.z).toBeDefined()
       expect(Number.isNaN(pt.x)).toBe(false)
       expect(Number.isNaN(pt.y)).toBe(false)
       expect(Number.isNaN(pt.z)).toBe(false)

--- a/tests/vitest/plot/ScatterPoint.test.ts
+++ b/tests/vitest/plot/ScatterPoint.test.ts
@@ -9,7 +9,7 @@ describe(`ScatterPoint`, () => {
   beforeEach(() => {
     const container = document.createElement(`div`)
     container.setAttribute(`style`, container_style)
-    document.body.appendChild(container)
+    document.body.append(container)
   })
 
   test(`renders with default props`, () => {

--- a/tests/vitest/plot/axis-utils.test.ts
+++ b/tests/vitest/plot/axis-utils.test.ts
@@ -91,7 +91,15 @@ describe(`create_axis_change_handler`, () => {
   test(`does not call data_loader when key unchanged and series loaded (no-op guard)`, async () => {
     const state = create_mock_state(`energy`)
     // Initialize with existing series so no-op guard is active
-    state.get_series = vi.fn(() => [{ x: [1], y: [1] }] as DataSeries[])
+    state.get_series = vi.fn(
+      () =>
+        [
+          {
+            x: [1],
+            y: [1],
+          },
+        ] as DataSeries[],
+    )
     const data_loader = vi.fn().mockResolvedValue({ series: [] })
     const on_axis_change = vi.fn()
 

--- a/tests/vitest/plot/data-cleaning.test.ts
+++ b/tests/vitest/plot/data-cleaning.test.ts
@@ -75,14 +75,14 @@ describe(`compute_local_variance`, () => {
 
   it(`handles NaN values gracefully`, () => {
     const result = compute_local_variance([1, 2, NaN, 4, 5], 3)
-    expect(result.length).toBe(5)
+    expect(result).toHaveLength(5)
     expect(result.every((v) => Number.isFinite(v))).toBe(true)
   })
 
   it(`handles different window sizes`, () => {
     const values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-    expect(compute_local_variance(values, 3).length).toBe(10)
-    expect(compute_local_variance(values, 7).length).toBe(10)
+    expect(compute_local_variance(values, 3)).toHaveLength(10)
+    expect(compute_local_variance(values, 7)).toHaveLength(10)
   })
 })
 
@@ -178,8 +178,8 @@ describe(`remove_local_outliers`, () => {
   it(`keeps all points for smooth linear data`, () => {
     const y = Array.from({ length: 30 }, (_, idx) => idx * 0.5)
     const result = remove_local_outliers(y)
-    expect(result.kept_indices.length).toBe(30)
-    expect(result.removed_indices.length).toBe(0)
+    expect(result.kept_indices).toHaveLength(30)
+    expect(result.removed_indices).toHaveLength(0)
   })
 
   it(`removes single isolated outlier`, () => {
@@ -257,7 +257,7 @@ describe(`remove_local_outliers`, () => {
 
   it(`respects mad_threshold parameter`, () => {
     const y = Array.from({ length: 50 }, (_, idx) => idx + Math.sin(idx) * 2)
-    y[25] = y[25] + 10 // Moderate deviation
+    y[25] += 10 // Moderate deviation
     // Low threshold = more aggressive = should catch it
     const low_threshold = remove_local_outliers(y, { mad_threshold: 1.5 })
     // High threshold = less aggressive = might keep it
@@ -279,8 +279,8 @@ describe(`remove_local_outliers`, () => {
     const y = Array(30).fill(5)
     const result = remove_local_outliers(y)
     // All points identical, zero MAD, nothing should be removed
-    expect(result.kept_indices.length).toBe(30)
-    expect(result.removed_indices.length).toBe(0)
+    expect(result.kept_indices).toHaveLength(30)
+    expect(result.removed_indices).toHaveLength(0)
   })
 
   it(`handles oscillating data without false positives`, () => {
@@ -296,9 +296,9 @@ describe(`remove_local_outliers`, () => {
     // Simulate typical thermodynamic data: G(T) = -aT^2 with spikes
     const y = Array.from({ length: 100 }, (_, idx) => -0.001 * idx * idx)
     // Add typical instability spikes at high T
-    y[70] = y[70] + 5
-    y[75] = y[75] - 8
-    y[80] = y[80] + 3
+    y[70] += 5
+    y[75] -= 8
+    y[80] += 3
     const result = remove_local_outliers(y, {
       window_half: 7,
       mad_threshold: 2.5,
@@ -325,7 +325,7 @@ describe(`handle_invalid_values`, () => {
     `$mode mode handles invalid values correctly`,
     ({ mode, y, expectedLen, invalidCount }) => {
       const result = handle_invalid_values([...y], mode)
-      expect(result.cleaned.length).toBe(expectedLen)
+      expect(result.cleaned).toHaveLength(expectedLen)
       expect(result.invalid_count).toBe(invalidCount)
       if (mode === `remove`) {
         expect(result.cleaned.every((v) => Number.isFinite(v))).toBe(true)
@@ -356,7 +356,7 @@ describe(`handle_invalid_values`, () => {
 
     // All invalid fallback
     const all = handle_invalid_values([NaN, NaN, NaN], `interpolate`)
-    expect(all.cleaned.length).toBe(3)
+    expect(all.cleaned).toHaveLength(3)
   })
 
   it(`handles ±Infinity correctly`, () => {
@@ -429,7 +429,7 @@ describe(`smooth_savitzky_golay`, () => {
     { input: [1, 2], window: 5, desc: `small array` },
   ])(`handles $desc`, ({ input, window }) => {
     const result = smooth_savitzky_golay(input, window)
-    expect(result.length).toBe(input.length)
+    expect(result).toHaveLength(input.length)
   })
 
   it(`preserves linear trends and smooths oscillations`, () => {
@@ -448,9 +448,9 @@ describe(`smooth_savitzky_golay`, () => {
 
   it(`handles different polynomial orders and NaN values`, () => {
     const quadratic = [0, 1, 4, 9, 16, 25, 36, 49, 64]
-    expect(smooth_savitzky_golay(quadratic, 5, 1).length).toBe(9)
-    expect(smooth_savitzky_golay(quadratic, 5, 2).length).toBe(9)
-    expect(smooth_savitzky_golay([1, 2, NaN, 4, 5, 6, 7], 5, 2).length).toBe(7)
+    expect(smooth_savitzky_golay(quadratic, 5, 1)).toHaveLength(9)
+    expect(smooth_savitzky_golay(quadratic, 5, 2)).toHaveLength(9)
+    expect(smooth_savitzky_golay([1, 2, NaN, 4, 5, 6, 7], 5, 2)).toHaveLength(7)
   })
 })
 
@@ -491,7 +491,7 @@ describe(`clean_series`, () => {
     }
     const result = clean_series(series, { in_place: false })
 
-    expect(result.series.x.length).toBe(4)
+    expect(result.series.x).toHaveLength(4)
     expect(result.quality.invalid_values_found).toBe(1)
     expect(result.series.metadata).toEqual([
       { id: `a` },
@@ -570,7 +570,7 @@ describe(`clean_series`, () => {
       expect(result.series.x.length).toBeLessThan(80)
     } else {
       expect(result.quality.stable_range).toBeDefined()
-      expect(result.series.x.length).toBe(80)
+      expect(result.series.x).toHaveLength(80)
     }
   })
 
@@ -595,7 +595,7 @@ describe(`clean_series`, () => {
       { x: [0, 1, 2, 3, 4], y: [0, NaN, 4, Infinity, 8] },
       { invalid_values: `propagate`, in_place: false },
     )
-    expect(result.series.x.length).toBe(5)
+    expect(result.series.x).toHaveLength(5)
     expect(Number.isNaN(result.series.y[1])).toBe(true)
     expect(result.series.y[3]).toBe(Infinity)
     expect(result.quality.points_removed).toBe(0)
@@ -654,7 +654,7 @@ describe(`clean_series`, () => {
       },
     )
     // All arrays should have same length
-    expect(result.series.y.length).toBe(result.series.x.length)
+    expect(result.series.y).toHaveLength(result.series.x.length)
     expect((result.series.metadata as { id: number }[])?.length).toBe(result.series.x.length)
     expect(result.series.color_values?.length).toBe(result.series.x.length)
     expect(result.series.size_values?.length).toBe(result.series.x.length)
@@ -674,7 +674,7 @@ describe(`clean_multi_series`, () => {
       ],
       { invalid_values: `interpolate` },
     )
-    expect(result.cleaned_y.length).toBe(2)
+    expect(result.cleaned_y).toHaveLength(2)
     expect(result.quality[0].invalid_values_found).toBe(1)
     expect(result.quality[1].invalid_values_found).toBe(1)
   })
@@ -686,8 +686,8 @@ describe(`clean_multi_series`, () => {
     const result = clean_multi_series([0, 1, 2], y_series, {
       invalid_values: `interpolate`,
     })
-    expect(result.cleaned_y.length).toBe(y_series.length)
-    expect(result.quality.length).toBe(y_series.length)
+    expect(result.cleaned_y).toHaveLength(y_series.length)
+    expect(result.quality).toHaveLength(y_series.length)
   })
 
   it(`applies bounds to all series`, () => {
@@ -717,9 +717,9 @@ describe(`clean_multi_series`, () => {
       { invalid_values: `remove` },
     )
     // Both NaN positions removed - only indices 0, 3, 4 should remain
-    expect(result.x.length).toBe(3)
-    expect(result.cleaned_y[0].length).toBe(result.x.length)
-    expect(result.cleaned_y[1].length).toBe(result.x.length)
+    expect(result.x).toHaveLength(3)
+    expect(result.cleaned_y[0]).toHaveLength(result.x.length)
+    expect(result.cleaned_y[1]).toHaveLength(result.x.length)
     // Verify correct values remain aligned
     expect(result.x).toEqual([0, 3, 4])
     expect(result.cleaned_y[0]).toEqual([0, 6, 8])
@@ -737,9 +737,9 @@ describe(`clean_multi_series`, () => {
     )
     // First series: -10 and 100 out of bounds -> indices 1, 2, 3 kept
     // All series filtered to intersection of valid indices
-    expect(result.x.length).toBe(3)
-    expect(result.cleaned_y[0].length).toBe(result.x.length)
-    expect(result.cleaned_y[1].length).toBe(result.x.length)
+    expect(result.x).toHaveLength(3)
+    expect(result.cleaned_y[0]).toHaveLength(result.x.length)
+    expect(result.cleaned_y[1]).toHaveLength(result.x.length)
     expect(result.x).toEqual([1, 2, 3])
   })
 
@@ -769,16 +769,16 @@ describe(`clean_xyz`, () => {
     const result = clean_xyz([0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, NaN, 4, 6, 8], {
       invalid_values: `interpolate`,
     })
-    expect(result.x.length).toBe(5)
-    expect(result.y.length).toBe(5)
-    expect(result.z.length).toBe(5)
+    expect(result.x).toHaveLength(5)
+    expect(result.y).toHaveLength(5)
+    expect(result.z).toHaveLength(5)
   })
 
   it.each([`x`, `y`, `z`] as const)(`respects primary_axis=%s option`, (axis) => {
     const result = clean_xyz([0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4], {
       primary_axis: axis,
     })
-    expect(result.x.length).toBe(5)
+    expect(result.x).toHaveLength(5)
     expect(result.quality).toBeDefined()
   })
 
@@ -801,9 +801,9 @@ describe(`clean_xyz`, () => {
         invalid_values: `remove`,
       },
     )
-    expect(result.x.length).toBe(4)
-    expect(result.y.length).toBe(result.x.length)
-    expect(result.z.length).toBe(result.x.length)
+    expect(result.x).toHaveLength(4)
+    expect(result.y).toHaveLength(result.x.length)
+    expect(result.z).toHaveLength(result.x.length)
     // Verify correct values at correct positions
     expect(result.x).toEqual([0, 1, 3, 4])
     expect(result.y).toEqual([10, 11, 13, 14])
@@ -821,9 +821,9 @@ describe(`clean_xyz`, () => {
       },
     )
     // Only indices 0 and 4 are valid across all three arrays
-    expect(result.x.length).toBe(2)
-    expect(result.y.length).toBe(2)
-    expect(result.z.length).toBe(2)
+    expect(result.x).toHaveLength(2)
+    expect(result.y).toHaveLength(2)
+    expect(result.z).toHaveLength(2)
     expect(result.x).toEqual([0, 4])
     expect(result.y).toEqual([10, 14])
     expect(result.z).toEqual([100, 104])
@@ -927,10 +927,10 @@ describe(`clean_trajectory_props`, () => {
     )
     // Only indices 0 and 4 are valid across all properties
     const expected_len = 2
-    expect(result.props.Step.length).toBe(expected_len)
-    expect(result.props.energy.length).toBe(expected_len)
-    expect(result.props.volume.length).toBe(expected_len)
-    expect(result.props.pressure.length).toBe(expected_len)
+    expect(result.props.Step).toHaveLength(expected_len)
+    expect(result.props.energy).toHaveLength(expected_len)
+    expect(result.props.volume).toHaveLength(expected_len)
+    expect(result.props.pressure).toHaveLength(expected_len)
     // Verify correct values remain
     expect(result.props.Step).toEqual([0, 4])
     expect(result.props.energy).toEqual([10, 50])
@@ -947,8 +947,8 @@ describe(`clean_trajectory_props`, () => {
       },
       { invalid_values: `remove`, independent_axis: `Step` },
     )
-    expect(result.props.Step.length).toBe(4)
-    expect(result.props.energy.length).toBe(4)
+    expect(result.props.Step).toHaveLength(4)
+    expect(result.props.energy).toHaveLength(4)
     expect(result.props.Step).toEqual([0, 2, 3, 4])
     expect(result.props.energy).toEqual([10, 30, 40, 50])
   })
@@ -983,7 +983,7 @@ describe(`Performance`, () => {
     const { x, y } = generate_linear_data(length, 0.1, 0.01)
     const start = performance.now()
     const result = clean_series({ x, y }, { smooth, in_place: false })
-    expect(result.series.x.length).toBe(length)
+    expect(result.series.x).toHaveLength(length)
     expect(performance.now() - start).toBeLessThan(maxMs)
   })
 })
@@ -1084,7 +1084,7 @@ describe(`Edge Cases`, () => {
     },
   ])(`handles $desc`, ({ x, y, expectedLen }) => {
     const result = clean_series({ x, y }, { invalid_values: `remove`, in_place: false })
-    expect(result.series.x.length).toBe(expectedLen)
+    expect(result.series.x).toHaveLength(expectedLen)
   })
 
   it(`preserves color_values and size_values during filtering`, () => {
@@ -1123,7 +1123,7 @@ describe(`Edge Cases`, () => {
         in_place: false,
       },
     )
-    expect(result.series.x.length).toBe(9)
+    expect(result.series.x).toHaveLength(9)
     expect(result.quality.invalid_values_found).toBe(1)
     expect(result.quality.bounds_violations).toBeGreaterThan(0)
   })
@@ -1139,7 +1139,7 @@ describe(`Edge Cases`, () => {
         in_place: false,
       },
     )
-    expect(result.series.x.length).toBe(length)
+    expect(result.series.x).toHaveLength(length)
     expect(result.quality.bounds_violations).toBeGreaterThan(0)
   })
 })

--- a/tests/vitest/plot/series-visibility.test.ts
+++ b/tests/vitest/plot/series-visibility.test.ts
@@ -166,7 +166,7 @@ describe(`handle_legend_double_click`, () => {
     const isolated = handle_legend_double_click(original, 1, null)
     const result = handle_legend_double_click(isolated.series, 1, isolated.prev_visibility)
     expect(result.series.map((srs) => srs.visible)).toEqual([true, true, true])
-    expect(result.prev_visibility).toBe(null)
+    expect(result.prev_visibility).toBeNull()
   })
 
   test.each([
@@ -185,7 +185,7 @@ describe(`handle_legend_double_click`, () => {
       isolated.prev_visibility,
     )
     expect(result.series.map((srs) => srs.visible)).toEqual([true, true, true, new_vis])
-    expect(result.prev_visibility).toBe(null)
+    expect(result.prev_visibility).toBeNull()
   })
 
   test(`does not restore stale visibility when series source changes`, () => {
@@ -204,7 +204,7 @@ describe(`handle_legend_double_click`, () => {
     const result = handle_legend_double_click(replacement, 1, isolated.prev_visibility)
 
     expect(result.series.map((srs) => srs.visible)).toEqual([false, true, false])
-    expect(result.prev_visibility).toBe(null)
+    expect(result.prev_visibility).toBeNull()
   })
 
   test(`isolates series by label`, () => {
@@ -222,7 +222,7 @@ describe(`handle_legend_double_click`, () => {
       { x: [1], y: [2], label: `A`, visible: true },
       { x: [3], y: [4], label: `B`, visible: false },
     ]
-    expect(handle_legend_double_click(series, 0, null).prev_visibility).toBe(null)
+    expect(handle_legend_double_click(series, 0, null).prev_visibility).toBeNull()
   })
 
   test(`isolates series without label by index`, () => {
@@ -246,6 +246,6 @@ describe(`handle_legend_double_click`, () => {
     const result = handle_legend_double_click(series, idx, null)
     // All series should remain visible (no isolation occurs)
     expect(result.series.map((srs) => srs.visible)).toEqual([true, true])
-    expect(result.prev_visibility).toBe(null)
+    expect(result.prev_visibility).toBeNull()
   })
 })

--- a/tests/vitest/rdf/calc-rdf.test.ts
+++ b/tests/vitest/rdf/calc-rdf.test.ts
@@ -475,7 +475,7 @@ describe(`calculate_all_pair_rdfs`, () => {
       n_bins: 50,
     })
 
-    expect(patterns1.length).toBe(patterns2.length)
+    expect(patterns1).toHaveLength(patterns2.length)
     for (let idx = 0; idx < patterns1.length; idx++) {
       expect(patterns1[idx].r).toEqual(patterns2[idx].r)
       expect(patterns1[idx].g_r).toEqual(patterns2[idx].g_r)

--- a/tests/vitest/sanitize.test.ts
+++ b/tests/vitest/sanitize.test.ts
@@ -132,7 +132,7 @@ describe(`sanitize_html`, () => {
   test.each([
     [`malicious toString()`, { toString: (): string => `<script>alert(1)</script>` }],
     [`double-encoded entities`, `<img src=x onerror=&#97;&#108;&#101;&#114;&#116;(1)>`],
-    [`null byte injection`, `<scr\x00ipt>alert(1)</script>`],
+    [`null byte injection`, `<scr\u0000ipt>alert(1)</script>`],
   ] as const)(`bypass attempt: %s`, (_name, input) => {
     assert_no_xss(sanitize_html(input))
   })

--- a/tests/vitest/setup.ts
+++ b/tests/vitest/setup.ts
@@ -4,8 +4,7 @@ import type { Crystal, LatticeParams, Pbc, Site } from '$lib/structure'
 import type { TrajectoryFrame } from '$lib/trajectory'
 import init from '@spglib/moyo-wasm'
 import { readFileSync } from 'node:fs'
-import { dirname, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { resolve } from 'node:path'
 import { flushSync, tick } from 'svelte'
 import { beforeEach, expect, vi } from 'vitest'
 
@@ -23,7 +22,7 @@ if (typeof localStorage.getItem !== `function`) {
 }
 
 // Resolve WASM path for Node.js environment (used by moyo-wasm integration tests)
-const current_dir = dirname(fileURLToPath(import.meta.url))
+const current_dir = import.meta.dirname
 const MOYO_WASM_PATH = resolve(
   current_dir,
   `../../node_modules/@spglib/moyo-wasm/moyo_wasm_bg.wasm`,
@@ -142,7 +141,8 @@ export async function assert_hover_scoped_shortcut(opts: {
   fire()
   expect(took_effect(), `hovered → fires without a prior click`).toBe(true)
 
-  const input = document.body.appendChild(document.createElement(`input`))
+  const input = document.createElement(`input`)
+  document.body.append(input)
   input.focus()
   fire()
   expect(took_effect(), `input focused → bails`).toBe(false)

--- a/tests/vitest/setup.ts
+++ b/tests/vitest/setup.ts
@@ -12,7 +12,7 @@ import { beforeEach, expect, vi } from 'vitest'
 // API (getItem/setItem/etc). Vitest's populateGlobal skips overriding globals
 // already present unless explicitly allowlisted — localStorage isn't.
 // Replace with happy-dom's spec-compliant Storage when methods are missing.
-if (typeof localStorage.getItem !== `function`) {
+if (typeof localStorage === `undefined` || typeof localStorage.getItem !== `function`) {
   const { Storage } = await import(`happy-dom`)
   Object.defineProperty(globalThis, `localStorage`, {
     value: new Storage(),

--- a/tests/vitest/site/phonons.test.ts
+++ b/tests/vitest/site/phonons.test.ts
@@ -199,7 +199,7 @@ describe(`Phonon Module Tests`, () => {
       expect(dos).toBeDefined()
       expect(Array.isArray(dos.frequencies)).toBe(true)
       expect(Array.isArray(dos.densities)).toBe(true)
-      expect(dos.frequencies.length).toBe(dos.densities.length)
+      expect(dos.frequencies).toHaveLength(dos.densities.length)
       expect(dos.frequencies.length).toBeGreaterThan(0)
 
       // Frequencies should be monotonically increasing
@@ -304,10 +304,7 @@ describe(`Phonon Module Tests`, () => {
 
       // Verify all bands have consistent length
       for (const [band_idx, band] of band_struct.bands.entries()) {
-        expect(
-          band.length,
-          `${id}: band ${band_idx} should have ${band_struct.qpoints.length} points`,
-        ).toBe(band_struct.qpoints.length)
+        expect(band, `${id}: band ${band_idx}`).toHaveLength(band_struct.qpoints.length)
       }
     },
   )
@@ -337,9 +334,7 @@ describe(`Phonon Module Tests`, () => {
       if (!raw_qpoints || !raw_bands || !raw_labels) return // Guard for TypeScript
 
       // Verify transformation preserves data dimensions
-      expect(transformed.qpoints.length, `${id}: qpoint count should match`).toBe(
-        raw_qpoints.length,
-      )
+      expect(transformed.qpoints).toHaveLength(raw_qpoints.length)
       expect(transformed.nb_bands, `${id}: band count should match`).toBe(raw_bands.length)
       expect(
         Object.keys(transformed.labels_dict).sort(),

--- a/tests/vitest/site/plot-utils.test.ts
+++ b/tests/vitest/site/plot-utils.test.ts
@@ -12,7 +12,7 @@ describe(`plot-utils random generators`, () => {
 
   test(`generators produce correct length and finite values`, () => {
     const size = 10
-    const thunks: ReadonlyArray<() => number[]> = [
+    const thunks: readonly (() => number[])[] = [
       () => utils.generate_normal(size, 0, 1),
       () => utils.generate_exponential(size, 1),
       () => utils.generate_uniform(size, 0, 1),
@@ -36,7 +36,7 @@ describe(`plot-utils random generators`, () => {
 
     for (const make_array of thunks) {
       const arr = make_array()
-      expect(arr.length).toBe(size)
+      expect(arr).toHaveLength(size)
       arr.forEach((num: number) => expect(Number.isFinite(num)).toBe(true))
     }
   })

--- a/tests/vitest/spectral/Bands.test.ts
+++ b/tests/vitest/spectral/Bands.test.ts
@@ -147,7 +147,7 @@ describe(`Bands component`, () => {
       highlight_regions: [{ y_min: 0.5, y_max: 1.5, label: `Window` }],
     })
     const fill_region_paths = document.querySelectorAll(`g.fill-region path[fill-opacity]`)
-    expect(fill_region_paths.length).toBe(1)
+    expect(fill_region_paths).toHaveLength(1)
   })
 
   it(`shows band-gap annotation when electronic gap exists`, async () => {

--- a/tests/vitest/spectral/Dos.test.ts
+++ b/tests/vitest/spectral/Dos.test.ts
@@ -189,7 +189,7 @@ describe(`Dos component`, () => {
     // Each spin-polarized DOS with overlay+stack should render 2 areas (up + down)
     // So 2 DOS entries = 4 area paths total
     const area_paths = document.querySelectorAll(`path[fill-opacity]`)
-    expect(area_paths.length).toBe(4)
+    expect(area_paths).toHaveLength(4)
 
     // Validate structural layering: spin-up and spin-down areas should have different colors
     // In overlay+stack mode, spin-up uses color at index dos_idx, spin-down at (dos_idx * 2 + 1)

--- a/tests/vitest/spectral/helpers.test.ts
+++ b/tests/vitest/spectral/helpers.test.ts
@@ -185,13 +185,13 @@ describe(`detect_zoom_change`, () => {
     { bands: zoomed, dos: zoomed, synced: zoomed, dos_en: true },
     { bands: [1, 9], dos: [2, 6], synced: null, dos_en: true },
   ])(`returns undefined for no change: $bands,$dos`, ({ bands, dos, synced, dos_en }) => {
-    expect(detect_zoom_change(bands, dos, shared, synced, dos_en)).toBe(undefined)
+    expect(detect_zoom_change(bands, dos, shared, synced, dos_en)).toBeUndefined()
   })
 
   // dos_enabled=false: ignores DOS
   it(`ignores dos when dos_enabled=false`, () => {
-    expect(detect_zoom_change(shared, zoomed, shared, null, false)).toBe(undefined)
-    expect(detect_zoom_change(zoomed, null, shared, zoomed, false)).toBe(undefined)
+    expect(detect_zoom_change(shared, zoomed, shared, null, false)).toBeUndefined()
+    expect(detect_zoom_change(zoomed, null, shared, zoomed, false)).toBeUndefined()
     expect(detect_zoom_change(zoomed, shared, shared, null, false)).toEqual(zoomed)
   })
 })
@@ -434,10 +434,10 @@ describe(`find_qpoint_at_distance`, () => {
   it(`returns null for empty or invalid band structure`, () => {
     expect(
       find_qpoint_at_distance({ distance: [] } as unknown as BaseBandStructure, 1.0),
-    ).toBe(null)
+    ).toBeNull()
     expect(
       find_qpoint_at_distance({ distance: undefined } as unknown as BaseBandStructure, 1.0),
-    ).toBe(null)
+    ).toBeNull()
   })
 
   it(`correctly distinguishes repeated symmetry points`, () => {
@@ -715,7 +715,7 @@ describe(`find_qpoint_at_rescaled_x`, () => {
     expect(find_qpoint_at_rescaled_x(rescaled_bs, 0.5, {})).toBe(0) // Fallback
     expect(
       find_qpoint_at_rescaled_x({ branches: [] } as unknown as BaseBandStructure, 0.5, {}),
-    ).toBe(null)
+    ).toBeNull()
   })
 })
 
@@ -1839,7 +1839,7 @@ describe(`compute_frequency_range`, () => {
     // 100 points from -0.1 to 10, with most density at positive frequencies
     const frequencies = Array.from({ length: 101 }, (_, idx) => -0.1 + idx * 0.101)
     const densities = frequencies.map((freq) =>
-      freq < 0 ? 0.001 : Math.exp(-Math.pow(freq - 5, 2)),
+      freq < 0 ? 0.001 : Math.exp(-((freq - 5) ** 2)),
     )
     const dos = { frequencies, densities }
     const range = compute_frequency_range(undefined, dos)

--- a/tests/vitest/structure/AtomLegend.test.ts
+++ b/tests/vitest/structure/AtomLegend.test.ts
@@ -517,15 +517,16 @@ describe(`AtomLegend Component`, () => {
         scale_type: `continuous` as const,
       }
 
-      const property_colors = unique_values.length
-        ? {
-            colors: legend_colors,
-            values: [...unique_values, ...unique_values], // Add duplicates
-            min_value: Math.min(...unique_values),
-            max_value: Math.max(...unique_values),
-            unique_values,
-          }
-        : null
+      const property_colors =
+        unique_values.length > 0
+          ? {
+              colors: legend_colors,
+              values: [...unique_values, ...unique_values], // Add duplicates
+              min_value: Math.min(...unique_values),
+              max_value: Math.max(...unique_values),
+              unique_values,
+            }
+          : null
 
       expect(() => {
         mount(AtomLegend, {
@@ -1010,8 +1011,8 @@ describe(`Disordered Site Color Assignment`, () => {
   test(`each species at disordered site gets own element color`, () => {
     const result = compute_atom_colors([create_species(`Bi`, 0.5), create_species(`Zr`, 0.5)])
 
-    expect(get_color(result, `Bi`)).toBe(colors.element[`Bi`])
-    expect(get_color(result, `Zr`)).toBe(colors.element[`Zr`])
+    expect(get_color(result, `Bi`)).toBe(colors.element.Bi)
+    expect(get_color(result, `Zr`)).toBe(colors.element.Zr)
     expect(result[0].color).not.toBe(result[1].color)
   })
 
@@ -1046,8 +1047,8 @@ describe(`Disordered Site Color Assignment`, () => {
         create_species(`Zr`, 0.5),
       ])
 
-      expect(get_color(result, `Bi`)).toBe(ELEMENT_COLOR_SCHEMES[scheme][`Bi`])
-      expect(get_color(result, `Zr`)).toBe(ELEMENT_COLOR_SCHEMES[scheme][`Zr`])
+      expect(get_color(result, `Bi`)).toBe(ELEMENT_COLOR_SCHEMES[scheme].Bi)
+      expect(get_color(result, `Zr`)).toBe(ELEMENT_COLOR_SCHEMES[scheme].Zr)
     },
   )
 })

--- a/tests/vitest/structure/CellSelect.test.svelte.ts
+++ b/tests/vitest/structure/CellSelect.test.svelte.ts
@@ -58,7 +58,7 @@ describe(`CellSelect`, () => {
         target: document.body,
         props: { supercell_scaling: `1x1x1`, loading },
       })
-      expect(!!document.querySelector(`.toggle-btn .spinner`)).toBe(has_spinner)
+      expect(Boolean(document.querySelector(`.toggle-btn .spinner`))).toBe(has_spinner)
     })
   })
 

--- a/tests/vitest/structure/Structure.test.svelte.ts
+++ b/tests/vitest/structure/Structure.test.svelte.ts
@@ -173,7 +173,7 @@ describe(`Structure`, () => {
     await tick()
 
     expect(event.defaultPrevented, `Delete should be handled`).toBe(true)
-    expect(state.structure.sites.length, `one atom removed`).toBe(n_before - 1)
+    expect(state.structure.sites).toHaveLength(n_before - 1)
   })
 
   test.each([
@@ -531,7 +531,7 @@ describe(`Structure`, () => {
 
     first_site_row.dispatchEvent(new MouseEvent(`mouseleave`, { bubbles: true }))
     expect(state.highlighted_sites).toEqual([])
-    expect(state.hovered_site_idx).toBe(null)
+    expect(state.hovered_site_idx).toBeNull()
 
     first_site_row.click()
     expect(state.selected_sites).toEqual([0])
@@ -865,7 +865,7 @@ describe(`atom label controls`, () => {
     ) as HTMLInputElement
 
     expect(parseFloat(size_input.value)).toBeCloseTo(1.2, 1)
-    expect(parseInt(padding_input.value)).toBe(4)
+    expect(parseInt(padding_input.value, 10)).toBe(4)
 
     size_input.value = `1.8`
     padding_input.value = `6`
@@ -873,7 +873,7 @@ describe(`atom label controls`, () => {
     padding_input.dispatchEvent(new Event(`input`, { bubbles: true }))
 
     expect(parseFloat(size_input.value)).toBeCloseTo(1.8, 1)
-    expect(parseInt(padding_input.value)).toBe(6)
+    expect(parseInt(padding_input.value, 10)).toBe(6)
   })
 
   test(`input constraints are correct`, () => {
@@ -1029,7 +1029,7 @@ describe(`Structure string parsing`, () => {
             el,
           ),
         )
-        expect(!!(`lattice` in parse_state.parsed && parse_state.parsed.lattice)).toBe(
+        expect(Boolean(`lattice` in parse_state.parsed && parse_state.parsed.lattice)).toBe(
           has_lattice,
         )
       }
@@ -1075,7 +1075,7 @@ describe(`Structure string parsing`, () => {
       props: {
         structure_string: SAMPLE_POSCAR_CONTENT,
         on_file_load: (data: StructureHandlerData) => {
-          size = data.file_size || 0
+          size = data.file_size ?? 0
         },
       },
     })
@@ -1094,7 +1094,7 @@ describe(`Structure string parsing`, () => {
       props: {
         data_url: `/test.poscar`,
         structure_string: `ignored`,
-        on_file_load: (data: StructureHandlerData) => (filename = data.filename || ``),
+        on_file_load: (data: StructureHandlerData) => (filename = data.filename ?? ``),
       },
     })
     await tick()

--- a/tests/vitest/structure/Structure.test.svelte.ts
+++ b/tests/vitest/structure/Structure.test.svelte.ts
@@ -52,29 +52,6 @@ const create_drop_event = (files: File[]): DragEvent => {
   return drag_event
 }
 
-// Wait for text to appear in document.body via MutationObserver polling
-const wait_for_dom_text = (text: string, timeout_ms = 3000): Promise<void> =>
-  new Promise((resolve, reject) => {
-    const timeout_id = setTimeout(() => {
-      observer.disconnect()
-      reject(new Error(`Timed out waiting for "${text}" in DOM`))
-    }, timeout_ms)
-    const check = () => {
-      if (document.body.textContent?.includes(text)) {
-        clearTimeout(timeout_id)
-        observer.disconnect()
-        resolve()
-      }
-    }
-    const observer = new MutationObserver(check)
-    observer.observe(document.body, {
-      childList: true,
-      subtree: true,
-      characterData: true,
-    })
-    check()
-  })
-
 // Tests for Structure component functionality
 describe(`Structure`, () => {
   test(`open control pane when clicking toggle button`, () => {
@@ -483,21 +460,36 @@ describe(`Structure`, () => {
     expect(file_content).toBe(`test content`)
   })
 
-  test(`drag and drop without on_file_drop handler`, async () => {
+  test(`drag and drop without on_file_drop handler parses the file internally`, async () => {
+    // No on_file_drop → component parses the dropped file itself and emits on_file_load.
+    // Awaiting the callback is deterministic (no DOM polling), unlike a rendered-text race.
+    let loaded: StructureHandlerData | undefined
+    let resolve_load!: () => void
+    const load_done = new Promise<void>((resolve) => (resolve_load = resolve))
+
     mount(Structure, {
       target: document.body,
-      props: { structure: undefined, show_controls: true },
+      props: {
+        structure: undefined,
+        show_controls: true,
+        on_file_load: (data: StructureHandlerData) => {
+          loaded = data
+          resolve_load()
+        },
+      },
     })
 
     const wrapper = document.querySelector(`.structure`) as HTMLElement
     expect(wrapper).toBeInstanceOf(HTMLElement)
 
     const file = new File([SAMPLE_POSCAR_CONTENT], `test.poscar`, { type: `text/plain` })
-    const drag_event = create_drop_event([file])
+    wrapper.dispatchEvent(create_drop_event([file]))
 
-    wrapper.dispatchEvent(drag_event)
-    await wait_for_dom_text(`Ba Ti O3`)
-    expect(document.body.textContent).toContain(`Ba Ti O3`)
+    await load_done
+    expect(loaded?.filename).toBe(`test.poscar`)
+    expect(loaded?.total_atoms).toBe(5)
+    const elements = loaded?.structure?.sites.map((site) => site.species[0].element)
+    expect(elements).toEqual(expect.arrayContaining([`Ba`, `Ti`, `O`]))
   })
 
   test(`info pane site hover updates highlighted sites`, async () => {

--- a/tests/vitest/structure/StructureControls.test.ts
+++ b/tests/vitest/structure/StructureControls.test.ts
@@ -66,7 +66,7 @@ describe(`StructureControls`, () => {
     })
     // Should not crash and supercell input should not be visible
     const supercell_inputs = document.querySelectorAll(`input[placeholder="1x1x1"]`)
-    expect(supercell_inputs.length).toBe(0)
+    expect(supercell_inputs).toHaveLength(0)
   })
 
   test(`handles undefined structure`, () => {

--- a/tests/vitest/structure/StructureExportPane.test.ts
+++ b/tests/vitest/structure/StructureExportPane.test.ts
@@ -127,7 +127,7 @@ describe(`StructureExportPane`, () => {
 
       await vi.waitFor(() => {
         expect(str_fn).toHaveBeenCalledWith(simple_structure)
-        expect(navigator.clipboard[`writeText`]).toHaveBeenCalledWith(expected_content)
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith(expected_content)
       })
     },
   )
@@ -340,16 +340,16 @@ describe(`StructureExportPane`, () => {
       h4.textContent?.includes(`Export as text`),
     )?.nextElementSibling
 
-    const download_buttons = Array.from(text_section?.querySelectorAll(`button`) || []).filter(
+    const download_buttons = Array.from(text_section?.querySelectorAll(`button`) ?? []).filter(
       (btn) => btn.title?.includes(`Download`),
     )
-    expect(download_buttons.length).toBe(4)
+    expect(download_buttons).toHaveLength(4)
     download_buttons.forEach((btn) => expect(btn.title).toContain(`Download`))
 
-    const copy_buttons = Array.from(text_section?.querySelectorAll(`button`) || []).filter(
+    const copy_buttons = Array.from(text_section?.querySelectorAll(`button`) ?? []).filter(
       (btn) => btn.title?.includes(`Copy`) && btn.title?.includes(`clipboard`),
     )
-    expect(copy_buttons.length).toBe(4)
+    expect(copy_buttons).toHaveLength(4)
     copy_buttons.forEach((btn) => {
       expect(btn.title).toContain(`Copy`)
       expect(btn.title).toContain(`clipboard`)

--- a/tests/vitest/structure/StructureInfoPane.test.ts
+++ b/tests/vitest/structure/StructureInfoPane.test.ts
@@ -100,7 +100,7 @@ describe(`StructureInfoPane`, () => {
       expect(state.hovered_site_idx).toBe(1)
       site_row.dispatchEvent(new MouseEvent(`mouseleave`, { bubbles: true }))
       expect(state.highlighted_sites).toEqual([])
-      expect(state.hovered_site_idx).toBe(null)
+      expect(state.hovered_site_idx).toBeNull()
 
       const filter_input = document.querySelector(`input.site-filter`) as HTMLInputElement
       filter_input.value = `H2`

--- a/tests/vitest/structure/atom-properties.test.ts
+++ b/tests/vitest/structure/atom-properties.test.ts
@@ -45,7 +45,7 @@ const make_cubic_structure = (
     species: [{ element: element as ElementSymbol, occu: 1, oxidation_state: 0 }],
     abc,
     xyz: [abc[0] * lattice_size, abc[1] * lattice_size, abc[2] * lattice_size] as Vec3,
-    label: label || element,
+    label: label ?? element,
     properties: {},
   })),
   lattice: {
@@ -491,7 +491,7 @@ describe(`get_atom_colors`, () => {
       `electroneg_ratio`,
       mode === `wyckoff` ? null : undefined,
     )
-    expect(colors.length).toBe(len)
+    expect(colors).toHaveLength(len)
   })
 
   test(`custom with fn`, () => {
@@ -515,7 +515,7 @@ describe(`Config`, () => {
 
   test(`partial uses defaults`, () => {
     const { colors } = ap.get_atom_colors(structure, { mode: `coordination` })
-    expect(colors.length).toBe(2)
+    expect(colors).toHaveLength(2)
   })
 
   test(`empty defaults to element`, () => {

--- a/tests/vitest/structure/bonding.test.ts
+++ b/tests/vitest/structure/bonding.test.ts
@@ -773,7 +773,7 @@ describe(`Electronegativity-Based Bonding`, () => {
       metal_metal_penalty: 0.1,
       metal_nonmetal_bonus: 2.5,
     })
-    expect(lenient.length).not.toBe(strict.length)
+    expect(lenient).not.toHaveLength(strict.length)
   })
 
   test(`distance constraints`, () => {
@@ -950,7 +950,7 @@ test(`electroneg_ratio treats original and image atoms symmetrically`, () => {
   bonds_orig.sort((a, b) => a.bond_length - b.bond_length)
   bonds_img.sort((a, b) => a.bond_length - b.bond_length)
 
-  expect(bonds_img.length).toBe(bonds_orig.length)
+  expect(bonds_img).toHaveLength(bonds_orig.length)
 
   // If fixed, both should have 1 bond (because the penalty is now applied to both)
   // Or both have 2 (if penalty wasn't strong enough).
@@ -963,7 +963,7 @@ test(`electroneg_ratio treats original and image atoms symmetrically`, () => {
   // because we calculate closest distances for all pairs BEFORE applying penalties.
   // So the Short bond (2.0) will penalize the Long bond (3.0) even for the original atom.
 
-  expect(bonds_orig.length).toBe(bonds_img.length)
+  expect(bonds_orig).toHaveLength(bonds_img.length)
 })
 test(`electroneg_ratio preserves longer C-C bonds in presence of shorter C-H bonds`, () => {
   // Benzene-like fragment: C bonded to C and H.

--- a/tests/vitest/structure/export.test.ts
+++ b/tests/vitest/structure/export.test.ts
@@ -231,7 +231,7 @@ describe(`Export functionality`, () => {
       const exported = out(to_any(parsed))
       const reparsed = parse_structure_file(exported)
       assert(reparsed?.lattice, `failed to reparse`)
-      expect(reparsed.sites.length).toBe(parsed.sites.length)
+      expect(reparsed.sites).toHaveLength(parsed.sites.length)
       const L = reparsed.lattice.matrix
       reparsed.sites.forEach((site, idx) => {
         expect(site.abc[0]).toBeCloseTo(parsed.sites[idx].abc[0], TOL)
@@ -1005,13 +1005,11 @@ describe(`Export functionality`, () => {
         const lines = content.split(`\n`)
         if (format === `xyz`) {
           expect(lines[2]).toBe(expected)
-        } else if (format === `cif`) {
-          const coord_line = lines.find((line) => line.includes(`H1`))
-          expect(coord_line).toBeDefined()
-          expect(coord_line).toContain(expected)
         } else {
-          // poscar
-          const coord_line = lines.find((line) => /^0\.\d+ 0\.\d+ 0\.\d+$/.exec(line))
+          const coord_line =
+            format === `cif`
+              ? lines.find((line) => line.includes(`H1`))
+              : lines.find((line) => /^0\.\d+ 0\.\d+ 0\.\d+$/.exec(line)) // poscar
           expect(coord_line).toBeDefined()
           expect(coord_line).toContain(expected)
         }
@@ -1166,7 +1164,7 @@ describe(`Export functionality`, () => {
       const xyz_content = structure_to_xyz_str(large_structure)
       const lines = xyz_content.split(`\n`)
       expect(lines[0]).toBe(`1000`)
-      expect(lines.length).toBe(1002) // 1 count + 1 comment + 1000 atoms
+      expect(lines).toHaveLength(1002) // 1 count + 1 comment + 1000 atoms
     })
 
     it(`handles structures with mixed coordinate types`, () => {

--- a/tests/vitest/structure/index.test.ts
+++ b/tests/vitest/structure/index.test.ts
@@ -169,12 +169,12 @@ test.each(structures)(`symmetrize_structure`, (structure) => {
 
   // Basic sanity checks
   expect(symmetrized.sites.length, msg).toBeGreaterThanOrEqual(orig_len)
-  expect(structure.sites.length, msg).toBe(orig_len) // Original structure unchanged
+  expect(structure.sites).toHaveLength(orig_len) // Original structure unchanged
 
   // If structure has lattice and any atoms at edges, should have image atoms
   if (structure.lattice) {
     const image_atoms = struct_utils.find_image_atoms(structure)
-    expect(symmetrized.sites.length, msg).toBe(orig_len + image_atoms.length)
+    expect(symmetrized.sites).toHaveLength(orig_len + image_atoms.length)
   }
 })
 

--- a/tests/vitest/structure/label-placement.test.ts
+++ b/tests/vitest/structure/label-placement.test.ts
@@ -41,7 +41,7 @@ describe(`label placement`, () => {
     const offset = choose_site_label_offset(bond_directions, base_offset)
 
     expect(Math.hypot(...offset)).toBeCloseTo(Math.hypot(...base_offset))
-    expect(math.dot(math.normalize_vec3(offset), [0, 1, 0])).toBeLessThan(0.5)
+    expect(math.dot(math.normalize_vec(offset), [0, 1, 0])).toBeLessThan(0.5)
   })
 
   test(`label position calculator reads updated label offset`, () => {

--- a/tests/vitest/structure/parse.test.ts
+++ b/tests/vitest/structure/parse.test.ts
@@ -725,7 +725,7 @@ O2   O   0.410  0.140  0.880  1.000`
 
     // Expect exact total sites from CIF header (_atom_type_number_in_cell)
     // Ru: 4, S: 24, P: 24, N: 16, C: 296, H: 252 → total = 616
-    expect(result.sites.length).toBe(616)
+    expect(result.sites).toHaveLength(616)
 
     // Per-element site counts must match header to ensure symmetry expansion isn't over-generating
     const element_counts: Record<string, number> = {}
@@ -925,7 +925,7 @@ H1   H   0.500  0.500  0.500  1.000  1.000`
 
       const result = parse_cif(malformed_cif)
       assert(result, `Failed to parse malformed CIF`)
-      expect(result.sites.length).toBe(3)
+      expect(result.sites).toHaveLength(3)
       expect(result.sites[0].species[0].occu).toBe(1.0)
     })
 
@@ -1327,7 +1327,7 @@ loop_
     assert(result, `Failed to parse CIF`)
 
     // Formula: Cs1 K1 B8 O12 F2 = 24 sites
-    expect(result.sites.length).toBe(24)
+    expect(result.sites).toHaveLength(24)
     const counts: Record<string, number> = {}
     for (const site of result.sites) {
       counts[site.species[0].element] = (counts[site.species[0].element] ?? 0) + 1
@@ -1440,7 +1440,7 @@ Na Na 0.000 0.000 0.000`
     // OH2: 1 site with 0.655 occupancy
     // OH: 1 site with 0.345 occupancy
     // Total: 5 oxygen sites
-    expect(oxygen_sites.length).toBe(5)
+    expect(oxygen_sites).toHaveLength(5)
 
     // Check that we have the expected number of each type
     const o1_count = oxygen_sites.filter((site) => site.label === `O1`).length
@@ -1456,7 +1456,7 @@ Na Na 0.000 0.000 0.000`
     expect(oh_count).toBe(1) // 1 unique site
 
     // Check total sites (5 O + 1 As + 3 Zn/Fe/Pb (mixed occupancy) + 1 Pb)
-    expect(result.sites.length).toBe(10)
+    expect(result.sites).toHaveLength(10)
 
     // Verify lattice parameters
     expect(result.lattice?.a).toBeCloseTo(9.143, 3)
@@ -1472,7 +1472,7 @@ Na Na 0.000 0.000 0.000`
 
     // P42/nmc (space group 137), 16 symmetry ops, 9 unique sites
     // After expansion: 62 sites (Ge1/P1 share position but are separate entries)
-    expect(result.sites.length).toBe(62)
+    expect(result.sites).toHaveLength(62)
 
     const count = el_count(result)
     expect(count(`Li`)).toBe(28)
@@ -1492,7 +1492,7 @@ Na Na 0.000 0.000 0.000`
 
     // Fm-3m (space group 225), 192 symmetry ops, 7 unique sites
     // Same as pymatgen: 424 sites (C=192, H=96, O=104, Zn=32)
-    expect(result.sites.length).toBe(424)
+    expect(result.sites).toHaveLength(424)
 
     const count = el_count(result)
     expect(count(`Zn`)).toBe(32)
@@ -1580,9 +1580,9 @@ unit_cell:
     },
     {
       name: `phonopy YAML with phonon_displacements`,
-      content:
-        simple_phonopy_yaml +
-        `\nphonon_displacements:\n- # This should be ignored for performance\n  - 0.1\n  - 0.2\n  - 0.3`,
+      content: `${
+        simple_phonopy_yaml
+      }\nphonon_displacements:\n- # This should be ignored for performance\n  - 0.1\n  - 0.2\n  - 0.3`,
       expected_result: `structure`,
       expected_sites: 2,
     },
@@ -1864,7 +1864,7 @@ describe(`parse_structure_file`, () => {
     // Verify the file contains valid JSON with expected structure
     const parsed = JSON.parse(content)
     expect(Array.isArray(parsed)).toBe(true)
-    expect(parsed.length).toBe(1)
+    expect(parsed).toHaveLength(1)
     expect(parsed[0]).toHaveProperty(`structure`)
 
     // Validate the nested structure format
@@ -1872,7 +1872,7 @@ describe(`parse_structure_file`, () => {
     expect(typeof nested_structure).toBe(`object`)
     expect(nested_structure).toHaveProperty(`sites`)
     expect(Array.isArray(nested_structure.sites)).toBe(true)
-    expect(nested_structure.sites.length).toBe(180)
+    expect(nested_structure.sites).toHaveLength(180)
 
     // Test the actual parsing function can handle this format
     const result = parse_structure_file(content, hea_hcp_filename)
@@ -2398,7 +2398,7 @@ describe(`OPTIMADE JSON parser`, () => {
     // Verify the expected error was logged
     if (expected_error) {
       const error_calls = console_error_spy.mock.calls
-      expect(error_calls.length).toBe(1)
+      expect(error_calls).toHaveLength(1)
       expect(error_calls[0][0]).toContain(expected_error)
     }
   })
@@ -2778,7 +2778,7 @@ describe(`OPTIMADE to Pymatgen Conversion`, () => {
 
     // Verify the expected error was logged
     const error_calls = console_error_spy.mock.calls
-    expect(error_calls.length).toBe(1)
+    expect(error_calls).toHaveLength(1)
     expect(error_calls[0][0]).toContain(expected_error)
   })
 
@@ -2917,7 +2917,7 @@ describe(`OPTIMADE to Pymatgen Conversion`, () => {
     expect(result.properties?.chemical_formula_descriptive).toBe(`SiO2`)
     expect(result.properties?.nelements).toBe(2)
     expect(result.properties?.last_modified).toBe(`2023-03-11`)
-    expect(result.properties?.[`_mp_stability`]).toEqual({ energy_above_hull: 0.0 })
+    expect(result.properties?._mp_stability).toEqual({ energy_above_hull: 0.0 })
     // Verify structural fields are NOT in properties
     expect(result.properties?.lattice_vectors).toBeUndefined()
     expect(result.properties?.cartesian_site_positions).toBeUndefined()

--- a/tests/vitest/structure/pbc.test.ts
+++ b/tests/vitest/structure/pbc.test.ts
@@ -372,7 +372,8 @@ C        -2.0      10.0      12.0`
   // For trajectory data, get_pbc_image_sites returns the structure unchanged
   expect(processed_structure.sites).toHaveLength(trajectory_structure.sites.length)
 
-  // Verify that some atoms are outside the unit cell (making it trajectory data)
+  // abc coords are wrapped into the cell on parse, so none read as outside the [-0.1, 1.1]
+  // margin (the raw cartesian positions extend past the 15 Å box, which is what flags trajectory)
   const atoms_outside = trajectory_structure.sites.filter(({ abc }) =>
     abc.some((coord) => coord < -0.1 || coord > 1.1),
   )

--- a/tests/vitest/structure/pbc.test.ts
+++ b/tests/vitest/structure/pbc.test.ts
@@ -180,9 +180,9 @@ test.each([
 
     const images = find_image_atoms(structure)
     if (expect_skip) {
-      expect(images.length).toBe(0)
+      expect(images).toHaveLength(0)
       const unchanged = get_pbc_image_sites(structure)
-      expect(unchanged.sites.length).toBe(structure.sites.length)
+      expect(unchanged.sites).toHaveLength(structure.sites.length)
     } else {
       // Not trajectory data; may or may not produce images depending on tolerance/edges
       const with_images = get_pbc_image_sites(structure)
@@ -213,7 +213,7 @@ test(`triclinic lattice image xyz must match lattice * abc`, () => {
       },
     ],
     lattice: {
-      matrix: matrix,
+      matrix,
       pbc: [true, true, true],
       ...params,
     },
@@ -301,7 +301,7 @@ test.each([
   const structure = make_crystal(5, [[`Na`, [coord, 0.5, 0.5]]])
   const images = find_image_atoms(structure, { tolerance })
   if (expect_images) expect(images.length).toBeGreaterThan(0)
-  else expect(images.length).toBe(0)
+  else expect(images).toHaveLength(0)
 })
 
 test(`upper boundary at abc=1.0 images wrap near 0 via epsilon`, () => {
@@ -367,16 +367,16 @@ C        -2.0      10.0      12.0`
 
   // This structure has atoms near cell boundaries, so it will be detected as trajectory data
   // and will NOT generate image atoms (trajectory data detection)
-  expect(image_atoms.length).toBe(0)
+  expect(image_atoms).toHaveLength(0)
 
   // For trajectory data, get_pbc_image_sites returns the structure unchanged
-  expect(processed_structure.sites.length).toBe(trajectory_structure.sites.length)
+  expect(processed_structure.sites).toHaveLength(trajectory_structure.sites.length)
 
   // Verify that some atoms are outside the unit cell (making it trajectory data)
   const atoms_outside = trajectory_structure.sites.filter(({ abc }) =>
     abc.some((coord) => coord < -0.1 || coord > 1.1),
   )
-  expect(atoms_outside.length).toBe(0)
+  expect(atoms_outside).toHaveLength(0)
 
   // Test multiple frames to ensure consistency
   for (
@@ -386,7 +386,7 @@ C        -2.0      10.0      12.0`
   ) {
     const frame_structure = trajectory_like.frames[frame_idx].structure as Crystal
     const frame_image_atoms = find_image_atoms(frame_structure)
-    expect(frame_image_atoms.length).toBe(0) // Should consistently treat as trajectory data
+    expect(frame_image_atoms).toHaveLength(0) // Should consistently treat as trajectory data
   }
 })
 
@@ -502,7 +502,7 @@ test(`edge detection should be precise for atoms at boundaries`, () => {
 
   // Atom at (0.5,0.5,0.5) should NOT generate images (not at edge)
   const center_images = image_atoms.filter(([idx]) => idx === 2)
-  expect(center_images.length).toBe(0)
+  expect(center_images).toHaveLength(0)
 
   // Check specific image positions for corner atom
   const corner_image_positions = corner_images.map(([_, xyz]) => xyz)
@@ -558,7 +558,7 @@ test.each([
     // Check that we get at least the expected minimum, allowing for algorithm complexity
     if (expected_count === 0) {
       // When we expect no images, assert exactly zero - any non-zero result indicates a regression
-      expect(image_atoms.length).toBe(0)
+      expect(image_atoms).toHaveLength(0)
     } else {
       // For non-zero expectations, check minimum but cap maximum to catch runaway generation
       expect(image_atoms.length).toBeGreaterThanOrEqual(expected_count)
@@ -658,7 +658,7 @@ test(`image atoms preserve fractional coordinates correctly`, () => {
   const orig_n_sites = test_structure.sites.length
   const image_sites = symmetrized.sites.slice(orig_n_sites) // Image atoms are added after original atoms
 
-  expect(image_sites.length).toBe(image_atoms.length)
+  expect(image_sites).toHaveLength(image_atoms.length)
 
   for (let idx = 0; idx < image_atoms.length; idx++) {
     const [orig_idx, expected_xyz, expected_abc] = image_atoms[idx]
@@ -821,7 +821,7 @@ test(`find_image_atoms uses physical tolerance for large cells`, () => {
   const c_images = image_atoms.filter(([idx]) => idx === 0)
   const h_images = image_atoms.filter(([idx]) => idx === 1)
 
-  expect(c_images.length).toBe(0)
+  expect(c_images).toHaveLength(0)
   expect(h_images.length).toBeGreaterThan(0)
 
   // Explicit tolerance override (fractional 0.05 = 5 Angstroms)

--- a/tests/vitest/structure/supercell-performance.test.ts
+++ b/tests/vitest/structure/supercell-performance.test.ts
@@ -164,13 +164,13 @@ describe(`supercell performance profiling`, () => {
               new_lattice_T_inv[2][2] * new_z
 
             // Wrap coordinates
-            abc_x = abc_x % 1
+            abc_x %= 1
             if (abc_x < 0) abc_x += 1
             if (abc_x >= 1 - 1e-10) abc_x = 0
-            abc_y = abc_y % 1
+            abc_y %= 1
             if (abc_y < 0) abc_y += 1
             if (abc_y >= 1 - 1e-10) abc_y = 0
-            abc_z = abc_z % 1
+            abc_z %= 1
             if (abc_z < 0) abc_z += 1
             if (abc_z >= 1 - 1e-10) abc_z = 0
 

--- a/tests/vitest/structure/supercell.test.ts
+++ b/tests/vitest/structure/supercell.test.ts
@@ -266,9 +266,9 @@ describe(`make_supercell`, () => {
     const original = structuredClone(sample_structure)
     const supercell = make_supercell(original, [2, 2, 2])
 
-    expect(original.sites.length).toBe(2)
+    expect(original.sites).toHaveLength(2)
     expect(`supercell_scaling` in original).toBe(false)
-    expect(supercell.sites.length).toBe(16)
+    expect(supercell.sites).toHaveLength(16)
     expect(`supercell_scaling` in supercell).toBe(true)
   })
 })
@@ -389,7 +389,7 @@ describe(`image atom behavior`, () => {
     const distant_negative = supercell_images.filter(([_idx, xyz]) =>
       xyz.some((coord) => coord < -1.0),
     )
-    expect(distant_negative.length).toBe(0)
+    expect(distant_negative).toHaveLength(0)
   })
 })
 
@@ -582,7 +582,7 @@ describe(`performance tests`, () => {
       const supercell = make_supercell(test_structure, scaling)
       const duration = performance.now() - start_time
 
-      expect(supercell.sites.length).toBe(expected_atoms)
+      expect(supercell.sites).toHaveLength(expected_atoms)
       expect(`supercell_scaling` in supercell).toBe(true)
       expect(duration).toBeLessThan(timeout_ms * 3) // CI multiplier
       expect(supercell.sites.every((site) => site.xyz && site.abc)).toBe(true)

--- a/tests/vitest/symmetry/index.test.ts
+++ b/tests/vitest/symmetry/index.test.ts
@@ -284,16 +284,11 @@ describe(`structure validation`, () => {
 
         structure.sites?.forEach((site, idx) => issues.push(...validateSite(site, idx)))
 
-        return { id: structure.id || `unknown`, issues }
+        return { id: structure.id ?? `unknown`, issues }
       })
       .filter((site) => site.issues.length > 0)
 
-    expect(
-      failed.length,
-      `Structures with issues:\n${failed
-        .map((site) => `${site.id}: ${site.issues.join(`, `)}`)
-        .join(`\n`)}`,
-    ).toBe(0)
+    expect(failed).toHaveLength(0)
   })
 
   test(`composition consistency`, () => {
@@ -564,7 +559,7 @@ describe(`site coverage verification`, () => {
 
       const wyckoff_positions = wyckoff_positions_from_moyo(mock_data)
       const total_multiplicity = wyckoff_positions.reduce((sum, pos) => {
-        const multiplicity = parseInt(pos.wyckoff) || 1
+        const multiplicity = parseInt(pos.wyckoff, 10) || 1
         return sum + multiplicity
       }, 0)
 

--- a/tests/vitest/table/HeatmapTable.test.svelte.ts
+++ b/tests/vitest/table/HeatmapTable.test.svelte.ts
@@ -31,9 +31,9 @@ describe(`HeatmapTable`, () => {
 
     const headers = document.querySelectorAll(`th`)
     expect(headers).toHaveLength(3)
-    expect(Array.from(headers).map((h) => h.textContent?.replace(/\s+/g, ` `).trim())).toEqual(
-      [`Model`, `Score`, `Value`],
-    )
+    expect(
+      Array.from(headers).map((h) => h.textContent?.replaceAll(/\s+/g, ` `).trim()),
+    ).toEqual([`Model`, `Score`, `Value`])
 
     expect(document.querySelectorAll(`tbody tr`)).toHaveLength(3)
     expect(document.querySelectorAll(`td[data-col="Hidden"]`)).toHaveLength(0)
@@ -418,7 +418,7 @@ describe(`HeatmapTable`, () => {
     })
 
     const header = document.querySelector(`th`)
-    expect(header?.getAttribute(`title`) || header?.getAttribute(`data-title`)).toBe(
+    expect(header?.getAttribute(`title`) ?? header?.getAttribute(`data-title`)).toBe(
       `Description`,
     )
     // sort_hint renders as a separate .sort-hint element, not inside the header
@@ -638,7 +638,7 @@ describe(`HeatmapTable`, () => {
 
       // Column headers should have duplicate label names (Value 1, Value 2) rendered for each group
       expect(
-        Array.from(col_headers).map((h) => h.textContent?.trim().replace(/\s+|[↑↓]/g, ``)),
+        Array.from(col_headers).map((h) => h.textContent?.trim().replaceAll(/\s+|[↑↓]/g, ``)),
       ).toEqual([`Name`, `Value1`, `Value2`, `Metric1`, `Metric2`, `Value1`, `Value2`])
     })
 
@@ -2032,8 +2032,8 @@ describe(`HeatmapTable`, () => {
       copy_btn.click()
       await tick()
 
-      expect(navigator.clipboard[`writeText`]).toHaveBeenCalledTimes(1)
-      const written = (navigator.clipboard[`writeText`] as ReturnType<typeof vi.fn>).mock
+      expect(navigator.clipboard.writeText).toHaveBeenCalledTimes(1)
+      const written = (navigator.clipboard.writeText as ReturnType<typeof vi.fn>).mock
         .calls[0][0] as string
       expect(written).toContain(`Model\tScore\tValue`)
       expect(written).toContain(`Model A`)

--- a/tests/vitest/table/ToggleMenu.svelte.test.ts
+++ b/tests/vitest/table/ToggleMenu.svelte.test.ts
@@ -413,7 +413,7 @@ describe(`ToggleMenu`, () => {
       const headers = document.querySelectorAll(`.section-header`)
       expect(headers[0].textContent).toContain(`Group B`) // first encountered
       expect(headers[1].textContent).toContain(`Group A`)
-      expect(document.querySelectorAll(`.section`).length).toBe(3) // 2 groups + ungrouped
+      expect(document.querySelectorAll(`.section`)).toHaveLength(3) // 2 groups + ungrouped
     })
 
     it(`renders columns with same label but different keys`, () => {

--- a/tests/vitest/trajectory/parse.test.ts
+++ b/tests/vitest/trajectory/parse.test.ts
@@ -447,7 +447,7 @@ describe(`LAMMPS Trajectory Format`, () => {
 
     expect(trajectory.metadata?.source_format).toBe(`lammps_trajectory`)
     expect(trajectory.frames.length).toBeGreaterThan(0)
-    expect(trajectory.frames[0].structure.sites.length).toBe(864)
+    expect(trajectory.frames[0].structure.sites).toHaveLength(864)
     expect(trajectory.metadata?.periodic_boundary_conditions).toEqual([true, true, true])
   })
 
@@ -455,12 +455,12 @@ describe(`LAMMPS Trajectory Format`, () => {
     const content = read_test_file(`lammps-sample.lammpstrj.gz`)
     const trajectory = await parse_trajectory_data(content, `test.lammpstrj`)
 
-    expect(trajectory.frames.length).toBe(5)
+    expect(trajectory.frames).toHaveLength(5)
     // First frame should have timestep 0
     expect(trajectory.frames[0].step).toBe(0)
     // Each frame should have consistent atom count
     trajectory.frames.forEach((frame) => {
-      expect(frame.structure.sites.length).toBe(864)
+      expect(frame.structure.sites).toHaveLength(864)
     })
   })
 
@@ -1045,7 +1045,7 @@ describe(`HDF5 Format`, () => {
     const trajectory = await parse_trajectory_data(content, `test.h5`)
 
     expect(trajectory.metadata?.source_format).toBe(`hdf5_trajectory`)
-    expect(trajectory.frames.length).toBe(20)
+    expect(trajectory.frames).toHaveLength(20)
     expect(trajectory.metadata?.num_atoms).toBe(55)
     expect(trajectory.frames[0].structure.sites[0].species[0].element).toBe(`Au`)
 
@@ -1135,7 +1135,7 @@ describe(`HDF5 Format`, () => {
     const trajectory2 = await parse_trajectory_data(content, `test2.h5`)
 
     // Results should be identical but independent
-    expect(trajectory1.frames.length).toBe(trajectory2.frames.length)
+    expect(trajectory1.frames).toHaveLength(trajectory2.frames.length)
     expect(trajectory1.metadata?.num_atoms).toBe(trajectory2.metadata?.num_atoms)
     expect(trajectory1.metadata?.discovered_datasets).toEqual(
       trajectory2.metadata?.discovered_datasets,
@@ -1298,7 +1298,7 @@ describe(`Unsupported Formats`, () => {
   })
 
   it(`should detect binary content as unsupported`, () => {
-    const message = get_unsupported_format_message(`unknown.bin`, `\x00\x01\x02\x03`)
+    const message = get_unsupported_format_message(`unknown.bin`, `\u0000\u0001\u0002\u0003`)
     expect(message).toContain(`Binary format not supported`)
   })
 

--- a/tests/vitest/trajectory/plotting.test.ts
+++ b/tests/vitest/trajectory/plotting.test.ts
@@ -153,7 +153,7 @@ describe(`generate_plot_series`, () => {
 
     const series = generate_plot_series(trajectory, test_extractor)
     const energy_series = find_series_by_label(series, `energy`)
-    expect(series.length).toBe(1)
+    expect(series).toHaveLength(1)
     expect(energy_series?.visible).toBe(true)
     expect(energy_series?.unit).toBe(`eV`)
     expect(energy_series?.y_axis).toBe(`y1`)

--- a/tests/vitest/trajectory/streaming.test.ts
+++ b/tests/vitest/trajectory/streaming.test.ts
@@ -495,7 +495,7 @@ describe(`Trajectory Streaming`, () => {
       // Verify metadata has expected structure
       expect(metadata).toBeDefined()
       expect(Array.isArray(metadata)).toBe(true)
-      expect(metadata.length).toBe(frame_count)
+      expect(metadata).toHaveLength(frame_count)
 
       // Verify each metadata entry has required fields
       for (const [idx, entry] of metadata.entries()) {

--- a/tests/vitest/utils.test.ts
+++ b/tests/vitest/utils.test.ts
@@ -69,9 +69,7 @@ describe(`merge_nested`, () => {
   test(`does not mutate inputs`, () => {
     const defaults = { a: 1, nested: { b: 2 } }
     const user = { a: 10, nested: { b: 20 } }
-    const [def_copy, user_copy] = [defaults, user].map((obj) =>
-      JSON.parse(JSON.stringify(obj)),
-    )
+    const [def_copy, user_copy] = [defaults, user].map((obj) => structuredClone(obj))
     merge_nested(defaults, user)
     expect([defaults, user]).toEqual([def_copy, user_copy])
   })
@@ -92,7 +90,7 @@ describe(`decode_url_safe_base64`, () => {
 
   test(`decodes a realistic JSON structure payload`, () => {
     const json = JSON.stringify({ lattice: [[1, 0, 0]], sites: [{ element: `Na` }] })
-    const url_safe = btoa(json).replace(/\+/g, `-`).replace(/\//g, `_`).replace(/=+$/, ``)
+    const url_safe = btoa(json).replaceAll('+', `-`).replaceAll('/', `_`).replace(/=+$/, ``)
     expect(decode_url_safe_base64(url_safe)).toBe(json)
   })
 })

--- a/tests/vitest/xrd/XrdPlot.test.ts
+++ b/tests/vitest/xrd/XrdPlot.test.ts
@@ -22,7 +22,7 @@ function create_sized_container(): HTMLDivElement {
   const target = document.createElement(`div`)
   target.style.width = `800px`
   target.style.height = `600px`
-  document.body.appendChild(target)
+  document.body.append(target)
   return target
 }
 
@@ -390,7 +390,7 @@ describe(`XrdPlot`, () => {
 
     // Should have 2 bar series for 2 patterns
     const bar_series = target.querySelectorAll(`.bar-series`)
-    expect(bar_series.length).toBe(2)
+    expect(bar_series).toHaveLength(2)
 
     // Verify both pattern labels appear in legend
     const text_content = target.textContent || ``
@@ -408,7 +408,7 @@ describe(`XrdPlot`, () => {
     await wait_for_plot_render(target)
 
     const bar_series = target.querySelectorAll(`.bar-series`)
-    expect(bar_series.length).toBe(1)
+    expect(bar_series).toHaveLength(1)
   })
 
   test(`dragover class toggles correctly`, async () => {

--- a/tests/vitest/xrd/calc-xrd.test.ts
+++ b/tests/vitest/xrd/calc-xrd.test.ts
@@ -161,7 +161,7 @@ describe(`compute_xrd_pattern edge cases`, () => {
       scaled: true,
       scaled_intensity_tol: 101, // higher than any scaled intensity
     })
-    expect(none_pass.x.length).toBe(0)
+    expect(none_pass.x).toHaveLength(0)
 
     const many_pass = compute_xrd_pattern(structure, {
       ...base_opts,
@@ -193,9 +193,9 @@ describe(`precomputed XRD fixtures are consistent`, () => {
   test.each(entries.map(([id, pattern]) => [id, pattern] as const))(
     `fixture %s length consistency`,
     (_id, pattern) => {
-      expect(pattern.x.length).toBe(pattern.y.length)
-      if (pattern.hkls) expect(pattern.hkls.length).toBe(pattern.x.length)
-      if (pattern.d_hkls) expect(pattern.d_hkls.length).toBe(pattern.x.length)
+      expect(pattern.x).toHaveLength(pattern.y.length)
+      if (pattern.hkls) expect(pattern.hkls).toHaveLength(pattern.x.length)
+      if (pattern.d_hkls) expect(pattern.d_hkls).toHaveLength(pattern.x.length)
     },
   )
 })

--- a/tests/vitest/xrd/index.test.ts
+++ b/tests/vitest/xrd/index.test.ts
@@ -47,7 +47,7 @@ describe(`@xrd/ api and compute_xrd_pattern options`, () => {
     const structure = make_simple_cubic(2)
     const pattern = compute_xrd_pattern(structure, { wavelength: 1.54184 })
     expect(pattern.x.length).toBeGreaterThan(0)
-    expect(pattern.y.length).toBe(pattern.x.length)
+    expect(pattern.y).toHaveLength(pattern.x.length)
   })
 
   test(`unknown element symbol throws`, () => {
@@ -101,8 +101,8 @@ describe(`@xrd/ api and compute_xrd_pattern options`, () => {
       wavelength: `CuKa`,
       scaled: true,
     })
-    expect(pattern.x.length).toBe(pattern.y.length)
-    if (pattern.hkls) expect(pattern.hkls.length).toBe(pattern.x.length)
-    if (pattern.d_hkls) expect(pattern.d_hkls.length).toBe(pattern.x.length)
+    expect(pattern.x).toHaveLength(pattern.y.length)
+    if (pattern.hkls) expect(pattern.hkls).toHaveLength(pattern.x.length)
+    if (pattern.d_hkls) expect(pattern.d_hkls).toHaveLength(pattern.x.length)
   })
 })

--- a/tests/vitest/xrd/parse.test.ts
+++ b/tests/vitest/xrd/parse.test.ts
@@ -117,7 +117,7 @@ describe(`parse_xy_file`, () => {
     // Generate 10000 points: background=1, peaks at their heights
     const lines = Array.from({ length: 10000 }, (_, idx) => {
       const peak_idx = peak_indices.indexOf(idx)
-      return `${10 + idx * 0.01} ${peak_idx >= 0 ? peak_heights[peak_idx] : 1}`
+      return `${10 + idx * 0.01} ${peak_idx !== -1 ? peak_heights[peak_idx] : 1}`
     }).join(`\n`)
 
     const result = parse_xy_file(lines)
@@ -853,7 +853,7 @@ describe(`real example files`, () => {
     if (!result) return // Type guard for TypeScript
     expect(result.x.length).toBeGreaterThan(0)
     expect(result.y.length).toBeGreaterThan(0)
-    expect(result.x.length).toBe(result.y.length)
+    expect(result.x).toHaveLength(result.y.length)
     // Verify max is normalized to 100
     expect(Math.max(...result.y)).toBeCloseTo(100, 0)
     // Min can be negative for background-subtracted data, but should be finite

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -125,8 +125,6 @@ export default defineConfig({
   // via `rules: { ...lint_config.rules, 'some-rule': 'off' }` if ever needed.
   lint: {
     ...lint_config,
-    // explicit-length-check false-positives on numeric `.size` marker-radius fields
-    rules: { ...lint_config.rules, 'eslint-plugin-unicorn/explicit-length-check': `off` },
     ignorePatterns: [
       ...lint_config.ignorePatterns,
       `extensions/**`,
@@ -134,8 +132,8 @@ export default defineConfig({
       `src/scripts/**`,
     ],
   },
-  // @ts-expect-error vite@8's Plugin and vite-plus's bundled Plugin are two copies
-  // of the same type; comparing them exceeds TS's instantiation depth here
+  // vite@8's Plugin and vite-plus's bundled Plugin are two copies of the same type;
+  // @ts-expect-error comparing them exceeds TS's instantiation depth here
   plugins: [
     json_gz_plugin,
     raw_text_plugin,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -120,11 +120,13 @@ export default defineConfig({
       `tests/vitest/phase-diagram/fixtures/*.json`,
     ],
   },
-  // Shared rules/plugins/categories live in @janosh/vite-lint-config (dotfiles).
+  // Shared rules/plugins/categories live in @janosh/vite-config (dotfiles).
   // Append only matterviz-specific ignore dirs here; add per-project rule overrides
   // via `rules: { ...lint_config.rules, 'some-rule': 'off' }` if ever needed.
   lint: {
     ...lint_config,
+    // explicit-length-check false-positives on numeric `.size` marker-radius fields
+    rules: { ...lint_config.rules, 'eslint-plugin-unicorn/explicit-length-check': `off` },
     ignorePatterns: [
       ...lint_config.ignorePatterns,
       `extensions/**`,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+import { lint_config } from '@janosh/vite-config'
 import { sveltekit } from '@sveltejs/kit/vite'
 import { readFileSync } from 'node:fs'
 import { resolve, dirname } from 'node:path'
@@ -119,89 +120,17 @@ export default defineConfig({
       `tests/vitest/phase-diagram/fixtures/*.json`,
     ],
   },
+  // Shared rules/plugins/categories live in @janosh/vite-lint-config (dotfiles).
+  // Append only matterviz-specific ignore dirs here; add per-project rule overrides
+  // via `rules: { ...lint_config.rules, 'some-rule': 'off' }` if ever needed.
   lint: {
-    plugins: [`oxc`, `typescript`, `unicorn`, `import`, `vitest`],
-    options: { typeAware: true, typeCheck: true },
-    categories: { correctness: `error`, suspicious: `error`, perf: `error` },
+    ...lint_config,
     ignorePatterns: [
-      `build/**`,
-      `.svelte-kit/**`,
-      `package/**`,
-      `dist/**`,
+      ...lint_config.ignorePatterns,
       `extensions/**`,
       `static/**`,
       `src/scripts/**`,
     ],
-    rules: {
-      // Extra rules not in the enabled categories
-      'no-console': [`error`, { allow: [`info`, `warn`, `error`] }],
-      'no-template-curly-in-string': `error`,
-      'no-constructor-return': `error`,
-      'default-param-last': `error`,
-      'guard-for-in': `error`,
-      'eslint-plugin-unicorn/prefer-array-find': `error`,
-      'eslint-plugin-unicorn/no-typeof-undefined': `error`,
-      'eslint-plugin-unicorn/prefer-optional-catch-binding': `error`,
-      'eslint-plugin-unicorn/no-length-as-slice-end': `error`,
-      'eslint-plugin-unicorn/prefer-node-protocol': `error`,
-      'eslint-plugin-unicorn/throw-new-error': `error`,
-      'eslint-plugin-unicorn/prefer-type-error': `error`,
-      'eslint-plugin-unicorn/prefer-date-now': `error`,
-      'eslint-plugin-unicorn/require-number-to-fixed-digits-argument': `error`,
-      'eslint-plugin-unicorn/no-useless-promise-resolve-reject': `error`,
-      'eslint-plugin-unicorn/custom-error-definition': `error`,
-      'eslint-plugin-import/no-duplicates': `error`,
-      '@typescript-eslint/no-non-null-assertion': `error`,
-      '@typescript-eslint/prefer-string-starts-ends-with': `error`,
-      '@typescript-eslint/prefer-readonly': `error`,
-      '@typescript-eslint/prefer-regexp-exec': `error`,
-      '@typescript-eslint/prefer-find': `error`,
-      '@typescript-eslint/no-deprecated': `error`,
-      '@typescript-eslint/no-misused-promises': `error`,
-      '@typescript-eslint/restrict-plus-operands': `error`,
-      '@typescript-eslint/no-dynamic-delete': `error`,
-      '@typescript-eslint/no-empty-object-type': `error`,
-      '@typescript-eslint/no-explicit-any': `error`,
-      '@typescript-eslint/no-import-type-side-effects': `error`,
-      '@typescript-eslint/no-invalid-void-type': `error`,
-      '@typescript-eslint/no-mixed-enums': `error`,
-      '@typescript-eslint/no-require-imports': `error`,
-      '@typescript-eslint/only-throw-error': `error`,
-      '@typescript-eslint/ban-ts-comment': `error`,
-      '@typescript-eslint/consistent-type-imports': `error`,
-      '@typescript-eslint/prefer-function-type': `error`,
-      '@typescript-eslint/prefer-includes': `error`,
-      '@typescript-eslint/prefer-optional-chain': `error`,
-      '@typescript-eslint/prefer-reduce-type-parameter': `error`,
-      '@typescript-eslint/prefer-ts-expect-error': `error`,
-      '@typescript-eslint/return-await': `error`,
-      '@typescript-eslint/switch-exhaustiveness-check': `error`,
-      '@typescript-eslint/unified-signatures': `error`,
-      'array-callback-return': `error`,
-      'prefer-object-has-own': `error`,
-      'eslint-plugin-promise/no-multiple-resolved': `error`,
-      'eslint-plugin-promise/no-return-in-finally': `error`,
-      'eslint-plugin-promise/param-names': `error`,
-      'eslint-plugin-promise/valid-params': `error`,
-      '@typescript-eslint/consistent-type-exports': `error`,
-      'eslint-plugin-unicorn/require-array-join-separator': `error`,
-      'no-useless-computed-key': `error`,
-      'eslint-plugin-vitest/prefer-strict-boolean-matchers': `error`,
-      'eslint-plugin-vitest/prefer-each': `error`,
-      'eslint-plugin-vitest/prefer-called-exactly-once-with': `error`,
-      'eslint-plugin-vitest/require-awaited-expect-poll': `error`,
-
-      'eslint-plugin-vitest/require-mock-type-parameters': `off`, // 242 violations, needs manual type annotations
-      'eslint-plugin-unicorn/consistent-function-scoping': `off`, // Svelte reactive closures
-      // Pervasive intentional patterns
-      '@typescript-eslint/no-unsafe-type-assertion': `off`,
-      '@typescript-eslint/restrict-template-expressions': `off`,
-      'no-await-in-loop': `off`,
-      'eslint-plugin-unicorn/no-array-sort': `off`, // [...arr].sort() is idiomatic
-      'oxc/no-map-spread': `off`,
-      'eslint-plugin-vitest/no-conditional-expect': `off`, // Vitest default rules — too noisy for this codebase
-      'eslint-plugin-vitest/valid-expect': [`error`, { maxArgs: 2 }], // Vitest supports expect(actual, message)
-    },
   },
   // @ts-expect-error vite@8's Plugin and vite-plus's bundled Plugin are two copies
   // of the same type; comparing them exceeds TS's instantiation depth here
@@ -212,6 +141,7 @@ export default defineConfig({
     sveltekit(),
     live_examples(),
     process.env.VITEST ? mock_vscode() : null,
+    // oxlint-disable-next-line eslint-plugin-unicorn/prefer-native-coercion-functions -- type predicate needed for narrowing
   ].filter((plugin): plugin is Plugin => Boolean(plugin)),
 
   test: {


### PR DESCRIPTION
- Replace the inlined oxlint plugins/categories/rules in `vite.config.ts` with the shared [`@janosh/vite-config`](https://github.com/janosh/dotfiles) package (oxlint config lives in [`index.js`](https://github.com/janosh/dotfiles/blob/main/index.js) at the [janosh/dotfiles](https://github.com/janosh/dotfiles) repo root), keeping only matterviz-specific ignore patterns (`extensions/**`, `static/**`, `src/scripts/**`).
- Apply the codebase-wide fixes the shared ruleset requires across ~226 files — e.g. `to_error()` error normalization, `prefer-to-have-length`, `prefer-node-protocol`, `prefer-string-starts-ends-with`, etc.
- Strip stray `<script>`-block semicolons in `ChemPotDiagram.svelte`.
- Migrate CI + tooling to pnpm (corepack), pin Node 24.