### PR TITLE
Add anywidget extension: prebuilt MatterViz bundle published to npm

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,10 @@ jobs:
       # (e.g. @types/vscode) so module resolution succeeds in CI.
       - run: pnpm -C extensions/vscode install
 
+      # anywidget extension is checked by root svelte-check; install its deps so
+      # its matterviz/* subpath imports resolve in CI (otherwise TS2882).
+      - run: pnpm -C extensions/anywidget install
+
       - uses: j178/prek-action@v2
 
   knip:

--- a/.github/workflows/publish-anywidget.yml
+++ b/.github/workflows/publish-anywidget.yml
@@ -36,13 +36,21 @@ jobs:
 
       - name: Resolve version
         id: version
+        # pass workflow inputs via env (not direct ${{ }} interpolation) to avoid
+        # shell injection, then validate before using downstream
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            version="${{ github.event.inputs.version }}"
+            version="$INPUT_VERSION"
           else
             version="${GITHUB_REF#refs/tags/}"
-            version="${version#v}"
           fi
+          version="${version#v}" # strip optional leading v from tags or manual input alike
+          [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] || {
+            echo "Invalid version: $version"
+            exit 1
+          }
           echo "version=$version" >> "$GITHUB_OUTPUT"
         shell: bash
 
@@ -50,7 +58,7 @@ jobs:
         working-directory: extensions/anywidget
         run: |
           pnpm install
-          npm version "${{ steps.version.outputs.version }}" --no-git-tag-version --allow-same-version
+          npm version "$PUBLISH_VERSION" --no-git-tag-version --allow-same-version
           pnpm run build
           # sanity-gate the build before publishing (catches empty/broken output;
           # runtime render coverage lives in pymatviz's test suite)
@@ -63,4 +71,5 @@ jobs:
           test "$js_bytes" -lt 5000000 || { echo "bundle too large ($js_bytes B) -- did h5wasm/moyo WASM get re-bundled?"; exit 1; }
           npm publish --provenance --access public
         env:
+          PUBLISH_VERSION: ${{ steps.version.outputs.version }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-anywidget.yml
+++ b/.github/workflows/publish-anywidget.yml
@@ -57,9 +57,10 @@ jobs:
           test -s build/matterviz.js && test -s build/matterviz.css
           js_bytes=$(wc -c < build/matterviz.js)
           test "$js_bytes" -gt 1000000 || { echo "bundle too small ($js_bytes B)"; exit 1; }
-          # upper bound guards the h5wasm stub (see h5wasm-stub.ts): if HDF5 WASM
-          # creeps back in, the bundle ~doubles -- fail loudly instead of shipping it
-          test "$js_bytes" -lt 8000000 || { echo "bundle too large ($js_bytes B) -- did h5wasm get re-bundled?"; exit 1; }
+          # upper bound guards the WASM exclusions (see vite.config.ts): if h5wasm
+          # or moyo WASM creep back in, the bundle balloons -- fail loudly instead
+          # of shipping it (~3.4 MB normally; either WASM back pushes it over 5 MB)
+          test "$js_bytes" -lt 5000000 || { echo "bundle too large ($js_bytes B) -- did h5wasm/moyo WASM get re-bundled?"; exit 1; }
           npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-anywidget.yml
+++ b/.github/workflows/publish-anywidget.yml
@@ -55,7 +55,11 @@ jobs:
           # sanity-gate the build before publishing (catches empty/broken output;
           # runtime render coverage lives in pymatviz's test suite)
           test -s build/matterviz.js && test -s build/matterviz.css
-          test "$(wc -c < build/matterviz.js)" -gt 1000000 || { echo 'bundle too small'; exit 1; }
+          js_bytes=$(wc -c < build/matterviz.js)
+          test "$js_bytes" -gt 1000000 || { echo "bundle too small ($js_bytes B)"; exit 1; }
+          # upper bound guards the h5wasm stub (see h5wasm-stub.ts): if HDF5 WASM
+          # creeps back in, the bundle ~doubles -- fail loudly instead of shipping it
+          test "$js_bytes" -lt 8000000 || { echo "bundle too large ($js_bytes B) -- did h5wasm get re-bundled?"; exit 1; }
           npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-anywidget.yml
+++ b/.github/workflows/publish-anywidget.yml
@@ -75,7 +75,9 @@ jobs:
           test "$js_bytes" -lt 5000000 || { echo "bundle too large ($js_bytes B) -- did h5wasm/moyo WASM get re-bundled?"; exit 1; }
           # npm (not pnpm) for publish: only `npm publish --provenance` emits npm
           # provenance attestations -- pnpm exposes no equivalent direct flag
-          npm publish --provenance --access public
+          # build already ran + was size-gated above; --ignore-scripts skips the
+          # redundant prepublishOnly rebuild (kept for safety on manual publishes)
+          npm publish --ignore-scripts --provenance --access public
         env:
           PUBLISH_VERSION: ${{ steps.version.outputs.version }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-anywidget.yml
+++ b/.github/workflows/publish-anywidget.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false # publish to npm only; no git writes need the token
 
       - name: Setup Node + pnpm
         uses: actions/setup-node@v6
@@ -64,11 +66,15 @@ jobs:
           # runtime render coverage lives in pymatviz's test suite)
           test -s build/matterviz.js && test -s build/matterviz.css
           js_bytes=$(wc -c < build/matterviz.js)
+          # lower bound: a healthy bundle (all viz components) is well over 1 MB;
+          # anything smaller means a broken/partial build
           test "$js_bytes" -gt 1000000 || { echo "bundle too small ($js_bytes B)"; exit 1; }
           # upper bound guards the WASM exclusions (see vite.config.ts): if h5wasm
           # or moyo WASM creep back in, the bundle balloons -- fail loudly instead
           # of shipping it (~3.4 MB normally; either WASM back pushes it over 5 MB)
           test "$js_bytes" -lt 5000000 || { echo "bundle too large ($js_bytes B) -- did h5wasm/moyo WASM get re-bundled?"; exit 1; }
+          # npm (not pnpm) for publish: only `npm publish --provenance` emits npm
+          # provenance attestations -- pnpm exposes no equivalent direct flag
           npm publish --provenance --access public
         env:
           PUBLISH_VERSION: ${{ steps.version.outputs.version }}

--- a/.github/workflows/publish-anywidget.yml
+++ b/.github/workflows/publish-anywidget.yml
@@ -1,0 +1,61 @@
+name: Publish matterviz-anywidget to npm
+
+# Builds the prebuilt anywidget bundle (extensions/anywidget) and publishes it to
+# npm as `matterviz-anywidget`. The bundle is then served with CORS + a JS MIME
+# type via jsDelivr/unpkg. `build/` stays gitignored -- nothing enters git.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to publish (e.g. 0.3.7)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write # required for `npm publish --provenance`
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node + pnpm
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - name: 'Build MatterViz component library (resolves the file: dependency)'
+        run: corepack enable && pnpm install && pnpm package:dist
+
+      - name: Resolve version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            version="${{ github.event.inputs.version }}"
+          else
+            version="${GITHUB_REF#refs/tags/}"
+            version="${version#v}"
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Build + publish extension
+        working-directory: extensions/anywidget
+        run: |
+          pnpm install
+          npm version "${{ steps.version.outputs.version }}" --no-git-tag-version --allow-same-version
+          pnpm run build
+          # sanity-gate the build before publishing (catches empty/broken output;
+          # runtime render coverage lives in pymatviz's test suite)
+          test -s build/matterviz.js && test -s build/matterviz.css
+          test "$(wc -c < build/matterviz.js)" -gt 1000000 || { echo 'bundle too small'; exit 1; }
+          npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/extensions/anywidget/.gitignore
+++ b/extensions/anywidget/.gitignore
@@ -1,0 +1,2 @@
+build/
+node_modules/

--- a/extensions/anywidget/anywidget.ts
+++ b/extensions/anywidget/anywidget.ts
@@ -1,0 +1,538 @@
+// MatterViz AnyWidget Entry Point
+
+import type { AnyModel, Render } from 'anywidget/types'
+import {
+  Bands,
+  BandsAndDos,
+  BarPlot,
+  BrillouinZone,
+  ChemPotDiagram,
+  Composition,
+  ConvexHull,
+  Dos,
+  FermiSurface,
+  HeatmapMatrix,
+  Histogram,
+  IsobaricBinaryPhaseDiagram,
+  PeriodicTable,
+  RdfPlot,
+  ScatterPlot,
+  ScatterPlot3D,
+  SpacegroupBarPlot,
+  Structure,
+  Trajectory,
+  XrdPlot,
+} from 'matterviz'
+import app_css from 'matterviz/app.css?raw'
+import type { ThemeType } from 'matterviz/theme'
+import { mount, unmount } from 'svelte'
+import {
+  detect_parent_theme,
+  get_theme_css,
+  on_theme_change,
+  setup_theme_watchers,
+} from './theme-detection'
+
+const adopted_sheets = new WeakMap<ShadowRoot, CSSStyleSheet>()
+
+function inject_app_css(theme_type?: ThemeType, target_element?: HTMLElement): void {
+  const style_id = `matterviz-widget-styles`
+  const detected_theme = theme_type ?? detect_parent_theme(target_element)
+
+  // Determine if we're in Shadow DOM (used by marimo cells) and get the appropriate root
+  const root_node = target_element?.getRootNode() ?? document
+  const in_shadow = root_node instanceof ShadowRoot
+
+  // Remove existing style element (if any)
+  ;(in_shadow ? root_node : document).querySelector(`#${style_id}`)?.remove()
+
+  // Create style content
+  const style_content = `
+    ${get_theme_css(detected_theme, in_shadow)}
+    .cell-output-ipywidget-background { background: transparent !important; }
+    :is(input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="color"]), textarea, select) {
+      background-color: var(--surface-bg); color: var(--text-color); border: 1px solid var(--border-color); border-radius: 4px; padding: 6px 8px;
+    }
+    :is(input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="color"]), textarea, select):focus {
+      outline: none; border-color: var(--accent-color); box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-color) 25%, transparent);
+    }
+    :is(input, textarea)::placeholder { color: var(--text-color-muted); }
+    select option { background-color: var(--surface-bg); color: var(--text-color); }
+    ${app_css}
+  `
+
+  // Apply styles via adoptedStyleSheets (reuse existing sheet to avoid accumulation)
+  if (in_shadow && `adoptedStyleSheets` in root_node) {
+    let sheet = adopted_sheets.get(root_node)
+    if (!sheet) {
+      sheet = new CSSStyleSheet()
+      root_node.adoptedStyleSheets = [...root_node.adoptedStyleSheets, sheet]
+      adopted_sheets.set(root_node, sheet)
+    }
+    sheet.replaceSync(style_content)
+    return
+  }
+
+  // Fallback: create style element
+  const style = document.createElement(`style`)
+  style.id = style_id
+  style.textContent = style_content
+  if (in_shadow) root_node.append(style)
+  else document.head.append(style)
+}
+
+const instances = new WeakMap<HTMLElement, ReturnType<typeof mount>>()
+const theme_unsubs = new WeakMap<HTMLElement, () => void>()
+
+const cleanup_element = (element: HTMLElement): void => {
+  theme_unsubs.get(element)?.()
+  theme_unsubs.delete(element)
+
+  const instance = instances.get(element)
+  if (instance) {
+    void unmount(instance)
+    instances.delete(element)
+  }
+}
+
+const get_prop = (model: AnyModel, key: string) => {
+  try {
+    return model.get(key) ?? void 0
+  } catch {
+    // Missing trait values are omitted from the frontend props object.
+    return void 0
+  }
+}
+
+// Build an object of { key: model.get(key) } for each key in the list
+const pick_props = (model: AnyModel, keys: readonly string[]) =>
+  Object.fromEntries(keys.map((key) => [key, get_prop(model, key)]))
+
+const plot_common_prop_keys = [
+  `series`,
+  `x_axis`,
+  `x2_axis`,
+  `y_axis`,
+  `y2_axis`,
+  `display`,
+  `legend`,
+  `ref_lines`,
+  `controls`,
+  `padding`,
+  `range_padding`,
+  `show_legend`,
+  `x_range`,
+  `x2_range`,
+  `y_range`,
+  `y2_range`,
+] as const
+
+const scatter_plot_prop_keys = [
+  ...plot_common_prop_keys,
+  `styles`,
+  `color_scale`,
+  `color_bar`,
+  `size_scale`,
+  `fill_regions`,
+  `error_bands`,
+  `hover_config`,
+  `label_placement_config`,
+  `point_tween`,
+  `line_tween`,
+  `point_events`,
+] as const
+
+const bar_plot_prop_keys = [
+  ...plot_common_prop_keys,
+  `orientation`,
+  `mode`,
+  `bar`,
+  `line`,
+  `color_scale`,
+  `size_scale`,
+  `point_tween`,
+] as const
+
+const histogram_prop_keys = [
+  ...plot_common_prop_keys,
+  `bins`,
+  `mode`,
+  `selected_property`,
+  `bar`,
+] as const
+
+// Mount a Svelte component with base props (notebook context, show_controls, style)
+const mount_widget = (
+  model: AnyModel,
+  el: HTMLElement,
+  component: unknown,
+  props: Record<string, unknown>,
+) => {
+  // Prevent widget overflow in notebook cell outputs
+  el.style.boxSizing = `border-box`
+  el.style.maxWidth = `100%`
+  el.style.marginRight = `2em` // In vscode-interactive window, content overflows cell container div without this
+  const base_props = {
+    allow_file_drop: false,
+    show_controls: get_prop(model, `show_controls`),
+    style: get_prop(model, `style`),
+  }
+  instances.set(
+    el,
+    mount(component as Parameters<typeof mount>[0], {
+      target: el,
+      props: { ...base_props, ...props },
+    }),
+  )
+}
+
+// Build scene/lattice props shared by structure and trajectory renderers
+const get_scene_props = (model: AnyModel) => ({
+  ...pick_props(model, [
+    `atom_radius`,
+    `show_atoms`,
+    `same_size_atoms`,
+    `show_bonds`,
+    `bond_thickness`,
+    `bond_color`,
+    `bonding_strategy`,
+    `vector_configs`,
+    `vector_scale`,
+    `vector_color`,
+    `vector_normalize`,
+    `vector_uniform_thickness`,
+    `vector_origin_gap`,
+  ]),
+  auto_rotate: get_prop(model, `auto_rotate`) ?? 0.2,
+  gizmo: get_prop(model, `show_gizmo`) ?? true,
+})
+
+const get_lattice_props = (model: AnyModel) =>
+  pick_props(model, [
+    `cell_edge_opacity`,
+    `cell_surface_opacity`,
+    `cell_edge_color`,
+    `cell_surface_color`,
+    `cell_edge_width`,
+    `show_cell_vectors`,
+  ])
+
+// Detect widget type and render
+const render: Render = (props) => {
+  const { model, el } = props
+  const widget_type = get_prop(model, `widget_type`) as string | undefined
+  const renderer = widget_type ? renderers[widget_type] : undefined
+  if (!renderer) throw new Error(`Unknown or missing widget_type: '${widget_type}'`)
+
+  cleanup_element(el)
+  inject_app_css(undefined, el)
+  setup_theme_watchers(el)
+
+  theme_unsubs.set(
+    el,
+    on_theme_change((theme_type) => inject_app_css(theme_type, el)),
+  )
+  void renderer(props)
+  return () => cleanup_element(el)
+}
+
+// === Widget renderers ===
+
+const render_composition: Render = ({ model, el }) => {
+  mount_widget(
+    model,
+    el,
+    Composition,
+    pick_props(model, [`composition`, `mode`, `show_percentages`, `color_scheme`]),
+  )
+}
+
+const render_structure: Render = ({ model, el }) => {
+  mount_widget(model, el, Structure, {
+    ...pick_props(model, [
+      `structure`,
+      `structure_string`,
+      `data_url`,
+      `show_site_labels`,
+      `show_site_indices`,
+      `show_image_atoms`,
+      `color_scheme`,
+      `background_color`,
+      `background_opacity`,
+      `enable_info_pane`,
+      `fullscreen_toggle`,
+      `png_dpi`,
+      `isosurface_settings`,
+      `volumetric_data`,
+    ]),
+    scene_props: get_scene_props(model),
+    lattice_props: get_lattice_props(model),
+  })
+}
+
+const render_trajectory: Render = ({ model, el }) => {
+  mount_widget(model, el, Trajectory, {
+    ...pick_props(model, [
+      `trajectory`,
+      `data_url`,
+      `current_step_idx`,
+      `layout`,
+      `display_mode`,
+      `fullscreen_toggle`,
+      `auto_play`,
+      `step_labels`,
+      `property_labels`,
+      `units`,
+    ]),
+    structure_props: {
+      scene_props: get_scene_props(model),
+      lattice_props: get_lattice_props(model),
+      ...pick_props(model, [
+        `show_site_labels`,
+        `show_site_indices`,
+        `show_image_atoms`,
+        `color_scheme`,
+        `background_color`,
+        `background_opacity`,
+      ]),
+      fullscreen_toggle: false,
+    },
+  })
+}
+
+const render_scatter_plot: Render = ({ model, el }) => {
+  mount_widget(model, el, ScatterPlot, pick_props(model, scatter_plot_prop_keys))
+}
+
+const render_bar_plot: Render = ({ model, el }) => {
+  mount_widget(model, el, BarPlot, pick_props(model, bar_plot_prop_keys))
+}
+
+const render_histogram: Render = ({ model, el }) => {
+  mount_widget(model, el, Histogram, pick_props(model, histogram_prop_keys))
+}
+
+const render_convex_hull: Render = ({ model, el }) => {
+  mount_widget(
+    model,
+    el,
+    ConvexHull,
+    pick_props(model, [
+      `entries`,
+      `show_stable`,
+      `show_unstable`,
+      `show_hull_faces`,
+      `hull_face_opacity`,
+      `show_stable_labels`,
+      `show_unstable_labels`,
+      `max_hull_dist_show_labels`,
+      `max_hull_dist_show_phases`,
+      `temperature`,
+    ]),
+  )
+}
+
+const render_band_structure: Render = ({ model, el }) => {
+  mount_widget(model, el, Bands, {
+    band_structs: get_prop(model, `band_structure`), // Renamed traitlet
+    ...pick_props(model, [`band_type`, `show_legend`, `fermi_level`, `reference_frequency`]),
+  })
+}
+
+const render_dos: Render = ({ model, el }) => {
+  mount_widget(model, el, Dos, {
+    doses: get_prop(model, `dos`), // Renamed traitlet
+    ...pick_props(model, [
+      `stack`,
+      `sigma`,
+      `normalize`,
+      `orientation`,
+      `show_legend`,
+      `spin_mode`,
+    ]),
+  })
+}
+
+const render_bands_and_dos: Render = ({ model, el }) => {
+  mount_widget(model, el, BandsAndDos, {
+    band_structs: get_prop(model, `band_structure`), // Renamed traitlet
+    doses: get_prop(model, `dos`), // Renamed traitlet
+  })
+}
+
+const render_fermi_surface: Render = ({ model, el }) => {
+  mount_widget(
+    model,
+    el,
+    FermiSurface,
+    pick_props(model, [
+      `fermi_data`,
+      `band_data`,
+      `mu`,
+      `representation`,
+      `surface_opacity`,
+      `show_bz`,
+      `bz_opacity`,
+      `show_vectors`,
+      `camera_projection`,
+    ]),
+  )
+}
+
+const render_brillouin_zone: Render = ({ model, el }) => {
+  mount_widget(
+    model,
+    el,
+    BrillouinZone,
+    pick_props(model, [
+      `structure`,
+      `bz_data`,
+      `surface_color`,
+      `surface_opacity`,
+      `edge_color`,
+      `edge_width`,
+      `show_vectors`,
+      `show_ibz`,
+      `ibz_color`,
+      `ibz_opacity`,
+      `camera_projection`,
+    ]),
+  )
+}
+
+const render_phase_diagram: Render = ({ model, el }) => {
+  mount_widget(model, el, IsobaricBinaryPhaseDiagram, pick_props(model, [`data`]))
+}
+
+const render_xrd: Render = ({ model, el }) => {
+  mount_widget(model, el, XrdPlot, pick_props(model, [`patterns`]))
+}
+
+const render_periodic_table: Render = ({ model, el }) => {
+  mount_widget(model, el, PeriodicTable, {
+    ...pick_props(model, [
+      `heatmap_values`,
+      `color_scale`,
+      `color_scale_range`,
+      `color_overrides`,
+      `labels`,
+      `show_color_bar`,
+      `gap`,
+      `missing_color`,
+    ]),
+    log: get_prop(model, `log_scale`),
+  })
+}
+
+const render_rdf_plot: Render = ({ model, el }) => {
+  mount_widget(
+    model,
+    el,
+    RdfPlot,
+    pick_props(model, [
+      `patterns`,
+      `structures`,
+      `mode`,
+      `show_reference_line`,
+      `cutoff`,
+      `n_bins`,
+      `x_axis`,
+      `y_axis`,
+    ]),
+  )
+}
+
+const render_scatter_plot_3d: Render = ({ model, el }) => {
+  mount_widget(
+    model,
+    el,
+    ScatterPlot3D,
+    pick_props(model, [
+      `series`,
+      `surfaces`,
+      `ref_lines`,
+      `ref_planes`,
+      `x_axis`,
+      `y_axis`,
+      `z_axis`,
+      `display`,
+      `styles`,
+      `color_scale`,
+      `size_scale`,
+      `legend`,
+      `controls`,
+      `camera_projection`,
+    ]),
+  )
+}
+
+const render_heatmap_matrix: Render = ({ model, el }) => {
+  mount_widget(model, el, HeatmapMatrix, {
+    ...pick_props(model, [
+      `x_items`,
+      `y_items`,
+      `values`,
+      `color_scale`,
+      `color_scale_range`,
+      `missing_color`,
+      `x_axis`,
+      `y_axis`,
+      `tile_size`,
+      `gap`,
+      `show_values`,
+      `label_style`,
+    ]),
+    log: get_prop(model, `log_scale`),
+  })
+}
+
+const render_spacegroup_bar: Render = ({ model, el }) => {
+  mount_widget(
+    model,
+    el,
+    SpacegroupBarPlot,
+    pick_props(model, [
+      `data`,
+      `show_counts`,
+      `show_legend`,
+      `orientation`,
+      `x_axis`,
+      `y_axis`,
+    ]),
+  )
+}
+
+const render_chem_pot_diagram: Render = ({ model, el }) => {
+  mount_widget(
+    model,
+    el,
+    ChemPotDiagram,
+    pick_props(model, [`entries`, `config`, `temperature`]),
+  )
+}
+
+// Static dispatch table — referenced by render() at call time (after module init)
+const renderers: Record<string, Render> = {
+  structure: render_structure,
+  trajectory: render_trajectory,
+  scatter_plot: render_scatter_plot,
+  scatter_plot_3d: render_scatter_plot_3d,
+  bar_plot: render_bar_plot,
+  histogram: render_histogram,
+  composition: render_composition,
+  convex_hull: render_convex_hull,
+  band_structure: render_band_structure,
+  dos: render_dos,
+  bands_and_dos: render_bands_and_dos,
+  fermi_surface: render_fermi_surface,
+  brillouin_zone: render_brillouin_zone,
+  phase_diagram: render_phase_diagram,
+  xrd: render_xrd,
+  periodic_table: render_periodic_table,
+  rdf_plot: render_rdf_plot,
+  heatmap_matrix: render_heatmap_matrix,
+  spacegroup_bar: render_spacegroup_bar,
+  chem_pot_diagram: render_chem_pot_diagram,
+}
+
+export default { render }

--- a/extensions/anywidget/anywidget.ts
+++ b/extensions/anywidget/anywidget.ts
@@ -228,9 +228,11 @@ const render: Render = (props) => {
   inject_app_css(undefined, el)
   setup_theme_watchers(el)
 
+  // Recompute the theme per element rather than reusing the single shared
+  // theme_type, so multiple widget roots/hosts each get their own detected theme.
   theme_unsubs.set(
     el,
-    on_theme_change((theme_type) => inject_app_css(theme_type, el)),
+    on_theme_change(() => inject_app_css(undefined, el)),
   )
   void renderer(props)
   return () => cleanup_element(el)
@@ -354,9 +356,14 @@ const render_dos: Render = ({ model, el }) => {
 }
 
 const render_bands_and_dos: Render = ({ model, el }) => {
+  // BandsAndDos forwards config to its child Bands/Dos via bands_props/dos_props.
+  // It internally controls fermi_level, reference_frequency and dos orientation,
+  // so those traits are intentionally not forwarded here (they'd be overridden).
   mount_widget(model, el, BandsAndDos, {
     band_structs: get_prop(model, `band_structure`), // Renamed traitlet
     doses: get_prop(model, `dos`), // Renamed traitlet
+    bands_props: pick_props(model, [`band_type`, `show_legend`]),
+    dos_props: pick_props(model, [`stack`, `sigma`, `normalize`, `show_legend`, `spin_mode`]),
   })
 }
 

--- a/extensions/anywidget/anywidget.ts
+++ b/extensions/anywidget/anywidget.ts
@@ -30,20 +30,10 @@ import { detect_parent_theme, get_theme_css, watch_theme } from './theme-detecti
 
 const adopted_sheets = new WeakMap<ShadowRoot, CSSStyleSheet>()
 
-function inject_app_css(theme_type?: ThemeType, target_element?: HTMLElement): void {
-  const style_id = `matterviz-widget-styles`
-  const detected_theme = theme_type ?? detect_parent_theme(target_element)
-
-  // Determine if we're in Shadow DOM (used by marimo cells) and get the appropriate root
-  const root_node = target_element?.getRootNode() ?? document
-  const in_shadow = root_node instanceof ShadowRoot
-
-  // Remove existing style element (if any)
-  ;(in_shadow ? root_node : document).querySelector(`#${style_id}`)?.remove()
-
-  // Create style content
-  const style_content = `
-    ${get_theme_css(detected_theme, in_shadow)}
+// Static widget chrome + bundled app styles. Only the theme-variable block
+// (get_theme_css) changes between calls, so keep this constant rather than
+// rebuilding the full ~150 KB string on every theme change.
+const widget_base_css = `
     .cell-output-ipywidget-background { background: transparent !important; }
     :is(input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="color"]), textarea, select) {
       background-color: var(--surface-bg); color: var(--text-color); border: 1px solid var(--border-color); border-radius: 4px; padding: 6px 8px;
@@ -55,6 +45,20 @@ function inject_app_css(theme_type?: ThemeType, target_element?: HTMLElement): v
     select option { background-color: var(--surface-bg); color: var(--text-color); }
     ${app_css}
   `
+
+function inject_app_css(theme_type?: ThemeType, target_element?: HTMLElement): void {
+  const style_id = `matterviz-widget-styles`
+  const detected_theme = theme_type ?? detect_parent_theme(target_element)
+
+  // Determine if we're in Shadow DOM (used by marimo cells) and get the appropriate root
+  const root_node = target_element?.getRootNode() ?? document
+  const in_shadow = root_node instanceof ShadowRoot
+
+  // Remove existing style element (if any)
+  ;(in_shadow ? root_node : document).querySelector(`#${style_id}`)?.remove()
+
+  // Only the theme-variable block varies per call; the rest is widget_base_css.
+  const style_content = `${get_theme_css(detected_theme, in_shadow)}${widget_base_css}`
 
   // Apply styles via adoptedStyleSheets (reuse existing sheet to avoid accumulation)
   if (in_shadow && `adoptedStyleSheets` in root_node) {
@@ -198,6 +202,7 @@ const get_scene_props = (model: AnyModel) => ({
     `vector_uniform_thickness`,
     `vector_origin_gap`,
   ]),
+  // defaults mirror the Structure component's own auto_rotate/gizmo defaults
   auto_rotate: get_prop(model, `auto_rotate`) ?? 0.2,
   gizmo: get_prop(model, `show_gizmo`) ?? true,
 })
@@ -216,7 +221,10 @@ const get_lattice_props = (model: AnyModel) =>
 const render: Render = (props) => {
   const { model, el } = props
   const widget_type = get_prop(model, `widget_type`) as string | undefined
-  const renderer = widget_type ? renderers[widget_type] : undefined
+  // guard with Object.hasOwn so prototype keys (toString, constructor, ...) don't
+  // resolve as renderers and silently bypass the unknown-widget_type error
+  const renderer =
+    widget_type && Object.hasOwn(renderers, widget_type) ? renderers[widget_type] : undefined
   if (!renderer) throw new Error(`Unknown or missing widget_type: '${widget_type}'`)
 
   cleanup_element(el)

--- a/extensions/anywidget/anywidget.ts
+++ b/extensions/anywidget/anywidget.ts
@@ -26,12 +26,7 @@ import {
 import app_css from 'matterviz/app.css?raw'
 import type { ThemeType } from 'matterviz/theme'
 import { mount, unmount } from 'svelte'
-import {
-  detect_parent_theme,
-  get_theme_css,
-  on_theme_change,
-  setup_theme_watchers,
-} from './theme-detection'
+import { detect_parent_theme, get_theme_css, watch_theme } from './theme-detection'
 
 const adopted_sheets = new WeakMap<ShadowRoot, CSSStyleSheet>()
 
@@ -226,13 +221,13 @@ const render: Render = (props) => {
 
   cleanup_element(el)
   inject_app_css(undefined, el)
-  setup_theme_watchers(el)
 
-  // Recompute the theme per element rather than reusing the single shared
-  // theme_type, so multiple widget roots/hosts each get their own detected theme.
+  // Watch this element's theme and re-inject CSS on change. The returned disposer
+  // (invoked by cleanup_element) unregisters this widget and tears down the shared
+  // DOM/media observers once the last widget is gone.
   theme_unsubs.set(
     el,
-    on_theme_change(() => inject_app_css(undefined, el)),
+    watch_theme(el, () => inject_app_css(undefined, el)),
   )
   void renderer(props)
   return () => cleanup_element(el)

--- a/extensions/anywidget/h5wasm-stub.ts
+++ b/extensions/anywidget/h5wasm-stub.ts
@@ -1,0 +1,38 @@
+// h5wasm stub for the MatterViz anywidget bundle.
+//
+// The widget never parses HDF5 (.h5) files in the browser -- pymatviz parses
+// trajectories on the Python side and passes structured data. Aliasing `h5wasm`
+// to this stub (see vite.config.ts) keeps ~5 MB of HDF5 WASM out of the
+// published bundle. The HDF5 parse path throws a clear error if ever reached.
+
+const unsupported = (): never => {
+  throw new Error(
+    `HDF5 (.h5) files cannot be parsed in the MatterViz widget. Parse the ` +
+      `trajectory in Python and pass the structured data instead.`,
+  )
+}
+
+export class Dataset {
+  constructor() {
+    unsupported()
+  }
+}
+export class Group {
+  constructor() {
+    unsupported()
+  }
+}
+export class File {
+  constructor() {
+    unsupported()
+  }
+}
+export type Entity = unknown
+
+// Thenable that rejects only when awaited (no unhandled rejection at load time).
+export const ready: PromiseLike<never> = {
+  then: (_on_fulfilled?: unknown, on_rejected?: (reason: Error) => void) =>
+    on_rejected?.(new Error(`HDF5 parsing is unavailable in the MatterViz widget bundle`)),
+}
+
+export default { Dataset, Group, File, ready }

--- a/extensions/anywidget/h5wasm-stub.ts
+++ b/extensions/anywidget/h5wasm-stub.ts
@@ -12,6 +12,10 @@ const unsupported = (): never => {
   )
 }
 
+// Mirror h5wasm's class exports so `new h5wasm.File()` and `x instanceof
+// h5wasm.Dataset/Group` in the stubbed HDF5 path still resolve -- these must be
+// classes (a function can't back `instanceof`), so the empty-class rule is moot.
+// oxlint-disable typescript/no-extraneous-class -- intentional class API stubs
 export class Dataset {
   constructor() {
     unsupported()
@@ -27,12 +31,15 @@ export class File {
     unsupported()
   }
 }
+// oxlint-enable typescript/no-extraneous-class
 export type Entity = unknown
 
-// Thenable that rejects only when awaited (no unhandled rejection at load time).
-export const ready: PromiseLike<never> = {
-  then: (_on_fulfilled?: unknown, on_rejected?: (reason: Error) => void) =>
-    on_rejected?.(new Error(`HDF5 parsing is unavailable in the MatterViz widget bundle`)),
-}
+// `await h5wasm.ready` in the (normally unused) HDF5 path fails fast with a clear
+// error. The no-op catch keeps the never-awaited common case from logging an
+// unhandled rejection at load; awaiters still receive the rejection.
+export const ready = Promise.reject(
+  new Error(`HDF5 parsing is unavailable in the MatterViz widget bundle`),
+)
+void ready.catch(() => {})
 
 export default { Dataset, Group, File, ready }

--- a/extensions/anywidget/package.json
+++ b/extensions/anywidget/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "matterviz-anywidget",
+  "version": "0.3.7",
+  "description": "Prebuilt anywidget bundle for MatterViz: renders MatterViz components (structures, trajectories, plots, periodic tables, ...) in Jupyter/marimo/VS Code via a single self-contained ESM file. Consumed by pymatviz and other Python wrappers, and served over CDNs (jsDelivr/unpkg) for HTML export.",
+  "homepage": "https://github.com/janosh/matterviz",
+  "license": "MIT",
+  "author": "Janosh Riebesell <janosh.riebesell@gmail.com>",
+  "repository": "https://github.com/janosh/matterviz",
+  "files": [
+    "build"
+  ],
+  "type": "module",
+  "exports": {
+    ".": "./build/matterviz.js",
+    "./style.css": "./build/matterviz.css"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "rm -rf build && vp build",
+    "dev": "vp dev",
+    "check": "vp check",
+    "prepublishOnly": "pnpm run build"
+  },
+  "devDependencies": {
+    "@janosh/vite-config": "github:janosh/dotfiles",
+    "@sveltejs/vite-plugin-svelte": "^7.0.0",
+    "@types/node": "^25.6.0",
+    "anywidget": "^0.11.0",
+    "matterviz": "file:../..",
+    "svelte": "^5.55.5",
+    "svelte-multiselect": "11.7.0",
+    "vite": "npm:@voidzero-dev/vite-plus-core@^0.1.20",
+    "vite-plus": "^0.1.20"
+  },
+  "packageManager": "pnpm@11.5.0"
+}

--- a/extensions/anywidget/package.json
+++ b/extensions/anywidget/package.json
@@ -25,14 +25,18 @@
   },
   "devDependencies": {
     "@janosh/vite-config": "github:janosh/dotfiles",
+    "@spglib/moyo-wasm": "^0.10.0",
     "@sveltejs/vite-plugin-svelte": "^7.0.0",
     "@types/node": "^25.6.0",
     "anywidget": "^0.11.0",
     "matterviz": "file:../..",
     "svelte": "^5.55.5",
-    "svelte-multiselect": "11.7.0",
-    "vite": "npm:@voidzero-dev/vite-plus-core@^0.1.20",
-    "vite-plus": "^0.1.20"
+    "svelte-multiselect": "^11.7.1",
+    "vite": "^8.0.16",
+    "vite-plus": "latest"
+  },
+  "engines": {
+    "node": ">=24"
   },
   "packageManager": "pnpm@11.5.0"
 }

--- a/extensions/anywidget/package.json
+++ b/extensions/anywidget/package.json
@@ -19,8 +19,6 @@
   },
   "scripts": {
     "build": "rm -rf build && vp build",
-    "dev": "vp dev",
-    "check": "vp check",
     "prepublishOnly": "pnpm run build"
   },
   "devDependencies": {
@@ -34,9 +32,6 @@
     "svelte-multiselect": "^11.7.1",
     "vite": "^8.0.16",
     "vite-plus": "latest"
-  },
-  "engines": {
-    "node": ">=24"
   },
   "packageManager": "pnpm@11.5.0"
 }

--- a/extensions/anywidget/readme.md
+++ b/extensions/anywidget/readme.md
@@ -15,12 +15,18 @@ that wraps the MatterViz component library for a specific host runtime.
 
 ## Bundle size
 
-`h5wasm` (the ~5 MB HDF5 reader used for client-side `.h5` trajectory parsing) is
-aliased to a stub (`h5wasm-stub.ts`, wired up in `vite.config.ts`), roughly halving
-the bundle. Hosts that drive this widget (e.g. pymatviz) parse trajectories on the
-Python side and pass structured data, so the in-browser HDF5 path is never hit; it
-throws a clear error if it ever is. The publish workflow's size gate fails if HDF5
-WASM creeps back in.
+Two large WASM dependencies are kept out of the inlined bundle (10.4 MB -> 3.4 MB),
+configured in `vite.config.ts`:
+
+- **h5wasm** (~5 MB HDF5 reader for client-side `.h5` trajectory parsing) is aliased
+  to a stub (`h5wasm-stub.ts`). Hosts that drive this widget (e.g. pymatviz) parse
+  trajectories on the Python side and pass structured data, so the in-browser HDF5
+  path is never hit; it throws a clear error if it ever is.
+- **moyo** (~1.9 MB spglib symmetry WASM, inlined twice) is loaded from jsDelivr on
+  demand by a small build plugin, only when spacegroup/symmetry analysis runs.
+  Rendering never needs it; symmetry needs network (no offline symmetry).
+
+The publish workflow's size gate fails if either WASM creeps back in.
 
 ## Consumers
 

--- a/extensions/anywidget/readme.md
+++ b/extensions/anywidget/readme.md
@@ -13,6 +13,15 @@ dependencies (matterviz components, Svelte runtime, three.js, ...) inlined.
 This is a peer of `extensions/dash` and `extensions/vscode`: a framework adapter
 that wraps the MatterViz component library for a specific host runtime.
 
+## Bundle size
+
+`h5wasm` (the ~5 MB HDF5 reader used for client-side `.h5` trajectory parsing) is
+aliased to a stub (`h5wasm-stub.ts`, wired up in `vite.config.ts`), roughly halving
+the bundle. Hosts that drive this widget (e.g. pymatviz) parse trajectories on the
+Python side and pass structured data, so the in-browser HDF5 path is never hit; it
+throws a clear error if it ever is. The publish workflow's size gate fails if HDF5
+WASM creeps back in.
+
 ## Consumers
 
 - [pymatviz](https://github.com/janosh/pymatviz) loads this bundle to render its

--- a/extensions/anywidget/readme.md
+++ b/extensions/anywidget/readme.md
@@ -1,0 +1,46 @@
+# MatterViz anywidget bundle
+
+A prebuilt [anywidget](https://anywidget.dev) bundle that renders MatterViz
+components in notebook environments (Jupyter, marimo, VS Code) and anywhere an
+ESM module can be loaded.
+
+`anywidget.ts` is the entry point: it dispatches on a `widget_type` string to the
+matching MatterViz Svelte component, mounts it into the host element, and forwards
+the widget's traitlet values as props. The build is a single self-contained ESM
+file (`build/matterviz.js`) plus its CSS (`build/matterviz.css`), with all
+dependencies (matterviz components, Svelte runtime, three.js, ...) inlined.
+
+This is a peer of `extensions/dash` and `extensions/vscode`: a framework adapter
+that wraps the MatterViz component library for a specific host runtime.
+
+## Consumers
+
+- [pymatviz](https://github.com/janosh/pymatviz) loads this bundle to render its
+  Python widget classes and to power headless image/HTML export.
+- Any Python (or JS) wrapper can mount the bundle: call its default export's
+  `render({ model, el })` with an anywidget-compatible model exposing
+  `get(key)` for the widget's `widget_type` and props.
+
+## Build
+
+```sh
+# from the matterviz repo root, build the component library first so the
+# `matterviz` file: dependency resolves to dist/
+pnpm install && pnpm package:dist
+
+cd extensions/anywidget
+pnpm install
+pnpm build        # -> build/matterviz.js + build/matterviz.css
+```
+
+## Publish (CDN distribution)
+
+Published to npm as `matterviz-anywidget`; the prebuilt bundle is then served with
+CORS and a JavaScript MIME type via jsDelivr/unpkg, e.g.:
+
+```txt
+https://cdn.jsdelivr.net/npm/matterviz-anywidget@<version>/build/matterviz.js
+```
+
+`build/` is gitignored; the bundle never enters version control. See
+`.github/workflows/publish-anywidget.yml`.

--- a/extensions/anywidget/theme-detection.ts
+++ b/extensions/anywidget/theme-detection.ts
@@ -220,6 +220,10 @@ export function watch_theme(target_element: HTMLElement, callback: ThemeCallback
     element_watchers.delete(target_element)
     if (element_watchers.size > 0) return // other widgets still need shared watchers
 
+    if (notify_timer) {
+      clearTimeout(notify_timer) // drop a pending notify; no widgets left to update
+      notify_timer = null
+    }
     doc_observer?.disconnect()
     doc_observer = null
     media_query_listener?.removeEventListener(`change`, schedule_notify)

--- a/extensions/anywidget/theme-detection.ts
+++ b/extensions/anywidget/theme-detection.ts
@@ -162,8 +162,13 @@ export function setup_theme_watchers(target_element?: HTMLElement): void {
     })
 
     const observe_opts = { attributes: true, attributeFilter: [`class`, `data-theme`] }
-    mutation_observer.observe(document.body, observe_opts)
     mutation_observer.observe(document.documentElement, observe_opts)
+    if (document.body) mutation_observer.observe(document.body, observe_opts)
+    // Shadow DOM hosts (e.g. marimo cells) carry the theme class/data-theme but
+    // aren't reachable from document.body/documentElement, so observe them too.
+    const root_node = target_element?.getRootNode()
+    if (root_node instanceof ShadowRoot)
+      mutation_observer.observe(root_node.host, observe_opts)
 
     // Watch system preference changes
     if (globalThis.matchMedia) {

--- a/extensions/anywidget/theme-detection.ts
+++ b/extensions/anywidget/theme-detection.ts
@@ -16,11 +16,21 @@ declare global {
   var MATTERVIZ_CSS_MAP: Record<string, string> | undefined
 }
 
-let current_theme: ThemeType = `light`
-const theme_observers = new Set<(theme_type: ThemeType) => void>()
-let mutation_observer: MutationObserver | null = null
+type ThemeCallback = (theme_type: ThemeType) => void
+
+// Per-element watcher (callback + last-seen theme for dedup + the element's own
+// Shadow-host observer). Widgets can mount in different roots with different
+// themes, so each is tracked and torn down independently.
+const element_watchers = new Map<
+  HTMLElement,
+  { callback: ThemeCallback; theme: ThemeType; shadow_observer: MutationObserver | null }
+>()
+// Shared document observer + media-query listener, created with the first widget
+// and disconnected with the last (counted via element_watchers.size).
+let doc_observer: MutationObserver | null = null
 let media_query_listener: MediaQueryList | null = null
-let media_query_handler: (() => void) | null = null
+
+const observe_opts = { attributes: true, attributeFilter: [`class`, `data-theme`] }
 
 export function detect_parent_theme(target_element?: HTMLElement): ThemeType {
   try {
@@ -137,68 +147,75 @@ function is_dark_color(color: string): boolean | null {
   return luminance(color) < 0.5
 }
 
-function notify_theme_change(target_element?: HTMLElement): void {
-  const new_theme = detect_parent_theme(target_element)
-  if (new_theme !== current_theme) {
-    current_theme = new_theme
-    theme_observers.forEach((callback) => callback(new_theme))
+function notify_theme_change(): void {
+  // Re-detect every element's theme; notify only those whose theme changed.
+  for (const [element, watcher] of element_watchers) {
+    const new_theme = detect_parent_theme(element)
+    if (new_theme !== watcher.theme) {
+      watcher.theme = new_theme
+      watcher.callback(new_theme)
+    }
   }
 }
 
-export function setup_theme_watchers(target_element?: HTMLElement): void {
-  if (mutation_observer || media_query_listener) return // Avoid duplicates
+const schedule_notify = () => setTimeout(notify_theme_change, 10) // Debounce
 
+function on_dom_mutation(mutations: MutationRecord[]): void {
+  if (
+    mutations.some(
+      (mut) =>
+        mut.type === `attributes` &&
+        (mut.attributeName === `class` || mut.attributeName === `data-theme`),
+    )
+  )
+    schedule_notify()
+}
+
+// Register a widget element + its theme-change callback. Returns a disposer that
+// removes this element's subscriber and Shadow-host observer and, once the last
+// widget is gone, disconnects the shared document/media-query watchers (fixing a
+// leak where observers stayed attached for the page's lifetime).
+export function watch_theme(target_element: HTMLElement, callback: ThemeCallback): () => void {
   try {
-    // Watch for DOM changes
-    mutation_observer = new MutationObserver((mutations) => {
-      if (
-        mutations.some(
-          (mut) =>
-            mut.type === `attributes` &&
-            (mut.attributeName === `class` || mut.attributeName === `data-theme`),
-        )
-      )
-        setTimeout(() => notify_theme_change(target_element), 10) // Debounce
-    })
-
-    const observe_opts = { attributes: true, attributeFilter: [`class`, `data-theme`] }
-    mutation_observer.observe(document.documentElement, observe_opts)
-    if (document.body) mutation_observer.observe(document.body, observe_opts)
-    // Shadow DOM hosts (e.g. marimo cells) carry the theme class/data-theme but
-    // aren't reachable from document.body/documentElement, so observe them too.
-    const root_node = target_element?.getRootNode()
-    if (root_node instanceof ShadowRoot)
-      mutation_observer.observe(root_node.host, observe_opts)
-
-    // Watch system preference changes
-    if (globalThis.matchMedia) {
+    // Shared document-level + system-preference watchers (created once for all).
+    if (!doc_observer) {
+      doc_observer = new MutationObserver(on_dom_mutation)
+      doc_observer.observe(document.documentElement, observe_opts)
+      if (document.body) doc_observer.observe(document.body, observe_opts)
+    }
+    if (!media_query_listener && globalThis.matchMedia) {
       media_query_listener = globalThis.matchMedia(`(prefers-color-scheme: dark)`)
-      media_query_handler = () => notify_theme_change(target_element)
-      media_query_listener.addEventListener(`change`, media_query_handler)
+      media_query_listener.addEventListener(`change`, schedule_notify)
     }
 
-    current_theme = detect_parent_theme(target_element) // Set initial theme
+    // Shadow DOM hosts (e.g. marimo cells) carry the theme class/data-theme but
+    // aren't reachable from document, so observe each widget's host individually
+    // (not just the first widget's).
+    let shadow_observer: MutationObserver | null = null
+    const root_node = target_element.getRootNode()
+    if (root_node instanceof ShadowRoot) {
+      shadow_observer = new MutationObserver(on_dom_mutation)
+      shadow_observer.observe(root_node.host, observe_opts)
+    }
+
+    element_watchers.set(target_element, {
+      callback,
+      theme: detect_parent_theme(target_element),
+      shadow_observer,
+    })
   } catch (error) {
     console.warn(`Failed to setup theme watchers:`, error)
   }
-}
 
-export function cleanup_theme_watchers(): void {
-  mutation_observer?.disconnect()
-  mutation_observer = null
-
-  if (media_query_listener && media_query_handler) {
-    media_query_listener.removeEventListener(`change`, media_query_handler)
-  }
-  media_query_listener = null
-  media_query_handler = null
-  theme_observers.clear()
-}
-
-export function on_theme_change(callback: (theme_type: ThemeType) => void): () => void {
-  theme_observers.add(callback)
   return () => {
-    theme_observers.delete(callback)
+    element_watchers.get(target_element)?.shadow_observer?.disconnect()
+    element_watchers.delete(target_element)
+    if (element_watchers.size > 0) return // other widgets still need shared watchers
+
+    doc_observer?.disconnect()
+    doc_observer = null
+    media_query_listener?.removeEventListener(`change`, schedule_notify)
+    media_query_listener = null
   }
 }
 

--- a/extensions/anywidget/theme-detection.ts
+++ b/extensions/anywidget/theme-detection.ts
@@ -29,6 +29,9 @@ const element_watchers = new Map<
 // and disconnected with the last (counted via element_watchers.size).
 let doc_observer: MutationObserver | null = null
 let media_query_listener: MediaQueryList | null = null
+// Pending debounce timer shared across all mutation sources; cleared before each
+// reschedule so bursts of mutations collapse into a single notify_theme_change.
+let notify_timer: ReturnType<typeof setTimeout> | null = null
 
 const observe_opts = { attributes: true, attributeFilter: [`class`, `data-theme`] }
 
@@ -148,6 +151,7 @@ function is_dark_color(color: string): boolean | null {
 }
 
 function notify_theme_change(): void {
+  notify_timer = null
   // Re-detect every element's theme; notify only those whose theme changed.
   for (const [element, watcher] of element_watchers) {
     const new_theme = detect_parent_theme(element)
@@ -158,7 +162,11 @@ function notify_theme_change(): void {
   }
 }
 
-const schedule_notify = () => setTimeout(notify_theme_change, 10) // Debounce
+const schedule_notify = () => {
+  // Debounce: cancel any pending notify so only the latest mutation burst fires.
+  if (notify_timer) clearTimeout(notify_timer)
+  notify_timer = setTimeout(notify_theme_change, 10)
+}
 
 function on_dom_mutation(mutations: MutationRecord[]): void {
   if (

--- a/extensions/anywidget/theme-detection.ts
+++ b/extensions/anywidget/theme-detection.ts
@@ -1,0 +1,220 @@
+// Theme Detection for AnyWidget
+
+import { luminance } from 'matterviz/colors'
+import { COLOR_THEMES, type ThemeType } from 'matterviz/theme'
+// oxlint-disable-next-line import/no-unassigned-import -- registers built-in themes
+import 'matterviz/theme/themes'
+
+// Extend globalThis with our custom properties
+declare global {
+  var jupyterlab:
+    | {
+        application?: { shell?: { dataset?: { theme?: string } } }
+      }
+    | undefined
+  var MATTERVIZ_THEMES: Record<string, Record<string, string>> | undefined
+  var MATTERVIZ_CSS_MAP: Record<string, string> | undefined
+}
+
+let current_theme: ThemeType = `light`
+const theme_observers = new Set<(theme_type: ThemeType) => void>()
+let mutation_observer: MutationObserver | null = null
+let media_query_listener: MediaQueryList | null = null
+let media_query_handler: (() => void) | null = null
+
+export function detect_parent_theme(target_element?: HTMLElement): ThemeType {
+  try {
+    // Check Shadow DOM context
+    if (target_element) {
+      const root_node = target_element.getRootNode()
+      if (root_node !== document && root_node instanceof ShadowRoot) {
+        const theme = check_element_hierarchy(root_node.host)
+        if (theme) return theme
+      }
+    }
+
+    // Check document theme indicators
+    const theme_classes = [
+      `dark-theme`,
+      `light-theme`,
+      `vscode-dark`,
+      `vscode-light`,
+      `dark`,
+      `light`,
+    ]
+    for (const cls of theme_classes) {
+      if (document.body.classList.contains(cls)) {
+        return cls.includes(`dark`) ? `dark` : `light`
+      }
+    }
+
+    // System preference
+    if (globalThis.matchMedia) {
+      if (globalThis.matchMedia(`(prefers-color-scheme: dark)`).matches) return `dark`
+      if (globalThis.matchMedia(`(prefers-color-scheme: light)`).matches) return `light`
+    }
+
+    // Jupyter Lab theme API
+    const jupyter_theme = globalThis.jupyterlab?.application?.shell?.dataset?.theme
+    if (jupyter_theme) {
+      return jupyter_theme.includes(`dark`) ? `dark` : `light`
+    }
+
+    // Jupyter CSS custom properties
+    const jp_bg = getComputedStyle(document.documentElement).getPropertyValue(
+      `--jp-layout-color0`,
+    )
+    if (jp_bg) {
+      const is_dark = is_dark_color(jp_bg)
+      if (is_dark !== null) return is_dark ? `dark` : `light`
+    }
+
+    // Analyze background colors
+    const backgrounds = [
+      getComputedStyle(document.body).backgroundColor,
+      getComputedStyle(document.documentElement).backgroundColor,
+    ]
+
+    for (const bg of backgrounds) {
+      const is_dark = is_dark_color(bg)
+      if (is_dark !== null) return is_dark ? `dark` : `light`
+    }
+
+    return `light`
+  } catch (error) {
+    console.warn(`Theme detection failed, defaulting to light:`, error)
+    return `light`
+  }
+}
+
+function check_element_hierarchy(element: Element): ThemeType | null {
+  let current_element: Element | null = element
+
+  while (current_element) {
+    // Check classes
+    const class_list = current_element.classList
+    if (
+      class_list.contains(`dark-theme`) ||
+      class_list.contains(`vscode-dark`) ||
+      class_list.contains(`dark`)
+    )
+      return `dark`
+    if (
+      class_list.contains(`light-theme`) ||
+      class_list.contains(`vscode-light`) ||
+      class_list.contains(`light`)
+    )
+      return `light`
+
+    // Check data attributes
+    const data_theme = current_element.getAttribute(`data-theme`)
+    if (data_theme === `dark`) return `dark`
+    if (data_theme === `light`) return `light`
+
+    // Check computed styles
+    const computed_style = getComputedStyle(current_element)
+    const bg_color = computed_style.backgroundColor
+    const text_color = computed_style.color
+
+    if (bg_color && bg_color !== `rgba(0, 0, 0, 0)` && bg_color !== `transparent`) {
+      const is_dark = is_dark_color(bg_color)
+      if (is_dark !== null) return is_dark ? `dark` : `light`
+    }
+
+    if (text_color && text_color !== `rgba(0, 0, 0, 0)` && text_color !== `transparent`) {
+      const text_is_dark = is_dark_color(text_color)
+      if (text_is_dark !== null) return text_is_dark ? `light` : `dark`
+    }
+
+    current_element = current_element.parentElement
+  }
+
+  return null
+}
+
+function is_dark_color(color: string): boolean | null {
+  if (!color || [`transparent`, `initial`, `inherit`].includes(color)) return null
+  return luminance(color) < 0.5
+}
+
+function notify_theme_change(target_element?: HTMLElement): void {
+  const new_theme = detect_parent_theme(target_element)
+  if (new_theme !== current_theme) {
+    current_theme = new_theme
+    theme_observers.forEach((callback) => callback(new_theme))
+  }
+}
+
+export function setup_theme_watchers(target_element?: HTMLElement): void {
+  if (mutation_observer || media_query_listener) return // Avoid duplicates
+
+  try {
+    // Watch for DOM changes
+    mutation_observer = new MutationObserver((mutations) => {
+      if (
+        mutations.some(
+          (mut) =>
+            mut.type === `attributes` &&
+            (mut.attributeName === `class` || mut.attributeName === `data-theme`),
+        )
+      )
+        setTimeout(() => notify_theme_change(target_element), 10) // Debounce
+    })
+
+    const observe_opts = { attributes: true, attributeFilter: [`class`, `data-theme`] }
+    mutation_observer.observe(document.body, observe_opts)
+    mutation_observer.observe(document.documentElement, observe_opts)
+
+    // Watch system preference changes
+    if (globalThis.matchMedia) {
+      media_query_listener = globalThis.matchMedia(`(prefers-color-scheme: dark)`)
+      media_query_handler = () => notify_theme_change(target_element)
+      media_query_listener.addEventListener(`change`, media_query_handler)
+    }
+
+    current_theme = detect_parent_theme(target_element) // Set initial theme
+  } catch (error) {
+    console.warn(`Failed to setup theme watchers:`, error)
+  }
+}
+
+export function cleanup_theme_watchers(): void {
+  mutation_observer?.disconnect()
+  mutation_observer = null
+
+  if (media_query_listener && media_query_handler) {
+    media_query_listener.removeEventListener(`change`, media_query_handler)
+  }
+  media_query_listener = null
+  media_query_handler = null
+  theme_observers.clear()
+}
+
+export function on_theme_change(callback: (theme_type: ThemeType) => void): () => void {
+  theme_observers.add(callback)
+  return () => {
+    theme_observers.delete(callback)
+  }
+}
+
+export function get_theme_css(theme_type: ThemeType, is_shadow_dom = false): string {
+  const theme_name = COLOR_THEMES[theme_type]
+
+  // Get theme data (matterviz/themes.js sets this)
+  const theme = globalThis.MATTERVIZ_THEMES?.[theme_name]
+  const css_map = globalThis.MATTERVIZ_CSS_MAP
+
+  if (!theme || !css_map) {
+    console.warn(`Theme data not available, skipping theme application`)
+    return ``
+  }
+
+  const css_vars = Object.entries(theme)
+    .map(([key, value]) => (css_map[key] ? `${css_map[key]}: ${value};` : ``))
+    .filter(Boolean)
+    .join(`\n\t`)
+
+  // Use :host for Shadow DOM, :root for regular DOM
+  const selector = is_shadow_dom ? `:host` : `:root`
+  return `${selector} {\n\t${css_vars}\n}`
+}

--- a/extensions/anywidget/vite.config.ts
+++ b/extensions/anywidget/vite.config.ts
@@ -1,0 +1,41 @@
+import { config } from '@janosh/vite-config'
+import { svelte } from '@sveltejs/vite-plugin-svelte'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { gunzipSync } from 'node:zlib'
+import { defineConfig } from 'vite-plus'
+
+export default defineConfig({
+  ...config, // shared lint/fmt/build from @janosh/vite-config (dotfiles)
+  plugins: [
+    {
+      name: `vite-plugin-json-gz`,
+      enforce: `pre`,
+      load(id) {
+        if (!id.endsWith(`.json.gz`)) return null
+        try {
+          const json_data = JSON.parse(gunzipSync(readFileSync(id)).toString(`utf-8`))
+          return { code: `export default ${JSON.stringify(json_data)}`, map: null }
+        } catch {
+          return null
+        }
+      },
+    },
+    svelte(),
+  ],
+  build: {
+    ...config.build, // keep shared cssTarget: esnext (for light-dark())
+    outDir: `build`,
+    lib: {
+      entry: resolve(import.meta.dirname, `anywidget.ts`),
+      formats: [`es`],
+      fileName: `matterviz`,
+      cssFileName: `matterviz`,
+    },
+    minify: true, // published to a CDN + parsed in browsers; halve size/parse cost
+    rollupOptions: {
+      // Disable code splitting -- widget asset loader expects a single JS file
+      output: { inlineDynamicImports: true },
+    },
+  },
+})

--- a/extensions/anywidget/vite.config.ts
+++ b/extensions/anywidget/vite.config.ts
@@ -7,6 +7,13 @@ import { defineConfig } from 'vite-plus'
 
 export default defineConfig({
   ...config, // shared lint/fmt/build from @janosh/vite-config (dotfiles)
+  resolve: {
+    alias: {
+      // The widget never parses HDF5 client-side (pymatviz parses on the Python
+      // side), so stub out h5wasm to drop ~5 MB of HDF5 WASM from the bundle.
+      h5wasm: resolve(import.meta.dirname, `h5wasm-stub.ts`),
+    },
+  },
   plugins: [
     {
       name: `vite-plugin-json-gz`,

--- a/extensions/anywidget/vite.config.ts
+++ b/extensions/anywidget/vite.config.ts
@@ -1,9 +1,38 @@
 import { config } from '@janosh/vite-config'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
 import { resolve } from 'node:path'
 import { gunzipSync } from 'node:zlib'
 import { defineConfig } from 'vite-plus'
+
+// Load moyo (spglib) symmetry WASM from jsDelivr on demand instead of inlining
+// it as base64 -- twice (once via symmetry/index.ts's `?url` import, once via the
+// wasm-bindgen glue's dead `new URL(..., import.meta.url)` default). Drops ~1.9 MB.
+// Symmetry/spacegroup analysis needs network; widget rendering itself does not.
+const moyo_version = createRequire(import.meta.url)(`@spglib/moyo-wasm/package.json`).version
+const moyo_wasm_cdn = `https://cdn.jsdelivr.net/npm/@spglib/moyo-wasm@${moyo_version}/moyo_wasm_bg.wasm`
+const moyo_glue_url = `new URL('moyo_wasm_bg.wasm', import.meta.url)`
+
+const moyo_wasm_cdn_plugin = {
+  name: `moyo-wasm-cdn`,
+  enforce: `pre` as const,
+  resolveId(source: string) {
+    if (source.includes(`@spglib/moyo-wasm`) && source.endsWith(`.wasm?url`)) {
+      return `\0moyo-wasm-cdn-url`
+    }
+  },
+  load(id: string) {
+    if (id === `\0moyo-wasm-cdn-url`) {
+      return `export default ${JSON.stringify(moyo_wasm_cdn)}`
+    }
+  },
+  transform(code: string, id: string) {
+    if (id.includes(`@spglib/moyo-wasm`) && code.includes(moyo_glue_url)) {
+      return { code: code.replace(moyo_glue_url, JSON.stringify(moyo_wasm_cdn)), map: null }
+    }
+  },
+}
 
 export default defineConfig({
   ...config, // shared lint/fmt/build from @janosh/vite-config (dotfiles)
@@ -15,6 +44,7 @@ export default defineConfig({
     },
   },
   plugins: [
+    moyo_wasm_cdn_plugin,
     {
       name: `vite-plugin-json-gz`,
       enforce: `pre`,

--- a/extensions/anywidget/vite.config.ts
+++ b/extensions/anywidget/vite.config.ts
@@ -14,6 +14,8 @@ const moyo_version = createRequire(import.meta.url)(`@spglib/moyo-wasm/package.j
 const moyo_wasm_cdn = `https://cdn.jsdelivr.net/npm/@spglib/moyo-wasm@${moyo_version}/moyo_wasm_bg.wasm`
 const moyo_glue_url = `new URL('moyo_wasm_bg.wasm', import.meta.url)`
 
+let json_gz_is_build = false
+
 const moyo_wasm_cdn_plugin = {
   name: `moyo-wasm-cdn`,
   enforce: `pre` as const,
@@ -48,13 +50,21 @@ export default defineConfig({
     {
       name: `vite-plugin-json-gz`,
       enforce: `pre`,
+      configResolved(resolved_config) {
+        json_gz_is_build = resolved_config.command === `build`
+      },
       load(id) {
         if (!id.endsWith(`.json.gz`)) return null
         try {
-          const json_data = JSON.parse(gunzipSync(readFileSync(id)).toString(`utf-8`))
-          return { code: `export default ${JSON.stringify(json_data)}`, map: null }
-        } catch {
-          return null
+          const json_str = gunzipSync(readFileSync(id)).toString(`utf-8`)
+          JSON.parse(json_str) // validate before passing to bundler
+          // Rolldown (build) needs moduleType:'json' for import.meta.glob with
+          // import:'default' to properly unwrap the default export. Dev/test
+          // server doesn't support moduleType, needs JS module format.
+          if (json_gz_is_build) return { code: json_str, moduleType: `json` }
+          return `export default ${json_str}`
+        } catch (error) {
+          return this.error(`Failed to decompress ${id}: ${error}`)
         }
       },
     },

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
     "d3-scale-chromatic": "^3.1.0",
     "d3-shape": "^3.2.0",
     "d3-time-format": "^4.1.0",
-    "dompurify": "^3.4.7",
+    "dompurify": "3.4.7",
     "fflate": "^0.8.3",
     "h5wasm": "^0.10.2",
     "js-yaml": "^4.2.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,8 +21,14 @@ export default {
       args: [`--enable-unsafe-swiftshader`, `--use-angle=swiftshader`, `--use-gl=angle`],
     },
   },
-  workers: 16, // 4x vCPUs - testing higher parallelism for I/O-bound browser tests
+  // CI runners have 4 vCPUs and software WebGL (SwiftShader) is CPU-bound, so oversubscribing
+  // workers starves the render path and makes timing-sensitive assertions miss their windows.
+  // Keep CI at 1 worker/vCPU to avoid contention; allow more parallelism locally.
+  workers: is_ci ? 4 : 16,
   timeout: is_ci ? 45_000 : 30_000, // CI gets longer timeout due to slower shared resources
+  // default expect timeout is 5s; give assertions more headroom on slower CI so transient
+  // contention (theme/tooltip/render updates) doesn't trip them before retries can help
+  expect: { timeout: is_ci ? 15_000 : 5_000 },
   retries: is_ci ? 2 : 0, // Retry flaky tests in CI
   testDir: `tests/playwright`,
   // Playwright runs all tests by default (maxFailures defaults to 0, useful for CI to see total failures)

--- a/tests/playwright/isosurface-controls.test.ts
+++ b/tests/playwright/isosurface-controls.test.ts
@@ -14,10 +14,10 @@ async function open_settings_pane(page: Page) {
     document.head.append(style)
   })
   const gear = page.locator(`button.structure-controls-toggle`)
-  await expect(gear).toBeVisible({ timeout: 5000 })
+  await expect(gear).toBeVisible({ timeout: 15_000 })
   await gear.click()
   const pane = page.locator(`.controls-pane`)
-  await expect(pane).toBeVisible({ timeout: 5000 })
+  await expect(pane).toBeVisible({ timeout: 15_000 })
   return pane
 }
 

--- a/tests/playwright/periodic-table.test.ts
+++ b/tests/playwright/periodic-table.test.ts
@@ -48,7 +48,7 @@ test.describe(`Periodic Table`, () => {
     await hydrogen_tile.hover({ force: true })
 
     // Check for stats display - use flexible assertion with retry
-    await expect(page.locator(`text=1 - Hydrogen`)).toBeVisible({ timeout: 5000 })
+    await expect(page.locator(`text=1 - Hydrogen`)).toBeVisible({ timeout: 15_000 })
   })
 
   test(`can hover random elements without throwing errors`, async ({ page }) => {
@@ -68,7 +68,7 @@ test.describe(`Periodic Table`, () => {
     for (const idx of indices) {
       const tile = tiles.nth(idx)
       await tile.scrollIntoViewIfNeeded()
-      await tile.hover({ timeout: 5000 })
+      await tile.hover({ timeout: 15_000 })
     }
 
     expect(logs, logs.join(`\n`)).toHaveLength(0)
@@ -92,7 +92,7 @@ test.describe(`Periodic Table`, () => {
       // The tooltip uses conditional rendering ({#if tooltip_visible}),
       // so when hidden, it doesn't exist in the DOM at all
       const tooltip = page.locator(`.tooltip`)
-      await expect(tooltip).toHaveCount(0, { timeout: 5000 })
+      await expect(tooltip).toHaveCount(0, { timeout: 15_000 })
     }
 
     test(`shows default tooltip on element hover when no heatmap is selected`, async ({
@@ -109,7 +109,7 @@ test.describe(`Periodic Table`, () => {
 
       // Hover on the H tile within the first periodic table
       const h_tile = periodic_table.locator(`.element-tile`).filter({ hasText: `H` }).first()
-      await expect(h_tile).toBeVisible({ timeout: 5000 })
+      await expect(h_tile).toBeVisible({ timeout: 15_000 })
       // force: true needed - element tiles have stacked text content that intercepts hover
       await h_tile.hover({ force: true })
 
@@ -133,7 +133,7 @@ test.describe(`Periodic Table`, () => {
       await multiselect.click({ force: true })
 
       const option_list = multiselect.locator(`ul.options`)
-      await expect(option_list).toBeVisible({ timeout: 5000 })
+      await expect(option_list).toBeVisible({ timeout: 15_000 })
       const first_option = option_list.locator(`li`).first()
       await first_option.click()
 
@@ -177,14 +177,14 @@ test.describe(`Periodic Table`, () => {
       await page.waitForSelector(`.element-tile`, { timeout: 10000 })
 
       const h_tile = get_element_tile(page, `H`)
-      await expect(h_tile).toBeVisible({ timeout: 5000 })
+      await expect(h_tile).toBeVisible({ timeout: 15_000 })
       await h_tile.hover({ force: true })
 
       const tooltip = get_tooltip(page)
       // Use toPass for robust visibility check
       await expect(async () => {
         await expect(tooltip).toBeVisible()
-      }).toPass({ timeout: 5000 })
+      }).toPass({ timeout: 15_000 })
 
       await clear_tooltip(page)
       await expect(tooltip).toBeHidden()
@@ -213,7 +213,7 @@ test.describe(`Periodic Table`, () => {
           })
           .first()
 
-        await expect(element_tile).toBeVisible({ timeout: 5000 })
+        await expect(element_tile).toBeVisible({ timeout: 15_000 })
         await element_tile.hover({ force: true })
 
         const tooltip = get_tooltip(page)
@@ -221,7 +221,7 @@ test.describe(`Periodic Table`, () => {
         await expect(async () => {
           await expect(tooltip).toBeVisible()
           await expect(tooltip).toContainText(element.name)
-        }).toPass({ timeout: 5000 })
+        }).toPass({ timeout: 15_000 })
         await expect(tooltip).toContainText(`${element.symbol} • ${element.number}`)
       })
     }

--- a/tests/playwright/spectral/bands-and-dos.test.ts
+++ b/tests/playwright/spectral/bands-and-dos.test.ts
@@ -64,7 +64,7 @@ test.describe(`BandsAndDos Component Tests`, () => {
         2,
       )
       expect(dos_y_ticks.filter((tick) => !isNaN(parseFloat(tick))).length).toBeGreaterThan(2)
-    }).toPass({ timeout: 5000 })
+    }).toPass({ timeout: 15_000 })
   })
 
   test(`applies custom widths and passes props to subcomponents`, async ({ page }) => {
@@ -141,7 +141,7 @@ test.describe(`BandsAndDos Component Tests`, () => {
 
         expect(hovered_bands_lines).toBeGreaterThan(initial_bands_lines)
         expect(hovered_dos_lines).toBeGreaterThan(initial_dos_lines)
-      }).toPass({ timeout: 2000 })
+      }).toPass({ timeout: 15_000 })
     }
   })
 
@@ -186,8 +186,8 @@ test.describe(`BandsAndDos Component Tests`, () => {
       const bands_fermi = plots.first().locator(`.fermi-level-line`)
       const dos_fermi = plots.nth(1).locator(`.fermi-level-line`)
 
-      await expect(bands_fermi).toHaveCount(1, { timeout: 10000 })
-      await expect(dos_fermi).toHaveCount(1, { timeout: 10000 })
+      await expect(bands_fermi).toHaveCount(1, { timeout: 15_000 })
+      await expect(dos_fermi).toHaveCount(1, { timeout: 15_000 })
 
       // Fermi lines should be at approximately the same y position
       await expect(async () => {
@@ -199,7 +199,7 @@ test.describe(`BandsAndDos Component Tests`, () => {
         expect(Math.abs(parseFloat(bands_y1) - parseFloat(dos_y1))).toBeLessThanOrEqual(
           tolerance,
         )
-      }).toPass({ timeout: 5000 })
+      }).toPass({ timeout: 15_000 })
     })
   }
 })

--- a/tests/playwright/theme-control.test.ts
+++ b/tests/playwright/theme-control.test.ts
@@ -14,7 +14,7 @@ test.describe(`ThemeControl`, () => {
   async function get_theme_control(page: Page) {
     await page.goto(`/`, { waitUntil: `networkidle` })
     const control = page.locator(`.theme-control`)
-    await expect(control).toBeVisible({ timeout: 10000 })
+    await expect(control).toBeVisible()
     return control
   }
 
@@ -45,14 +45,14 @@ test.describe(`ThemeControl`, () => {
       await theme_control.selectOption(theme)
 
       // Check DOM attribute (auto-retries built-in)
-      await expect(html_element).toHaveAttribute(`data-theme`, theme, { timeout: 5000 })
+      await expect(html_element).toHaveAttribute(`data-theme`, theme, { timeout: 15_000 })
 
       // Use expect.poll for evaluated values
       const expected_scheme = theme === `white` || theme === `light` ? `light` : `dark`
       await expect
         .poll(
           () => page.evaluate(() => getComputedStyle(document.documentElement).colorScheme),
-          { timeout: 5000 },
+          { timeout: 15_000 },
         )
         .toBe(expected_scheme)
     }
@@ -68,7 +68,9 @@ test.describe(`ThemeControl`, () => {
     await page.emulateMedia({ colorScheme: `light` })
     const theme_control = await get_theme_control(page)
     await theme_control.selectOption(`dark`)
-    await expect(page.locator(`html`)).toHaveAttribute(`data-theme`, `dark`, { timeout: 5000 })
+    await expect(page.locator(`html`)).toHaveAttribute(`data-theme`, `dark`, {
+      timeout: 15_000,
+    })
 
     await expect
       .poll(
@@ -78,7 +80,7 @@ test.describe(`ThemeControl`, () => {
               .getPropertyValue(`--color-prettylights-syntax-storage-modifier-import`)
               .trim(),
           ),
-        { timeout: 5000 },
+        { timeout: 15_000 },
       )
       .toBe(`#f0f6fc`)
   })
@@ -91,11 +93,11 @@ test.describe(`ThemeControl`, () => {
 
     // Test dark preference
     await page.emulateMedia({ colorScheme: `dark` })
-    await expect(html_element).toHaveAttribute(`data-theme`, `dark`, { timeout: 5000 })
+    await expect(html_element).toHaveAttribute(`data-theme`, `dark`, { timeout: 15_000 })
 
     // Test light preference
     await page.emulateMedia({ colorScheme: `light` })
-    await expect(html_element).toHaveAttribute(`data-theme`, `light`, { timeout: 5000 })
+    await expect(html_element).toHaveAttribute(`data-theme`, `light`, { timeout: 15_000 })
   })
 
   test(`persists preferences and handles page navigation`, async ({ browser }) => {
@@ -117,7 +119,7 @@ test.describe(`ThemeControl`, () => {
     // Use expect.poll for evaluated values
     await expect
       .poll(() => page.evaluate(() => localStorage.getItem(`matterviz-theme`)), {
-        timeout: 5000,
+        timeout: 15_000,
       })
       .toBe(`dark`)
 
@@ -126,15 +128,19 @@ test.describe(`ThemeControl`, () => {
     theme_control = page.locator(`.theme-control`)
     await expect(theme_control).toBeVisible({ timeout: 10000 })
 
-    await expect(theme_control).toHaveValue(`dark`, { timeout: 5000 })
-    await expect(page.locator(`html`)).toHaveAttribute(`data-theme`, `dark`, { timeout: 5000 })
+    await expect(theme_control).toHaveValue(`dark`, { timeout: 15_000 })
+    await expect(page.locator(`html`)).toHaveAttribute(`data-theme`, `dark`, {
+      timeout: 15_000,
+    })
 
     // Test persistence across navigation
     await page.goto(`/bohr-atoms`, { waitUntil: `networkidle` })
     const nav_theme_control = page.locator(`.theme-control`)
     await expect(nav_theme_control).toBeVisible({ timeout: 10000 })
-    await expect(nav_theme_control).toHaveValue(`dark`, { timeout: 5000 })
-    await expect(page.locator(`html`)).toHaveAttribute(`data-theme`, `dark`, { timeout: 5000 })
+    await expect(nav_theme_control).toHaveValue(`dark`, { timeout: 15_000 })
+    await expect(page.locator(`html`)).toHaveAttribute(`data-theme`, `dark`, {
+      timeout: 15_000,
+    })
 
     await context.close()
   })

--- a/tests/playwright/theme-control.test.ts
+++ b/tests/playwright/theme-control.test.ts
@@ -111,7 +111,7 @@ test.describe(`ThemeControl`, () => {
     await page.reload({ waitUntil: `networkidle` })
 
     let theme_control = page.locator(`.theme-control`)
-    await expect(theme_control).toBeVisible({ timeout: 10000 })
+    await expect(theme_control).toBeVisible({ timeout: 15_000 })
 
     // Set theme and check localStorage
     await theme_control.selectOption(`dark`)
@@ -126,7 +126,7 @@ test.describe(`ThemeControl`, () => {
     // Test persistence across reload (no addInitScript to interfere)
     await page.reload({ waitUntil: `networkidle` })
     theme_control = page.locator(`.theme-control`)
-    await expect(theme_control).toBeVisible({ timeout: 10000 })
+    await expect(theme_control).toBeVisible({ timeout: 15_000 })
 
     await expect(theme_control).toHaveValue(`dark`, { timeout: 15_000 })
     await expect(page.locator(`html`)).toHaveAttribute(`data-theme`, `dark`, {
@@ -136,7 +136,7 @@ test.describe(`ThemeControl`, () => {
     // Test persistence across navigation
     await page.goto(`/bohr-atoms`, { waitUntil: `networkidle` })
     const nav_theme_control = page.locator(`.theme-control`)
-    await expect(nav_theme_control).toBeVisible({ timeout: 10000 })
+    await expect(nav_theme_control).toBeVisible({ timeout: 15_000 })
     await expect(nav_theme_control).toHaveValue(`dark`, { timeout: 15_000 })
     await expect(page.locator(`html`)).toHaveAttribute(`data-theme`, `dark`, {
       timeout: 15_000,

--- a/tests/playwright/theme-control.test.ts
+++ b/tests/playwright/theme-control.test.ts
@@ -14,7 +14,7 @@ test.describe(`ThemeControl`, () => {
   async function get_theme_control(page: Page) {
     await page.goto(`/`, { waitUntil: `networkidle` })
     const control = page.locator(`.theme-control`)
-    await expect(control).toBeVisible()
+    await expect(control).toBeVisible({ timeout: 15_000 })
     return control
   }
 

--- a/tests/vitest/anywidget-theme-detection.test.ts
+++ b/tests/vitest/anywidget-theme-detection.test.ts
@@ -94,7 +94,7 @@ describe(`watch_theme lifecycle`, () => {
     expect(live_observers).toBe(0) // b's shadow observer + shared doc observer all gone
   })
 
-  test(`notifies every current widget on a theme change, never a stale/disposed one`, async () => {
+  test(`debounces mutations and notifies every current widget, never a stale/disposed one`, async () => {
     vi.useFakeTimers()
     try {
       const { watch_theme } = await import(`../../extensions/anywidget/theme-detection`)
@@ -106,9 +106,14 @@ describe(`watch_theme lifecycle`, () => {
       const dispose_a = watch_theme(el_a, (theme) => seen_a.push(theme))
       watch_theme(el_b, (theme) => seen_b.push(theme))
 
-      prefers_dark = true // flip system preference, then signal a DOM change
+      prefers_dark = true // flip system preference, then signal a burst of changes
       trigger_dom_mutation()
+      trigger_dom_mutation()
+      trigger_dom_mutation()
+      // debounce: a burst collapses into one pending timer (old code queued 3)
+      expect(vi.getTimerCount()).toBe(1)
       vi.advanceTimersByTime(20) // past the debounce window
+      expect(vi.getTimerCount()).toBe(0) // timer cleared after it fires
       // both widgets react -- the old code only re-checked the first element's closure
       expect(seen_a).toEqual([`dark`])
       expect(seen_b).toEqual([`dark`])

--- a/tests/vitest/anywidget-theme-detection.test.ts
+++ b/tests/vitest/anywidget-theme-detection.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+// theme-detection.ts only pulls these from matterviz; mock them so the test
+// needs neither the built library nor the (CI-uninstalled) extension deps.
+vi.mock(`matterviz/colors`, () => ({ luminance: () => 1 }))
+vi.mock(`matterviz/theme`, () => ({ COLOR_THEMES: { light: `light`, dark: `dark` } }))
+vi.mock(`matterviz/theme/themes`, () => ({}))
+
+let live_observers = 0
+const observers: FakeMutationObserver[] = []
+const observed_targets: Node[] = []
+
+class FakeMutationObserver {
+  disconnected = false
+  constructor(public cb: MutationCallback) {
+    live_observers += 1
+    observers.push(this)
+  }
+  observe(target: Node): void {
+    observed_targets.push(target)
+  }
+  disconnect(): void {
+    if (this.disconnected) return
+    this.disconnected = true
+    live_observers -= 1
+  }
+  takeRecords(): MutationRecord[] {
+    return []
+  }
+}
+
+let prefers_dark = false
+
+beforeEach(() => {
+  live_observers = 0
+  observers.length = 0
+  observed_targets.length = 0
+  prefers_dark = false
+  globalThis.MutationObserver = FakeMutationObserver as unknown as typeof MutationObserver
+  globalThis.matchMedia = ((query: string) => ({
+    matches: query.includes(`dark`) ? prefers_dark : !prefers_dark,
+    media: query,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  })) as unknown as typeof matchMedia
+  vi.resetModules() // fresh module-singleton state per test
+})
+
+afterEach(() => {
+  document.body.innerHTML = ``
+})
+
+const make_shadow_element = (): { host: HTMLElement; inner: HTMLElement } => {
+  const host = document.createElement(`div`)
+  document.body.append(host)
+  const inner = document.createElement(`div`)
+  host.attachShadow({ mode: `open` }).append(inner)
+  return { host, inner }
+}
+
+const trigger_dom_mutation = (): void => {
+  const record = { type: `attributes`, attributeName: `class` } as unknown as MutationRecord
+  for (const observer of observers) {
+    if (!observer.disconnected) observer.cb([record], observer as unknown as MutationObserver)
+  }
+}
+
+describe(`watch_theme lifecycle`, () => {
+  test(`Bug 2: every widget's Shadow DOM host is observed, not just the first`, async () => {
+    const { watch_theme } = await import(`../../extensions/anywidget/theme-detection`)
+    const { host: host_a, inner: inner_a } = make_shadow_element()
+    const { host: host_b, inner: inner_b } = make_shadow_element()
+
+    watch_theme(inner_a, () => {})
+    watch_theme(inner_b, () => {})
+
+    expect(observed_targets).toContain(host_a)
+    expect(observed_targets).toContain(host_b) // would FAIL with the old early-return
+  })
+
+  test(`Bug 1: shared observers are disconnected once the last widget is gone`, async () => {
+    const { watch_theme } = await import(`../../extensions/anywidget/theme-detection`)
+    const { inner: inner_a } = make_shadow_element()
+    const { inner: inner_b } = make_shadow_element()
+
+    const dispose_a = watch_theme(inner_a, () => {})
+    const dispose_b = watch_theme(inner_b, () => {})
+
+    expect(live_observers).toBe(3) // 1 shared doc observer + 2 per-element shadow observers
+    dispose_a()
+    expect(live_observers).toBe(2) // a's shadow observer gone; shared survives for b
+    dispose_b()
+    expect(live_observers).toBe(0) // b's shadow observer + shared doc observer all gone
+  })
+
+  test(`notifies every current widget on a theme change, never a stale/disposed one`, async () => {
+    vi.useFakeTimers()
+    try {
+      const { watch_theme } = await import(`../../extensions/anywidget/theme-detection`)
+      const el_a = document.createElement(`div`)
+      const el_b = document.createElement(`div`)
+      document.body.append(el_a, el_b)
+      const seen_a: string[] = []
+      const seen_b: string[] = []
+      const dispose_a = watch_theme(el_a, (theme) => seen_a.push(theme))
+      watch_theme(el_b, (theme) => seen_b.push(theme))
+
+      prefers_dark = true // flip system preference, then signal a DOM change
+      trigger_dom_mutation()
+      vi.advanceTimersByTime(20) // past the debounce window
+      // both widgets react -- the old code only re-checked the first element's closure
+      expect(seen_a).toEqual([`dark`])
+      expect(seen_b).toEqual([`dark`])
+
+      // after disposing A, a further change must not touch its (stale) callback
+      dispose_a()
+      prefers_dark = false
+      trigger_dom_mutation()
+      vi.advanceTimersByTime(20)
+      expect(seen_a).toEqual([`dark`]) // unchanged: A no longer notified
+      expect(seen_b).toEqual([`dark`, `light`])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/tests/vitest/anywidget-theme-detection.test.ts
+++ b/tests/vitest/anywidget-theme-detection.test.ts
@@ -104,7 +104,7 @@ describe(`watch_theme lifecycle`, () => {
       const seen_a: string[] = []
       const seen_b: string[] = []
       const dispose_a = watch_theme(el_a, (theme) => seen_a.push(theme))
-      watch_theme(el_b, (theme) => seen_b.push(theme))
+      const dispose_b = watch_theme(el_b, (theme) => seen_b.push(theme))
 
       prefers_dark = true // flip system preference, then signal a burst of changes
       trigger_dom_mutation()
@@ -125,6 +125,12 @@ describe(`watch_theme lifecycle`, () => {
       vi.advanceTimersByTime(20)
       expect(seen_a).toEqual([`dark`]) // unchanged: A no longer notified
       expect(seen_b).toEqual([`dark`, `light`])
+
+      // disposing the last widget with a notify still pending clears the timer
+      trigger_dom_mutation()
+      expect(vi.getTimerCount()).toBe(1)
+      dispose_b()
+      expect(vi.getTimerCount()).toBe(0)
     } finally {
       vi.useRealTimers()
     }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -134,9 +134,15 @@ export default defineConfig({
     ...config.lint,
     // src/scripts/** are standalone utility scripts excluded from tsconfig (so
     // type-aware rules can't resolve $lib/Deno-style imports there) — keep them unlinted.
-    // extensions/dash/** is a separate package (react/prop-types/three deps) not
-    // installed in root CI, so type-aware rules can't resolve its imports here.
-    ignorePatterns: [`static/**`, `src/scripts/**`, `extensions/dash/**`],
+    // extensions/dash/** and extensions/anywidget/** are separate packages
+    // (react/three, anywidget/svelte deps) not installed in root CI, so type-aware
+    // rules can't resolve their imports here.
+    ignorePatterns: [
+      `static/**`,
+      `src/scripts/**`,
+      `extensions/dash/**`,
+      `extensions/anywidget/**`,
+    ],
   },
 
   test: {


### PR DESCRIPTION
## Summary

- **New `extensions/anywidget/`** — a framework adapter (peer of `extensions/dash` and `extensions/vscode`) that renders MatterViz components in notebook/host runtimes via a single self-contained ESM bundle. `anywidget.ts` dispatches on a `widget_type` string to the matching component and forwards traitlet values as props.
- **New `.github/workflows/publish-anywidget.yml`** — on `release` / `workflow_dispatch`, builds the component library (`pnpm package:dist`) + extension bundle and `npm publish --provenance` to npm as `matterviz-anywidget`. `build/` stays gitignored — nothing enters git. A post-build sanity gate (`test -s` + `>1 MB`) guards against empty/broken output.
- **Root `vite.config.ts`** — registers `extensions/anywidget/**` in the lint ignore (mirrors `extensions/dash/**`): a separate package whose deps aren't installed in root CI, so type-aware rules can't resolve its imports here.

- Automatic theme detection follows live theme changes and works through Shadow DOM.
- Browser-side `.h5` parsing is blocked by an explicit stub that surfaces a clear error.

## Why

Publishing to npm means the bundle is served with CORS + a JavaScript MIME type via jsDelivr/unpkg (GitHub release assets are `application/octet-stream` with no CORS, so `import()` fails). [pymatviz](https://github.com/janosh/pymatviz) consumes this for widget rendering and headless image/HTML export — its `to_html()` resolves the bundle from `https://cdn.jsdelivr.net/npm/matterviz-anywidget@<version>/build/matterviz.js`.