### PR TITLE
Fix correctness bugs across science kernels, parsers, and plots with regression tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ static/tmp
 *.vsix
 !extensions/vscode/.vscode/
 src/lib/element/data.json
+
+# agent worktrees / local config
+.claude

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
         pass_filenames: false
       - id: svelte-check
         name: Svelte type check
-        entry: bash -c 'npx svelte-kit sync && npx svelte-check-rs --threshold error'
+        entry: bash -c "npx svelte-kit sync && npx svelte-check-rs --threshold error --ignore '.claude/**'"
         language: system
         types_or: [ts, svelte]
         pass_filenames: false

--- a/src/lib/brillouin/compute.ts
+++ b/src/lib/brillouin/compute.ts
@@ -32,7 +32,10 @@ export function extract_point_group_from_operations(
     if (seen.has(key)) continue
     seen.add(key)
 
-    const rot = math.vec9_to_mat3x3(Array.from(rotation)) as Matrix3x3
+    // moyo serializes rotations COLUMN-major; vec9_to_mat3x3 reads row-major → transpose to get W
+    const rot = math.transpose_3x3_matrix(
+      math.vec9_to_mat3x3(Array.from(rotation)) as Matrix3x3,
+    )
     unique_rotations.push(rot)
   }
 
@@ -54,23 +57,18 @@ function mat3x3_multiply(A: Matrix3x3, B: Matrix3x3): Matrix3x3 {
   return result
 }
 
-// Convert fractional-coordinate rotation W to Cartesian k-space rotation.
-// In reciprocal space: R_cart = B · W^{-T} · B^{-1}, where B is the k_lattice
-// and W^{-T} is the inverse transpose of the direct-space rotation matrix.
-// This follows the dual-basis relation: if direct fractional rotation is x' = W·x,
-// then reciprocal fractional rotation is q' = W^{-T}·q. For non-orthogonal lattices
-// (monoclinic, triclinic, hexagonal), W^{-1} ≠ W^T since integer rotation matrices
-// are not orthogonal in these systems.
+// Convert fractional rotation W to Cartesian k-space rotation. k_lattice stores reciprocal
+// vectors as ROWS (k_cart = Bᵀ·q) and reciprocal fractional rotation is q' = W^{-T}·q, so
+// R_cart = Bᵀ·W^{-T}·B^{-T}. For non-orthogonal lattices W^{-1} ≠ Wᵀ, so the transpose matters.
 export function fractional_to_cartesian_rotation(
   W: Matrix3x3,
   k_lattice: Matrix3x3,
 ): Matrix3x3 {
   try {
-    const k_lattice_inv = math.matrix_inverse_3x3(k_lattice)
-    const W_inv = math.matrix_inverse_3x3(W)
-    const W_inv_T = math.transpose_3x3_matrix(W_inv)
-    // R_cart = B · W^{-T} · B^{-1}
-    return mat3x3_multiply(mat3x3_multiply(k_lattice, W_inv_T), k_lattice_inv)
+    const B_T = math.transpose_3x3_matrix(k_lattice)
+    const W_inv_T = math.transpose_3x3_matrix(math.matrix_inverse_3x3(W))
+    // R_cart = Bᵀ · W^{-T} · B^{-T}
+    return mat3x3_multiply(mat3x3_multiply(B_T, W_inv_T), math.matrix_inverse_3x3(B_T))
   } catch {
     // Fallback to identity if inversion fails (shouldn't happen for valid rotations)
     return [
@@ -479,7 +477,7 @@ export function compute_irreducible_bz(
   edge_sharp_angle_deg = 5,
 ): IrreducibleBZData | null {
   // Convert fractional rotations to Cartesian k-space rotations
-  // R_cart = B · W^{-T} · B^{-1}, where B is k_lattice and W^{-T} is inverse-transpose
+  // R_cart = Bᵀ · W^{-T} · B^{-T}, where B is k_lattice (reciprocal vectors as rows)
   const cartesian_ops = point_group_ops.map((W) =>
     fractional_to_cartesian_rotation(W, bz_data.k_lattice),
   )

--- a/src/lib/colors/index.ts
+++ b/src/lib/colors/index.ts
@@ -1,4 +1,4 @@
-import { rgb } from 'd3-color'
+import { color as d3_color, rgb } from 'd3-color'
 import * as d3_sc from 'd3-scale-chromatic'
 import type { Vec3 } from '$lib/math'
 import type { ELEM_SYMBOLS } from '$lib/labels'
@@ -78,32 +78,13 @@ export const ELEMENT_COLOR_SCHEMES = {
 export type ColorSchemeName = keyof typeof ELEMENT_COLOR_SCHEMES
 export const default_element_colors = { ...vesta_hex }
 
-// Hex colors and rgb/rgba, hsl/hsla, color(), var() functions (incomplete prefixes like `rgb` fail)
-const COLOR_FN_REGEX =
-  /^(#[0-9a-f]{3,8}|rgba?\([^)]+\)|hsla?\([^)]+\)|color\([^)]+\)|var\([^)]+\))$/i
-
-// Validate a bare word (e.g. `red`) via the browser's CSS parser, which rejects arbitrary
-// strings like `pending`. Cached since is_color runs per-cell in large tables. SSR has no
-// `document`, so bare named colors aren't recognized server-side (functional forms still are).
-const named_color_cache = new Map<string, boolean>()
-const is_css_named_color = (word: string): boolean => {
-  if (typeof document === `undefined`) return false
-  let is_named = named_color_cache.get(word)
-  if (is_named === undefined) {
-    const { style } = document.createElement(`span`)
-    style.color = word
-    is_named = style.color !== ``
-    named_color_cache.set(word, is_named)
-  }
-  return is_named
-}
-
-// Helper function to detect if a value is a color string
+// Detect if a value is a CSS color string. d3-color parses hex, rgb()/rgba(),
+// hsl()/hsla(), and named colors case-insensitively, rejecting arbitrary words like
+// `pending`. It doesn't parse var()/color()/currentcolor, so match those explicitly.
 export const is_color = (val: unknown): val is string => {
   if (typeof val !== `string`) return false
   const trimmed = val.trim()
-  // bare words must be real CSS named colors, not arbitrary strings like `pending`
-  return COLOR_FN_REGEX.test(trimmed) || is_css_named_color(trimmed.toLowerCase())
+  return /^(?:var|color)\([^)]+\)$|^currentcolor$/i.test(trimmed) || d3_color(trimmed) !== null
 }
 
 export const PLOT_COLORS = [

--- a/src/lib/colors/index.ts
+++ b/src/lib/colors/index.ts
@@ -78,14 +78,32 @@ export const ELEMENT_COLOR_SCHEMES = {
 export type ColorSchemeName = keyof typeof ELEMENT_COLOR_SCHEMES
 export const default_element_colors = { ...vesta_hex }
 
+// Hex colors and rgb/rgba, hsl/hsla, color(), var() functions (incomplete prefixes like `rgb` fail)
+const COLOR_FN_REGEX =
+  /^(#[0-9a-f]{3,8}|rgba?\([^)]+\)|hsla?\([^)]+\)|color\([^)]+\)|var\([^)]+\))$/i
+
+// Validate a bare word (e.g. `red`) via the browser's CSS parser, which rejects arbitrary
+// strings like `pending`. Cached since is_color runs per-cell in large tables. SSR has no
+// `document`, so bare named colors aren't recognized server-side (functional forms still are).
+const named_color_cache = new Map<string, boolean>()
+const is_css_named_color = (word: string): boolean => {
+  if (typeof document === `undefined`) return false
+  let is_named = named_color_cache.get(word)
+  if (is_named === undefined) {
+    const { style } = document.createElement(`span`)
+    style.color = word
+    is_named = style.color !== ``
+    named_color_cache.set(word, is_named)
+  }
+  return is_named
+}
+
 // Helper function to detect if a value is a color string
 export const is_color = (val: unknown): val is string => {
   if (typeof val !== `string`) return false
-  // Check for hex colors, rgb/rgba, hsl/hsla, color(), var(), and named colors
-  // Exclude incomplete function prefixes like 'rgb', 'hsl', 'var', 'color'
-  return /^(#[0-9a-f]{3,8}|rgba?\([^)]+\)|hsla?\([^)]+\)|color\([^)]+\)|var\([^)]+\)|(?!rgb$|hsl$|var$|color$)[a-z]+)$/i.test(
-    val.trim(),
-  )
+  const trimmed = val.trim()
+  // bare words must be real CSS named colors, not arbitrary strings like `pending`
+  return COLOR_FN_REGEX.test(trimmed) || is_css_named_color(trimmed.toLowerCase())
 }
 
 export const PLOT_COLORS = [

--- a/src/lib/composition/FormulaFilter.svelte
+++ b/src/lib/composition/FormulaFilter.svelte
@@ -338,8 +338,8 @@
       normalized = normalized.replaceAll(superscript, ascii)
     }
     return normalized
-      .replaceAll(`·`, ``)
-      .replaceAll(`⋅`, ``)
+      // keep hydrate dots (deleting would glue digits: CuSO4·5H2O -> CuSO45H2O)
+      .replaceAll(`⋅`, `·`)
       .replaceAll(`−`, `-`)
       .replaceAll(/\s+/g, ``)
   }

--- a/src/lib/composition/format.ts
+++ b/src/lib/composition/format.ts
@@ -39,9 +39,11 @@ export const format_composition_formula = (
   return sort_fn(symbols)
     .filter((el) => composition[el] && composition[el] > 0)
     .map((el) => {
-      const amount = composition[el]
+      const amount = Number(composition[el])
       if (amount === 1) return el
-      const formatted_amount = format_num(Number(amount), amount_format)
+      // avoid d3 SI prefixes for sub-1 amounts (`s` formats render 0.5 as 500m)
+      const fmt = amount_format.endsWith(`s`) && Math.abs(amount) < 1 ? `.3~g` : amount_format
+      const formatted_amount = format_num(amount, fmt)
       return plain_text ? `${el}${formatted_amount}` : `${el}<sub>${formatted_amount}</sub>`
     })
     .join(delim)

--- a/src/lib/composition/parse.ts
+++ b/src/lib/composition/parse.ts
@@ -80,7 +80,7 @@ export const atomic_symbol_to_num = (
 // Expand parentheses in chemical formulas
 const expand_parentheses = (formula: string): string => {
   while (formula.includes(`(`)) {
-    formula = formula.replaceAll(
+    const expanded = formula.replaceAll(
       /\(([^()]+)\)(\d+(?:\.\d+)?|\.\d+)?/g,
       (_match, group, multiplier) => {
         const mult = parse_count(multiplier)
@@ -93,21 +93,32 @@ const expand_parentheses = (formula: string): string => {
         )
       },
     )
+    if (expanded === formula) {
+      // unclosed/empty parens match nothing -> would loop forever
+      throw new Error(`Unbalanced or empty parentheses in formula: ${formula}`)
+    }
+    formula = expanded
   }
   return formula
 }
 
-// Parse chemical formula string into composition object
+// Parse chemical formula string into composition object. Hydrate/adduct segments
+// joined by ·, ⋅, or * are scaled by their leading coefficient (CuSO4·5H2O -> Cu S O9 H10)
 export const parse_formula = (formula: string): CompositionType => {
   const composition: CompositionType = {}
-  const cleaned_formula = expand_parentheses(formula.replaceAll(/\s/g, ``))
+  const cleaned = formula.replaceAll(/\s/g, ``)
+  const segments = cleaned.split(/[·⋅*]/).filter(Boolean)
 
-  for (const match of cleaned_formula.matchAll(/([A-Z][a-z]?)(\d+(?:\.\d+)?|\.\d+)?/g)) {
-    const element = match[1]
-    const count = parse_count(match[2])
-
-    if (!is_valid_element(element)) throw new Error(`Invalid element symbol: ${element}`)
-    composition[element] = (composition[element] ?? 0) + count
+  for (const [seg_idx, segment] of segments.entries()) {
+    // only hydrate segments (after a separator) carry a leading multiplier
+    const coeff = seg_idx > 0 ? /^\d+(?:\.\d+)?/.exec(segment)?.[0] : undefined
+    const multiplier = coeff ? parseFloat(coeff) : 1
+    const expanded = expand_parentheses(segment.slice(coeff?.length ?? 0))
+    for (const match of expanded.matchAll(/([A-Z][a-z]?)(\d+(?:\.\d+)?|\.\d+)?/g)) {
+      const [element, count] = [match[1], parse_count(match[2])]
+      if (!is_valid_element(element)) throw new Error(`Invalid element symbol: ${element}`)
+      composition[element] = (composition[element] ?? 0) + count * multiplier
+    }
   }
   return composition
 }

--- a/src/lib/composition/parse.ts
+++ b/src/lib/composition/parse.ts
@@ -111,7 +111,7 @@ export const parse_formula = (formula: string): CompositionType => {
 
   for (const [seg_idx, segment] of segments.entries()) {
     // only hydrate segments (after a separator) carry a leading multiplier
-    const coeff = seg_idx > 0 ? /^\d+(?:\.\d+)?/.exec(segment)?.[0] : undefined
+    const coeff = seg_idx > 0 ? /^(?:\d+(?:\.\d+)?|\.\d+)/.exec(segment)?.[0] : undefined
     const multiplier = coeff ? parseFloat(coeff) : 1
     const expanded = expand_parentheses(segment.slice(coeff?.length ?? 0))
     for (const match of expanded.matchAll(/([A-Z][a-z]?)(\d+(?:\.\d+)?|\.\d+)?/g)) {

--- a/src/lib/composition/parse.ts
+++ b/src/lib/composition/parse.ts
@@ -115,9 +115,9 @@ export const parse_formula = (formula: string): CompositionType => {
     const multiplier = coeff ? parseFloat(coeff) : 1
     const expanded = expand_parentheses(segment.slice(coeff?.length ?? 0))
     for (const match of expanded.matchAll(/([A-Z][a-z]?)(\d+(?:\.\d+)?|\.\d+)?/g)) {
-      const [element, count] = [match[1], parse_count(match[2])]
+      const [, element, count] = match
       if (!is_valid_element(element)) throw new Error(`Invalid element symbol: ${element}`)
-      composition[element] = (composition[element] ?? 0) + count * multiplier
+      composition[element] = (composition[element] ?? 0) + parse_count(count) * multiplier
     }
   }
   return composition

--- a/src/lib/convex-hull/ConvexHull2D.svelte
+++ b/src/lib/convex-hull/ConvexHull2D.svelte
@@ -320,7 +320,7 @@
   let copy_feedback = $state({ visible: false, position: { x: 0, y: 0 } })
 
   // Structure popup state
-  let structure_popup = $state<{
+  let structure_popup = $state.raw<{
     open: boolean
     structure: AnyStructure | null
     entry: ConvexHullEntry | null
@@ -489,7 +489,7 @@
   )
 
   // Custom hover tooltip state used with ScatterPlot events
-  let hover_data = $state<HoverData3D<ConvexHullEntry> | null>(null)
+  let hover_data = $state.raw<HoverData3D<ConvexHullEntry> | null>(null)
   $effect(() => {
     const current_selection = helpers.current_entry(selected_entry, plot_entries)
     if (selected_entry && !current_selection) selected_entry = null

--- a/src/lib/convex-hull/ConvexHull3D.svelte
+++ b/src/lib/convex-hull/ConvexHull3D.svelte
@@ -422,7 +422,7 @@
   let is_dragging = $state(false)
   let drag_started = $state(false)
   let last_mouse = $state({ x: 0, y: 0 })
-  let hover_data = $state<HoverData3D<ConvexHullEntry> | null>(null)
+  let hover_data = $state.raw<HoverData3D<ConvexHullEntry> | null>(null)
   let copy_feedback = $state({ visible: false, position: { x: 0, y: 0 } })
 
   // Drag and drop state

--- a/src/lib/convex-hull/ConvexHull4D.svelte
+++ b/src/lib/convex-hull/ConvexHull4D.svelte
@@ -326,7 +326,7 @@
   let is_dragging = $state(false)
   let drag_started = $state(false)
   let last_mouse = $state({ x: 0, y: 0 })
-  let hover_data = $state<HoverData3D<ConvexHullEntry> | null>(null)
+  let hover_data = $state.raw<HoverData3D<ConvexHullEntry> | null>(null)
   let copy_feedback = $state({ visible: false, position: { x: 0, y: 0 } })
 
   // Drag and drop state

--- a/src/lib/convex-hull/gas-thermodynamics.ts
+++ b/src/lib/convex-hull/gas-thermodynamics.ts
@@ -377,15 +377,11 @@ export function apply_gas_corrections(
     // If no correction needed, return entry unchanged
     if (Math.abs(correction) < 1e-12) return entry
 
-    // Apply correction to energy (update both energy and energy_per_atom
-    // so downstream formation energy calculations use the corrected value)
-    // Both fields store per-atom values, and correction is also per-atom
-    const corrected_energy = entry.energy + correction
-    return {
-      ...entry,
-      energy: corrected_energy,
-      energy_per_atom: corrected_energy,
-    }
+    // compute_gas_correction is PER-ATOM: shift energy_per_atom by it and rescale total
+    // energy by atom count so downstream formation energies use the corrected values
+    const atoms = count_atoms_in_composition(entry.composition)
+    const energy_per_atom = (entry.energy_per_atom ?? entry.energy / atoms) + correction
+    return { ...entry, energy: energy_per_atom * atoms, energy_per_atom }
   })
 }
 

--- a/src/lib/convex-hull/thermodynamics.ts
+++ b/src/lib/convex-hull/thermodynamics.ts
@@ -215,6 +215,7 @@ export function calculate_e_above_hull(
     const hull_input_map = new Map<number, number>() // x -> min_e_form
 
     for (const ref of reference_entries) {
+      if (ref.exclude_from_hull) continue // Shown but not used in hull construction
       const e_form = compute_e_form(ref)
       if (typeof e_form !== `number`) continue
       const total = count_atoms_in_composition(ref.composition)
@@ -252,6 +253,7 @@ export function calculate_e_above_hull(
     // Ternary system
     const ref_points: Point3D[] = []
     for (const ref of reference_entries) {
+      if (ref.exclude_from_hull) continue // Shown but not used in hull construction
       const e_form = compute_e_form(ref)
       if (typeof e_form !== `number`) continue
       try {
@@ -280,6 +282,8 @@ export function calculate_e_above_hull(
 
     const hull_triangles = compute_lower_hull_triangles(ref_points)
     const hull_models = build_lower_hull_model(hull_triangles)
+    // No facets despite enough refs → all coplanar at e_form = 0: use elemental tie-plane
+    const degenerate_hull_3d = hull_triangles.length === 0 && ref_points.length >= arity
 
     for (const { entry, e_form } of interest_data) {
       const id = entry.entry_id ?? JSON.stringify(entry.composition)
@@ -289,6 +293,10 @@ export function calculate_e_above_hull(
       }
       try {
         const bary = composition_to_barycentric_3d(entry.composition, elements)
+        if (degenerate_hull_3d) {
+          results[id] = Math.max(0, e_form)
+          continue
+        }
         const point = barycentric_to_ternary_xyz(bary, e_form)
         const z_hull = e_hull_at_xy(hull_models, point.x, point.y)
         results[id] = z_hull === null ? NaN : Math.max(0, point.z - z_hull)
@@ -300,6 +308,7 @@ export function calculate_e_above_hull(
     // Quaternary system
     const ref_points: Point4D[] = []
     for (const ref of reference_entries) {
+      if (ref.exclude_from_hull) continue // Shown but not used in hull construction
       const e_form = compute_e_form(ref)
       if (typeof e_form !== `number`) continue
       try {
@@ -323,6 +332,8 @@ export function calculate_e_above_hull(
     }
 
     const hull_tetrahedra = compute_lower_hull_4d(ref_points)
+    // No facets despite enough refs → all coplanar at e_form = 0: use elemental tie-plane
+    const degenerate_hull_4d = hull_tetrahedra.length === 0 && ref_points.length >= arity
     const interest_points: Point4D[] = []
     const interest_indices: number[] = []
 
@@ -349,21 +360,22 @@ export function calculate_e_above_hull(
 
     // Map back
     for (let idx = 0; idx < interest_data.length; idx++) {
-      const { entry } = interest_data[idx]
+      const { entry, e_form } = interest_data[idx]
       const id = entry.entry_id ?? JSON.stringify(entry.composition)
       const point_idx = idx_to_point_idx.get(idx) ?? -1
-      if (point_idx !== -1) {
-        results[id] = Math.max(0, distances[point_idx])
-      } else {
-        results[id] = NaN
-      }
+      const on_tie_plane = degenerate_hull_4d && typeof e_form === `number`
+      if (point_idx === -1) results[id] = NaN
+      else results[id] = Math.max(0, on_tie_plane ? e_form : distances[point_idx])
     }
   } else {
     // Arity 5+ uses generalized N-dimensional convex hull
-    // Helper to convert entry to hull point, returns null on expected errors
+    // Helper to convert entry to hull point, returns null on expected errors.
+    // Barycentric coords sum to 1, so the first is dropped: keeping all N would confine
+    // points to an (N-1)-dim affine subspace, leaving the hull permanently degenerate.
     const to_hull_point = (entry: PhaseData, e_form: number): number[] | null => {
       try {
-        return [...composition_to_barycentric_nd(entry.composition, elements), e_form]
+        const bary = composition_to_barycentric_nd(entry.composition, elements)
+        return [...bary.slice(1), e_form]
       } catch (err) {
         // Skip expected errors (missing elements), warn on unexpected
         if (err instanceof Error && !err.message.includes(`no elements from the system`)) {
@@ -376,16 +388,18 @@ export function calculate_e_above_hull(
     // Build reference points
     const ref_points: number[][] = []
     for (const ref of reference_entries) {
+      if (ref.exclude_from_hull) continue // Shown but not used in hull construction
       const e_form = compute_e_form(ref)
       if (typeof e_form !== `number`) continue
       const point = to_hull_point(ref, e_form)
       if (point) ref_points.push(point)
     }
 
-    // Ensure corner points (pure elements default to e_form = 0)
+    // Ensure corner points (pure elements default to e_form = 0). In reduced
+    // coordinates, element 0 is the origin; element k > 0 has (k-1)th coord = 1.
     for (let el_idx = 0; el_idx < arity; el_idx++) {
-      const corner = Array(arity + 1).fill(0)
-      corner[el_idx] = 1 // ith barycentric coord = 1
+      const corner = Array(arity).fill(0)
+      if (el_idx > 0) corner[el_idx - 1] = 1
       if (!ref_points.some((pt) => norm_nd(subtract_nd(pt, corner)) < EPS)) {
         ref_points.push(corner)
       }
@@ -393,12 +407,11 @@ export function calculate_e_above_hull(
 
     const hull_facets = compute_lower_hull_nd(compute_quickhull_nd(ref_points))
 
-    // Warn if hull is degenerate (all points coplanar or insufficient spread)
+    // Degenerate hull (all refs co-hyperplanar, e.g. all e_form = 0): tie-plane fallback is exact
     if (hull_facets.length === 0 && ref_points.length >= arity + 1) {
       console.warn(
-        `N-dimensional hull for ${arity}-element system is degenerate. ` +
-          `Falling back to tie-hyperplane at energy 0. ` +
-          `Consider using pymatgen for complex high-dimensional phase diagrams.`,
+        `N-dimensional hull for ${arity}-element system is degenerate ` +
+          `(all reference points co-hyperplanar). Falling back to tie-hyperplane at energy 0.`,
       )
     }
 

--- a/src/lib/convex-hull/thermodynamics.ts
+++ b/src/lib/convex-hull/thermodynamics.ts
@@ -144,6 +144,9 @@ export function find_lowest_energy_unary_refs(
   return refs
 }
 
+// Result key for an entry: entry_id, falling back to its serialized composition
+const id_of = (entry: PhaseData) => entry.entry_id ?? JSON.stringify(entry.composition)
+
 // Calculate energy above hull (eV/atom). Missing pure element refs default to E_form = 0.
 export function calculate_e_above_hull(
   entry: PhaseData,
@@ -201,7 +204,7 @@ export function calculate_e_above_hull(
   if (arity === 1) {
     // Unary system
     for (const { entry, e_form } of interest_data) {
-      const id = entry.entry_id ?? JSON.stringify(entry.composition)
+      const id = id_of(entry)
       // For unary, e_above_hull is simply e_form (since stable state is 0)
       // Unless we have multiple polymorphs, in which case the hull is at min(e_form) which should be 0
       // But compute_e_form_per_atom already subtracts the stable unary reference energy.
@@ -234,7 +237,7 @@ export function calculate_e_above_hull(
     const lower_hull = compute_lower_hull_2d(hull_points)
 
     for (const { entry, e_form } of interest_data) {
-      const id = entry.entry_id ?? JSON.stringify(entry.composition)
+      const id = id_of(entry)
       if (typeof e_form !== `number`) {
         results[id] = NaN
         continue
@@ -270,14 +273,9 @@ export function calculate_e_above_hull(
         composition_to_barycentric_3d({ [el]: 1 }, elements),
         0,
       )
-      if (
-        !ref_points.some(
-          (point) =>
-            Math.hypot(point.x - corner.x, point.y - corner.y, point.z - corner.z) < 1e-9,
-        )
-      ) {
-        ref_points.push(corner)
-      }
+      const dist = (point: Point3D) =>
+        Math.hypot(point.x - corner.x, point.y - corner.y, point.z - corner.z)
+      if (!ref_points.some((point) => dist(point) < 1e-9)) ref_points.push(corner)
     }
 
     const hull_triangles = compute_lower_hull_triangles(ref_points)
@@ -286,7 +284,7 @@ export function calculate_e_above_hull(
     const degenerate_hull_3d = hull_triangles.length === 0 && ref_points.length >= arity
 
     for (const { entry, e_form } of interest_data) {
-      const id = entry.entry_id ?? JSON.stringify(entry.composition)
+      const id = id_of(entry)
       if (typeof e_form !== `number`) {
         results[id] = NaN
         continue
@@ -335,36 +333,29 @@ export function calculate_e_above_hull(
     // No facets despite enough refs → all coplanar at e_form = 0: use elemental tie-plane
     const degenerate_hull_4d = hull_tetrahedra.length === 0 && ref_points.length >= arity
     const interest_points: Point4D[] = []
-    const interest_indices: number[] = []
+    const idx_to_point_idx = new Map<number, number>() // entry idx -> point idx
 
     interest_data.forEach(({ entry, e_form }, idx) => {
-      if (typeof e_form === `number`) {
-        try {
-          const bary = composition_to_barycentric_4d(entry.composition, elements)
-          const tet = barycentric_to_tetrahedral(bary)
-          interest_points.push({ ...tet, w: e_form })
-          interest_indices.push(idx)
-        } catch {
-          // Skip
-        }
+      if (typeof e_form !== `number`) return
+      try {
+        const bary = composition_to_barycentric_4d(entry.composition, elements)
+        const tet = barycentric_to_tetrahedral(bary)
+        idx_to_point_idx.set(idx, interest_points.length)
+        interest_points.push({ ...tet, w: e_form })
+      } catch {
+        // Skip
       }
     })
 
     const distances = compute_e_above_hull_4d(interest_points, hull_tetrahedra)
 
-    // Build reverse lookup for O(1) access
-    const idx_to_point_idx = new Map<number, number>()
-    interest_indices.forEach((original_idx, point_idx) => {
-      idx_to_point_idx.set(original_idx, point_idx)
-    })
-
     // Map back
     for (let idx = 0; idx < interest_data.length; idx++) {
       const { entry, e_form } = interest_data[idx]
-      const id = entry.entry_id ?? JSON.stringify(entry.composition)
-      const point_idx = idx_to_point_idx.get(idx) ?? -1
+      const id = id_of(entry)
+      const point_idx = idx_to_point_idx.get(idx)
       const on_tie_plane = degenerate_hull_4d && typeof e_form === `number`
-      if (point_idx === -1) results[id] = NaN
+      if (point_idx === undefined) results[id] = NaN
       else results[id] = Math.max(0, on_tie_plane ? e_form : distances[point_idx])
     }
   } else {
@@ -435,28 +426,18 @@ export function calculate_e_above_hull(
         ? compute_e_above_hull_nd(interest_points, hull_facets, ref_points)
         : []
 
-    // Map results back to entries
+    // Map results back to entries (degenerate hull → tie-hyperplane at energy 0)
     for (let idx = 0; idx < interest_data.length; idx++) {
       const { entry, e_form } = interest_data[idx]
-      const id = entry.entry_id ?? JSON.stringify(entry.composition)
+      const id = id_of(entry)
       const point_idx = idx_to_point_idx.get(idx)
-
-      if (point_idx === undefined) {
-        results[id] = NaN
-      } else if (hull_facets.length === 0 && typeof e_form === `number`) {
-        // Degenerate case: hull is tie-hyperplane at energy 0
-        results[id] = Math.max(0, e_form)
-      } else {
-        results[id] = Math.max(0, distances[point_idx])
-      }
+      const on_tie_plane = hull_facets.length === 0 && typeof e_form === `number`
+      if (point_idx === undefined) results[id] = NaN
+      else results[id] = Math.max(0, on_tie_plane ? e_form : distances[point_idx])
     }
   }
 
-  if (is_single) {
-    const id =
-      entries_of_interest[0].entry_id ?? JSON.stringify(entries_of_interest[0].composition)
-    return results[id]
-  }
+  if (is_single) return results[id_of(entries_of_interest[0])]
   return results
 }
 
@@ -583,7 +564,7 @@ export function process_hull_for_stats(
     const hull_distances = calculate_e_above_hull(processed.entries, processed.entries)
 
     for (const entry of processed.entries) {
-      const dist = hull_distances[entry.entry_id ?? JSON.stringify(entry.composition)]
+      const dist = hull_distances[id_of(entry)]
       if (typeof dist === `number` && Number.isFinite(dist)) {
         entry.e_above_hull = dist
         entry.is_stable = dist < HULL_STABILITY_TOL

--- a/src/lib/heatmap-matrix/HeatmapMatrix.svelte
+++ b/src/lib/heatmap-matrix/HeatmapMatrix.svelte
@@ -358,14 +358,18 @@
     return numeric_values
   })
 
-  // Single-pass min/max to avoid spreading large arrays into Math.min/max
-  let [auto_min, auto_max] = $derived.by(() => {
-    let [min, max] = [Infinity, -Infinity]
+  // Single-pass min/max to avoid spreading large arrays into Math.min/max. min_pos is
+  // the log-mode lower bound when the domain min is <= 0 (the old Number.MIN_VALUE
+  // floor gave log_min ~ -744, squashing all colors to the top)
+  let [auto_min, auto_max, min_pos] = $derived.by(() => {
+    let [min, max, pos] = [Infinity, -Infinity, Infinity]
     for (const value of valid_numeric_values) {
       if (value < min) min = value
       if (value > max) max = value
+      if (value > 0 && value < pos) pos = value
     }
-    return min <= max ? [min, max] as const : [0, 1] as const
+    const min_pos_val = Number.isFinite(pos) ? pos : null
+    return min <= max ? [min, max, min_pos_val] as const : [0, 1, min_pos_val] as const
   })
 
   let [robust_min, robust_max] = $derived.by(() => {
@@ -418,7 +422,7 @@
       const lower_bound = Math.min(cs_min, cs_max)
       const upper_bound = Math.max(cs_min, cs_max)
       if (upper_bound <= 0) return missing_color || null
-      const safe_lower_bound = Math.max(lower_bound, Number.MIN_VALUE)
+      const safe_lower_bound = lower_bound > 0 ? lower_bound : (min_pos ?? upper_bound)
       const safe_value = Math.max(val, safe_lower_bound)
       const log_min = Math.log(safe_lower_bound)
       const log_max = Math.log(upper_bound)

--- a/src/lib/io/url-drop.ts
+++ b/src/lib/io/url-drop.ts
@@ -110,24 +110,32 @@ export async function load_from_url(
   // Skip Range requests for known text formats to avoid production server issues
   // Include VASP files that don't have extensions (POSCAR, XDATCAR, CONTCAR)
   const is_known_text = TEXT_EXTENSIONS.has(ext) || VASP_BASENAME_RE.test(url_basename)
-  let binary_callback_args: [content: ArrayBuffer, filename: string] | undefined
+  let sniffed_callback_args: [content: string | ArrayBuffer, filename: string] | undefined
 
   if (!is_known_text) {
     try {
-      // Check for magic bytes only for unknown formats
+      // Check for magic bytes only for unknown formats (covers extensionless URLs
+      // like blob: object URLs whose basenames are UUIDs)
       const head = await fetch(url, { headers: { Range: `bytes=0-15` } })
       if (head.ok) {
         const buf = new Uint8Array(await head.arrayBuffer())
         const is_gzip = buf[0] === 0x1f && buf[1] === 0x8b
         const is_hdf5 =
           buf[0] === 0x89 && buf[1] === 0x48 && buf[2] === 0x44 && buf[3] === 0x46
-        if (is_gzip || is_hdf5) {
+        // ASE .traj files start with the Ulm signature "- of Ulm"
+        const is_ase_traj = [0x2d, 0x20, 0x6f, 0x66, 0x20, 0x55, 0x6c, 0x6d].every(
+          (byte, idx) => buf[idx] === byte,
+        )
+        if (is_gzip || is_hdf5 || is_ase_traj) {
           const resp = await fetch(url)
           if (!resp.ok) throw new Error(`Fetch failed: ${resp.status}`)
-          binary_callback_args = [
-            await resp.arrayBuffer(),
-            extract_filename(resp.headers, url_basename),
-          ]
+          const filename = extract_filename(resp.headers, url_basename)
+          const buffer = await resp.arrayBuffer()
+          // Decompress sniffed gzip since downstream parsers expect text or
+          // format-specific binary, not raw gzip bytes
+          sniffed_callback_args = is_gzip
+            ? [await decompress_data(buffer, `gzip`), filename.replace(/\.gz$/i, ``)]
+            : [buffer, filename]
         }
       }
     } catch {
@@ -135,7 +143,7 @@ export async function load_from_url(
     }
   }
 
-  if (binary_callback_args) return callback(...binary_callback_args)
+  if (sniffed_callback_args) return callback(...sniffed_callback_args)
 
   const resp = await fetch(url)
   if (!resp.ok) throw new Error(`Fetch failed: ${resp.status}`)

--- a/src/lib/io/url-drop.ts
+++ b/src/lib/io/url-drop.ts
@@ -73,8 +73,8 @@ export async function load_from_url(
       // Need to decompress manually
       const buffer = await resp.arrayBuffer()
       const content = await decompress_data(buffer, `gzip`)
-      // Remove .gz extension when manually decompressing
-      return callback(content, filename.replace(/\.gz$/, ``))
+      // Remove .gz/.gzip extension when manually decompressing
+      return callback(content, filename.replace(/\.(gz|gzip)$/i, ``))
     }
 
     // For H5 files, always load as binary regardless of signature
@@ -134,7 +134,7 @@ export async function load_from_url(
           // Decompress sniffed gzip since downstream parsers expect text or
           // format-specific binary, not raw gzip bytes
           sniffed_callback_args = is_gzip
-            ? [await decompress_data(buffer, `gzip`), filename.replace(/\.gz$/i, ``)]
+            ? [await decompress_data(buffer, `gzip`), filename.replace(/\.(gz|gzip)$/i, ``)]
             : [buffer, filename]
         }
       }

--- a/src/lib/isosurface/slice.ts
+++ b/src/lib/isosurface/slice.ts
@@ -53,9 +53,10 @@ export function trilinear_interpolate(
   const y1 = periodic ? (y0 + 1) % ny : Math.min(y0 + 1, ny - 1)
   const z1 = periodic ? (z0 + 1) % nz : Math.min(z0 + 1, nz - 1)
 
-  const xd = gx - Math.floor(gx)
-  const yd = gy - Math.floor(gy)
-  const zd = gz - Math.floor(gz)
+  // deltas from clamped lower index (non-periodic x0 clamps to nx-2 so floor(gx) may != x0)
+  const xd = periodic ? gx - Math.floor(gx) : gx - x0
+  const yd = periodic ? gy - Math.floor(gy) : gy - y0
+  const zd = periodic ? gz - Math.floor(gz) : gz - z0
 
   // 8-point interpolation
   const c000 = grid[x0][y0][z0]

--- a/src/lib/labels.ts
+++ b/src/lib/labels.ts
@@ -186,8 +186,9 @@ export function parse_si_float<T extends string | number | null | undefined>(
   // Remove whitespace and commas
   const cleaned = value.trim().replaceAll(/(\d),(\d)/g, `$1$2`)
 
-  // Check if the value is a SI-formatted number (e.g. "1.23k", "4.56M", "789µ", "12n")
-  const match = /^([-+]?\d*\.?\d+)\s*([yzafpnµmkMGTPEZY])?$/i.exec(cleaned)
+  // SI-formatted number (e.g. "1.23k", "789µ"). Suffixes are case-sensitive (m=milli vs
+  // M=mega), so no `i` flag: mismatched-case suffixes return the string as-is.
+  const match = /^([-+]?\d*\.?\d+)\s*([yzafpnµmkMGTPEZY])?$/.exec(cleaned)
   if (match) {
     const [, num_part, suffix] = match
     let multiplier = 1

--- a/src/lib/marching-cubes.ts
+++ b/src/lib/marching-cubes.ts
@@ -387,9 +387,11 @@ export function marching_cubes(
   const faces: number[][] = []
   const normals: Vec3[] = []
 
-  // Precompute grid dimension products for flattening and cache keys
-  const ny_nz = ny * nz
-  const max_flat = nx * ny_nz // for computing cache keys
+  // Cache keys use UNWRAPPED grid coords (reach n in periodic mode, hence radix n+1):
+  // wrapping would merge vertices on opposite cell faces into cell-spanning triangles.
+  const key_nz = nz + 1
+  const key_ny_nz = (ny + 1) * key_nz
+  const max_flat = (nx + 1) * key_ny_nz // for computing cache keys
   // Use numeric cache key - safe for grids up to ~300³ (2^53 / 2 / max_flat)
   // For much larger grids (>30M cells), consider switching to Map<string, number>
   // with keys like `${flat1},${flat2}` or Map<bigint, number> to avoid
@@ -429,18 +431,10 @@ export function marching_cubes(
     const oy2 = CUBE_VERTS_Y[v2_idx]
     const oz2 = CUBE_VERTS_Z[v2_idx]
 
-    // Compute wrapped grid positions using safe modulo for periodic boundaries
-    const g1x = periodic ? wrap_grid_idx(ix + ox1, nx) : ix + ox1
-    const g1y = periodic ? wrap_grid_idx(iy + oy1, ny) : iy + oy1
-    const g1z = periodic ? wrap_grid_idx(iz + oz1, nz) : iz + oz1
-    const g2x = periodic ? wrap_grid_idx(ix + ox2, nx) : ix + ox2
-    const g2y = periodic ? wrap_grid_idx(iy + oy2, ny) : iy + oy2
-    const g2z = periodic ? wrap_grid_idx(iz + oz2, nz) : iz + oz2
-
-    // Create numeric cache key (sorted for consistency)
+    // Sorted numeric key from UNWRAPPED coords (value/gradient lookups wrap internally).
     // Safe for grids up to ~300³ before exceeding Number.MAX_SAFE_INTEGER
-    const flat1 = g1x * ny_nz + g1y * nz + g1z
-    const flat2 = g2x * ny_nz + g2y * nz + g2z
+    const flat1 = (ix + ox1) * key_ny_nz + (iy + oy1) * key_nz + (iz + oz1)
+    const flat2 = (ix + ox2) * key_ny_nz + (iy + oy2) * key_nz + (iz + oz2)
     const cache_key = flat1 < flat2 ? flat1 * max_flat + flat2 : flat2 * max_flat + flat1
 
     const cached = vertex_cache.get(cache_key)

--- a/src/lib/math.ts
+++ b/src/lib/math.ts
@@ -799,6 +799,8 @@ export function merge_coplanar_triangles(
       emit_tri(verts[0], verts[1], verts[2])
     }
   }
+  const tri_area = (va: Vec3, vb: Vec3, vc: Vec3): number =>
+    0.5 * Math.hypot(...cross_3d(subtract(vb, va), subtract(vc, va)))
   for (const members of groups.values()) {
     if (members.length === 1) {
       emit_original(members)
@@ -845,6 +847,18 @@ export function merge_coplanar_triangles(
       }
       return unique_verts[best_idx]
     })
+
+    // Convex hull fills notches of concave patches, inventing area — keep originals then
+    let group_area = 0
+    let fan_area = 0
+    for (const tri_idx of members) group_area += tri_area(...tri_planes[tri_idx].verts)
+    for (let idx = 1; idx < hull_3d.length - 1; idx++) {
+      fan_area += tri_area(hull_3d[0], hull_3d[idx], hull_3d[idx + 1])
+    }
+    if (Math.abs(fan_area - group_area) > Math.max(group_area, 1e-12) * 1e-6) {
+      emit_original(members)
+      continue
+    }
 
     // Fan-triangulate from hull vertex 0
     for (let idx = 1; idx < hull_3d.length - 1; idx++) {

--- a/src/lib/periodic-table/PeriodicTable.svelte
+++ b/src/lib/periodic-table/PeriodicTable.svelte
@@ -209,8 +209,7 @@
   // smallest positive bound for log color mapping (matches the auto ColorBar's log scale)
   let cs_min_pos = $derived.by(() => {
     if (cs_min > 0) return cs_min
-    const pos = heat_values.flat()
-      .filter((val): val is number => typeof val === `number` && val > 0)
+    const pos = heat_values.flat().filter((v): v is number => typeof v === `number` && v > 0)
     return pos.length > 0 ? Math.min(...pos) : cs_max
   })
 

--- a/src/lib/periodic-table/PeriodicTable.svelte
+++ b/src/lib/periodic-table/PeriodicTable.svelte
@@ -206,6 +206,14 @@
         : 1),
   )
 
+  // smallest positive bound for log color mapping (matches the auto ColorBar's log scale)
+  let cs_min_pos = $derived.by(() => {
+    if (cs_min > 0) return cs_min
+    const pos = heat_values.flat()
+      .filter((val): val is number => typeof val === `number` && val > 0)
+    return pos.length > 0 ? Math.min(...pos) : cs_max
+  })
+
   let bg_color = $derived(
     (
       value: number | number[] | string | string[] | false,
@@ -238,8 +246,12 @@
       const span = cs_max - cs_min
       if (span === 0) return color_scale_fn?.(0.5) // midpoint when all values equal
 
-      if (log) value = Math.log((value as number) - cs_min + 1) / Math.log(span + 1)
-      else value = ((value as number) - cs_min) / span
+      if (log) {
+        // log mapping matching the log ColorBar (value <= 0 returned missing_color above)
+        const log_span = Math.log(cs_max) - Math.log(cs_min_pos)
+        if (log_span === 0) return color_scale_fn?.(0.5)
+        value = (Math.log(value as number) - Math.log(cs_min_pos)) / log_span
+      } else value = ((value as number) - cs_min) / span
       return color_scale_fn?.(value as number)
     },
   )

--- a/src/lib/plot/bar/BarPlot.svelte
+++ b/src/lib/plot/bar/BarPlot.svelte
@@ -1270,33 +1270,18 @@
   // Stack offsets (only for bar series in stacked mode, grouped by y-axis)
   let stacked_offsets = $derived.by(() => {
     if (mode !== `stacked`) return [] as number[][]
-    const max_len = Math.max(
-      0,
-      ...internal_series.map((srs) => srs.y.length),
-    )
-    const offsets = internal_series.map(() =>
-      Array.from({ length: max_len }, () => 0)
-    )
-
-    // Separate accumulators for y1 and y2 axes
-    const y1_pos_acc = Array.from({ length: max_len }, () => 0)
-    const y1_neg_acc = Array.from({ length: max_len }, () => 0)
-    const y2_pos_acc = Array.from({ length: max_len }, () => 0)
-    const y2_neg_acc = Array.from({ length: max_len }, () => 0)
-
+    const offsets = internal_series.map((srs) => Array.from(srs.x, () => 0))
+    // Cumulative totals keyed by axis/sign/x value so series with misaligned x grids
+    // stack on the correct baseline (matching stacked_totals in auto_ranges)
+    const acc = new SvelteMap<string, number>()
     internal_series.forEach((srs, series_idx) => {
       if (!(srs?.visible ?? true) || srs.render_mode === `line`) return
-
-      const use_y2 = srs.y_axis === `y2`
-      const pos_acc = use_y2 ? y2_pos_acc : y1_pos_acc
-      const neg_acc = use_y2 ? y2_neg_acc : y1_neg_acc
-
-      for (let bar_idx = 0; bar_idx < max_len; bar_idx++) {
+      srs.x.forEach((x_val, bar_idx) => {
         const y_val = srs.y[bar_idx] ?? 0
-        const acc = y_val >= 0 ? pos_acc : neg_acc
-        offsets[series_idx][bar_idx] = acc[bar_idx]
-        acc[bar_idx] += y_val
-      }
+        const key = `${srs.y_axis === `y2` ? `y2` : `y1`}:${y_val >= 0 ? `+` : `-`}:${x_val}`
+        offsets[series_idx][bar_idx] = acc.get(key) ?? 0
+        acc.set(key, (acc.get(key) ?? 0) + y_val)
+      })
     })
     return offsets
   })

--- a/src/lib/plot/box/kde.ts
+++ b/src/lib/plot/box/kde.ts
@@ -59,10 +59,11 @@ function silverman_bandwidth_unordered(samples: number[]): number {
 }
 
 // Scott's rule: std * n^(-1/5) for 1-D data.
-export function scott_bandwidth(sorted: readonly number[]): number {
-  const n_vals = sorted.length
+// `samples` need not be sorted (only uses sample_deviation, unlike silverman_bandwidth)
+export function scott_bandwidth(samples: readonly number[]): number {
+  const n_vals = samples.length
   if (n_vals < 2) return 1
-  const std = sample_deviation(sorted) || 1
+  const std = sample_deviation(samples) || 1
   return std * n_vals ** (-1 / 5)
 }
 

--- a/src/lib/plot/core/hover-lock.svelte.ts
+++ b/src/lib/plot/core/hover-lock.svelte.ts
@@ -27,12 +27,10 @@ export function create_hover_lock(): {
   return {
     is_locked: locked_ref,
     set_locked(locked: boolean) {
-      if (locked) {
-        if (timeout) clearTimeout(timeout)
-        is_locked = true
-      } else {
-        timeout = setTimeout(() => (is_locked = false), HOVER_DEBOUNCE_MS)
-      }
+      // Always clear any pending unlock so rapid calls don't queue multiple timeouts
+      if (timeout) clearTimeout(timeout)
+      if (locked) is_locked = true
+      else timeout = setTimeout(() => (is_locked = false), HOVER_DEBOUNCE_MS)
     },
     // Clear pending timeout to prevent state updates after unmount
     cleanup() {

--- a/src/lib/plot/core/reference-line.ts
+++ b/src/lib/plot/core/reference-line.ts
@@ -210,30 +210,16 @@ export function resolve_line_endpoints(
     }
 
     if (!handled_as_vertical) {
-      // Clip line to y bounds
-      let x1 = x_min
-      let x2 = x_max
-      let y1 = slope * x_min + intercept
-      let y2 = slope * x_max + intercept
-
-      if (slope === 0) {
-        if (y1 < y_min || y1 > y_max) return null
-      } else {
-        // Clip each endpoint to y bounds
-        const clip_y = (x: number, y: number, bound: number) =>
-          y < y_min || y > y_max ? [(bound - intercept) / slope, bound] : [x, y]
-        ;[x1, y1] = clip_y(x1, y1, y1 < y_min ? y_min : y_max)
-        ;[x2, y2] = clip_y(x2, y2, y2 < y_min ? y_min : y_max)
-        // If both endpoints clipped to same point, line is entirely outside bounds
-        if (x1 === x2 && y1 === y2) return null
-      }
-
-      // Ensure consistent ordering before applying span constraints
-      const [x_lo, x_hi] = x1 <= x2 ? [x1, x2] : [x2, x1]
-      const [y_lo, y_hi] = y1 <= y2 ? [y1, y2] : [y2, y1]
-      ;[x1_data, x2_data] = apply_x_span(x_lo, x_hi)
-      ;[y1_data, y2_data] = apply_y_span(y_lo, y_hi)
-      if (x1_data > x_max || x2_data < x_min) return null
+      // Intersect bounds with span constraints, then clip the line segment spanning the
+      // clipped x-extent to that rect — keeps endpoints paired on y = slope·x + intercept
+      const [x_lo, x_hi] = apply_x_span(x_min, x_max)
+      const [y_lo, y_hi] = apply_y_span(y_min, y_max)
+      if (x_lo > x_hi || y_lo > y_hi) return null
+      const [y_at_lo, y_at_hi] = [slope * x_lo + intercept, slope * x_hi + intercept]
+      const seg = clip_segment_to_rect(x_lo, y_at_lo, x_hi, y_at_hi, x_lo, x_hi, y_lo, y_hi)
+      // Degenerate (single-point) result means the line only grazes a corner
+      if (!seg || (seg[0] === seg[2] && seg[1] === seg[3])) return null
+      ;[x1_data, y1_data, x2_data, y2_data] = seg
     }
   } else if (line_type === `segment`) {
     const [p1x, p1y] = normalize_point(ref_line.p1)

--- a/src/lib/plot/core/scales.ts
+++ b/src/lib/plot/core/scales.ts
@@ -497,7 +497,13 @@ export function generate_log_ticks(
     return detailed_ticks.filter((tick) => tick >= min && tick <= max)
   }
 
-  return powers.filter((power) => power >= min && power <= max)
+  const filtered_powers = powers.filter((power) => power >= min && power <= max)
+  if (filtered_powers.length >= 2) return filtered_powers
+
+  // Sub-decade domains (e.g. after zoom) have <2 powers of 10 — use d3's mantissa log ticks
+  const tick_count = typeof ticks_option === `number` && ticks_option > 0 ? ticks_option : 5
+  const fallback = scaleLog().domain([min, max]).ticks(tick_count)
+  return fallback.length > 0 ? fallback : filtered_powers
 }
 
 // Get custom label for a tick value if provided, otherwise return null

--- a/src/lib/plot/histogram/Histogram.svelte
+++ b/src/lib/plot/histogram/Histogram.svelte
@@ -270,9 +270,10 @@
   )
 
   let auto_ranges = $derived.by(() => {
-    const all_values = selected_series.flatMap((srs: DataSeries) => srs.y)
+    // Only x1 series contribute to the x1 auto-range (x2 series get their own domain below)
+    const x1_values = selected_series.flatMap((srs) => srs.x_axis === `x2` ? [] : srs.y)
     const auto_x = get_nice_data_range(
-      all_values.map((val) => ({ x: val, y: 0 })),
+      x1_values.map((val) => ({ x: val, y: 0 })),
       ({ x }) => x,
       x_range,
       final_x_axis.scale_type ?? `linear`,
@@ -303,12 +304,14 @@
         const fallback = type_name === `log` ? 1 : 0
         return [fallback, 1]
       }
-      const hist = bin().domain([auto_x[0], auto_x[1]]).thresholds(bins)
+      // Bin each series over the domain of the x-axis it renders on (d3 bin() drops
+      // out-of-domain values, so binning x2 series over the x1 domain skews max_count)
       const max_count = Math.max(
         0,
-        ...series_list.map((srs: DataSeries) =>
-          max(hist(srs.y), (data) => data.length) || 0
-        ),
+        ...series_list.map((srs: DataSeries) => {
+          const hist = bin().domain(srs.x_axis === `x2` ? auto_x2 : auto_x).thresholds(bins)
+          return max(hist(srs.y), (data) => data.length) || 0
+        }),
       )
 
       // If there's effectively no data, avoid log-range issues (counts can't be <= 0 on log)

--- a/src/lib/plot/scatter/BinnedScatterPlot.svelte
+++ b/src/lib/plot/scatter/BinnedScatterPlot.svelte
@@ -25,6 +25,7 @@
     get_metadata_at,
     pick_from_index,
     range_bounds,
+    scale_bin_transform,
     series_extents,
     should_render_points,
     type DensityBin,
@@ -237,9 +238,17 @@
     x: Math.max(8, Math.ceil(plot_width / density_settings.bin_px)),
     y: Math.max(8, Math.ceil(plot_height / density_settings.bin_px)),
   })
+  // Bin in scale space so the heatmap, hover, and zoom stay aligned with log/arcsinh axes
+  let bin_transforms = $derived({
+    x: scale_bin_transform(x_scale_type),
+    y: scale_bin_transform(y_scale_type),
+  })
+  let bin_series = $derived(has_plot_size ? series : [])
   let density_result = $derived(
-    bin_points(has_plot_size ? series : [], x_range, y_range, density_bins.x, density_bins.y),
+    bin_points(bin_series, x_range, y_range, density_bins.x, density_bins.y, bin_transforms),
   )
+  const bin_at = (coords: Point2D) =>
+    density_bin_at_point(density_result, coords, plot_rect, x_range, y_range, bin_transforms)
   let auto_color_range = $derived<Vec2>([1, Math.max(1, density_result.max_count)])
   let color_scale_fn = $derived(create_color_scale(density_settings.color_scale, auto_color_range))
   let hovered_bin_color = $derived(hovered_bin ? color_scale_fn(hovered_bin.count) : undefined)
@@ -655,7 +664,7 @@
 
     if (render_mode === `density`) {
       hovered_point = null
-      const bin = density_bin_at_point(density_result, coords, plot_rect, x_range, y_range)
+      const bin = bin_at(coords)
       if (
         hovered_bin?.x_bin !== bin?.x_bin ||
         hovered_bin?.y_bin !== bin?.y_bin ||
@@ -701,7 +710,7 @@
     if (!coords) return
 
     if (render_mode === `density`) {
-      const bin = density_bin_at_point(density_result, coords, plot_rect, x_range, y_range)
+      const bin = bin_at(coords)
       if (!bin) return
       if (density_settings.bin_click === `none`) return
       if (bin.count > 1 && density_settings.bin_click === `zoom`) {

--- a/src/lib/plot/scatter/adaptive-density.ts
+++ b/src/lib/plot/scatter/adaptive-density.ts
@@ -1,4 +1,4 @@
-import type { Point2D, Vec2 } from '$lib/math'
+import { LOG_EPS, type Point2D, type Vec2 } from '$lib/math'
 import type { ScaleType } from '$lib/plot/core/types'
 import { get_arcsinh_threshold, get_scale_type_name } from '$lib/plot/core/types'
 
@@ -80,8 +80,9 @@ const identity: BinTransform = { forward: (val) => val, inverse: (val) => val }
 export function scale_bin_transform(scale_type?: ScaleType): BinTransform {
   const type_name = get_scale_type_name(scale_type)
   if (type_name === `log`) {
-    // Clamp to avoid -Infinity for non-positive values (not displayable on log axes anyway)
-    return { forward: (val) => Math.log(Math.max(val, Number.MIN_VALUE)), inverse: Math.exp }
+    // Clamp to LOG_EPS (same floor as the rendered log scale) so bin edges align with the
+    // axis; non-positive samples are already dropped by the range filter in bin_points
+    return { forward: (val) => Math.log(Math.max(val, LOG_EPS)), inverse: Math.exp }
   }
   if (type_name !== `arcsinh`) return identity
   const threshold = get_arcsinh_threshold(scale_type)

--- a/src/lib/plot/scatter/adaptive-density.ts
+++ b/src/lib/plot/scatter/adaptive-density.ts
@@ -1,4 +1,6 @@
 import type { Point2D, Vec2 } from '$lib/math'
+import type { ScaleType } from '$lib/plot/core/types'
+import { get_arcsinh_threshold, get_scale_type_name } from '$lib/plot/core/types'
 
 export type NumericArray = ArrayLike<number>
 
@@ -64,6 +66,38 @@ export interface PlotRect {
   height: number
 }
 
+// Monotonic transform pair: density bins are uniform in transformed (scale) space so
+// they align with the axis pixel grid on log/arcsinh axes
+export interface BinTransform {
+  forward: (value: number) => number
+  inverse: (value: number) => number
+}
+export type BinTransforms = { x?: BinTransform; y?: BinTransform }
+
+const identity: BinTransform = { forward: (val) => val, inverse: (val) => val }
+
+// Map an axis scale_type to the transform density binning should happen in
+export function scale_bin_transform(scale_type?: ScaleType): BinTransform {
+  const type_name = get_scale_type_name(scale_type)
+  if (type_name === `log`) {
+    // Clamp to avoid -Infinity for non-positive values (not displayable on log axes anyway)
+    return { forward: (val) => Math.log(Math.max(val, Number.MIN_VALUE)), inverse: Math.exp }
+  }
+  if (type_name !== `arcsinh`) return identity
+  const threshold = get_arcsinh_threshold(scale_type)
+  return {
+    forward: (val) => Math.asinh(val / threshold),
+    inverse: (val) => Math.sinh(val) * threshold,
+  }
+}
+
+// Data range of one bin: edges are uniform in transformed space, mapped back via inverse
+const bin_range = (txf: BinTransform, lo: number, hi: number, bin: number, n_bins: number) => {
+  const t_min = txf.forward(lo)
+  const step = (txf.forward(hi) - t_min || 1) / n_bins
+  return [txf.inverse(t_min + bin * step), txf.inverse(t_min + (bin + 1) * step)] as Vec2
+}
+
 export const get_metadata_at = <Metadata>(
   metadata: DensePointSeries<Metadata>[`metadata`],
   point_idx: number,
@@ -121,16 +155,20 @@ export function bin_points(
   y_range: Vec2,
   x_bins: number,
   y_bins: number,
+  transforms?: BinTransforms,
 ): DensityBinResult {
   const counts = new Uint32Array(x_bins * y_bins)
   const first_point_idxs = new Int32Array(counts.length)
   const first_series_idxs = new Int32Array(counts.length)
   const [x_min, x_max] = range_bounds(x_range)
   const [y_min, y_max] = range_bounds(y_range)
-  const x_span = x_max - x_min || 1
-  const y_span = y_max - y_min || 1
-  const x_bin_scale = x_bins / x_span
-  const y_bin_scale = y_bins / y_span
+  // Bin in transformed (scale) space so bins align with the axis pixel grid
+  const x_fwd = transforms?.x?.forward ?? identity.forward
+  const y_fwd = transforms?.y?.forward ?? identity.forward
+  const t_x_min = x_fwd(x_min)
+  const t_y_min = y_fwd(y_min)
+  const x_bin_scale = x_bins / (x_fwd(x_max) - t_x_min || 1)
+  const y_bin_scale = y_bins / (y_fwd(y_max) - t_y_min || 1)
   const last_x_bin = x_bins - 1
   const last_y_bin = y_bins - 1
   let visible_count = 0
@@ -152,10 +190,10 @@ export function bin_points(
       )
         continue
 
-      const raw_x_bin = Math.floor((x - x_min) * x_bin_scale)
-      const raw_y_bin = Math.floor((y - y_min) * y_bin_scale)
-      const x_bin = raw_x_bin > last_x_bin ? last_x_bin : raw_x_bin
-      const y_bin = raw_y_bin > last_y_bin ? last_y_bin : raw_y_bin
+      const raw_x_bin = Math.floor((x_fwd(x) - t_x_min) * x_bin_scale)
+      const raw_y_bin = Math.floor((y_fwd(y) - t_y_min) * y_bin_scale)
+      const x_bin = raw_x_bin < 0 ? 0 : raw_x_bin > last_x_bin ? last_x_bin : raw_x_bin
+      const y_bin = raw_y_bin < 0 ? 0 : raw_y_bin > last_y_bin ? last_y_bin : raw_y_bin
       const idx = y_bin * x_bins + x_bin
       const count = ++counts[idx]
       if (count === 1) {
@@ -184,6 +222,7 @@ export function density_bin_at_point(
   plot_rect: PlotRect,
   x_range: Vec2,
   y_range: Vec2,
+  transforms?: BinTransforms,
 ): DensityBin | null {
   const rel_x = pointer.x - plot_rect.x
   const rel_y = pointer.y - plot_rect.y
@@ -199,14 +238,12 @@ export function density_bin_at_point(
 
   const [x_min, x_max] = range_bounds(x_range)
   const [y_min, y_max] = range_bounds(y_range)
-  const x_step = (x_max - x_min || 1) / density.x_bins
-  const y_step = (y_max - y_min || 1) / density.y_bins
   return {
     x_bin,
     y_bin,
     count,
-    x_range: [x_min + x_bin * x_step, x_min + (x_bin + 1) * x_step],
-    y_range: [y_min + y_bin * y_step, y_min + (y_bin + 1) * y_step],
+    x_range: bin_range(transforms?.x ?? identity, x_min, x_max, x_bin, density.x_bins),
+    y_range: bin_range(transforms?.y ?? identity, y_min, y_max, y_bin, density.y_bins),
   }
 }
 

--- a/src/lib/plot/scatter/adaptive-density.ts
+++ b/src/lib/plot/scatter/adaptive-density.ts
@@ -92,10 +92,19 @@ export function scale_bin_transform(scale_type?: ScaleType): BinTransform {
 }
 
 // Data range of one bin: edges are uniform in transformed space, mapped back via inverse
-const bin_range = (txf: BinTransform, lo: number, hi: number, bin: number, n_bins: number) => {
-  const t_min = txf.forward(lo)
-  const step = (txf.forward(hi) - t_min || 1) / n_bins
-  return [txf.inverse(t_min + bin * step), txf.inverse(t_min + (bin + 1) * step)] as Vec2
+const bin_range = (
+  txf: BinTransform | undefined,
+  range: Vec2,
+  bin: number,
+  n_bins: number,
+) => {
+  const transform = txf ?? identity
+  const [t_min, t_max] = range_bounds(range).map(transform.forward)
+  const step = (t_max - t_min || 1) / n_bins
+  return [
+    transform.inverse(t_min + bin * step),
+    transform.inverse(t_min + (bin + 1) * step),
+  ] as Vec2
 }
 
 export const get_metadata_at = <Metadata>(
@@ -236,14 +245,12 @@ export function density_bin_at_point(
   const count = density.counts[y_bin * density.x_bins + x_bin]
   if (!count) return null
 
-  const [x_min, x_max] = range_bounds(x_range)
-  const [y_min, y_max] = range_bounds(y_range)
   return {
     x_bin,
     y_bin,
     count,
-    x_range: bin_range(transforms?.x ?? identity, x_min, x_max, x_bin, density.x_bins),
-    y_range: bin_range(transforms?.y ?? identity, y_min, y_max, y_bin, density.y_bins),
+    x_range: bin_range(transforms?.x, x_range, x_bin, density.x_bins),
+    y_range: bin_range(transforms?.y, y_range, y_bin, density.y_bins),
   }
 }
 

--- a/src/lib/rdf/calc-rdf.ts
+++ b/src/lib/rdf/calc-rdf.ts
@@ -5,7 +5,7 @@ import {
   euclidean_dist,
   pbc_dist,
 } from '$lib/math'
-import type { Crystal, Pbc } from '$lib/structure'
+import type { Crystal } from '$lib/structure'
 import { make_supercell } from '$lib/structure/supercell'
 import type { RdfOptions, RdfPattern } from './index'
 
@@ -26,7 +26,7 @@ export function calculate_rdf(structure: Crystal, options: RdfOptions = {}): Rdf
     auto_expand = true,
     expansion_factor = 2.0,
   } = options
-  let { pbc = [true, true, true] } = options
+  const { pbc = [true, true, true] } = options
   if (cutoff <= 0 || n_bins <= 0) {
     throw new Error(`cutoff and n_bins must be positive`)
   }
@@ -38,6 +38,7 @@ export function calculate_rdf(structure: Crystal, options: RdfOptions = {}): Rdf
 
   let lattice: Matrix3x3 = structure.lattice.matrix
   let { sites } = structure
+  let center_sites = sites
 
   // Expand structure if needed to ensure shortest lattice vector is expansion_factor× the cutoff
   // This prevents artificial close contacts at cell boundaries when using PBC
@@ -55,7 +56,10 @@ export function calculate_rdf(structure: Crystal, options: RdfOptions = {}): Rdf
       )
       sites = expanded_structure.sites
       lattice = expanded_structure.lattice.matrix
-      pbc = [false, false, false] // Disable PBC since we explicitly expanded the structure
+      // Keep PBC: min-image is exact once every lattice vector ≥ 2× cutoff (disabling PBC
+      // starves boundary atoms and biases g(r) low). Under full PBC all periodic copies are
+      // equivalent, so restrict centers to the first copy (make_supercell emits (0,0,0) first)
+      center_sites = pbc.every(Boolean) ? sites.slice(0, structure.sites.length) : sites
     }
   }
 
@@ -66,7 +70,7 @@ export function calculate_rdf(structure: Crystal, options: RdfOptions = {}): Rdf
   if (sites.length === 0) return { r, g_r }
 
   // Get occupancy weight for a site-species pair (supports mixed occupancy)
-  const centers = sites.filter((site) => has_species(site, center_species))
+  const centers = center_sites.filter((site) => has_species(site, center_species))
   const neighbors = sites.filter((site) => has_species(site, neighbor_species))
 
   if (centers.length === 0 || neighbors.length === 0) {
@@ -130,35 +134,11 @@ export function calculate_all_pair_rdfs(
     ...new Set(structure.sites.flatMap((site) => site.species.map((spec) => spec.element))),
   ].sort()
 
-  // If auto_expand is true, expand the structure once and reuse it for all pairs
-  // to avoid repeated supercell computations
-  let structure_to_use = structure
-  if (options.auto_expand !== false) {
-    const { cutoff = 15, expansion_factor = 2.0 } = options
-    const lattice = structure.lattice?.matrix
-    if (lattice) {
-      const { a, b, c } = calc_lattice_params(lattice)
-      const min_size = cutoff * expansion_factor
-      const [n_a, n_b, n_c] = [a, b, c].map((len) => Math.ceil(min_size / len))
-
-      if (n_a > 1 || n_b > 1 || n_c > 1) {
-        structure_to_use = make_supercell(
-          structure,
-          [n_a, n_b, n_c] as Vec3,
-          false, // Don't fold back to unit cell
-        )
-      }
-    }
-  }
-
-  // Pass auto_expand=false since we've already expanded, and pbc=false for expanded structure
-  const pbc = [false, false, false] as Pbc
-  const rdf_options = { ...options, auto_expand: false, pbc }
-
+  // Forward options unchanged (preserves caller's pbc); each calculate_rdf expands itself
   return elems.flatMap((el1, idx1) =>
     elems.slice(idx1).map((el2) =>
-      calculate_rdf(structure_to_use, {
-        ...rdf_options,
+      calculate_rdf(structure, {
+        ...options,
         center_species: el1,
         neighbor_species: el2,
       }),

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1813,6 +1813,7 @@ export const merge = (user?: Partial<DefaultSettings>): DefaultSettings =>
   ({
     ...DEFAULTS,
     ...user,
+    symmetry: merge_nested(DEFAULTS.symmetry, user?.symmetry),
     structure: merge_nested(DEFAULTS.structure, user?.structure),
     trajectory: merge_nested(DEFAULTS.trajectory, user?.trajectory),
     composition: merge_nested(DEFAULTS.composition, user?.composition),

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -469,10 +469,13 @@
   let bond_order_overrides = $state<StructureBond[]>([])
   let bond_undo_stack = $state<BondEditHistorySnapshot[]>([])
   let bond_redo_stack = $state<BondEditHistorySnapshot[]>([])
-  let bond_history_context = $state<BondEditContext>()
-  let last_bond_structure_identity = $state(structure)
+  // These hold object-identity tokens (structure_identity) compared with ===/!==,
+  // so they must stay raw — proxying them via $state would break identity comparisons
+  // (state_proxy_equality_mismatch) against the raw `structure` prop.
+  let bond_history_context = $state.raw<BondEditContext>()
+  let last_bond_structure_identity = $state.raw(structure)
   let last_emitted_bond_signature = $state<string>()
-  let bond_edit_snapshot = $state<BondEditSnapshot>()
+  let bond_edit_snapshot = $state.raw<BondEditSnapshot>()
   let has_bond_edits = $derived(
     added_bonds.length > 0 || removed_bonds.length > 0 ||
       bond_order_overrides.length > 0,

--- a/src/lib/structure/parse.ts
+++ b/src/lib/structure/parse.ts
@@ -119,9 +119,7 @@ function parse_coordinate_line(line: string): number[] {
     tokens = sanitized.split(/\s+/)
   }
 
-  if (tokens.length < 3) {
-    throw new Error(`Insufficient coordinates in line: ${line}`)
-  }
+  if (tokens.length < 3) throw new Error(`Insufficient coordinates in line: ${line}`)
 
   return tokens.slice(0, 3).map(parse_coordinate)
 }
@@ -142,19 +140,22 @@ function validate_element_symbol(symbol: string, index: number): ElementSymbol {
 // Per OPTIMADE spec, species_at_sites holds species NAMES (e.g. 'Si1') resolved via the
 // species list: highest-concentration entry in chemical_symbols wins, non-element entries
 // like 'vacancy' are skipped, and unresolved names are treated as element symbols.
+// Returns the chosen element plus its index into the species' chemical_symbols
+// (sym_idx = -1 on fallback), so callers can read the matching mass/concentration entry.
 function resolve_optimade_element(
   species_name: string,
   species_list: OptimadeStructure[`attributes`][`species`],
   index: number,
-): ElementSymbol {
+): { symbol: ElementSymbol; sym_idx: number } {
   const spec = species_list?.find((entry) => entry.name === species_name)
-  let best: { symbol: ElementSymbol; conc: number } | undefined
+  let best: { symbol: ElementSymbol; conc: number; sym_idx: number } | undefined
   for (const [sym_idx, symbol] of (spec?.chemical_symbols ?? []).entries()) {
     if (!is_known_element_symbol(symbol)) continue
     const conc = spec?.concentration?.[sym_idx] ?? 0
-    if (!best || conc > best.conc) best = { symbol, conc }
+    if (!best || conc > best.conc) best = { symbol, conc, sym_idx }
   }
-  return best?.symbol ?? validate_element_symbol(species_name, index)
+  if (best) return { symbol: best.symbol, sym_idx: best.sym_idx }
+  return { symbol: validate_element_symbol(species_name, index), sym_idx: -1 }
 }
 
 const try_create_cart_to_frac = (
@@ -648,16 +649,12 @@ const extract_cif_cell_parameters = (text: string, type: string, strict = true):
       const sans_comment = line.replace(/\s#.*$/, ``)
       const tokens = sans_comment.split(/\s+/).filter(Boolean)
       if (tokens.length < 2) {
-        if (strict) {
-          throw new Error(`Invalid CIF cell parameter line format: ${line}`)
-        }
+        if (strict) throw new Error(`Invalid CIF cell parameter line format: ${line}`)
         return null
       }
       const value = parseFloat(tokens[1].split(`(`)[0])
       if (isNaN(value)) {
-        if (strict) {
-          throw new Error(`Invalid CIF cell parameter in line: ${line}`)
-        }
+        if (strict) throw new Error(`Invalid CIF cell parameter in line: ${line}`)
         return null // Return null for invalid values in non-strict mode
       }
       return value
@@ -1030,13 +1027,7 @@ export function parse_cif(
           seen_site_keys.add(key)
           const xyz = frac_to_cart(abc)
           all_sites.push({
-            species: [
-              {
-                element,
-                occu: equiv_atom.occupancy,
-                oxidation_state: 0,
-              },
-            ],
+            species: [{ element, occu: equiv_atom.occupancy, oxidation_state: 0 }],
             abc,
             xyz,
             label: equiv_atom.id,
@@ -1084,10 +1075,7 @@ function convert_phonopy_cell(cell: PhonopyCell): ParsedStructure {
   // Calculate lattice parameters
   const calculated_lattice_params = math.calc_lattice_params(lattice_matrix)
 
-  return {
-    sites,
-    lattice: { matrix: lattice_matrix, ...calculated_lattice_params },
-  }
+  return { sites, lattice: { matrix: lattice_matrix, ...calculated_lattice_params } }
 }
 
 export type CellType =
@@ -1505,7 +1493,11 @@ export function parse_optimade_from_raw(raw: unknown): ParsedStructure | null {
         continue
       }
 
-      const element = resolve_optimade_element(element_symbol, optimade_species, idx)
+      const { symbol: element } = resolve_optimade_element(
+        element_symbol,
+        optimade_species,
+        idx,
+      )
 
       // Calculate fractional coordinates if lattice is available
       const abc: Vec3 = optimade_cart_to_frac ? optimade_cart_to_frac(xyz) : [0, 0, 0]
@@ -1616,17 +1608,27 @@ export function optimade_to_crystal(optimade_structure: OptimadeStructure): Crys
     const sites = cartesian_site_positions.map((pos, idx) => {
       const element_symbol = species_at_sites[idx]
       if (!element_symbol) throw new Error(`Missing species for site ${idx}`)
-      const element = resolve_optimade_element(element_symbol, species, idx)
+      const { symbol: element, sym_idx } = resolve_optimade_element(
+        element_symbol,
+        species,
+        idx,
+      )
 
       const xyz = vec3_from_values(pos, `OPTIMADE atom position ${idx + 1}`)
       const abc: Vec3 = crystal_cart_to_frac ? crystal_cart_to_frac(xyz) : [0, 0, 0]
 
-      // Extract mass/concentration from species data
+      // Extract mass/concentration for the chosen element. sym_idx indexes the (parallel)
+      // chemical_symbols/mass/concentration arrays; -1 (name resolved directly, no
+      // chemical_symbols) falls back to index 0 — the single-element entry.
       const spec = species?.find((entry) => entry.name === element_symbol)
+      const spec_idx = Math.max(sym_idx, 0)
       const site_props: Record<string, unknown> = {}
-      if (spec?.mass?.[0] !== undefined) site_props.mass = spec.mass[0]
-      if (spec?.concentration?.[0] !== undefined && spec.concentration[0] !== 1) {
-        site_props.concentration = spec.concentration[0]
+      if (spec?.mass?.[spec_idx] !== undefined) site_props.mass = spec.mass[spec_idx]
+      if (
+        spec?.concentration?.[spec_idx] !== undefined &&
+        spec.concentration[spec_idx] !== 1
+      ) {
+        site_props.concentration = spec.concentration[spec_idx]
       }
       return {
         species: [{ element, occu: 1, oxidation_state: 0 }],
@@ -1639,11 +1641,7 @@ export function optimade_to_crystal(optimade_structure: OptimadeStructure): Crys
 
     return {
       sites,
-      lattice: {
-        matrix: lattice_matrix,
-        ...lattice_params,
-        pbc: [true, true, true],
-      },
+      lattice: { matrix: lattice_matrix, ...lattice_params, pbc: [true, true, true] },
       id: optimade_structure.id,
       properties,
     }
@@ -1658,9 +1656,7 @@ export function is_structure_file(filename: string): boolean {
   const name = filename.toLowerCase()
 
   // Trajectory-only formats (can't be structures)
-  if (/\.(traj|xtc|h5|hdf5)$/i.test(name) || /xdatcar/i.test(name)) {
-    return false
-  }
+  if (/\.(traj|xtc|h5|hdf5)$/i.test(name) || /xdatcar/i.test(name)) return false
 
   // Always structure formats
   if (STRUCTURE_EXTENSIONS_REGEX.test(name)) return true
@@ -1670,9 +1666,7 @@ export function is_structure_file(filename: string): boolean {
   if (/\.(xyz|extxyz)$/i.test(name)) return !TRAJ_KEYWORDS_REGEX.test(name)
 
   // Keyword-based detection for YAML/XML
-  if (/\.(yaml|yml|xml)$/i.test(name) && STRUCT_KEYWORDS_REGEX.test(name)) {
-    return true
-  }
+  if (/\.(yaml|yml|xml)$/i.test(name) && STRUCT_KEYWORDS_REGEX.test(name)) return true
 
   // More restrictive keyword detection for JSON files
   if (
@@ -1680,9 +1674,8 @@ export function is_structure_file(filename: string): boolean {
     STRUCT_KEYWORDS_STRICT_REGEX.test(name) &&
     !TRAJ_KEYWORDS_REGEX.test(name) &&
     !CONFIG_DIRS_REGEX.test(name)
-  ) {
+  )
     return true
-  }
 
   // Compressed files - check base filename recursively
   if (COMPRESSION_EXTENSIONS_REGEX.test(name)) {

--- a/src/lib/structure/parse.ts
+++ b/src/lib/structure/parse.ts
@@ -119,7 +119,9 @@ function parse_coordinate_line(line: string): number[] {
     tokens = sanitized.split(/\s+/)
   }
 
-  if (tokens.length < 3) throw new Error(`Insufficient coordinates in line: ${line}`)
+  if (tokens.length < 3) {
+    throw new Error(`Insufficient coordinates in line: ${line}`)
+  }
 
   return tokens.slice(0, 3).map(parse_coordinate)
 }
@@ -137,17 +139,15 @@ function validate_element_symbol(symbol: string, index: number): ElementSymbol {
   return fallback
 }
 
-type OptimadeSpecies = NonNullable<OptimadeStructure[`attributes`][`species`]>[number]
-
 // Per OPTIMADE spec, species_at_sites holds species NAMES (e.g. 'Si1') resolved via the
 // species list: highest-concentration entry in chemical_symbols wins, non-element entries
 // like 'vacancy' are skipped, and unresolved names are treated as element symbols.
 function resolve_optimade_element(
   species_name: string,
-  species_map: Map<string, OptimadeSpecies>,
+  species_list: OptimadeStructure[`attributes`][`species`],
   index: number,
 ): ElementSymbol {
-  const spec = species_map.get(species_name)
+  const spec = species_list?.find((entry) => entry.name === species_name)
   let best: { symbol: ElementSymbol; conc: number } | undefined
   for (const [sym_idx, symbol] of (spec?.chemical_symbols ?? []).entries()) {
     if (!is_known_element_symbol(symbol)) continue
@@ -340,24 +340,16 @@ export function parse_poscar(content: string): ParsedStructure | null {
               selective_dynamics = [tokens[3] === `T`, tokens[4] === `T`, tokens[5] === `T`]
             }
           }
-          let xyz: Vec3
-          let abc: Vec3
-
-          if (is_direct) {
-            // Store fractional coordinates, wrapping to [0, 1) range
-            abc = wrap_to_unit_cell(coords)
-            xyz = poscar_frac_to_cart(abc)
-          } else {
-            // Already Cartesian, scale if needed
-            xyz = apply_axis_scale(coords)
-            const raw_abc = poscar_cart_to_frac
-              ? poscar_cart_to_frac(xyz)
-              : approximate_cart_to_frac(xyz, poscar_axis_lengths)
-            // Wrap fractional coordinates to [0, 1) range
-            abc = wrap_to_unit_cell(raw_abc)
-            // Sync xyz with wrapped abc (skip approximate path for singular lattices)
-            if (poscar_cart_to_frac) xyz = poscar_frac_to_cart(abc)
-          }
+          // Cartesian input is scaled then converted to fractional (axis-length fallback
+          // for singular lattices); abc wraps to [0, 1) and xyz is recomputed from it so
+          // both stay consistent (singular Cartesian keeps the scaled input as xyz)
+          const cart = is_direct ? null : apply_axis_scale(coords)
+          const raw_abc = cart
+            ? (poscar_cart_to_frac?.(cart) ??
+              approximate_cart_to_frac(cart, poscar_axis_lengths))
+            : coords
+          const abc = wrap_to_unit_cell(raw_abc)
+          const xyz = cart && !poscar_cart_to_frac ? cart : poscar_frac_to_cart(abc)
 
           const site: Site = {
             species: [{ element, occu: 1, oxidation_state: 0 }],
@@ -656,12 +648,16 @@ const extract_cif_cell_parameters = (text: string, type: string, strict = true):
       const sans_comment = line.replace(/\s#.*$/, ``)
       const tokens = sans_comment.split(/\s+/).filter(Boolean)
       if (tokens.length < 2) {
-        if (strict) throw new Error(`Invalid CIF cell parameter line format: ${line}`)
+        if (strict) {
+          throw new Error(`Invalid CIF cell parameter line format: ${line}`)
+        }
         return null
       }
       const value = parseFloat(tokens[1].split(`(`)[0])
       if (isNaN(value)) {
-        if (strict) throw new Error(`Invalid CIF cell parameter in line: ${line}`)
+        if (strict) {
+          throw new Error(`Invalid CIF cell parameter in line: ${line}`)
+        }
         return null // Return null for invalid values in non-strict mode
       }
       return value
@@ -1034,7 +1030,13 @@ export function parse_cif(
           seen_site_keys.add(key)
           const xyz = frac_to_cart(abc)
           all_sites.push({
-            species: [{ element, occu: equiv_atom.occupancy, oxidation_state: 0 }],
+            species: [
+              {
+                element,
+                occu: equiv_atom.occupancy,
+                oxidation_state: 0,
+              },
+            ],
             abc,
             xyz,
             label: equiv_atom.id,
@@ -1082,7 +1084,10 @@ function convert_phonopy_cell(cell: PhonopyCell): ParsedStructure {
   // Calculate lattice parameters
   const calculated_lattice_params = math.calc_lattice_params(lattice_matrix)
 
-  return { sites, lattice: { matrix: lattice_matrix, ...calculated_lattice_params } }
+  return {
+    sites,
+    lattice: { matrix: lattice_matrix, ...calculated_lattice_params },
+  }
 }
 
 export type CellType =
@@ -1486,9 +1491,7 @@ export function parse_optimade_from_raw(raw: unknown): ParsedStructure | null {
     if (lattice_matrix && !optimade_exact_cart_to_frac) {
       console.warn(`Failed to create exact coordinate converter for OPTIMADE structure`)
     }
-    const optimade_species_map = new Map<string, OptimadeSpecies>(
-      Array.isArray(attrs.species) ? attrs.species.map((spec) => [spec.name, spec]) : [],
-    )
+    const optimade_species = Array.isArray(attrs.species) ? attrs.species : undefined
     const sites: Site[] = []
     for (let idx = 0; idx < positions.length; idx++) {
       const pos = positions[idx]
@@ -1502,7 +1505,7 @@ export function parse_optimade_from_raw(raw: unknown): ParsedStructure | null {
         continue
       }
 
-      const element = resolve_optimade_element(element_symbol, optimade_species_map, idx)
+      const element = resolve_optimade_element(element_symbol, optimade_species, idx)
 
       // Calculate fractional coordinates if lattice is available
       const abc: Vec3 = optimade_cart_to_frac ? optimade_cart_to_frac(xyz) : [0, 0, 0]
@@ -1605,8 +1608,6 @@ export function optimade_to_crystal(optimade_structure: OptimadeStructure): Crys
     ]
     const lattice_params = math.calc_lattice_params(lattice_matrix)
 
-    // Build species lookup for site properties (mass, concentration, etc.)
-    const species_map = new Map(species?.map((spec) => [spec.name, spec]))
     const crystal_cart_to_frac =
       try_create_cart_to_frac(lattice_matrix) ??
       ((xyz: Vec3): Vec3 =>
@@ -1615,13 +1616,13 @@ export function optimade_to_crystal(optimade_structure: OptimadeStructure): Crys
     const sites = cartesian_site_positions.map((pos, idx) => {
       const element_symbol = species_at_sites[idx]
       if (!element_symbol) throw new Error(`Missing species for site ${idx}`)
-      const element = resolve_optimade_element(element_symbol, species_map, idx)
+      const element = resolve_optimade_element(element_symbol, species, idx)
 
       const xyz = vec3_from_values(pos, `OPTIMADE atom position ${idx + 1}`)
       const abc: Vec3 = crystal_cart_to_frac ? crystal_cart_to_frac(xyz) : [0, 0, 0]
 
       // Extract mass/concentration from species data
-      const spec = species_map.get(element_symbol)
+      const spec = species?.find((entry) => entry.name === element_symbol)
       const site_props: Record<string, unknown> = {}
       if (spec?.mass?.[0] !== undefined) site_props.mass = spec.mass[0]
       if (spec?.concentration?.[0] !== undefined && spec.concentration[0] !== 1) {
@@ -1638,7 +1639,11 @@ export function optimade_to_crystal(optimade_structure: OptimadeStructure): Crys
 
     return {
       sites,
-      lattice: { matrix: lattice_matrix, ...lattice_params, pbc: [true, true, true] },
+      lattice: {
+        matrix: lattice_matrix,
+        ...lattice_params,
+        pbc: [true, true, true],
+      },
       id: optimade_structure.id,
       properties,
     }
@@ -1653,7 +1658,9 @@ export function is_structure_file(filename: string): boolean {
   const name = filename.toLowerCase()
 
   // Trajectory-only formats (can't be structures)
-  if (/\.(traj|xtc|h5|hdf5)$/i.test(name) || /xdatcar/i.test(name)) return false
+  if (/\.(traj|xtc|h5|hdf5)$/i.test(name) || /xdatcar/i.test(name)) {
+    return false
+  }
 
   // Always structure formats
   if (STRUCTURE_EXTENSIONS_REGEX.test(name)) return true
@@ -1663,7 +1670,9 @@ export function is_structure_file(filename: string): boolean {
   if (/\.(xyz|extxyz)$/i.test(name)) return !TRAJ_KEYWORDS_REGEX.test(name)
 
   // Keyword-based detection for YAML/XML
-  if (/\.(yaml|yml|xml)$/i.test(name) && STRUCT_KEYWORDS_REGEX.test(name)) return true
+  if (/\.(yaml|yml|xml)$/i.test(name) && STRUCT_KEYWORDS_REGEX.test(name)) {
+    return true
+  }
 
   // More restrictive keyword detection for JSON files
   if (
@@ -1671,8 +1680,9 @@ export function is_structure_file(filename: string): boolean {
     STRUCT_KEYWORDS_STRICT_REGEX.test(name) &&
     !TRAJ_KEYWORDS_REGEX.test(name) &&
     !CONFIG_DIRS_REGEX.test(name)
-  )
+  ) {
     return true
+  }
 
   // Compressed files - check base filename recursively
   if (COMPRESSION_EXTENSIONS_REGEX.test(name)) {

--- a/src/lib/structure/parse.ts
+++ b/src/lib/structure/parse.ts
@@ -137,6 +137,26 @@ function validate_element_symbol(symbol: string, index: number): ElementSymbol {
   return fallback
 }
 
+type OptimadeSpecies = NonNullable<OptimadeStructure[`attributes`][`species`]>[number]
+
+// Per OPTIMADE spec, species_at_sites holds species NAMES (e.g. 'Si1') resolved via the
+// species list: highest-concentration entry in chemical_symbols wins, non-element entries
+// like 'vacancy' are skipped, and unresolved names are treated as element symbols.
+function resolve_optimade_element(
+  species_name: string,
+  species_map: Map<string, OptimadeSpecies>,
+  index: number,
+): ElementSymbol {
+  const spec = species_map.get(species_name)
+  let best: { symbol: ElementSymbol; conc: number } | undefined
+  for (const [sym_idx, symbol] of (spec?.chemical_symbols ?? []).entries()) {
+    if (!is_known_element_symbol(symbol)) continue
+    const conc = spec?.concentration?.[sym_idx] ?? 0
+    if (!best || conc > best.conc) best = { symbol, conc }
+  }
+  return best?.symbol ?? validate_element_symbol(species_name, index)
+}
+
 const try_create_cart_to_frac = (
   lattice_matrix: math.Matrix3x3,
 ): ((v: Vec3) => Vec3) | null => {
@@ -156,19 +176,23 @@ const approximate_cart_to_frac = (xyz: Vec3, axis_lengths: Vec3): Vec3 => [
 // Parse VASP POSCAR file format
 export function parse_poscar(content: string): ParsedStructure | null {
   try {
-    const lines = content.replace(/^\s+/, ``).split(/\r?\n/)
+    // Strip only horizontal whitespace: a blank first (comment) line is valid POSCAR
+    const lines = content.replace(/^[ \t]+/, ``).split(/\r?\n/)
 
     if (lines.length < 8) {
       console.error(`POSCAR file too short`)
       return null
     }
 
-    // Parse scaling factor (line 2)
-    let scale_factor = parseFloat(lines[1])
+    // Scale line: one value (negative = target volume) or three per-axis Cartesian factors
+    const scale_tokens = lines[1].trim().split(/\s+/).map(parseFloat)
+    let scale_factor = scale_tokens[0]
     if (isNaN(scale_factor)) {
       console.error(`Invalid scaling factor in POSCAR`)
       return null
     }
+    const scale_vec = scale_tokens.slice(0, 3) as Vec3
+    const per_axis_scale = scale_vec.length === 3 && !scale_vec.some(isNaN) ? scale_vec : null
 
     // Parse lattice vectors (lines 3-5)
     const parse_vector = (line: string, line_num: number): Vec3 => {
@@ -182,18 +206,17 @@ export function parse_poscar(content: string): ParsedStructure | null {
       parse_vector(lines[4], 5),
     ]
 
-    // Handle negative scale factor (volume-based scaling)
-    if (scale_factor < 0) {
+    // Handle negative scale factor (volume-based scaling, single-factor form only)
+    if (!per_axis_scale && scale_factor < 0) {
       const volume = Math.abs(math.det_3x3(lattice_vecs))
       scale_factor = (-scale_factor / volume) ** (1 / 3)
     }
 
-    // Scale lattice vectors
-    const scaled_lattice: math.Matrix3x3 = [
-      math.scale(lattice_vecs[0], scale_factor),
-      math.scale(lattice_vecs[1], scale_factor),
-      math.scale(lattice_vecs[2], scale_factor),
-    ]
+    // Scale lattice vectors (per-axis factors multiply Cartesian components)
+    const axis_scale: Vec3 = per_axis_scale ?? [scale_factor, scale_factor, scale_factor]
+    const apply_axis_scale = (vec: Vec3): Vec3 =>
+      vec.map((val, axis) => val * axis_scale[axis]) as Vec3
+    const scaled_lattice = lattice_vecs.map(apply_axis_scale) as math.Matrix3x3
 
     // Parse element symbols and atom counts (may span multiple lines)
     let line_index = 5
@@ -326,12 +349,14 @@ export function parse_poscar(content: string): ParsedStructure | null {
             xyz = poscar_frac_to_cart(abc)
           } else {
             // Already Cartesian, scale if needed
-            xyz = math.scale(coords, scale_factor)
+            xyz = apply_axis_scale(coords)
             const raw_abc = poscar_cart_to_frac
               ? poscar_cart_to_frac(xyz)
               : approximate_cart_to_frac(xyz, poscar_axis_lengths)
             // Wrap fractional coordinates to [0, 1) range
             abc = wrap_to_unit_cell(raw_abc)
+            // Sync xyz with wrapped abc (skip approximate path for singular lattices)
+            if (poscar_cart_to_frac) xyz = poscar_frac_to_cart(abc)
           }
 
           const site: Site = {
@@ -627,12 +652,14 @@ const extract_cif_cell_parameters = (text: string, type: string, strict = true):
     .split(`\n`)
     .filter((line) => line.startsWith(`_${type}`))
     .map((line) => {
-      const tokens = line.split(/\s+/).filter((token) => token.length > 0)
+      // Strip trailing comment (# after whitespace) and take the value right after the tag
+      const sans_comment = line.replace(/\s#.*$/, ``)
+      const tokens = sans_comment.split(/\s+/).filter(Boolean)
       if (tokens.length < 2) {
         if (strict) throw new Error(`Invalid CIF cell parameter line format: ${line}`)
         return null
       }
-      const value = parseFloat((tokens.at(-1) ?? ``).split(`(`)[0])
+      const value = parseFloat(tokens[1].split(`(`)[0])
       if (isNaN(value)) {
         if (strict) throw new Error(`Invalid CIF cell parameter in line: ${line}`)
         return null // Return null for invalid values in non-strict mode
@@ -1459,6 +1486,9 @@ export function parse_optimade_from_raw(raw: unknown): ParsedStructure | null {
     if (lattice_matrix && !optimade_exact_cart_to_frac) {
       console.warn(`Failed to create exact coordinate converter for OPTIMADE structure`)
     }
+    const optimade_species_map = new Map<string, OptimadeSpecies>(
+      Array.isArray(attrs.species) ? attrs.species.map((spec) => [spec.name, spec]) : [],
+    )
     const sites: Site[] = []
     for (let idx = 0; idx < positions.length; idx++) {
       const pos = positions[idx]
@@ -1472,7 +1502,7 @@ export function parse_optimade_from_raw(raw: unknown): ParsedStructure | null {
         continue
       }
 
-      const element = validate_element_symbol(element_symbol, idx)
+      const element = resolve_optimade_element(element_symbol, optimade_species_map, idx)
 
       // Calculate fractional coordinates if lattice is available
       const abc: Vec3 = optimade_cart_to_frac ? optimade_cart_to_frac(xyz) : [0, 0, 0]
@@ -1585,7 +1615,7 @@ export function optimade_to_crystal(optimade_structure: OptimadeStructure): Crys
     const sites = cartesian_site_positions.map((pos, idx) => {
       const element_symbol = species_at_sites[idx]
       if (!element_symbol) throw new Error(`Missing species for site ${idx}`)
-      const element = validate_element_symbol(element_symbol, idx)
+      const element = resolve_optimade_element(element_symbol, species_map, idx)
 
       const xyz = vec3_from_values(pos, `OPTIMADE atom position ${idx + 1}`)
       const abc: Vec3 = crystal_cart_to_frac ? crystal_cart_to_frac(xyz) : [0, 0, 0]

--- a/src/lib/symmetry/index.ts
+++ b/src/lib/symmetry/index.ts
@@ -289,12 +289,12 @@ export function apply_symmetry_operations(
 
   return operations
     .map(({ rotation, translation }) => {
-      // Apply 3x3 rotation matrix and translation: new_pos = R * position + t
+      // new_pos = W·position + t; moyo serializes W COLUMN-major: W[dim][j] = rotation[dim + 3j]
       const new_pos: Vec3 = [0, 1, 2].map(
         (dim) =>
-          rotation[dim * 3] * position[0] +
-          rotation[dim * 3 + 1] * position[1] +
-          rotation[dim * 3 + 2] * position[2] +
+          rotation[dim] * position[0] +
+          rotation[dim + 3] * position[1] +
+          rotation[dim + 6] * position[2] +
           translation[dim],
       ) as Vec3
       return new_pos.map(to_unit) as Vec3

--- a/src/lib/table/HeatmapTable.svelte
+++ b/src/lib/table/HeatmapTable.svelte
@@ -548,6 +548,9 @@
             sensitivity: `base`,
           })
           if (cmp !== 0) return cmp * modifier
+        } else if (typeof sort_val1 !== typeof sort_val2) {
+          // number<string is false both ways, breaking the comparator: numbers sort first
+          return (typeof sort_val1 === `number` ? -1 : 1) * modifier
         } else if (sort_val1 !== sort_val2) {
           return (sort_val1 ?? 0) < (sort_val2 ?? 0) ? -modifier : modifier
         }

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -32,7 +32,6 @@
   import { TrajectoryError, TrajectoryExportPane, TrajectoryInfoPane } from './index'
   import type { AtomTypeMapping, LoadingOptions } from './parse'
   import {
-    create_frame_loader,
     get_unsupported_format_message,
     MAX_BIN_FILE_SIZE,
     MAX_TEXT_FILE_SIZE,
@@ -751,9 +750,10 @@
         parsing_progress = progress
       }, merged_options)
 
-      // Attach frame loader and original data directly to trajectory for unified access
+      // Keep original data for on-demand frame loads. Indexed parsing attaches its own
+      // frame_loader; direct-parse fallbacks (e.g. large JSON or extensionless blob:
+      // filenames) load all frames upfront and don't need one.
       orig_data = data
-      trajectory.frame_loader = create_frame_loader(filename)
     } catch (error) {
       console.error(`Indexed loading failed:`, error)
       throw error

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -750,10 +750,10 @@
         parsing_progress = progress
       }, merged_options)
 
-      // Keep original data for on-demand frame loads. Indexed parsing attaches its own
-      // frame_loader; direct-parse fallbacks (e.g. large JSON or extensionless blob:
-      // filenames) load all frames upfront and don't need one.
-      orig_data = data
+      // Keep original data for on-demand frame loads only when indexed parsing attached a
+      // frame_loader. Direct-parse fallbacks (e.g. large JSON or extensionless blob:
+      // filenames) load all frames upfront, so retaining a full duplicate payload wastes memory.
+      orig_data = trajectory?.frame_loader ? data : null
     } catch (error) {
       console.error(`Indexed loading failed:`, error)
       throw error

--- a/src/lib/trajectory/format-detect.ts
+++ b/src/lib/trajectory/format-detect.ts
@@ -18,11 +18,28 @@ export function strip_compression_extensions(filename: string): string {
   return base_name
 }
 
-// Unified format detection
+// Extensions that explicitly identify a format — when present, format detection trusts
+// the extension instead of sniffing content
+const KNOWN_FORMAT_EXT_REGEX =
+  /\.(xyz|extxyz|traj|h5|hdf5|lammpstrj|json|cif|poscar|vasp|yaml|yml|xml|csv)$/
+
+// Classify the filename hint for a format whose extensions match ext_regex:
+// true = filename matches, false = filename names a different known format,
+// null = no usable hint (missing filename or unrecognized extension, e.g. the UUID
+// basenames of blob: object URLs) — callers should fall back to content detection
+export function ext_hint(filename: string | undefined, ext_regex: RegExp): boolean | null {
+  if (!filename) return null
+  const base = strip_compression_extensions(filename)
+  if (ext_regex.test(base)) return true
+  return KNOWN_FORMAT_EXT_REGEX.test(base) ? false : null
+}
+
+// Unified format detection. Each pattern trusts a matching file extension when present
+// but falls back to content/magic-byte detection when the filename gives no hint
+// (e.g. blob: object URLs, extensionless API endpoints).
 export const FORMAT_PATTERNS = {
   ase: (data: unknown, filename?: string) => {
-    const base_name = filename ? strip_compression_extensions(filename) : undefined
-    if (!base_name?.endsWith(`.traj`) || !(data instanceof ArrayBuffer)) {
+    if (ext_hint(filename, /\.traj$/) === false || !(data instanceof ArrayBuffer)) {
       return false
     }
     const view = new Uint8Array(data.slice(0, 24))
@@ -32,9 +49,8 @@ export const FORMAT_PATTERNS = {
   },
 
   hdf5: (data: unknown, filename?: string) => {
-    const base_name = filename ? strip_compression_extensions(filename) : undefined
-    const has_ext = base_name?.match(/\.(h5|hdf5)$/)
-    if (!has_ext || !(data instanceof ArrayBuffer) || data.byteLength < 8) return false
+    if (ext_hint(filename, /\.(h5|hdf5)$/) === false) return false
+    if (!(data instanceof ArrayBuffer) || data.byteLength < 8) return false
     const signature = new Uint8Array(data.slice(0, 8))
     return [0x89, 0x48, 0x44, 0x46, 0x0d, 0x0a, 0x1a, 0x0a].every(
       (b, idx) => signature[idx] === b,
@@ -54,14 +70,12 @@ export const FORMAT_PATTERNS = {
   },
 
   xyz_multi: (data: string, filename?: string) => {
-    const base = filename ? strip_compression_extensions(filename) : ``
-    if (!/\.(xyz|extxyz)$/.test(base)) return false
+    if (ext_hint(filename, /\.(xyz|extxyz)$/) === false) return false
     return count_xyz_frames(data) >= 2
   },
 
   lammpstrj: (data: string, filename?: string) => {
-    const base = filename ? strip_compression_extensions(filename) : ``
-    if (!base.endsWith(`.lammpstrj`)) return false
+    if (ext_hint(filename, /\.lammpstrj$/) === false) return false
     return data.includes(`ITEM: TIMESTEP`) && data.includes(`ITEM: ATOMS`)
   },
 } as const

--- a/src/lib/trajectory/frame-reader.ts
+++ b/src/lib/trajectory/frame-reader.ts
@@ -18,6 +18,7 @@ import {
   validate_3x3_matrix,
 } from './helpers'
 import { strip_compression_extensions } from './format-detect'
+import { parse_extxyz_columns, parse_extxyz_lattice } from './parse/xyz'
 
 export class TrajFrameReader implements FrameLoader {
   private readonly format: `xyz` | `ase`
@@ -283,13 +284,16 @@ export class TrajFrameReader implements FrameLoader {
     const comment = lines[line_idx + 1] || ``
     const positions: number[][] = []
     const elements: ElementSymbol[] = []
+    const forces: number[][] = []
+    const lattice_matrix = parse_extxyz_lattice(comment)
+    const { species_col, pos_col, forces_col, min_cols } = parse_extxyz_columns(comment)
 
     for (let idx = 0; idx < num_atoms; idx++) {
       const parts = lines[line_idx + 2 + idx]?.trim().split(/\s+/)
-      if (parts?.length >= 4) {
-        const x_coord = parseFloat(parts[1])
-        const y_coord = parseFloat(parts[2])
-        const z_coord = parseFloat(parts[3])
+      if (parts && parts.length >= min_cols) {
+        const x_coord = parseFloat(parts[pos_col])
+        const y_coord = parseFloat(parts[pos_col + 1])
+        const z_coord = parseFloat(parts[pos_col + 2])
         if (
           !Number.isFinite(x_coord) ||
           !Number.isFinite(y_coord) ||
@@ -303,7 +307,7 @@ export class TrajFrameReader implements FrameLoader {
           continue
         }
 
-        const raw_symbol = parts[0]
+        const raw_symbol = parts[species_col]
         const element_symbol = coerce_element_symbol(raw_symbol)
         if (!element_symbol) {
           console.warn(
@@ -314,17 +318,31 @@ export class TrajFrameReader implements FrameLoader {
 
         elements.push(element_symbol)
         positions.push([x_coord, y_coord, z_coord])
+
+        if (forces_col >= 0 && parts.length >= forces_col + 3) {
+          const force_vec = parts.slice(forces_col, forces_col + 3).map(parseFloat)
+          if (force_vec.every(Number.isFinite)) forces.push(force_vec)
+        }
       }
     }
 
     const metadata = this.parse_xyz_metadata(comment, frame_number)
+    const properties: Record<string, unknown> = { ...metadata.properties }
+    if (forces.length > 0) {
+      const mags = forces.map((force) => Math.hypot(...force))
+      properties.forces = forces
+      properties.force_max = Math.max(...mags)
+      properties.force_norm = Math.sqrt(
+        mags.reduce((sum, mag) => sum + mag ** 2, 0) / mags.length,
+      )
+    }
     return create_trajectory_frame(
       positions,
       elements,
-      undefined,
-      undefined,
+      lattice_matrix,
+      lattice_matrix ? [true, true, true] : undefined,
       metadata.step,
-      metadata.properties,
+      properties,
     )
   }
 
@@ -388,11 +406,12 @@ export class TrajFrameReader implements FrameLoader {
   private parse_xyz_metadata(comment: string, frame_number: number): TrajectoryMetadata {
     const properties: Record<string, number> = {}
 
+    // Keys anchored at ^|\s and followed by [=:] so single-letter keys don't match mid-word
     const patterns = {
-      energy: /(?:energy|E|etot)\s*[=:]?\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)/i,
-      volume: /(?:volume|vol|V)\s*[=:]?\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)/i,
-      pressure: /(?:pressure|press|P)\s*[=:]?\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)/i,
-      force_max: /(?:max_force|fmax)\s*[=:]?\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)/i,
+      energy: /(?:^|\s)(?:energy|E|etot)\s*[=:]\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)/i,
+      volume: /(?:^|\s)(?:volume|vol|V)\s*[=:]\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)/i,
+      pressure: /(?:^|\s)(?:pressure|press|P)\s*[=:]\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)/i,
+      force_max: /(?:^|\s)(?:max_force|fmax)\s*[=:]\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)/i,
     }
 
     Object.entries(patterns).forEach(([key, pattern]) => {
@@ -400,7 +419,7 @@ export class TrajFrameReader implements FrameLoader {
       if (match) properties[key] = parseFloat(match[1])
     })
 
-    const step_match = /(?:step|frame)\s*[=:]?\s*(\d+)/i.exec(comment)
+    const step_match = /(?:^|\s)(?:step|frame)\s*[=:]?\s*(\d+)/i.exec(comment)
     const step = step_match ? parseInt(step_match[1], 10) : frame_number
 
     return { frame_number, step, properties }

--- a/src/lib/trajectory/frame-reader.ts
+++ b/src/lib/trajectory/frame-reader.ts
@@ -289,13 +289,16 @@ export class TrajFrameReader implements FrameLoader {
       `indexed frame ${frame_number}`,
     )
     const { step, properties } = this.parse_xyz_metadata(comment, frame_number)
+    const metadata: Record<string, unknown> = { ...properties, ...force_stats }
+    // Derive volume from the lattice (parity with the eager parse_xyz_trajectory parser)
+    if (lattice_matrix) metadata.volume = math.calc_lattice_params(lattice_matrix).volume
     return create_trajectory_frame(
       positions,
       elements,
       lattice_matrix,
       lattice_matrix ? [true, true, true] : undefined,
       step,
-      { ...properties, ...force_stats },
+      metadata,
     )
   }
 

--- a/src/lib/trajectory/frame-reader.ts
+++ b/src/lib/trajectory/frame-reader.ts
@@ -1,5 +1,4 @@
 // Unified frame loader for XYZ and ASE trajectories (large file indexing)
-import type { ElementSymbol } from '$lib/element/types'
 import * as math from '$lib/math'
 import type {
   FrameIndex,
@@ -10,7 +9,6 @@ import type {
 } from './index'
 import { MAX_METADATA_SIZE } from './constants'
 import {
-  coerce_element_symbol,
   convert_atomic_numbers,
   count_xyz_frames,
   create_trajectory_frame,
@@ -18,7 +16,11 @@ import {
   validate_3x3_matrix,
 } from './helpers'
 import { strip_compression_extensions } from './format-detect'
-import { parse_extxyz_columns, parse_extxyz_lattice } from './parse/xyz'
+import {
+  parse_extxyz_lattice,
+  parse_xyz_atom_lines,
+  parse_xyz_comment_metadata,
+} from './parse/xyz'
 
 export class TrajFrameReader implements FrameLoader {
   private readonly format: `xyz` | `ase`
@@ -264,16 +266,12 @@ export class TrajFrameReader implements FrameLoader {
     let [current_frame, line_idx] = [0, 0]
 
     while (line_idx < lines.length && current_frame < frame_number) {
-      if (!lines[line_idx]?.trim()) {
-        line_idx++
+      const skip_atoms = parseInt(lines[line_idx].trim(), 10)
+      if (isNaN(skip_atoms) || skip_atoms <= 0) {
+        line_idx++ // skip blank/invalid lines until the next frame's atom-count line
         continue
       }
-      const num_atoms = parseInt(lines[line_idx].trim(), 10)
-      if (isNaN(num_atoms) || num_atoms <= 0) {
-        line_idx++
-        continue
-      }
-      line_idx += 2 + num_atoms
+      line_idx += 2 + skip_atoms
       current_frame++
     }
 
@@ -282,67 +280,22 @@ export class TrajFrameReader implements FrameLoader {
     if (isNaN(num_atoms) || line_idx + num_atoms + 1 >= lines.length) return null
 
     const comment = lines[line_idx + 1] || ``
-    const positions: number[][] = []
-    const elements: ElementSymbol[] = []
-    const forces: number[][] = []
     const lattice_matrix = parse_extxyz_lattice(comment)
-    const { species_col, pos_col, forces_col, min_cols } = parse_extxyz_columns(comment)
-
-    for (let idx = 0; idx < num_atoms; idx++) {
-      const parts = lines[line_idx + 2 + idx]?.trim().split(/\s+/)
-      if (parts && parts.length >= min_cols) {
-        const x_coord = parseFloat(parts[pos_col])
-        const y_coord = parseFloat(parts[pos_col + 1])
-        const z_coord = parseFloat(parts[pos_col + 2])
-        if (
-          !Number.isFinite(x_coord) ||
-          !Number.isFinite(y_coord) ||
-          !Number.isFinite(z_coord)
-        ) {
-          console.warn(
-            `Skipping XYZ atom with invalid coordinates in indexed frame ${frame_number} at line ${
-              line_idx + 2 + idx
-            }`,
-          )
-          continue
-        }
-
-        const raw_symbol = parts[species_col]
-        const element_symbol = coerce_element_symbol(raw_symbol)
-        if (!element_symbol) {
-          console.warn(
-            `Skipping XYZ atom with unknown element symbol "${raw_symbol}" in indexed frame ${frame_number}`,
-          )
-          continue
-        }
-
-        elements.push(element_symbol)
-        positions.push([x_coord, y_coord, z_coord])
-
-        if (forces_col >= 0 && parts.length >= forces_col + 3) {
-          const force_vec = parts.slice(forces_col, forces_col + 3).map(parseFloat)
-          if (force_vec.every(Number.isFinite)) forces.push(force_vec)
-        }
-      }
-    }
-
-    const metadata = this.parse_xyz_metadata(comment, frame_number)
-    const properties: Record<string, unknown> = { ...metadata.properties }
-    if (forces.length > 0) {
-      const mags = forces.map((force) => Math.hypot(...force))
-      properties.forces = forces
-      properties.force_max = Math.max(...mags)
-      properties.force_norm = Math.sqrt(
-        mags.reduce((sum, mag) => sum + mag ** 2, 0) / mags.length,
-      )
-    }
+    const { elements, positions, force_stats } = parse_xyz_atom_lines(
+      lines,
+      line_idx + 2,
+      num_atoms,
+      comment,
+      `indexed frame ${frame_number}`,
+    )
+    const { step, properties } = this.parse_xyz_metadata(comment, frame_number)
     return create_trajectory_frame(
       positions,
       elements,
       lattice_matrix,
       lattice_matrix ? [true, true, true] : undefined,
-      metadata.step,
-      properties,
+      step,
+      { ...properties, ...force_stats },
     )
   }
 
@@ -404,25 +357,8 @@ export class TrajFrameReader implements FrameLoader {
   }
 
   private parse_xyz_metadata(comment: string, frame_number: number): TrajectoryMetadata {
-    const properties: Record<string, number> = {}
-
-    // Keys anchored at ^|\s and followed by [=:] so single-letter keys don't match mid-word
-    const patterns = {
-      energy: /(?:^|\s)(?:energy|E|etot)\s*[=:]\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)/i,
-      volume: /(?:^|\s)(?:volume|vol|V)\s*[=:]\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)/i,
-      pressure: /(?:^|\s)(?:pressure|press|P)\s*[=:]\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)/i,
-      force_max: /(?:^|\s)(?:max_force|fmax)\s*[=:]\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)/i,
-    }
-
-    Object.entries(patterns).forEach(([key, pattern]) => {
-      const match = pattern.exec(comment)
-      if (match) properties[key] = parseFloat(match[1])
-    })
-
-    const step_match = /(?:^|\s)(?:step|frame)\s*[=:]?\s*(\d+)/i.exec(comment)
-    const step = step_match ? parseInt(step_match[1], 10) : frame_number
-
-    return { frame_number, step, properties }
+    const { step, properties } = parse_xyz_comment_metadata(comment)
+    return { frame_number, step: step ?? frame_number, properties }
   }
 
   private parse_ase_metadata(

--- a/src/lib/trajectory/parse/index.ts
+++ b/src/lib/trajectory/parse/index.ts
@@ -7,12 +7,17 @@ import type { AnyStructure } from '$lib/structure/index'
 import { parse_xyz } from '$lib/structure/parse'
 import { INDEX_SAMPLE_RATE, LARGE_FILE_THRESHOLD } from '$lib/trajectory/constants'
 import {
+  ext_hint,
   FORMAT_PATTERNS,
   is_trajectory_file,
   strip_compression_extensions,
 } from '$lib/trajectory/format-detect'
 import { TrajFrameReader } from '$lib/trajectory/frame-reader'
-import { create_trajectory_frame, validate_3x3_matrix } from '$lib/trajectory/helpers'
+import {
+  count_xyz_frames,
+  create_trajectory_frame,
+  validate_3x3_matrix,
+} from '$lib/trajectory/helpers'
 import type {
   FrameLoader,
   ParseProgress,
@@ -63,8 +68,10 @@ export async function parse_trajectory_data(
       return parse_lammps_trajectory(content, filename, atom_type_mapping)
     }
 
-    // Single XYZ fallback
-    if (filename?.toLowerCase().match(/\.(?:xyz|extxyz)$/)) {
+    // Single XYZ fallback (content-sniffed when the filename gives no format hint,
+    // e.g. blob: object URLs whose basenames are UUIDs)
+    const xyz_hint = ext_hint(filename, /\.(xyz|extxyz)$/)
+    if (xyz_hint || (xyz_hint === null && count_xyz_frames(content) === 1)) {
       try {
         const structure = parse_xyz(content)
         if (structure) {
@@ -281,8 +288,15 @@ export async function parse_trajectory_async(
     }
 
     // Use indexed loading for supported large files (including compressed names).
+    // When the filename gives no format hint (e.g. blob: URLs), sniff a content
+    // prefix for XYZ frames so large extensionless files still get indexed.
     const base_filename = strip_compression_extensions(filename)
-    if (should_use_indexing && /\.(xyz|extxyz|traj)$/.test(base_filename)) {
+    const can_index =
+      /\.(xyz|extxyz|traj)$/.test(base_filename) ||
+      (typeof data === `string` &&
+        ext_hint(filename, /\.(xyz|extxyz)$/) === null &&
+        count_xyz_frames(data.slice(0, 2 ** 20)) >= 1)
+    if (should_use_indexing && can_index) {
       return await parse_with_unified_loader(
         data,
         filename,

--- a/src/lib/trajectory/parse/vasp.ts
+++ b/src/lib/trajectory/parse/vasp.ts
@@ -17,7 +17,7 @@ export function parse_vasp_xdatcar(content: string, filename?: string): Trajecto
   const scale = parseFloat(lines[1])
   if (isNaN(scale)) throw new Error(`Invalid scale factor`)
 
-  const lattice_matrix = validate_3x3_matrix(
+  let lattice_matrix = validate_3x3_matrix(
     lines.slice(2, 5).map((line) =>
       line
         .trim()
@@ -48,19 +48,46 @@ export function parse_vasp_xdatcar(content: string, filename?: string): Trajecto
     }
     return name
   })
-  const elements: ElementSymbol[] = validated_element_names.flatMap((name, idx) =>
+  let elements: ElementSymbol[] = validated_element_names.flatMap((name, idx) =>
     Array(element_counts[idx]).fill(name),
   )
 
   const frames: TrajectoryFrame[] = []
   let line_idx = 7
-  const frac_to_cart = math.create_frac_to_cart(lattice_matrix)
+  let frac_to_cart = math.create_frac_to_cart(lattice_matrix)
 
   while (line_idx < lines.length) {
     const config_idx = lines.findIndex(
       (line, idx) => idx >= line_idx && line.includes(`Direct configuration=`),
     )
     if (config_idx === -1) break
+
+    // Variable-cell runs (NPT/ISIF=3) repeat the full 7-line header before each configuration
+    if (config_idx - line_idx >= 7) {
+      const hdr = config_idx - 7
+      const new_scale = parseFloat(lines[hdr + 1])
+      const rows = lines.slice(hdr + 2, hdr + 5).map((line) =>
+        line
+          .trim()
+          .split(/\s+/)
+          .map((val) => parseFloat(val) * new_scale),
+      )
+      const names = lines[hdr + 5].trim().split(/\s+/)
+      const counts = lines[hdr + 6].trim().split(/\s+/).map(Number)
+      if (
+        Number.isFinite(new_scale) &&
+        rows.every((row) => row.length === 3 && row.every(Number.isFinite))
+      ) {
+        lattice_matrix = validate_3x3_matrix(rows)
+        frac_to_cart = math.create_frac_to_cart(lattice_matrix)
+        if (
+          names.length === counts.length &&
+          names.every(is_valid_element_symbol) &&
+          counts.every((count) => Number.isInteger(count) && count > 0)
+        )
+          elements = names.flatMap((name, idx) => Array(counts[idx]).fill(name))
+      }
+    }
 
     const config_line = lines[config_idx]
     line_idx = config_idx + 1

--- a/src/lib/trajectory/parse/vasp.ts
+++ b/src/lib/trajectory/parse/vasp.ts
@@ -10,24 +10,30 @@ import {
   validate_3x3_matrix,
 } from '$lib/trajectory/helpers'
 
+// Parse the 7-line XDATCAR header at lines[start]: title, scale factor, 3 lattice rows
+// (multiplied by scale), element names, element counts
+function parse_xdatcar_header(lines: string[], start: number) {
+  const scale = parseFloat(lines[start + 1])
+  const rows = lines.slice(start + 2, start + 5).map((line) =>
+    line
+      .trim()
+      .split(/\s+/)
+      .map((val) => parseFloat(val) * scale),
+  )
+  const names = lines[start + 5].trim().split(/\s+/)
+  const counts = lines[start + 6].trim().split(/\s+/).map(Number)
+  return { scale, rows, names, counts }
+}
+
 export function parse_vasp_xdatcar(content: string, filename?: string): TrajectoryType {
   const lines = content.trim().split(/\r?\n/)
   if (lines.length < 10) throw new Error(`XDATCAR file too short`)
 
-  const scale = parseFloat(lines[1])
-  if (isNaN(scale)) throw new Error(`Invalid scale factor`)
+  const header = parse_xdatcar_header(lines, 0)
+  const { names: element_names, counts: element_counts } = header
+  if (isNaN(header.scale)) throw new Error(`Invalid scale factor`)
+  let lattice_matrix = validate_3x3_matrix(header.rows)
 
-  let lattice_matrix = validate_3x3_matrix(
-    lines.slice(2, 5).map((line) =>
-      line
-        .trim()
-        .split(/\s+/)
-        .map((component) => parseFloat(component) * scale),
-    ),
-  )
-
-  const element_names = lines[5].trim().split(/\s+/)
-  const element_counts = lines[6].trim().split(/\s+/).map(Number)
   if (element_names.length !== element_counts.length) {
     throw new Error(
       `XDATCAR element names/counts mismatch: names=${element_names.length}, counts=${element_counts.length}`,
@@ -42,13 +48,9 @@ export function parse_vasp_xdatcar(content: string, filename?: string): Trajecto
       `XDATCAR contains invalid element counts: expected finite positive integers`,
     )
   }
-  const validated_element_names = element_names.map((name) => {
-    if (!is_valid_element_symbol(name)) {
-      throw new Error(`Invalid element symbol in XDATCAR: ${name}`)
-    }
-    return name
-  })
-  let elements: ElementSymbol[] = validated_element_names.flatMap((name, idx) =>
+  const bad_element = element_names.find((name) => !is_valid_element_symbol(name))
+  if (bad_element) throw new Error(`Invalid element symbol in XDATCAR: ${bad_element}`)
+  let elements: ElementSymbol[] = element_names.flatMap((name, idx) =>
     Array(element_counts[idx]).fill(name),
   )
 
@@ -64,28 +66,20 @@ export function parse_vasp_xdatcar(content: string, filename?: string): Trajecto
 
     // Variable-cell runs (NPT/ISIF=3) repeat the full 7-line header before each configuration
     if (config_idx - line_idx >= 7) {
-      const hdr = config_idx - 7
-      const new_scale = parseFloat(lines[hdr + 1])
-      const rows = lines.slice(hdr + 2, hdr + 5).map((line) =>
-        line
-          .trim()
-          .split(/\s+/)
-          .map((val) => parseFloat(val) * new_scale),
-      )
-      const names = lines[hdr + 5].trim().split(/\s+/)
-      const counts = lines[hdr + 6].trim().split(/\s+/).map(Number)
+      const hdr = parse_xdatcar_header(lines, config_idx - 7)
       if (
-        Number.isFinite(new_scale) &&
-        rows.every((row) => row.length === 3 && row.every(Number.isFinite))
+        Number.isFinite(hdr.scale) &&
+        hdr.rows.every((row) => row.length === 3 && row.every(Number.isFinite))
       ) {
-        lattice_matrix = validate_3x3_matrix(rows)
+        lattice_matrix = validate_3x3_matrix(hdr.rows)
         frac_to_cart = math.create_frac_to_cart(lattice_matrix)
         if (
-          names.length === counts.length &&
-          names.every(is_valid_element_symbol) &&
-          counts.every((count) => Number.isInteger(count) && count > 0)
-        )
-          elements = names.flatMap((name, idx) => Array(counts[idx]).fill(name))
+          hdr.names.length === hdr.counts.length &&
+          hdr.names.every(is_valid_element_symbol) &&
+          hdr.counts.every((count) => Number.isInteger(count) && count > 0)
+        ) {
+          elements = hdr.names.flatMap((name, idx) => Array(hdr.counts[idx]).fill(name))
+        }
       }
     }
 

--- a/src/lib/trajectory/parse/xyz.ts
+++ b/src/lib/trajectory/parse/xyz.ts
@@ -30,115 +30,126 @@ export function parse_extxyz_lattice(comment: string): math.Matrix3x3 | undefine
   return [vals.slice(0, 3), vals.slice(3, 6), vals.slice(6, 9)] as math.Matrix3x3
 }
 
+// Keys anchored at ^|\s and followed by [=:] so single-letter keys (E/V/P/T) don't match mid-word
+const make_pattern = (keys: string): RegExp =>
+  new RegExp(`(?:^|\\s)(?:${keys})\\s*[=:]\\s*([-+]?\\d*\\.?\\d+(?:[eE][-+]?\\d+)?)`, `i`)
+
+const METADATA_PATTERNS = {
+  energy: make_pattern(`energy|E|etot|total_energy`),
+  volume: make_pattern(`volume|vol|V`),
+  pressure: make_pattern(`pressure|press|P`),
+  temperature: make_pattern(`temperature|temp|T`),
+  force_max: make_pattern(`max_force|force_max|fmax`),
+  bandgap: make_pattern(`bandgap|E_gap|gap`),
+} as const
+
+// Extract step number and scalar properties from an (ext)XYZ comment line
+export function parse_xyz_comment_metadata(comment: string): {
+  step?: number
+  properties: Record<string, number>
+} {
+  const properties: Record<string, number> = {}
+  for (const [key, pattern] of Object.entries(METADATA_PATTERNS)) {
+    const match = pattern.exec(comment)
+    if (match) properties[key] = parseFloat(match[1])
+  }
+  const step = /(?:^|\s)(?:step|frame|ionic_step)\s*[=:]?\s*(\d+)/i.exec(comment)?.[1]
+  return { step: step ? parseInt(step, 10) : undefined, properties }
+}
+
+type ForceStats = { forces: number[][]; force_max: number; force_norm: number }
+
+// Parse num_atoms atom lines starting at lines[start], reading species/pos/forces from
+// their Properties-declared column offsets; invalid atoms are skipped with a warning.
+// force_stats holds raw forces plus max and RMS force magnitudes when forces are present.
+export function parse_xyz_atom_lines(
+  lines: string[],
+  start: number,
+  num_atoms: number,
+  comment: string,
+  frame_label: string,
+): { elements: ElementSymbol[]; positions: number[][]; force_stats: ForceStats | null } {
+  const { species_col, pos_col, forces_col, min_cols } = parse_extxyz_columns(comment)
+  const elements: ElementSymbol[] = []
+  const positions: number[][] = []
+  const forces: number[][] = []
+
+  for (let idx = 0; idx < num_atoms; idx++) {
+    const parts = lines[start + idx]?.trim().split(/\s+/) ?? []
+    if (parts.length < min_cols) continue
+    const pos = parts.slice(pos_col, pos_col + 3).map(parseFloat)
+    if (!pos.every(Number.isFinite)) {
+      console.warn(
+        `Skipping XYZ atom with invalid coordinates in ${frame_label} at line ${
+          start + idx + 1
+        }`,
+      )
+      continue
+    }
+    const symbol = parts[species_col]
+    const element_symbol = coerce_element_symbol(symbol)
+    if (!element_symbol) {
+      console.warn(
+        `Skipping XYZ atom with unknown element symbol "${symbol}" in ${frame_label}`,
+      )
+      continue
+    }
+    elements.push(element_symbol)
+    positions.push(pos)
+    if (forces_col >= 0 && parts.length >= forces_col + 3) {
+      const force_vec = parts.slice(forces_col, forces_col + 3).map(parseFloat)
+      if (force_vec.every(Number.isFinite)) forces.push(force_vec)
+    }
+  }
+
+  if (forces.length === 0) return { elements, positions, force_stats: null }
+  const mags = forces.map((force) => Math.hypot(...force))
+  const force_norm = Math.sqrt(mags.reduce((sum, mag) => sum + mag ** 2, 0) / mags.length)
+  return {
+    elements,
+    positions,
+    force_stats: { forces, force_max: Math.max(...mags), force_norm },
+  }
+}
+
 export function parse_xyz_trajectory(content: string): TrajectoryType {
   const lines = content.trim().split(/\r?\n/)
   const frames: TrajectoryFrame[] = []
   let line_idx = 0
 
   while (line_idx < lines.length) {
-    if (!lines[line_idx]?.trim()) {
-      line_idx++
-      continue
-    }
-
     const num_atoms = parseInt(lines[line_idx].trim(), 10)
     if (isNaN(num_atoms) || num_atoms <= 0 || line_idx + num_atoms + 1 >= lines.length) {
-      line_idx++
+      line_idx++ // skip blank/invalid lines until the next frame's atom-count line
       continue
     }
 
-    const comment = lines[++line_idx] || ``
-    const metadata: Record<string, unknown> = {}
-
-    // Keys anchored at ^|\s and followed by [=:] so single-letter keys don't match mid-word
-    const extractors = {
-      step: /(?:^|\s)(?:step|frame|ionic_step)\s*[=:]?\s*(\d+)/i,
-      energy:
-        /(?:^|\s)(?:energy|E|etot|total_energy)\s*[=:]\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)/i,
-      volume: /(?:^|\s)(?:volume|vol|V)\s*[=:]\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)/i,
-      pressure: /(?:^|\s)(?:pressure|press|P)\s*[=:]\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)/i,
-      temperature:
-        /(?:^|\s)(?:temperature|temp|T)\s*[=:]\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)/i,
-      force_max:
-        /(?:^|\s)(?:max_force|force_max|fmax)\s*[=:]\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)/i,
-      bandgap: /(?:^|\s)(?:bandgap|E_gap|gap)\s*[=:]\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)/i,
-    }
-
-    const step_match = extractors.step.exec(comment)
-    const step = step_match?.[1] ? parseInt(step_match[1], 10) : frames.length
-    Object.entries(extractors).forEach(([key, pattern]) => {
-      if (key === `step`) return
-      const match = pattern.exec(comment)
-      if (match) metadata[key] = parseFloat(match[1])
-    })
+    const comment = lines[line_idx + 1] || ``
+    const { step, properties } = parse_xyz_comment_metadata(comment)
+    const metadata: Record<string, unknown> = { ...properties }
 
     const lattice_matrix = parse_extxyz_lattice(comment)
     if (lattice_matrix) metadata.volume = math.calc_lattice_params(lattice_matrix).volume
 
-    // Parse atoms, reading each field from its Properties-declared column offset
-    const positions: number[][] = []
-    const elements: ElementSymbol[] = []
-    const forces: number[][] = []
-    const { species_col, pos_col, forces_col, min_cols } = parse_extxyz_columns(comment)
-
-    for (let idx = 0; idx < num_atoms; idx++) {
-      line_idx++
-      if (line_idx >= lines.length) break
-      const parts = lines[line_idx].trim().split(/\s+/)
-      if (parts.length >= min_cols) {
-        const x_coord = parseFloat(parts[pos_col])
-        const y_coord = parseFloat(parts[pos_col + 1])
-        const z_coord = parseFloat(parts[pos_col + 2])
-        if (
-          !Number.isFinite(x_coord) ||
-          !Number.isFinite(y_coord) ||
-          !Number.isFinite(z_coord)
-        ) {
-          console.warn(
-            `Skipping XYZ atom with invalid coordinates in frame ${frames.length} at line ${
-              line_idx + 1
-            }`,
-          )
-          continue
-        }
-
-        const raw_symbol = parts[species_col]
-        const element_symbol = coerce_element_symbol(raw_symbol)
-        if (!element_symbol) {
-          console.warn(
-            `Skipping XYZ atom with unknown element symbol "${raw_symbol}" in frame ${frames.length}`,
-          )
-          continue
-        }
-        elements.push(element_symbol)
-        positions.push([x_coord, y_coord, z_coord])
-
-        if (forces_col >= 0 && parts.length >= forces_col + 3) {
-          const force_vec = parts.slice(forces_col, forces_col + 3).map(parseFloat)
-          if (force_vec.every(Number.isFinite)) forces.push(force_vec)
-        }
-      }
-    }
-    if (forces.length > 0) {
-      metadata.forces = forces
-      const magnitudes = forces.map((force) => Math.hypot(...force))
-      metadata.force_max = Math.max(...magnitudes)
-      // Calculate RMS (root mean square) of force magnitudes
-      metadata.force_norm = Math.sqrt(
-        magnitudes.reduce((sum, mag) => sum + mag ** 2, 0) / magnitudes.length,
-      )
-    }
+    const { elements, positions, force_stats } = parse_xyz_atom_lines(
+      lines,
+      line_idx + 2,
+      num_atoms,
+      comment,
+      `frame ${frames.length}`,
+    )
+    Object.assign(metadata, force_stats)
     frames.push(
       create_trajectory_frame(
         positions,
         elements,
         lattice_matrix,
         lattice_matrix ? [true, true, true] : undefined,
-        step,
+        step ?? frames.length,
         metadata,
       ),
     )
-    line_idx++
+    line_idx += num_atoms + 2
   }
 
   return {

--- a/src/lib/trajectory/parse/xyz.ts
+++ b/src/lib/trajectory/parse/xyz.ts
@@ -9,7 +9,10 @@ import type { TrajectoryFrame, TrajectoryType } from '$lib/trajectory/index'
 // to the conventional "symbol x y z" layout when absent or malformed
 export function parse_extxyz_columns(comment: string) {
   const fields = /Properties\s*=\s*"?([^"\s]+)"?/i.exec(comment)?.[1].split(`:`) ?? []
-  let layout: Record<string, { offset: number; ncols: number }> | null = {}
+  // Well-formed Properties is name:type:ncols triples; a non-multiple of 3 is malformed,
+  // so bail to the conventional default rather than trusting a partial layout
+  let layout: Record<string, { offset: number; ncols: number }> | null =
+    fields.length % 3 === 0 ? {} : null
   for (let idx = 0, offset = 0; layout && idx + 3 <= fields.length; idx += 3) {
     const ncols = parseInt(fields[idx + 2], 10)
     if (Number.isInteger(ncols) && ncols > 0) {

--- a/src/lib/trajectory/parse/xyz.ts
+++ b/src/lib/trajectory/parse/xyz.ts
@@ -4,6 +4,32 @@ import * as math from '$lib/math'
 import { coerce_element_symbol, create_trajectory_frame } from '$lib/trajectory/helpers'
 import type { TrajectoryFrame, TrajectoryType } from '$lib/trajectory/index'
 
+// Resolve species/pos/forces column offsets from an extxyz Properties string of
+// name:type:ncols triples (e.g. "species:S:1:pos:R:3:forces:R:3"), falling back
+// to the conventional "symbol x y z" layout when absent or malformed
+export function parse_extxyz_columns(comment: string) {
+  const fields = /Properties\s*=\s*"?([^"\s]+)"?/i.exec(comment)?.[1].split(`:`) ?? []
+  let layout: Record<string, { offset: number; ncols: number }> | null = {}
+  for (let idx = 0, offset = 0; layout && idx + 3 <= fields.length; idx += 3) {
+    const ncols = parseInt(fields[idx + 2], 10)
+    if (Number.isInteger(ncols) && ncols > 0) {
+      layout[fields[idx].toLowerCase()] = { offset, ncols }
+      offset += ncols
+    } else layout = null
+  }
+  const species_col = layout?.species?.offset ?? 0
+  const pos_col = layout?.pos?.offset ?? 1
+  const forces_col = layout?.forces && layout.forces.ncols >= 3 ? layout.forces.offset : -1
+  return { species_col, pos_col, forces_col, min_cols: Math.max(pos_col + 3, species_col + 1) }
+}
+
+// Parse Lattice="ax ay az bx by bz cx cy cz" from an extxyz comment line
+export function parse_extxyz_lattice(comment: string): math.Matrix3x3 | undefined {
+  const vals = /Lattice\s*=\s*"([^"]+)"/i.exec(comment)?.[1].trim().split(/\s+/).map(Number)
+  if (vals?.length !== 9 || !vals.every(Number.isFinite)) return undefined
+  return [vals.slice(0, 3), vals.slice(3, 6), vals.slice(6, 9)] as math.Matrix3x3
+}
+
 export function parse_xyz_trajectory(content: string): TrajectoryType {
   const lines = content.trim().split(/\r?\n/)
   const frames: TrajectoryFrame[] = []
@@ -24,15 +50,18 @@ export function parse_xyz_trajectory(content: string): TrajectoryType {
     const comment = lines[++line_idx] || ``
     const metadata: Record<string, unknown> = {}
 
-    // Extract properties efficiently
+    // Keys anchored at ^|\s and followed by [=:] so single-letter keys don't match mid-word
     const extractors = {
-      step: /(?:step|frame|ionic_step)\s*[=:]?\s*(\d+)/i,
-      energy: /(?:energy|E|etot|total_energy)\s*[=:]?\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)/i,
-      volume: /(?:volume|vol|V)\s*[=:]?\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)/i,
-      pressure: /(?:pressure|press|P)\s*[=:]?\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)/i,
-      temperature: /(?:temperature|temp|T)\s*[=:]?\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)/i,
-      force_max: /(?:max_force|force_max|fmax)\s*[=:]?\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)/i,
-      bandgap: /(?:bandgap|E_gap|gap)\s*[=:]?\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)/i,
+      step: /(?:^|\s)(?:step|frame|ionic_step)\s*[=:]?\s*(\d+)/i,
+      energy:
+        /(?:^|\s)(?:energy|E|etot|total_energy)\s*[=:]\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)/i,
+      volume: /(?:^|\s)(?:volume|vol|V)\s*[=:]\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)/i,
+      pressure: /(?:^|\s)(?:pressure|press|P)\s*[=:]\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)/i,
+      temperature:
+        /(?:^|\s)(?:temperature|temp|T)\s*[=:]\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)/i,
+      force_max:
+        /(?:^|\s)(?:max_force|force_max|fmax)\s*[=:]\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)/i,
+      bandgap: /(?:^|\s)(?:bandgap|E_gap|gap)\s*[=:]\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)/i,
     }
 
     const step_match = extractors.step.exec(comment)
@@ -43,35 +72,23 @@ export function parse_xyz_trajectory(content: string): TrajectoryType {
       if (match) metadata[key] = parseFloat(match[1])
     })
 
-    // Extract lattice matrix
-    const lattice_match = /Lattice\s*=\s*"([^"]+)"/i.exec(comment)
-    let lattice_matrix: math.Matrix3x3 | undefined
-    if (lattice_match) {
-      const values = lattice_match[1].split(/\s+/).map(Number)
-      if (values.length === 9 && values.every((value) => Number.isFinite(value))) {
-        lattice_matrix = [
-          [values[0], values[1], values[2]],
-          [values[3], values[4], values[5]],
-          [values[6], values[7], values[8]],
-        ]
-        metadata.volume = math.calc_lattice_params(lattice_matrix).volume
-      }
-    }
+    const lattice_matrix = parse_extxyz_lattice(comment)
+    if (lattice_matrix) metadata.volume = math.calc_lattice_params(lattice_matrix).volume
 
-    // Parse atoms
+    // Parse atoms, reading each field from its Properties-declared column offset
     const positions: number[][] = []
     const elements: ElementSymbol[] = []
     const forces: number[][] = []
-    const has_forces = comment.includes(`forces:R:3`)
+    const { species_col, pos_col, forces_col, min_cols } = parse_extxyz_columns(comment)
 
     for (let idx = 0; idx < num_atoms; idx++) {
       line_idx++
       if (line_idx >= lines.length) break
       const parts = lines[line_idx].trim().split(/\s+/)
-      if (parts.length >= 4) {
-        const x_coord = parseFloat(parts[1])
-        const y_coord = parseFloat(parts[2])
-        const z_coord = parseFloat(parts[3])
+      if (parts.length >= min_cols) {
+        const x_coord = parseFloat(parts[pos_col])
+        const y_coord = parseFloat(parts[pos_col + 1])
+        const z_coord = parseFloat(parts[pos_col + 2])
         if (
           !Number.isFinite(x_coord) ||
           !Number.isFinite(y_coord) ||
@@ -85,7 +102,7 @@ export function parse_xyz_trajectory(content: string): TrajectoryType {
           continue
         }
 
-        const raw_symbol = parts[0]
+        const raw_symbol = parts[species_col]
         const element_symbol = coerce_element_symbol(raw_symbol)
         if (!element_symbol) {
           console.warn(
@@ -96,17 +113,9 @@ export function parse_xyz_trajectory(content: string): TrajectoryType {
         elements.push(element_symbol)
         positions.push([x_coord, y_coord, z_coord])
 
-        if (has_forces && parts.length >= 7) {
-          const force_x = parseFloat(parts[4])
-          const force_y = parseFloat(parts[5])
-          const force_z = parseFloat(parts[6])
-          if (
-            Number.isFinite(force_x) &&
-            Number.isFinite(force_y) &&
-            Number.isFinite(force_z)
-          ) {
-            forces.push([force_x, force_y, force_z])
-          }
+        if (forces_col >= 0 && parts.length >= forces_col + 3) {
+          const force_vec = parts.slice(forces_col, forces_col + 3).map(parseFloat)
+          if (force_vec.every(Number.isFinite)) forces.push(force_vec)
         }
       }
     }

--- a/src/lib/xrd/calc-xrd.ts
+++ b/src/lib/xrd/calc-xrd.ts
@@ -94,18 +94,18 @@ function compute_reciprocal_lattice_rows(structure: Crystal): number[][] {
 
 function enumerate_reciprocal_points(
   recip_rows: number[][],
+  direct_rows: number[][],
   max_radius: number,
   min_radius: number,
 ): RecipPoint[] {
   const recip_b1 = recip_rows[0]
   const recip_b2 = recip_rows[1]
   const recip_b3 = recip_rows[2]
-  const n1 = Math.max(Math.hypot(...recip_b1), 1e-12)
-  const n2 = Math.max(Math.hypot(...recip_b2), 1e-12)
-  const n3 = Math.max(Math.hypot(...recip_b3), 1e-12)
-  const h_max = Math.ceil(max_radius / n1 + 2)
-  const k_max = Math.ceil(max_radius / n2 + 2)
-  const l_max = Math.ceil(max_radius / n3 + 2)
+  // Exact index bound: |h_i| = |g·a_i| ≤ R·|a_i| (since a_i·b_j = δ_ij). Bounds from
+  // reciprocal-row norms (R/|b_i| + 2) undercount for skewed cells, dropping reflections.
+  const [h_max, k_max, l_max] = direct_rows.map(
+    (row) => Math.ceil(max_radius * Math.hypot(...row)) + 1,
+  )
   // Safety cap to avoid pathological enumeration volume
   const CAP = 512
   if (Math.max(h_max, k_max, l_max) > CAP) {
@@ -173,10 +173,16 @@ export function compute_xrd_pattern(structure: Crystal, options: XrdOptions = {}
           return [r_min, r_max]
         })(two_theta_range)
 
-  const recip_points = enumerate_reciprocal_points(recip_rows, max_radius, min_radius)
+  const recip_points = enumerate_reciprocal_points(
+    recip_rows,
+    structure.lattice.matrix,
+    max_radius,
+    min_radius,
+  )
 
   // Flatten species with occupancies; gather coeffs, frac coords, occu, DW factors.
-  type ScatteringCoeffs = { a: number[]; b: number[]; c?: number }
+  // z is set only for pymatgen-style fitted params (array form); {a, b, c} = Cromer-Mann
+  type ScatteringCoeffs = { a: number[]; b: number[]; c?: number; z?: number }
   const coeffs: ScatteringCoeffs[] = []
   const frac_coords: math.Vec3[] = []
   const occus: number[] = []
@@ -200,7 +206,7 @@ export function compute_xrd_pattern(structure: Crystal, options: XrdOptions = {}
       if (Array.isArray(raw_coeff)) {
         const a_arr = raw_coeff.map(([a]) => a)
         const b_arr = raw_coeff.map(([_, b]) => b)
-        coeff_entry = { a: a_arr, b: b_arr }
+        coeff_entry = { a: a_arr, b: b_arr, z: ELEMENT_Z[element_symbol] }
       } else {
         coeff_entry = { a: raw_coeff.a.slice(), b: raw_coeff.b.slice(), c: raw_coeff.c }
       }
@@ -234,7 +240,7 @@ export function compute_xrd_pattern(structure: Crystal, options: XrdOptions = {}
 
     // Atomic scattering factors (vectorized style)
     const f_scattering: number[] = coeffs.map((coeff_entry) => {
-      const { a: a_arr, b: b_arr } = coeff_entry
+      const { a: a_arr, b: b_arr, z } = coeff_entry
       const num_terms = Math.min(a_arr.length, b_arr.length)
       const sum_terms = a_arr
         .slice(0, num_terms)
@@ -243,6 +249,8 @@ export function compute_xrd_pattern(structure: Crystal, options: XrdOptions = {}
             sum + a_i * Math.exp(-b_arr[term_idx] * sin_theta_over_lambda_sq),
           0,
         )
+      // pymatgen-style fitted params: f = Z − 41.78214·s²·Σ aᵢ·exp(−bᵢ·s²)
+      if (z !== undefined) return z - 41.78214 * sin_theta_over_lambda_sq * sum_terms
       return sum_terms + (coeff_entry.c ?? 0)
     })
 

--- a/tests/vitest/brillouin-compute.test.ts
+++ b/tests/vitest/brillouin-compute.test.ts
@@ -222,35 +222,20 @@ describe(`compute_convex_hull`, () => {
     ).toThrow(/Need ≥4 vertices/)
   })
 
+  // All 8 corners of the [-1, 1]³ cube
+  const cube_verts = [-1, 1].flatMap((z) =>
+    [-1, 1].flatMap((y) => [-1, 1].map((x) => [x, y, z] as Vec3)),
+  )
+  const tetrahedron_verts: Vec3[] = [
+    [0, 0, 0],
+    [1, 0, 0],
+    [0.5, Math.sqrt(3) / 2, 0],
+    [0.5, Math.sqrt(3) / 6, Math.sqrt(2 / 3)],
+  ]
+
   test.each([
-    [
-      `tetrahedron`,
-      [
-        [0, 0, 0],
-        [1, 0, 0],
-        [0.5, Math.sqrt(3) / 2, 0],
-        [0.5, Math.sqrt(3) / 6, Math.sqrt(2 / 3)],
-      ],
-      4,
-      4,
-      6,
-    ],
-    [
-      `cube`,
-      [
-        [-1, -1, -1],
-        [1, -1, -1],
-        [-1, 1, -1],
-        [1, 1, -1],
-        [-1, -1, 1],
-        [1, -1, 1],
-        [-1, 1, 1],
-        [1, 1, 1],
-      ],
-      8,
-      12,
-      12,
-    ],
+    [`tetrahedron`, tetrahedron_verts, 4, 4, 6],
+    [`cube`, cube_verts, 8, 12, 12],
   ] as [string, Vec3[], number, number, number][])(
     `%s: %d vertices, %d faces, %d edges`,
     (_, vertices, v_count, f_count, e_count) => {
@@ -262,18 +247,8 @@ describe(`compute_convex_hull`, () => {
   )
 
   test(`edge_sharp_angle_deg controls edge filtering`, () => {
-    const cube: Vec3[] = [
-      [-1, -1, -1],
-      [1, -1, -1],
-      [-1, 1, -1],
-      [1, 1, -1],
-      [-1, -1, 1],
-      [1, -1, 1],
-      [-1, 1, 1],
-      [1, 1, 1],
-    ]
-    const strict = compute_convex_hull(cube, 1)
-    const loose = compute_convex_hull(cube, 45)
+    const strict = compute_convex_hull(cube_verts, 1)
+    const loose = compute_convex_hull(cube_verts, 45)
     expect(strict.edges.length).toBeGreaterThan(0)
     expect(loose.edges.length).toBeGreaterThan(0)
   })
@@ -498,30 +473,20 @@ describe(`fractional_to_cartesian_rotation`, () => {
     },
   )
 
+  const singular_w: Matrix3x3 = [
+    [0, 0, 0],
+    [0, 1, 0],
+    [0, 0, 1],
+  ]
+  const zero_mat: Matrix3x3 = [
+    [0, 0, 0],
+    [0, 0, 0],
+    [0, 0, 0],
+  ]
   test.each([
-    {
-      name: `singular W`,
-      W: [
-        [0, 0, 0],
-        [0, 1, 0],
-        [0, 0, 1],
-      ] as Matrix3x3,
-      k: k_lattice,
-    },
-    {
-      name: `singular k_lattice`,
-      W: IDENTITY_MAT,
-      k: [
-        [0, 0, 0],
-        [0, 0, 0],
-        [0, 0, 0],
-      ] as Matrix3x3,
-    },
-  ])(`returns identity matrix for $name`, ({ W, k }) => {
-    expect(fractional_to_cartesian_rotation(W, k)).toEqual([
-      [1, 0, 0],
-      [0, 1, 0],
-      [0, 0, 1],
-    ])
+    [`singular W`, singular_w, k_lattice],
+    [`singular k_lattice`, IDENTITY_MAT, zero_mat],
+  ] as [string, Matrix3x3, Matrix3x3][])(`returns identity matrix for %s`, (_, W, k) => {
+    expect(fractional_to_cartesian_rotation(W, k)).toEqual(IDENTITY_MAT)
   })
 })

--- a/tests/vitest/brillouin-compute.test.ts
+++ b/tests/vitest/brillouin-compute.test.ts
@@ -8,7 +8,8 @@ import {
   generate_bz_vertices,
   reciprocal_lattice,
 } from '$lib/brillouin/compute'
-import type { Matrix3x3, Vec3, Vec9 } from '$lib/math'
+import type { Matrix3x3, Vec3 } from '$lib/math'
+import * as math from '$lib/math'
 import type { MoyoDataset } from '@spglib/moyo-wasm'
 import { describe, expect, test } from 'vitest'
 import { load_json } from './setup'
@@ -342,92 +343,64 @@ describe(`error handling`, () => {
   })
 })
 
-// Rotation matrices as Vec9 (row-major)
-const IDENTITY_ROT: Vec9 = [1, 0, 0, 0, 1, 0, 0, 0, 1]
-const ROT_Z_90: Vec9 = [0, -1, 0, 1, 0, 0, 0, 0, 1]
-const ROT_Z_180: Vec9 = [-1, 0, 0, 0, -1, 0, 0, 0, 1]
-const ROT_Z_270: Vec9 = [0, 1, 0, -1, 0, 0, 0, 0, 1]
-const MIRROR_Z: Vec9 = [1, 0, 0, 0, 1, 0, 0, 0, -1]
-const INVERSION_ROT: Vec9 = [-1, 0, 0, 0, -1, 0, 0, 0, -1]
+// Fractional rotation matrices (row-major) for mock moyo operations
+const ROT_Z_90 = math.vec9_to_mat3x3([0, -1, 0, 1, 0, 0, 0, 0, 1]) as Matrix3x3
+const ROT_Z_180 = math.vec9_to_mat3x3([-1, 0, 0, 0, -1, 0, 0, 0, 1]) as Matrix3x3
+const ROT_Z_270 = math.vec9_to_mat3x3([0, 1, 0, -1, 0, 0, 0, 0, 1]) as Matrix3x3
+const MIRROR_Z = math.vec9_to_mat3x3([1, 0, 0, 0, 1, 0, 0, 0, -1]) as Matrix3x3
 
-// Create mock operation for testing (Vec9 substitutes for Float64Array in tests)
-const make_op = (rot: Vec9, trans: Vec3 = [0, 0, 0]): MoyoDataset[`operations`][number] =>
-  ({ rotation: rot, translation: trans }) as unknown as MoyoDataset[`operations`][number]
+// moyo-wasm serializes nalgebra Matrix3 rotations as flat 9-arrays in COLUMN-major order
+// (number[] substitutes for Float64Array in tests)
+const make_op = (rot: Matrix3x3, translation: Vec3 = [0, 0, 0]) =>
+  ({
+    rotation: [0, 1, 2].flatMap((col) => rot.map((row) => row[col])),
+    translation,
+  }) as unknown as MoyoDataset[`operations`][number]
 
 describe(`extract_point_group_from_operations`, () => {
-  test(`extracts identity and transposes for reciprocal space`, () => {
-    const pg = extract_point_group_from_operations([make_op(IDENTITY_ROT)])
-    expect(pg).toHaveLength(1)
-    expect(pg[0]).toEqual(IDENTITY_MAT)
-  })
-
   test(`deduplicates same rotation with different translations`, () => {
-    const ops = [
-      make_op(IDENTITY_ROT),
-      make_op(IDENTITY_ROT, [0.5, 0, 0]),
-      make_op(IDENTITY_ROT, [0, 0.5, 0]),
-    ]
+    const ops = [make_op(IDENTITY_MAT), make_op(IDENTITY_MAT, [0.5, 0, 0])]
     expect(extract_point_group_from_operations(ops)).toHaveLength(1)
   })
 
   test.each([
-    [`C4 group`, [IDENTITY_ROT, ROT_Z_90, ROT_Z_180, ROT_Z_270], 4],
-    [`with inversion/mirror`, [IDENTITY_ROT, INVERSION_ROT, MIRROR_Z], 3],
+    [`C4 group`, [IDENTITY_MAT, ROT_Z_90, ROT_Z_180, ROT_Z_270], 4],
+    [`with inversion/mirror`, [IDENTITY_MAT, INVERSION_MAT, MIRROR_Z], 3],
     [`empty input`, [], 0],
-  ])(`%s → %d unique rotations`, (_, rots, expected) => {
+  ] as [string, Matrix3x3[], number][])(`%s → %d unique rotations`, (_, rots, expected) => {
     expect(extract_point_group_from_operations(rots.map((r) => make_op(r)))).toHaveLength(
       expected,
     )
   })
 
-  test(`preserves fractional rotation (no transpose)`, () => {
-    // ROT_Z_90 [[0,-1,0],[1,0,0],[0,0,1]] - returned as-is for later conversion
-    const [pg] = extract_point_group_from_operations([make_op(ROT_Z_90)])
-    expect(pg[0][1]).toBe(-1) // original value at [0][1]
-    expect(pg[1][0]).toBe(1) // original value at [1][0]
+  // Regression: moyo flat arrays are column-major, so a row-major read returns Wᵀ instead
+  // of W. Non-symmetric Ws (C4z, hex C3) catch the layout mix-up.
+  test(`decodes column-major moyo rotations (round-trip)`, () => {
+    for (const rot of [IDENTITY_MAT, ROT_Z_90, C3_HEX, C3_HEX_SQ]) {
+      expect(extract_point_group_from_operations([make_op(rot)])).toEqual([rot])
+    }
   })
 })
 
 describe(`compute_ibz_clipping_planes`, () => {
-  const ROT_90: Matrix3x3 = [
-    [0, 1, 0],
-    [-1, 0, 0],
-    [0, 0, 1],
-  ]
-  const ROT_180: Matrix3x3 = [
-    [-1, 0, 0],
-    [0, -1, 0],
-    [0, 0, 1],
-  ]
-  const ROT_270: Matrix3x3 = [
-    [0, -1, 0],
-    [1, 0, 0],
-    [0, 0, 1],
-  ]
-
   test(`identity-only → no planes`, () => {
     expect(compute_ibz_clipping_planes([IDENTITY_MAT])).toHaveLength(0)
   })
 
   test(`non-trivial symmetry → planes through origin`, () => {
-    const planes = compute_ibz_clipping_planes([IDENTITY_MAT, ROT_90])
+    const planes = compute_ibz_clipping_planes([IDENTITY_MAT, ROT_Z_90])
     expect(planes.length).toBeGreaterThan(0)
     planes.forEach((p) => expect(p.dist).toBe(0))
   })
 
   test(`C4 group deduplicates planes`, () => {
-    const planes = compute_ibz_clipping_planes([IDENTITY_MAT, ROT_90, ROT_180, ROT_270])
+    const planes = compute_ibz_clipping_planes([IDENTITY_MAT, ROT_Z_90, ROT_Z_180, ROT_Z_270])
     expect(planes.length).toBeLessThanOrEqual(3)
   })
 })
 
 describe(`compute_irreducible_bz`, () => {
   const bz = compute_brillouin_zone(reciprocal_lattice(CUBIC_5), 1)
-  const MIRROR_Z_MAT: Matrix3x3 = [
-    [1, 0, 0],
-    [0, 1, 0],
-    [0, 0, -1],
-  ]
 
   test(`P1 (identity only) → full BZ`, () => {
     const ibz = compute_irreducible_bz(bz, [IDENTITY_MAT])
@@ -447,7 +420,7 @@ describe(`compute_irreducible_bz`, () => {
   })
 
   test(`mirror symmetry → valid geometry`, () => {
-    const ibz = compute_irreducible_bz(bz, [IDENTITY_MAT, MIRROR_Z_MAT])
+    const ibz = compute_irreducible_bz(bz, [IDENTITY_MAT, MIRROR_Z])
     expect(ibz).not.toBeNull()
     if (!ibz) return
     expect(ibz.vertices.length).toBeGreaterThanOrEqual(4)
@@ -491,21 +464,39 @@ describe(`compute_irreducible_bz`, () => {
 describe(`fractional_to_cartesian_rotation`, () => {
   const k_lattice = reference_data.hexagonal.reciprocal_lattice as Matrix3x3
 
-  test(`det = +1 and correct matrix elements for hexagonal C3`, () => {
-    const R = fractional_to_cartesian_rotation(C3_HEX, k_lattice)
+  // The old convention R = B·W^{-T}·B^{-1} gave non-orthogonal "rotations" (row norm
+  // 1.1547 for hex C3) — assert physical invariants instead of hardcoded matrix elements
+  test.each([
+    [`hexagonal C3 (120°)`, C3_HEX, k_lattice, 0],
+    [`hexagonal C3² (240°)`, C3_HEX_SQ, k_lattice, 0],
+    [`cubic C4z (90°)`, ROT_Z_90, reciprocal_lattice(CUBIC_5), 1],
+  ] as [string, Matrix3x3, Matrix3x3, number][])(
+    `%s: R is a proper rotation mapping the reciprocal lattice onto itself`,
+    (_, frac_rot, k_latt, trace) => {
+      const R = fractional_to_cartesian_rotation(frac_rot, k_latt)
 
-    // det(R) should be +1 for proper rotation
-    const det =
-      R[0][0] * (R[1][1] * R[2][2] - R[1][2] * R[2][1]) -
-      R[0][1] * (R[1][0] * R[2][2] - R[1][2] * R[2][0]) +
-      R[0][2] * (R[1][0] * R[2][1] - R[1][1] * R[2][0])
-    expect(det).toBeCloseTo(1, 10)
+      // Orthogonal (RᵀR = I), proper (det = +1), right angle (trace = 1 + 2·cosθ — also
+      // rules out the identity fallback, which trivially passes the other invariants)
+      math
+        .dot(math.transpose_3x3_matrix(R), R)
+        .forEach((row, ii) =>
+          row.forEach((val, jj) =>
+            expect(val, `RᵀR[${ii}][${jj}]`).toBeCloseTo(ii === jj ? 1 : 0, 10),
+          ),
+        )
+      expect(math.det_3x3(R)).toBeCloseTo(1, 10)
+      expect(R[0][0] + R[1][1] + R[2][2], `trace`).toBeCloseTo(trace, 10)
 
-    // These values distinguish W^{-T} from W^T (wrong impl gives ~-0.577, ~-0.906, ~0.577)
-    expect(R[0][0]).toBeCloseTo(-0.4226497308103744, 6)
-    expect(R[0][1]).toBeCloseTo(-0.6547005383792517, 6)
-    expect(R[1][0]).toBeCloseTo(1.1547005383792515, 6)
-  })
+      // R must map the reciprocal lattice onto itself: coordinates of R·bᵢ in the
+      // reciprocal basis (k_cart = Bᵀ·q) must be integers
+      const basis_inv = math.matrix_inverse_3x3(math.transpose_3x3_matrix(k_latt))
+      for (const b_vec of k_latt) {
+        for (const coord of math.dot(basis_inv, math.dot(R, b_vec))) {
+          expect(coord, `R·b lattice coords`).toBeCloseTo(Math.round(coord), 8)
+        }
+      }
+    },
+  )
 
   test.each([
     {

--- a/tests/vitest/colors.test.ts
+++ b/tests/vitest/colors.test.ts
@@ -186,8 +186,12 @@ describe(`is_color function`, () => {
     [`red`, true],
     [`blue`, true],
     [`green`, true],
+    [`rebeccapurple`, true],
+    [`RED`, true], // named colors are case-insensitive
     [`transparent`, true],
     [`currentcolor`, true],
+
+    [`pending`, false], // arbitrary words are not colors
 
     // Invalid patterns - incomplete functions
     [`rgb`, false],

--- a/tests/vitest/colors.test.ts
+++ b/tests/vitest/colors.test.ts
@@ -132,6 +132,8 @@ describe(`is_color function`, () => {
     // Invalid patterns - malformed
     [`rgb(255, 0)`, false], // incomplete rgb values are rejected
     [`#gg0000`, false],
+    [`#12345`, false], // 5-digit hex is invalid (regression vs old COLOR_FN_REGEX)
+    [`#1234567`, false], // 7-digit hex is invalid (regression vs old COLOR_FN_REGEX)
     [`hello world`, false],
     [``, false],
     [123, false],

--- a/tests/vitest/colors.test.ts
+++ b/tests/vitest/colors.test.ts
@@ -13,76 +13,21 @@ import { describe, expect, test, vi } from 'vitest'
 // Generate expected element symbols from atomic numbers 1-109 (first 109 elements)
 const EXPECTED_ELEMENTS = Array.from({ length: 109 }, (_, idx) => ELEM_SYMBOLS[idx])
 
-// Test if a string is a valid hex color
-function is_valid_hex_color(color: string): boolean {
-  const hex_regex = /^#[0-9A-Fa-f]{6}$/
-  return hex_regex.test(color)
-}
-
 describe(`Element Color Schemes`, () => {
-  test(`all schemes exist and are objects`, () => {
-    expect(ELEMENT_COLOR_SCHEMES).toBeDefined()
-    expect(typeof ELEMENT_COLOR_SCHEMES).toBe(`object`)
-
-    const schemes = Object.keys(ELEMENT_COLOR_SCHEMES)
-    expect(schemes.length).toBeGreaterThanOrEqual(6)
-    expect(schemes).toContain(`Vesta`)
-    expect(schemes).toContain(`Jmol`)
-    expect(schemes).toContain(`Alloy`)
-    expect(schemes).toContain(`Pastel`)
-    expect(schemes).toContain(`Muted`)
-    expect(schemes).toContain(`Dark Mode`)
-  })
-
-  test(`each scheme has complete element coverage`, () => {
+  test(`all schemes have identical, complete element coverage`, () => {
+    expect(Object.keys(ELEMENT_COLOR_SCHEMES).sort()).toEqual([
+      `Alloy`,
+      `Dark Mode`,
+      `Jmol`,
+      `Muted`,
+      `Pastel`,
+      `Vesta`,
+    ])
+    const expected_keys = Object.keys(ELEMENT_COLOR_SCHEMES.Vesta).sort()
+    expect(expected_keys.length).toBeGreaterThanOrEqual(109)
+    expect(expected_keys).toEqual(expect.arrayContaining(EXPECTED_ELEMENTS))
     for (const [scheme_name, colors] of Object.entries(ELEMENT_COLOR_SCHEMES)) {
-      const scheme_elements = Object.keys(colors)
-
-      // Check minimum element count
-      expect(
-        scheme_elements.length,
-        `${scheme_name} should have at least 109 elements`,
-      ).toBeGreaterThanOrEqual(109)
-
-      // Check that all expected elements are present
-      for (const element of EXPECTED_ELEMENTS) {
-        expect(
-          colors[element],
-          `${scheme_name} should contain element ${element}`,
-        ).toBeDefined()
-      }
-    }
-  })
-
-  test(`all schemes have identical element coverage`, () => {
-    const schemes = Object.entries(ELEMENT_COLOR_SCHEMES)
-    const [first_scheme_name, first_scheme] = schemes[0]
-    const first_elements = new Set(Object.keys(first_scheme))
-
-    for (const [scheme_name, colors] of schemes.slice(1)) {
-      const scheme_elements = new Set(Object.keys(colors))
-
-      // Check same number of elements
-      expect(
-        scheme_elements.size,
-        `${scheme_name} should have same number of elements as ${first_scheme_name}`,
-      ).toBe(first_elements.size)
-
-      // Check for missing elements
-      const missing_elements = [...first_elements]
-        .filter((el) => !scheme_elements.has(el))
-        .join(`, `)
-      expect(
-        missing_elements,
-        `${scheme_name} is missing elements from ${first_scheme_name}: ${missing_elements}`,
-      ).toHaveLength(0)
-
-      // Check for extra elements
-      const extra_elements = [...scheme_elements]
-        .filter((el) => !first_elements.has(el))
-        .join(`, `)
-      const fail_msg = `${scheme_name} has extra elements not in ${first_scheme_name}: ${extra_elements}`
-      expect(extra_elements, fail_msg).toHaveLength(0)
+      expect(Object.keys(colors).sort(), `${scheme_name} coverage`).toEqual(expected_keys)
     }
   })
 
@@ -90,11 +35,9 @@ describe(`Element Color Schemes`, () => {
     for (const [scheme_name, colors] of Object.entries(ELEMENT_COLOR_SCHEMES)) {
       // Check all colors are valid hex format
       for (const [element, color] of Object.entries(colors)) {
-        expect(typeof color, `${scheme_name}.${element} should be a string`).toBe(`string`)
-        expect(
-          is_valid_hex_color(color),
-          `${scheme_name}.${element} should be valid hex color (got: ${color})`,
-        ).toBe(true)
+        expect(color, `${scheme_name}.${element} should be a valid hex color`).toMatch(
+          /^#[0-9a-f]{6}$/i,
+        )
       }
 
       // Check color uniqueness within scheme
@@ -118,19 +61,6 @@ describe(`Element Color Schemes`, () => {
       expect(duplicate_count, `${scheme_name} too many duplicate colors`).toBeLessThan(
         max_duplicates,
       )
-
-      // Check key elements are present
-      const key_elements = [`H`, `C`, `N`, `O`, `Fe`, `Au`, `U`]
-      for (const element of key_elements) {
-        expect(
-          colors[element],
-          `${scheme_name} should have color for ${element}`,
-        ).toBeDefined()
-        expect(
-          is_valid_hex_color(colors[element]),
-          `${scheme_name}.${element} should be valid hex`,
-        ).toBe(true)
-      }
     }
   })
 
@@ -200,7 +130,7 @@ describe(`is_color function`, () => {
     [`color`, false],
 
     // Invalid patterns - malformed
-    [`rgb(255, 0)`, true], // incomplete rgb values but still matches our relaxed pattern
+    [`rgb(255, 0)`, false], // incomplete rgb values are rejected
     [`#gg0000`, false],
     [`hello world`, false],
     [``, false],
@@ -301,18 +231,11 @@ test.each([
 })
 
 test.each([
-  [`#ffffff`, `black`, `light background`],
-  [`#000000`, `white`, `dark background`],
-  [`#808080`, `black`, `custom threshold`],
-  [`#ffffff`, `black`, `null element`],
-])(`pick_contrast_color: %s → %s (%s)`, (bg_color, expected, description) => {
-  if (description === `custom threshold`) {
-    expect(pick_contrast_color({ bg_color, luminance_threshold: 0.5 })).toBe(expected)
-  } else if (description === `null element`) {
-    expect(pick_contrast_color({ bg_color })).toBe(expected)
-  } else {
-    expect(pick_contrast_color({ bg_color })).toBe(expected)
-  }
+  [`#ffffff`, undefined, `black`], // light background
+  [`#000000`, undefined, `white`], // dark background
+  [`#808080`, 0.5, `black`], // custom threshold
+])(`pick_contrast_color: %s (threshold %s) → %s`, (bg_color, threshold, expected) => {
+  expect(pick_contrast_color({ bg_color, luminance_threshold: threshold })).toBe(expected)
 })
 
 test(`pick_contrast_color uses custom colors`, () => {

--- a/tests/vitest/composition/FormulaFilter.svelte.test.ts
+++ b/tests/vitest/composition/FormulaFilter.svelte.test.ts
@@ -1024,38 +1024,19 @@ describe(`FormulaFilter`, () => {
       )
     })
 
-    test(`invalid exact formulas emit invalid validation state`, () => {
+    test.each([
+      [`Xx2`, `Invalid element symbol`],
+      // unbalanced parentheses must neither hang nor escape input handling
+      [`Ca(OH2`, `parentheses`],
+      [`Fe(`, `parentheses`],
+      [`Mg()O2`, `parentheses`],
+    ])(`invalid exact formula %s emits invalid validation state`, (raw_input, msg_part) => {
       const on_validation = vi.fn()
       mount_filter({ value: ``, on_validation })
-      submit_input(`Xx2`)
-
-      const last_validation = on_validation.mock.calls[
-        on_validation.mock.calls.length - 1
-      ][0] as {
-        state: string
-        message: string | null
-      }
-      expect(last_validation.state).toBe(`invalid`)
-      expect(last_validation.message).toContain(`Invalid element symbol`)
+      submit_input(raw_input)
+      expect(on_validation.mock.lastCall?.[0].state).toBe(`invalid`)
+      expect(on_validation.mock.lastCall?.[0].message).toContain(msg_part)
       expect(doc_query(`.formula-filter`).classList.contains(`invalid`)).toBe(true)
-    })
-
-    test.each([`Ca(OH2`, `Fe(`, `Mg()O2`])(
-      `unbalanced parentheses %s neither hang nor escape input handling`,
-      (raw_input) => {
-        const on_validation = vi.fn()
-        mount_filter({ value: ``, on_validation })
-        submit_input(raw_input)
-        expect(on_validation.mock.lastCall?.[0].state).toBe(`invalid`)
-        expect(on_validation.mock.lastCall?.[0].message).toContain(`parentheses`)
-      },
-    )
-
-    test(`hydrate dot survives unicode normalization (deleting it would glue digits)`, () => {
-      const onchange = vi.fn()
-      mount_filter({ value: ``, onchange })
-      submit_input(`CuSO4·5H2O`)
-      expect(onchange).toHaveBeenLastCalledWith(`CuH10O9S`, `exact`)
     })
 
     test(`invalid non-exact tokens are not silently dropped on submit`, () => {
@@ -1085,19 +1066,11 @@ describe(`FormulaFilter`, () => {
     })
 
     test.each([
-      {
-        case_name: `normalize_exact=false preserves user exact formula order`,
-        props: { normalize_exact: false },
-        input: `NaCl`,
-        expected: `NaCl`,
-      },
-      {
-        case_name: `unicode subscripts normalize in exact mode`,
-        props: {},
-        input: `Fe₂O₃`,
-        expected: `Fe2O3`,
-      },
-    ])(`$case_name`, ({ props, input, expected }) => {
+      [`normalize_exact=false preserves order`, { normalize_exact: false }, `NaCl`, `NaCl`],
+      [`unicode subscripts normalize`, {}, `Fe₂O₃`, `Fe2O3`],
+      // deleting the hydrate dot in normalization would glue digits: CuSO45H2O
+      [`hydrate dot survives normalization`, {}, `CuSO4·5H2O`, `CuH10O9S`],
+    ])(`exact mode: %s`, (_name, props, input, expected) => {
       const onchange = vi.fn()
       mount_filter({ value: ``, onchange, ...props })
       submit_input(input)

--- a/tests/vitest/composition/FormulaFilter.svelte.test.ts
+++ b/tests/vitest/composition/FormulaFilter.svelte.test.ts
@@ -1040,6 +1040,24 @@ describe(`FormulaFilter`, () => {
       expect(doc_query(`.formula-filter`).classList.contains(`invalid`)).toBe(true)
     })
 
+    test.each([`Ca(OH2`, `Fe(`, `Mg()O2`])(
+      `unbalanced parentheses %s neither hang nor escape input handling`,
+      (raw_input) => {
+        const on_validation = vi.fn()
+        mount_filter({ value: ``, on_validation })
+        submit_input(raw_input)
+        expect(on_validation.mock.lastCall?.[0].state).toBe(`invalid`)
+        expect(on_validation.mock.lastCall?.[0].message).toContain(`parentheses`)
+      },
+    )
+
+    test(`hydrate dot survives unicode normalization (deleting it would glue digits)`, () => {
+      const onchange = vi.fn()
+      mount_filter({ value: ``, onchange })
+      submit_input(`CuSO4·5H2O`)
+      expect(onchange).toHaveBeenLastCalledWith(`CuH10O9S`, `exact`)
+    })
+
     test(`invalid non-exact tokens are not silently dropped on submit`, () => {
       const onchange = vi.fn()
       const on_validation = vi.fn()

--- a/tests/vitest/composition/format.test.ts
+++ b/tests/vitest/composition/format.test.ts
@@ -46,6 +46,9 @@ describe(`get_alphabetical_formula`, () => {
     [{ Fe: 0.001, O: 0.002 }, false, ` `, `.3~g`, `Fe<sub>0.001</sub> O<sub>0.002</sub>`],
     [`Fe2.5O3.75`, false, ` `, `.1f`, `Fe<sub>2.5</sub> O<sub>3.8</sub>`],
     [`Fe2.5O3.75`, false, ` `, `.2f`, `Fe<sub>2.50</sub> O<sub>3.75</sub>`],
+    // default SI format must not render sub-1 amounts with SI prefixes (0.5 -> 500m)
+    [`Li0.5FeO2`, true, ``, undefined, `FeLi0.5O2`],
+    [{ Li: 0.001, Fe: 1, O: 2 }, true, ``, `.3~s`, `FeLi0.001O2`],
     // Invalid inputs return empty string
     [`invalid`, undefined, undefined, undefined, ``],
     [`123`, undefined, undefined, undefined, ``],

--- a/tests/vitest/composition/parse.test.ts
+++ b/tests/vitest/composition/parse.test.ts
@@ -81,6 +81,12 @@ describe(`parse_formula`, () => {
     [`Ca(OH)0.5`, { Ca: 1, O: 0.5, H: 0.5 }, `decimal parentheses multiplier`],
     [`(H.0000001)2`, { H: 0.0000002 }, `small decimal parentheses multiplier`],
     [`(H0.1)3`, { H: 0.3 }, `rounds expanded decimal products`],
+    [`CuSO4·5H2O`, { Cu: 1, S: 1, O: 9, H: 10 }, `hydrate dot notation`],
+    [`CuSO4⋅5H2O`, { Cu: 1, S: 1, O: 9, H: 10 }, `hydrate unicode dot operator`],
+    [`MgSO4*7H2O`, { Mg: 1, S: 1, O: 11, H: 14 }, `hydrate asterisk notation`],
+    [`Ca(OH)2·2H2O`, { Ca: 1, O: 4, H: 6 }, `hydrate with parentheses`],
+    [`CaCl2·H2O`, { Ca: 1, Cl: 2, H: 2, O: 1 }, `hydrate without coefficient`],
+    [`CaSO4·0.5H2O`, { Ca: 1, S: 1, O: 4.5, H: 1 }, `hydrate decimal coefficient`],
     [``, {}, `empty formula`],
   ])(`%s -> %j (%s)`, (formula, expected, _description) => {
     expect(parse_formula(formula)).toEqual(expected)
@@ -89,6 +95,9 @@ describe(`parse_formula`, () => {
   test.each([
     [`Xx2`, `Invalid element symbol: Xx`],
     [`ABC`, `Invalid element symbol: A`],
+    [`Ca(OH2`, `parentheses`],
+    [`)(`, `parentheses`],
+    [`Mg()O2`, `parentheses`],
   ])(`throws for invalid formula %s`, (formula, error) => {
     expect(() => parse_formula(formula)).toThrow(error)
   })

--- a/tests/vitest/composition/parse.test.ts
+++ b/tests/vitest/composition/parse.test.ts
@@ -87,6 +87,7 @@ describe(`parse_formula`, () => {
     [`Ca(OH)2·2H2O`, { Ca: 1, O: 4, H: 6 }, `hydrate with parentheses`],
     [`CaCl2·H2O`, { Ca: 1, Cl: 2, H: 2, O: 1 }, `hydrate without coefficient`],
     [`CaSO4·0.5H2O`, { Ca: 1, S: 1, O: 4.5, H: 1 }, `hydrate decimal coefficient`],
+    [`CuSO4·.5H2O`, { Cu: 1, S: 1, O: 4.5, H: 1 }, `hydrate leading-dot coefficient`],
     [``, {}, `empty formula`],
   ])(`%s -> %j (%s)`, (formula, expected, _description) => {
     expect(parse_formula(formula)).toEqual(expected)

--- a/tests/vitest/convex-hull/ConvexHullSelection.test.ts
+++ b/tests/vitest/convex-hull/ConvexHullSelection.test.ts
@@ -2,6 +2,20 @@ import { flushSync, mount, tick } from 'svelte'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import ConvexHullSelectionHarness from './ConvexHullSelectionHarness.svelte'
 
+// Force the canvas hit-test to resolve to a real plot entry so hovering can be
+// exercised deterministically in jsdom (synthetic events can't land on points).
+vi.mock(`$lib/convex-hull/helpers`, async (import_actual) => {
+  const actual = await import_actual()
+  return {
+    ...(actual as Record<string, unknown>),
+    find_hull_entry_at_mouse: (
+      _canvas: unknown,
+      _event: unknown,
+      entries: readonly unknown[],
+    ) => entries?.[0] ?? null,
+  }
+})
+
 class MockPath2D {
   arc(): void {}
 }
@@ -62,6 +76,31 @@ describe(`convex hull replacement state`, () => {
       await tick()
 
       expect(selected_text()).toBe(replaced)
+    },
+  )
+
+  // Regression: hovering a point stored hover_data in a deeply-proxied $state, so
+  // current_entry() returned the raw plot entry while hover_data.entry was its proxy.
+  // The identity comparison was always unequal -> reassign -> effect_update_depth_exceeded.
+  test.each([`3d`, `4d`] as const)(
+    `hovering a point does not trigger an infinite effect loop (%s)`,
+    async (dim) => {
+      mount(ConvexHullSelectionHarness, { target: document.body, props: { dim } })
+      flushSync()
+      await tick()
+
+      const canvas = document.querySelector(`canvas`)
+      expect(canvas instanceof HTMLCanvasElement).toBe(true)
+
+      // Dispatching a mousemove sets hover_data via the (mocked) hit-test; flushSync
+      // would throw effect_update_depth_exceeded if the proxy-identity loop regressed.
+      canvas?.dispatchEvent(
+        new MouseEvent(`mousemove`, { bubbles: true, clientX: 100, clientY: 100 }),
+      )
+      expect(() => flushSync()).not.toThrow()
+      await tick()
+
+      expect(document.querySelector(`[data-has-hover="true"]`)).not.toBeNull()
     },
   )
 })

--- a/tests/vitest/convex-hull/gas-thermodynamics.test.ts
+++ b/tests/vitest/convex-hull/gas-thermodynamics.test.ts
@@ -3,6 +3,7 @@ import {
   apply_gas_corrections,
   compute_element_chemical_potential,
   compute_gas_chemical_potential,
+  compute_gas_correction,
   create_default_gas_provider,
   DEFAULT_ELEMENT_TO_GAS,
   format_chemical_potential,
@@ -319,6 +320,20 @@ describe(`gas-thermodynamics: apply_gas_corrections`, () => {
 
     expect(result).toHaveLength(1)
     expect(result[0].energy).toBe(-5) // Compound unchanged
+  })
+
+  test(`per-atom correction scales total energy by atom count for O2-style refs`, () => {
+    // {O: 2} entry: 2 atoms, energy_per_atom = energy / 2
+    const entry: PhaseData = { composition: { O: 2 }, energy: -9.86, energy_per_atom: -4.93 }
+    const config: GasThermodynamicsConfig = { enabled_gases: [`O2`], pressures: { O2: 1.0 } }
+    const pressures = get_effective_pressures(config)
+    const correction = compute_gas_correction(entry, config, 1000, pressures)
+    expect(correction).toBeCloseTo(-1.2623, 4) // -T*S(O2, 1000K) per atom at P_REF
+
+    const [result] = apply_gas_corrections([entry], config, 1000)
+    // correction is PER-ATOM: energy_per_atom shifts by it, total energy by 2x
+    expect(result.energy_per_atom).toBeCloseTo(-4.93 + correction, 10)
+    expect(result.energy).toBeCloseTo((-4.93 + correction) * 2, 10)
   })
 
   test(`correction to O reference changes with pressure`, () => {

--- a/tests/vitest/convex-hull/pymatgen-validation.test.ts
+++ b/tests/vitest/convex-hull/pymatgen-validation.test.ts
@@ -1,16 +1,8 @@
 // Cross-validation test comparing our N-dimensional convex hull implementation
 // against pymatgen's PhaseDiagram for a 5-element (quinary) system.
 //
-// NOTE: The N-dimensional quickhull algorithm works correctly for well-separated
-// point configurations (as demonstrated in thermodynamics.test.ts). However, when
-// all interior points cluster near the center of the simplex (as in realistic
-// phase diagrams where stable compounds are near equimolar compositions), the
-// algorithm may fall back to a degenerate hull. This is a known numerical limitation.
-//
-// For production use with complex datasets, consider:
-// 1. Using pymatgen directly for phase diagram calculations
-// 2. Restricting to 4-element (quaternary) systems where the specialized 4D hull works
-// 3. Pre-filtering data to ensure well-separated point distributions
+// Hull points use reduced barycentric coords ((N-1) spatial + 1 energy): full barycentric
+// coords sum to 1 and would confine all points to an affine subspace (degenerate hull).
 
 import { calculate_e_above_hull } from '$lib/convex-hull/thermodynamics'
 import type { PhaseData } from '$lib/convex-hull/types'
@@ -54,6 +46,13 @@ describe(`Pymatgen cross-validation for quinary (5-element) system`, () => {
     expect(reference.entries).toHaveLength(12)
     expect(reference.n_stable).toBe(6)
     expect(reference.n_unstable).toBe(6)
+  })
+
+  // Direct comparison of e_above_hull against pymatgen's PhaseDiagram values
+  test.each(reference.entries)(`e_above_hull matches pymatgen for $id`, (entry) => {
+    const results = calculate_e_above_hull(all_entries, all_entries)
+    expect(results[entry.id]).toBeCloseTo(entry.e_above_hull, 3)
+    expect(results[entry.id] < 1e-6).toBe(entry.is_stable)
   })
 
   // Elemental references should always have e_above_hull = 0

--- a/tests/vitest/convex-hull/pymatgen-validation.test.ts
+++ b/tests/vitest/convex-hull/pymatgen-validation.test.ts
@@ -40,56 +40,41 @@ function to_phase_data(entry: PymatgenEntry): PhaseData {
 
 describe(`Pymatgen cross-validation for quinary (5-element) system`, () => {
   const all_entries = reference.entries.map(to_phase_data)
+  const results = calculate_e_above_hull(all_entries, all_entries)
 
   test(`reference data has expected structure`, () => {
     expect(reference.elements).toEqual([`Li`, `Na`, `K`, `Rb`, `Cs`])
     expect(reference.entries).toHaveLength(12)
     expect(reference.n_stable).toBe(6)
     expect(reference.n_unstable).toBe(6)
+    // Every element must have an elemental reference entry in the fixture
+    const unary_elements = reference.entries
+      .filter((entry) => Object.keys(entry.composition).length === 1)
+      .flatMap((entry) => Object.keys(entry.composition))
+    expect(unary_elements.toSorted()).toEqual(reference.elements.toSorted())
   })
 
   // Direct comparison of e_above_hull against pymatgen's PhaseDiagram values
   test.each(reference.entries)(`e_above_hull matches pymatgen for $id`, (entry) => {
-    const results = calculate_e_above_hull(all_entries, all_entries)
     expect(results[entry.id]).toBeCloseTo(entry.e_above_hull, 3)
     expect(results[entry.id] < 1e-6).toBe(entry.is_stable)
-  })
-
-  // Elemental references should always have e_above_hull = 0
-  test.each(reference.elements)(`elemental %s has e_above_hull = 0`, (element) => {
-    const entry = reference.entries.find(
-      (reference_entry) =>
-        Object.keys(reference_entry.composition).length === 1 &&
-        element in reference_entry.composition,
-    )
-    if (!entry) throw new Error(`${element} not found`)
-    expect(calculate_e_above_hull(to_phase_data(entry), all_entries)).toBeCloseTo(0, 10)
-  })
-
-  test(`single entry mode matches batch mode`, () => {
-    const batch_results = calculate_e_above_hull(all_entries, all_entries)
-    for (const entry of reference.entries) {
-      const single_result = calculate_e_above_hull(to_phase_data(entry), all_entries)
-      expect(single_result).toBeCloseTo(batch_results[entry.id], 10)
+    expect(results[entry.id]).toBeGreaterThanOrEqual(0) // valid: non-NaN, non-negative
+    // Elemental references sit exactly on the hull
+    if (Object.keys(entry.composition).length === 1) {
+      expect(results[entry.id]).toBeCloseTo(0, 10)
     }
   })
 
-  // All results should be valid (non-NaN, non-negative)
-  test(`returns valid results for all entries`, () => {
-    const results = calculate_e_above_hull(all_entries, all_entries)
-
+  test(`single entry mode matches batch mode`, () => {
     for (const entry of reference.entries) {
-      const result = results[entry.id]
-      expect(Number.isNaN(result)).toBe(false)
-      expect(result).toBeGreaterThanOrEqual(0)
+      const single_result = calculate_e_above_hull(to_phase_data(entry), all_entries)
+      expect(single_result).toBeCloseTo(results[entry.id], 10)
     }
   })
 
   // Test that results are monotonic in energy for same-composition entries
   // (entries with higher energy should have higher or equal e_above_hull)
   test(`e_above_hull is monotonic in energy for same composition`, () => {
-    const results = calculate_e_above_hull(all_entries, all_entries)
-
     // Group entries by composition key
     const by_composition = new Map<string, PymatgenEntry[]>()
     for (const entry of reference.entries) {

--- a/tests/vitest/convex-hull/thermodynamics.test.ts
+++ b/tests/vitest/convex-hull/thermodynamics.test.ts
@@ -361,6 +361,27 @@ describe(`calculate_e_above_hull`, () => {
     ).toBeGreaterThanOrEqual(0)
   })
 
+  // exclude_from_hull guard exists in all arity branches (ternary, quaternary, N-D);
+  // each must skip the excluded entry when building the hull
+  test.each([
+    { arity: 3, els: [`Li`, `Fe`, `O`] },
+    { arity: 4, els: [`Li`, `Fe`, `P`, `O`] },
+    { arity: 5, els: [`Li`, `Na`, `K`, `Rb`, `Cs`] },
+  ])(`arity-$arity exclude_from_hull entry doesn't shape the hull`, ({ els }) => {
+    const comp = Object.fromEntries(els.map((el) => [el, 1])) as Partial<
+      Record<ElementSymbol, number>
+    >
+    const refs = [
+      ...els.map((el) => make_quinary_elem(el, 0)),
+      // Very stable compound, but excluded → must not lower the hull
+      make_phase(comp, -2.0, { entry_id: `excluded`, exclude_from_hull: true }),
+    ]
+    // Same-composition query below the elemental tie-plane → clamped to 0. If the
+    // excluded compound wrongly shaped the hull, this would be ~1.0.
+    const query = make_phase(comp, -1.0, { entry_id: `query` })
+    expect(calculate_e_above_hull(query, refs)).toBeCloseTo(0, 10)
+  })
+
   test(`throws for empty refs`, () => {
     expect(() => calculate_e_above_hull(make_phase({ Fe: 1 }, -4.0), [])).toThrow(
       /cannot be empty/,
@@ -394,6 +415,34 @@ describe(`calculate_e_above_hull`, () => {
       calculate_e_above_hull(make_phase({ Li: 1 }, -1.5, { entry_id: `Li-unstable` }), refs),
     ).toBeCloseTo(0.4, 5)
   })
+
+  test(`quinary: compound phase below tie-plane shapes the hull (non-degenerate)`, () => {
+    // Stable equimolar compound at e_form = -1.0 eV/atom (elements at -1.0 eV/atom each)
+    const equimolar = { Li: 1, Na: 1, K: 1, Rb: 1, Cs: 1 }
+    const refs = [
+      ...Object.keys(equimolar).map((el) => make_quinary_elem(el)),
+      make_phase(equimolar, -2.0, { entry_id: `stable-quinary` }),
+    ]
+    // Query at same composition with e_form = -0.5 eV/atom sits 0.5 eV/atom above the
+    // stable compound. A degenerate hull would wrongly report 0 (elemental tie-plane).
+    const query = make_phase(equimolar, -1.5, { entry_id: `above-hull` })
+    expect(calculate_e_above_hull(query, refs)).toBeCloseTo(0.5, 5)
+  })
+
+  test.each([
+    { arity: 3, comp: { Li: 1, Fe: 1, O: 1 } },
+    { arity: 4, comp: { Li: 1, Fe: 1, P: 1, O: 1 } },
+  ])(
+    `arity-$arity falls back to elemental tie-plane when all refs have e_form = 0`,
+    ({ comp }) => {
+      // All refs coplanar at e_form = 0 → no hull facets; tie-plane fallback must apply
+      const refs = Object.keys(comp).map((el) => make_quinary_elem(el, 0))
+      const above = make_phase(comp, 0.5, { entry_id: `above-tie-plane` })
+      expect(calculate_e_above_hull(above, refs)).toBeCloseTo(0.5, 10)
+      const below = make_phase(comp, -0.2, { entry_id: `below-tie-plane` })
+      expect(calculate_e_above_hull(below, refs)).toBeCloseTo(0, 10)
+    },
+  )
 
   test(`quinary: interior point above hull has positive distance`, () => {
     const refs = [`Li`, `Na`, `K`, `Rb`, `Cs`].map((el) => make_quinary_elem(el))
@@ -608,6 +657,23 @@ describe(`process_hull_for_stats`, () => {
     // Fe is unary → is_element
     const fe_entry = all.find((entry) => Object.keys(entry.composition).length === 1)
     expect(fe_entry?.is_element).toBe(true)
+  })
+
+  test(`exclude_from_hull entries don't shape the hull but are still scored`, () => {
+    const entries: PhaseData[] = [
+      make_phase({ Li: 1 }, 0, { entry_id: `Li` }),
+      make_phase({ Fe: 1 }, 0, { entry_id: `Fe` }),
+      make_phase({ Li: 1, Fe: 1 }, -0.5, { entry_id: `LiFe`, exclude_from_hull: true }),
+      make_phase({ Li: 1, Fe: 2 }, -0.1, { entry_id: `LiFe2` }),
+    ]
+    const result = process_hull_for_stats(entries)
+    const all = [...(result?.stable_entries ?? []), ...(result?.unstable_entries ?? [])]
+    // Excluded LiFe (-0.5 eV/atom) must not shape the hull: LiFe2 (-0.1) sits on the
+    // Li-Fe tie-line (else ~0.233 eV/atom above the Li-LiFe-Fe hull). LiFe itself is
+    // still scored as a query (below hull → clamped to 0) but never counted stable.
+    expect(all.find((entry) => entry.entry_id === `LiFe2`)?.e_above_hull).toBeCloseTo(0, 10)
+    expect(all.find((entry) => entry.entry_id === `LiFe`)?.e_above_hull).toBeCloseTo(0, 10)
+    expect(result?.stable_entries.some((entry) => entry.entry_id === `LiFe`)).toBe(false)
   })
 
   test(`preserves pre-computed e_form_per_atom`, () => {

--- a/tests/vitest/convex-hull/thermodynamics.test.ts
+++ b/tests/vitest/convex-hull/thermodynamics.test.ts
@@ -423,10 +423,12 @@ describe(`calculate_e_above_hull`, () => {
       ...Object.keys(equimolar).map((el) => make_quinary_elem(el)),
       make_phase(equimolar, -2.0, { entry_id: `stable-quinary` }),
     ]
-    // Query at same composition with e_form = -0.5 eV/atom sits 0.5 eV/atom above the
-    // stable compound. A degenerate hull would wrongly report 0 (elemental tie-plane).
+    // Same-composition queries sit (e_form + 1.0) eV/atom above the stable compound.
+    // A degenerate hull would wrongly report max(0, e_form) off the elemental tie-plane.
     const query = make_phase(equimolar, -1.5, { entry_id: `above-hull` })
     expect(calculate_e_above_hull(query, refs)).toBeCloseTo(0.5, 5)
+    const above_tie = make_phase(equimolar, -0.8, { entry_id: `above-tie-plane` })
+    expect(calculate_e_above_hull(above_tie, refs)).toBeCloseTo(1.2, 5)
   })
 
   test.each([
@@ -443,23 +445,6 @@ describe(`calculate_e_above_hull`, () => {
       expect(calculate_e_above_hull(below, refs)).toBeCloseTo(0, 10)
     },
   )
-
-  test(`quinary: interior point above hull has positive distance`, () => {
-    const refs = [`Li`, `Na`, `K`, `Rb`, `Cs`].map((el) => make_quinary_elem(el))
-    refs.push(
-      make_phase(
-        { Li: 1, Na: 1, K: 1, Rb: 1, Cs: 1 } as Partial<Record<ElementSymbol, number>>,
-        -1.5,
-        { entry_id: `stable-interior` },
-      ),
-    )
-    const unstable = make_phase(
-      { Li: 1, Na: 1, K: 1, Rb: 1, Cs: 1 } as Partial<Record<ElementSymbol, number>>,
-      -0.8,
-      { entry_id: `unstable-interior` },
-    )
-    expect(calculate_e_above_hull(unstable, refs)).toBeGreaterThan(0)
-  })
 
   test.each([
     { id: `Li-1`, energy: -1.0, expected: 0 },

--- a/tests/vitest/heatmap-matrix/HeatmapMatrix.test.ts
+++ b/tests/vitest/heatmap-matrix/HeatmapMatrix.test.ts
@@ -202,6 +202,25 @@ describe(`values and colors`, () => {
     expect(cells[0].style.backgroundColor).not.toBe(`rgb(1, 2, 3)`)
   })
 
+  test(`log mode anchors at smallest positive value when data has non-positives`, () => {
+    mount_matrix({
+      x_items: make_items([`A`, `B`, `C`, `D`]),
+      y_items: make_items([`X`]),
+      values: [[-1, 0.01, 1, 100]],
+      log: true,
+      missing_color: `red`,
+      color_scale: (val: number) => `rgb(${Math.round(val * 255)}, 0, 0)`,
+    })
+    const cells = get_data_cells()
+    const red = (idx: number) => Number(/\d+/.exec(cells[idx].style.backgroundColor)?.[0])
+    expect(cells[0].style.backgroundColor).toBe(`red`) // non-positive -> missing color
+    // a Number.MIN_VALUE lower bound squashes all positives into [0.985, 1]; instead
+    // 0.01 must map to the bottom, 100 to the top, 1 to the log midpoint
+    expect(red(1)).toBe(0)
+    expect(Math.abs(red(2) - 127.5)).toBeLessThanOrEqual(1)
+    expect(red(3)).toBe(255)
+  })
+
   test(`log mode safely handles non-positive color range minimum`, () => {
     mount(HeatmapMatrix, {
       target: document.body,

--- a/tests/vitest/heatmap-matrix/HeatmapMatrix.test.ts
+++ b/tests/vitest/heatmap-matrix/HeatmapMatrix.test.ts
@@ -186,18 +186,13 @@ describe(`values and colors`, () => {
   })
 
   test(`color_overrides takes precedence over computed color`, () => {
-    mount(HeatmapMatrix, {
-      target: document.body,
-      props: {
-        x_items: make_items([`A`, `B`]),
-        y_items: make_items([`X`]),
-        values: [[0.2, 0.8]],
-        color_overrides: {
-          [make_color_override_key(`B`, `X`)]: `rgb(1, 2, 3)`,
-        },
-      },
+    mount_matrix({
+      x_items: make_items([`A`, `B`]),
+      y_items: make_items([`X`]),
+      values: [[0.2, 0.8]],
+      color_overrides: { [make_color_override_key(`B`, `X`)]: `rgb(1, 2, 3)` },
     })
-    const cells = document.querySelectorAll<HTMLElement>(`.cell:not(.empty)`)
+    const cells = get_data_cells()
     expect(cells[1].style.backgroundColor).toBe(`rgb(1, 2, 3)`)
     expect(cells[0].style.backgroundColor).not.toBe(`rgb(1, 2, 3)`)
   })
@@ -222,15 +217,12 @@ describe(`values and colors`, () => {
   })
 
   test(`log mode safely handles non-positive color range minimum`, () => {
-    mount(HeatmapMatrix, {
-      target: document.body,
-      props: {
-        x_items: make_items([`A`]),
-        y_items: make_items([`X`]),
-        values: [[1]],
-        log: true,
-        color_scale_range: [-10, 10],
-      },
+    mount_matrix({
+      x_items: make_items([`A`]),
+      y_items: make_items([`X`]),
+      values: [[1]],
+      log: true,
+      color_scale_range: [-10, 10],
     })
     const cell = doc_query(`.cell:not(.empty)`)
     expect(cell.style.backgroundColor).not.toBe(``)

--- a/tests/vitest/io/index.test.ts
+++ b/tests/vitest/io/index.test.ts
@@ -197,15 +197,21 @@ describe(`load_from_url`, () => {
   })
 
   test.each([
-    [`GZIP magic bytes`, [0x1f, 0x8b], `ArrayBuffer`, undefined, undefined],
     [
-      `GZIP magic bytes with callback rejection`,
-      [0x1f, 0x8b],
+      `HDF5 magic bytes with callback rejection`,
+      [0x89, 0x48, 0x44, 0x46],
       `ArrayBuffer`,
       undefined,
       `callback failed`,
     ],
     [`HDF5 magic bytes`, [0x89, 0x48, 0x44, 0x46], `ArrayBuffer`, undefined, undefined],
+    [
+      `ASE Ulm magic bytes`,
+      [0x2d, 0x20, 0x6f, 0x66, 0x20, 0x55, 0x6c, 0x6d],
+      `ArrayBuffer`,
+      undefined,
+      undefined,
+    ],
     [
       `unknown format`,
       [0x12, 0x34, 0x56, 0x78],
@@ -266,6 +272,46 @@ describe(`load_from_url`, () => {
       expect(globalThis.fetch).toHaveBeenCalledTimes(2)
     },
   )
+
+  test(`sniffed gzip without .gz extension is decompressed`, async () => {
+    mock_decompress.mockResolvedValue(`decompressed content`)
+    const header = new Uint8Array([0x1f, 0x8b, ...Array(14).fill(0)])
+    const full_body = new ArrayBuffer(100)
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(create_mock_response(header.buffer, {}))
+      .mockResolvedValueOnce(create_mock_response(full_body, {}))
+
+    let received_content: string | ArrayBuffer | null = null
+    let received_filename: string | null = null
+    await load_from_url(`https://example.com/data.bin`, (content, filename) => {
+      received_content = content
+      received_filename = filename
+    })
+
+    expect(received_content).toBe(`decompressed content`)
+    expect(received_filename).toBe(`data.bin`)
+    expect(mock_decompress).toHaveBeenCalledWith(full_body, `gzip`)
+  })
+
+  test(`blob: object URL with text content passes UUID basename to callback`, async () => {
+    const xyz_content = `3\ncomment\nH 0.0 0.0 0.0\nH 1.0 0.0 0.0\nH 0.0 1.0 0.0`
+    const mock_response = create_mock_response(xyz_content, {})
+    globalThis.fetch = vi.fn().mockResolvedValue(mock_response)
+
+    let received_content: string | ArrayBuffer | null = null
+    let received_filename: string | null = null
+    await load_from_url(
+      `blob:http://localhost:5173/8a3bf2c4-d1e2-4f5a-9b8c-7d6e5f4a3b2c`,
+      (content, filename) => {
+        received_content = content
+        received_filename = filename
+      },
+    )
+
+    expect(received_content).toBe(xyz_content)
+    expect(received_filename).toBe(`8a3bf2c4-d1e2-4f5a-9b8c-7d6e5f4a3b2c`)
+  })
 
   test(`fetch error`, async () => {
     globalThis.fetch = vi.fn().mockRejectedValue(new Error(`Network error`))

--- a/tests/vitest/isosurface/slice.test.ts
+++ b/tests/vitest/isosurface/slice.test.ts
@@ -76,6 +76,17 @@ describe(`trilinear_interpolate`, () => {
     expect(trilinear_interpolate(grid, 0.5, 0, 0, false)).toBeCloseTo(1.5)
   })
 
+  test(`non-periodic grid is exact and continuous at the upper boundary`, () => {
+    const grid = make_grid(4, 4, 4, (ix) => ix)
+    // fx=1 must hit grid[3]=3 (floor-based xd gave grid[nx-2]=2, vs f(0.999)≈2.997)
+    expect(trilinear_interpolate(grid, 1, 0, 0, false)).toBe(3)
+    expect(trilinear_interpolate(grid, 0.999, 0, 0, false)).toBeCloseTo(2.997)
+    const grid_y = make_grid(4, 4, 4, (_ix, iy) => iy)
+    const grid_z = make_grid(4, 4, 4, (_ix, _iy, iz) => iz)
+    expect(trilinear_interpolate(grid_y, 0, 1, 0, false)).toBe(3)
+    expect(trilinear_interpolate(grid_z, 0, 0, 1, false)).toBe(3)
+  })
+
   test(`returns 0 for empty grid`, () => {
     expect(trilinear_interpolate([], 0.5, 0.5, 0.5, true)).toBe(0)
   })

--- a/tests/vitest/labels.test.ts
+++ b/tests/vitest/labels.test.ts
@@ -138,6 +138,9 @@ describe(`parse_si_float function`, () => {
     [`2 µ`, 0.000002], // with space
     [`foo`, `foo`],
     [`123foo`, `123foo`],
+    [`12K`, `12K`], // mismatched-case suffix returned as-is (kilo is lowercase k)
+    [`2g`, `2g`], // giga is uppercase G
+    [`5E`, 5e18], // exa (uppercase E) is a valid SI suffix
     [-12, -12], // int -> int
     [124.847321, 124.847321], // float -> float
     [``, ``], // empty string

--- a/tests/vitest/marching-cubes.test.ts
+++ b/tests/vitest/marching-cubes.test.ts
@@ -108,6 +108,25 @@ describe(`marching_cubes`, () => {
     expect(periodic.faces.length).toBeGreaterThanOrEqual(non_periodic.faces.length)
   })
 
+  test(`periodic boundary-crossing isosurface has no cell-spanning triangles`, () => {
+    // Gaussian at frac (0,0,0) wraps all cell boundaries. Regression: edge cache keys
+    // used wrapped grid coords, merging opposite-face vertices into spanning triangles.
+    const min_frac = (idx: number) => Math.min(idx / 8, 1 - idx / 8)
+    const grid = make_grid(8, 8, 8, (ix, iy, iz) =>
+      Math.exp(-(min_frac(ix) ** 2 + min_frac(iy) ** 2 + min_frac(iz) ** 2) / 0.045),
+    )
+    const opts = { periodic: true, centered: false }
+    const { vertices, faces } = marching_cubes(grid, 0.3, IDENTITY, opts)
+    expect(faces.length).toBeGreaterThan(0)
+    const edge_len = (i1: number, i2: number) =>
+      Math.hypot(...vertices[i1].map((coord, axis) => coord - vertices[i2][axis]))
+    const max_edge = Math.max(
+      ...faces.flatMap(([a, b, c]) => [edge_len(a, b), edge_len(b, c), edge_len(c, a)]),
+    )
+    // No triangle edge should span more than half the unit cell
+    expect(max_edge).toBeLessThan(0.5)
+  })
+
   test(`interpolate=false places vertices at different positions than interpolated`, () => {
     // Quadratic gradient: interpolation won't land at midpoints
     const grid = make_grid(4, 4, 4, (ix) => ix * ix)

--- a/tests/vitest/math.test.ts
+++ b/tests/vitest/math.test.ts
@@ -2770,6 +2770,22 @@ describe(`merge_coplanar_triangles`, () => {
     expect(result).toHaveLength(3 * 9)
   })
 
+  test(`concave coplanar patch preserves total area`, () => {
+    // Concave dart quad on z=0: 2 triangles, total area 1.0.
+    // Regression: re-triangulating the convex hull filled the notch → area 2.0.
+    const input = new Float32Array([
+      0, 0, 0, 2, 0, 0, 0.5, 0.5, 0, 0, 0, 0, 0.5, 0.5, 0, 0, 2, 0,
+    ])
+    const result = math.merge_coplanar_triangles(input)
+    let area = 0
+    for (let idx = 0; idx < result.length; idx += 9) {
+      const [ax, ay, az, bx, by, bz, cx, cy, cz] = result.subarray(idx, idx + 9)
+      const cr = math.cross_3d([bx - ax, by - ay, bz - az], [cx - ax, cy - ay, cz - az])
+      area += 0.5 * Math.hypot(...cr)
+    }
+    expect(area).toBeCloseTo(1.0, 6)
+  })
+
   test(`degenerate zero-area triangle passes through`, () => {
     // All 3 vertices are the same point
     const input = new Float32Array([1, 1, 1, 1, 1, 1, 1, 1, 1])

--- a/tests/vitest/periodic-table/PeriodicTable.test.svelte.ts
+++ b/tests/vitest/periodic-table/PeriodicTable.test.svelte.ts
@@ -632,6 +632,20 @@ describe(`PeriodicTable`, () => {
       expect(tick_text.some((text) => text?.includes(`1`) && text.length > 1)).toBe(true)
     })
 
+    test(`log tile colors use true log mapping matching the log ColorBar`, () => {
+      const color_scale = (val: number) => `rgb(${Math.round(val * 255)}, 0, 0)`
+      mount(PeriodicTable, {
+        target: document.body,
+        props: { heatmap_values: [0.001, 0.01, 0.1], log: true, color_scale },
+      })
+      const tiles = document.querySelectorAll<HTMLElement>(`.element-tile`)
+      const red = (idx: number) => Number(/\d+/.exec(tiles[idx].style.backgroundColor)?.[0])
+      // 0.01 is the log midpoint of [0.001, 0.1] (the old log1p mapping put it at ~0.095)
+      expect(red(0)).toBe(0)
+      expect(Math.abs(red(1) - 127.5)).toBeLessThanOrEqual(1)
+      expect(red(2)).toBe(255)
+    })
+
     test(`customizes via color_bar_props`, () => {
       mount(PeriodicTable, {
         target: document.body,

--- a/tests/vitest/plot/BarPlot.test.ts
+++ b/tests/vitest/plot/BarPlot.test.ts
@@ -222,6 +222,35 @@ describe(`BarPlot`, () => {
     expect(plot.querySelectorAll(`path[role="button"]`)).toHaveLength(6)
   })
 
+  test(`stacked mode keys offsets by x value for misaligned series grids`, async () => {
+    // Regression test: offsets accumulated per array index stacked B's x=4 bar on A's x=3 total
+    const plot = await mount_sized_bar_plot({
+      series: [
+        { x: [1, 2, 3], y: [10, 20, 30] },
+        { x: [2, 3, 4], y: [5, 5, 5] },
+      ],
+      mode: `stacked`,
+      bar: { border_radius: 0 }, // square corners -> parseable `M x,y h w v h` paths
+    })
+    // Parse a series' rect paths into { top, bottom } screen coords
+    const rects = (idx: number) =>
+      Array.from(
+        plot.querySelectorAll(`.bar-series[data-series-idx="${idx}"] path[role="button"]`),
+        (path) => {
+          const [, y_str, h_str] =
+            path.getAttribute(`d`)?.match(/^M[\d.-]+,([\d.-]+)h[\d.-]+v([\d.-]+)/) ?? []
+          return { top: Number(y_str), bottom: Number(y_str) + Number(h_str) }
+        },
+      )
+    const [a_rects, b_rects] = [rects(0), rects(1)]
+    expect([a_rects.length, b_rects.length]).toEqual([3, 3])
+    // B bars at x=2,3 sit on top of A bars at x=2,3 (B bottom == A top)
+    expect(b_rects[0].bottom).toBeCloseTo(a_rects[1].top, 4)
+    expect(b_rects[1].bottom).toBeCloseTo(a_rects[2].top, 4)
+    // B bar at x=4 has no A bar below it -> starts at baseline 0 (same bottom as A bars)
+    expect(b_rects[2].bottom).toBeCloseTo(a_rects[0].bottom, 4)
+  })
+
   test(`event callbacks`, () => {
     const [change_fn, hover_fn, click_fn] = [vi.fn(), vi.fn(), vi.fn()]
     mount(BarPlot, {

--- a/tests/vitest/plot/Histogram.test.ts
+++ b/tests/vitest/plot/Histogram.test.ts
@@ -17,10 +17,12 @@ function mount_histogram(props: Record<string, unknown>) {
   })
 }
 
-function get_y_tick_numbers(): number[] {
-  const nodes = Array.from(document.querySelectorAll(`g.y-axis .tick text`))
+function get_tick_numbers(axis: `x` | `y`): number[] {
+  const nodes = Array.from(document.querySelectorAll(`g.${axis}-axis .tick text`))
   return nodes.map((n) => Number((n.textContent || ``).trim())).filter((v) => !Number.isNaN(v))
 }
+
+const get_y_tick_numbers = (): number[] => get_tick_numbers(`y`)
 
 describe(`Histogram`, () => {
   test.each([
@@ -157,9 +159,10 @@ describe(`Histogram`, () => {
   test(`mounts with x2-axis series and renders x2 axis`, async () => {
     mount_histogram({
       series: [
-        { x: [0, 1, 2], y: [70, 72, 68], label: `Mass (kg)` },
-        { x: [0, 1, 2], y: [154, 158, 150], label: `Mass (lbs)`, x_axis: `x2` },
+        { x: [], y: [70, 72, 68], label: `Mass (kg)` },
+        { x: [], y: [154, 154, 154, 154, 158], label: `Mass (lbs)`, x_axis: `x2` },
       ],
+      bins: 5,
       x2_axis: { label: `Mass (lbs)` },
       mode: `overlay`,
     })
@@ -167,6 +170,12 @@ describe(`Histogram`, () => {
     expect(document.querySelector(`.histogram`)).toBeInstanceOf(HTMLElement)
     expect(document.querySelector(`g.x2-axis`)).toBeInstanceOf(SVGGElement)
     expect(document.querySelector(`.x2-label`)?.textContent).toBe(`Mass (lbs)`)
+    // x1 auto-range must come from x1 series only, excluding x2 magnitudes (~150)
+    const x_ticks = get_tick_numbers(`x`)
+    expect(x_ticks.length).toBeGreaterThan(0)
+    expect(Math.max(...x_ticks)).toBeLessThan(100)
+    // y-range must bin the x2 series over the x2 domain (4 of 5 values share one bin)
+    expect(Math.max(...get_y_tick_numbers())).toBeGreaterThanOrEqual(4)
   })
 
   test(`renders without error when legend prop is null`, async () => {

--- a/tests/vitest/plot/adaptive-density.test.ts
+++ b/tests/vitest/plot/adaptive-density.test.ts
@@ -4,6 +4,7 @@ import {
   density_bin_at_point,
   first_point_in_bin,
   pick_from_index,
+  scale_bin_transform,
   series_extents,
   should_render_points,
   type DensePointSeries,
@@ -173,6 +174,34 @@ describe(`adaptive density utilities`, () => {
 
     expect(picked?.point_id).toBe(`d`)
     expect(accesses).toBe(2)
+  })
+
+  describe(`log-scale binning`, () => {
+    const log_xy = { x: scale_bin_transform(`log`), y: scale_bin_transform(`log`) }
+    const range: [number, number] = [1, 100]
+
+    it(`bins log-scale data in transformed space`, () => {
+      const log_series: DensePointSeries[] = [{ x: [10], y: [10] }]
+      const linear = bin_points(log_series, range, range, 3, 3)
+      const log_binned = bin_points(log_series, range, range, 3, 3, log_xy)
+      // x=10 sits at 9% of the linear span (bin 0) but is the geometric midpoint of [1, 100]
+      expect([...linear.counts].indexOf(1)).toBe(0)
+      expect([...log_binned.counts].indexOf(1)).toBe(1 * 3 + 1) // center bin
+      // linear/undefined scale types fall back to the identity transform
+      expect(scale_bin_transform(`linear`).forward(42)).toBe(42)
+      expect(scale_bin_transform(undefined).inverse(42)).toBe(42)
+    })
+
+    it(`maps density bins back through the inverse transform`, () => {
+      // x=y=20 is strictly inside the upper log-space half of [1, 100] (geometric mid: 10)
+      const density = bin_points([{ x: [20], y: [20] }], range, range, 2, 2, log_xy)
+      const rect = { x: 0, y: 0, width: 100, height: 100 }
+      // pointer in upper-right screen quadrant = data bin ([10, 100], [10, 100])
+      const bin = density_bin_at_point(density, { x: 75, y: 25 }, rect, range, range, log_xy)
+      expect(bin?.count).toBe(1)
+      expect(bin?.x_range.map(Math.round)).toEqual([10, 100])
+      expect(bin?.y_range.map(Math.round)).toEqual([10, 100])
+    })
   })
 
   it(`bins one million finite points below the interaction latency budget`, () => {

--- a/tests/vitest/plot/reference-line.test.ts
+++ b/tests/vitest/plot/reference-line.test.ts
@@ -143,14 +143,20 @@ describe(`resolve_line_endpoints`, () => {
     ])
   })
 
-  test(`negative slope diagonal with x_span normalizes endpoint order`, () => {
-    const result = resolve_line_endpoints(
-      { type: `diagonal`, slope: -1, intercept: 100, x_span: [20, 80] },
-      bounds,
-      scales,
-    )
-    expect(result?.[0]).toBe(scales.x_scale(20))
-    expect(result?.[2]).toBe(scales.x_scale(80))
+  // Endpoints must stay paired: each must satisfy y = slope·x + intercept, spans recompute
+  // the other coordinate instead of clamping one independently
+  test.each([
+    [{ type: `diagonal`, slope: -1, intercept: 100, x_span: [20, 80] }, [20, 80, 80, 20]],
+    [{ type: `diagonal`, slope: -1, intercept: 100 }, [0, 100, 100, 0]],
+    [{ type: `diagonal`, slope: 1, intercept: 0, x_span: [20, 80] }, [20, 20, 80, 80]],
+    [{ type: `diagonal`, slope: 1, intercept: 0, y_span: [30, 70] }, [30, 30, 70, 70]],
+  ] as const)(`%o keeps endpoints paired`, (line, expected) => {
+    const result = resolve_line_endpoints(line as RefLine, bounds, scales)
+    const [x1, y1, x2, y2] = expected
+    expect(result?.[0]).toBeCloseTo(scales.x_scale(x1))
+    expect(result?.[1]).toBeCloseTo(scales.y_scale(y1))
+    expect(result?.[2]).toBeCloseTo(scales.x_scale(x2))
+    expect(result?.[3]).toBeCloseTo(scales.y_scale(y2))
   })
 
   // Liang-Barsky segment clipping: preserves angle by computing true intersections

--- a/tests/vitest/plot/reference-line.test.ts
+++ b/tests/vitest/plot/reference-line.test.ts
@@ -93,70 +93,25 @@ describe(`resolve_line_endpoints`, () => {
     y_scale: (val: number) => 190 - val * 1.8,
   }
 
-  test(`horizontal line returns correct endpoints`, () => {
-    const result = resolve_line_endpoints({ type: `horizontal`, y: 50 }, bounds, scales)
-    expect(result).not.toBeNull()
-    expect(result?.[1]).toBe(result?.[3]) // y1 === y2
-    expect(result?.[0]).toBe(scales.x_scale(0))
-    expect(result?.[2]).toBe(scales.x_scale(100))
-  })
-
-  test(`vertical line returns correct endpoints`, () => {
-    const result = resolve_line_endpoints({ type: `vertical`, x: 50 }, bounds, scales)
-    expect(result).not.toBeNull()
-    expect(result?.[0]).toBe(result?.[2]) // x1 === x2
-  })
-
-  test(`x_span constrains horizontal line`, () => {
-    const result = resolve_line_endpoints(
-      { type: `horizontal`, y: 50, x_span: [20, 80] },
-      bounds,
-      scales,
-    )
-    expect(result).not.toBeNull()
-    expect(result?.[0]).toBe(scales.x_scale(20))
-    expect(result?.[2]).toBe(scales.x_scale(80))
-  })
-
-  test(`y_span constrains vertical line`, () => {
-    const result = resolve_line_endpoints(
-      { type: `vertical`, x: 50, y_span: [10, 90] },
-      bounds,
-      scales,
-    )
-    expect(result).not.toBeNull()
-    expect(result?.[1]).toBe(scales.y_scale(10))
-    expect(result?.[3]).toBe(scales.y_scale(90))
-  })
-
-  test(`diagonal slope=0 within bounds returns endpoints`, () => {
-    const result = resolve_line_endpoints(
-      { type: `diagonal`, slope: 0, intercept: 50 },
-      bounds,
-      scales,
-    )
-    expect(result).toEqual([
-      scales.x_scale(0),
-      scales.y_scale(50),
-      scales.x_scale(100),
-      scales.y_scale(50),
-    ])
-  })
-
-  // Endpoints must stay paired: each must satisfy y = slope·x + intercept, spans recompute
-  // the other coordinate instead of clamping one independently
+  // Expected [x1, y1, x2, y2] in data coords. Diagonal endpoints must stay paired: each
+  // must satisfy y = slope·x + intercept, spans recompute the other coordinate instead of
+  // clamping one independently
   test.each([
+    [{ type: `horizontal`, y: 50 }, [0, 50, 100, 50]],
+    [{ type: `horizontal`, y: 50, x_span: [20, 80] }, [20, 50, 80, 50]],
+    [{ type: `vertical`, x: 50 }, [50, 0, 50, 100]],
+    [{ type: `vertical`, x: 50, y_span: [10, 90] }, [50, 10, 50, 90]],
+    [{ type: `diagonal`, slope: 0, intercept: 50 }, [0, 50, 100, 50]],
     [{ type: `diagonal`, slope: -1, intercept: 100, x_span: [20, 80] }, [20, 80, 80, 20]],
     [{ type: `diagonal`, slope: -1, intercept: 100 }, [0, 100, 100, 0]],
     [{ type: `diagonal`, slope: 1, intercept: 0, x_span: [20, 80] }, [20, 20, 80, 80]],
     [{ type: `diagonal`, slope: 1, intercept: 0, y_span: [30, 70] }, [30, 30, 70, 70]],
-  ] as const)(`%o keeps endpoints paired`, (line, expected) => {
+  ] as const)(`%o resolves expected endpoints`, (line, [x1, y1, x2, y2]) => {
     const result = resolve_line_endpoints(line as RefLine, bounds, scales)
-    const [x1, y1, x2, y2] = expected
-    expect(result?.[0]).toBeCloseTo(scales.x_scale(x1))
-    expect(result?.[1]).toBeCloseTo(scales.y_scale(y1))
-    expect(result?.[2]).toBeCloseTo(scales.x_scale(x2))
-    expect(result?.[3]).toBeCloseTo(scales.y_scale(y2))
+    expect(result?.[0]).toBeCloseTo(scales.x_scale(x1), 8)
+    expect(result?.[1]).toBeCloseTo(scales.y_scale(y1), 8)
+    expect(result?.[2]).toBeCloseTo(scales.x_scale(x2), 8)
+    expect(result?.[3]).toBeCloseTo(scales.y_scale(y2), 8)
   })
 
   // Liang-Barsky segment clipping: preserves angle by computing true intersections

--- a/tests/vitest/plot/scales.test.ts
+++ b/tests/vitest/plot/scales.test.ts
@@ -216,6 +216,16 @@ describe(`scales`, () => {
       const result = generate_log_ticks(-10, 100, 5)
       expect(result.every((t) => t >= math.LOG_EPS)).toBe(true)
     })
+
+    // Sub-decade domains (e.g. after zoom-drag) must not return zero ticks at default count
+    test(`sub-decade domains get in-range mantissa ticks; decades keep powers of 10`, () => {
+      for (const [min, max] of Object.entries({ 2: 8, 3: 7, 0.2: 0.8, 5: 50 })) {
+        const ticks = generate_log_ticks(Number(min), max, 5)
+        expect(ticks.length, `[${min}, ${max}]`).toBeGreaterThanOrEqual(2)
+        expect(ticks.every((tick) => tick >= Number(min) && tick <= max)).toBe(true)
+      }
+      expect(generate_log_ticks(0.1, 1000, 5)).toEqual([0.1, 1, 10, 100, 1000])
+    })
   })
 
   describe(`generate_ticks`, () => {

--- a/tests/vitest/plot/scales.test.ts
+++ b/tests/vitest/plot/scales.test.ts
@@ -219,10 +219,15 @@ describe(`scales`, () => {
 
     // Sub-decade domains (e.g. after zoom-drag) must not return zero ticks at default count
     test(`sub-decade domains get in-range mantissa ticks; decades keep powers of 10`, () => {
-      for (const [min, max] of Object.entries({ 2: 8, 3: 7, 0.2: 0.8, 5: 50 })) {
-        const ticks = generate_log_ticks(Number(min), max, 5)
+      for (const [min, max] of [
+        [2, 8],
+        [3, 7],
+        [0.2, 0.8],
+        [5, 50],
+      ]) {
+        const ticks = generate_log_ticks(min, max, 5)
         expect(ticks.length, `[${min}, ${max}]`).toBeGreaterThanOrEqual(2)
-        expect(ticks.every((tick) => tick >= Number(min) && tick <= max)).toBe(true)
+        expect(ticks.every((tick) => tick >= min && tick <= max)).toBe(true)
       }
       expect(generate_log_ticks(0.1, 1000, 5)).toEqual([0.1, 1, 10, 100, 1000])
     })

--- a/tests/vitest/rdf/calc-rdf.test.ts
+++ b/tests/vitest/rdf/calc-rdf.test.ts
@@ -227,6 +227,59 @@ describe(`calculate_rdf`, () => {
     expect(sum_pbc).toBeGreaterThan(sum_no_pbc)
   })
 
+  // Regression: auto-expansion used to disable PBC on the expanded structure, so atoms near
+  // the supercell boundary lost neighbors while normalization still assumed homogeneous
+  // density, biasing g(r) low (first-shell coordination 5.26 instead of 6)
+  test(`simple cubic keeps PBC after auto-expansion: coordination numbers exact`, () => {
+    const [a_len, cutoff, n_bins] = [4, 15, 150]
+    const structure = create_test_structure(a_len, [`Si`], [[0, 0, 0]])
+    const { r, g_r } = calculate_rdf(structure, { cutoff, n_bins, auto_expand: true })
+
+    // Coordination number n(r_max) = ∫₀^r_max 4πr²ρ·g(r)dr with ρ = 1/a³
+    const coordination = (r_max: number) =>
+      r.reduce(
+        (sum, rad, idx) =>
+          rad < r_max
+            ? sum + (4 * Math.PI * rad ** 2 * g_r[idx] * (cutoff / n_bins)) / a_len ** 3
+            : sum,
+        0,
+      )
+
+    // First shell: 6 neighbors at r = a (second shell sits at a·√2 ≈ 5.66)
+    expect(coordination(1.2 * a_len)).toBeCloseTo(6, 1)
+
+    // Full integral must recover the exact brute-force count of cubic-lattice neighbors
+    const span = Array.from({ length: 9 }, (_, idx) => idx - 4) // |idx| ≤ 4 > cutoff/a_len
+    const exact_count = span
+      .flatMap((ii) => span.flatMap((jj) => span.map((kk) => a_len * Math.hypot(ii, jj, kk))))
+      .filter((dist) => dist > 0 && dist < cutoff).length
+    expect(coordination(Infinity)).toBeCloseTo(exact_count, 0)
+  })
+
+  // Regression: calculate_all_pair_rdfs used to force pbc=[false,false,false], discarding
+  // the caller's pbc (e.g. from RdfPlot) and dropping cross-boundary pairs
+  test(`calculate_all_pair_rdfs preserves caller pbc`, () => {
+    // min-image distance between the sites is 1 Å, reachable only with PBC; without PBC
+    // the nearest pair sits at 9 Å, beyond the cutoff, leaving g(r) all zero
+    const structure = create_test_structure(
+      10,
+      [`Si`, `Si`],
+      [
+        [0.05, 0.05, 0.05],
+        [0.95, 0.05, 0.05],
+      ],
+    )
+    const opts = { cutoff: 8, n_bins: 80, auto_expand: false, pbc: [true, true, true] as Pbc }
+    const [all_pair] = calculate_all_pair_rdfs(structure, opts)
+    const direct = calculate_rdf(structure, {
+      ...opts,
+      center_species: `Si`,
+      neighbor_species: `Si`,
+    })
+    expect(all_pair.r[all_pair.g_r.findIndex((val) => val > 0)]).toBeCloseTo(1, 0)
+    expect(all_pair.g_r).toEqual(direct.g_r)
+  })
+
   test(`RDF calculation should be deterministic`, () => {
     const result1 = calculate_rdf(lu_al_structure, { cutoff: 5, n_bins: 50 })
     const result2 = calculate_rdf(lu_al_structure, { cutoff: 5, n_bins: 50 })

--- a/tests/vitest/rdf/calc-rdf.test.ts
+++ b/tests/vitest/rdf/calc-rdf.test.ts
@@ -15,6 +15,12 @@ if (!lu_al_structure || !pd_structure || !bi2zr2o8_structure) {
   throw new Error(`Required test structures not found in structure_map`)
 }
 
+// Cartesian-site shorthand for create_test_structure
+const make_site = (element: string, xyz: number[]) => ({
+  species: [{ element, occu: 1, oxidation_state: 0 }],
+  xyz,
+})
+
 // Helper to check basic RDF properties that all RDFs should satisfy
 function check_basic_rdf_properties(
   radii: number[],
@@ -44,24 +50,9 @@ describe(`calculate_rdf`, () => {
 
   test.each([
     { sites: [], name: `empty structure`, should_be_zero: true },
+    { sites: [make_site(`Si`, [0, 0, 0])], name: `single atom`, should_be_zero: true },
     {
-      sites: [
-        {
-          species: [{ element: `Si`, occu: 1, oxidation_state: 0 }],
-          xyz: [0, 0, 0],
-        },
-      ],
-      name: `single atom`,
-      should_be_zero: true,
-    },
-    {
-      sites: [
-        { species: [{ element: `Si`, occu: 1, oxidation_state: 0 }], xyz: [0, 0, 0] },
-        {
-          species: [{ element: `Si`, occu: 1, oxidation_state: 0 }],
-          xyz: [4.5, 4.5, 4.5],
-        },
-      ],
+      sites: [make_site(`Si`, [0, 0, 0]), make_site(`Si`, [4.5, 4.5, 4.5])],
       name: `distant atoms (cutoff 0.1)`,
       should_be_zero: true,
       cutoff: 0.1,
@@ -120,10 +111,9 @@ describe(`calculate_rdf`, () => {
     let seed = 12345
     const random = () => ((seed = (seed * 1664525 + 1013904223) % 2 ** 32), seed / 2 ** 32)
 
-    const sites = Array.from({ length: n_atoms }, () => ({
-      species: [{ element: `Si`, occu: 1, oxidation_state: 0 }],
-      xyz: [random() * 30, random() * 30, random() * 30],
-    }))
+    const sites = Array.from({ length: n_atoms }, () =>
+      make_site(`Si`, [random() * 30, random() * 30, random() * 30]),
+    )
 
     const large_structure = create_test_structure(30, sites)
     const result = calculate_rdf(large_structure, { cutoff: 12, n_bins: 75 })
@@ -135,64 +125,20 @@ describe(`calculate_rdf`, () => {
     expect(avg_last).toBeLessThan(1.1)
   })
 
+  const corner_sites = [
+    [0.5, 0.5, 0.5],
+    [9.5, 0.5, 0.5],
+    [0.5, 9.5, 0.5],
+    [9.5, 9.5, 0.5],
+  ].map((xyz) => make_site(`Si`, xyz))
+
   test.each([
-    {
-      pbc: [true, true, true] as Pbc,
-      name: `full PBC`,
-      sites: [
-        {
-          species: [{ element: `Si`, occu: 1, oxidation_state: 0 }],
-          xyz: [0.5, 0.5, 0.5],
-        },
-        {
-          species: [{ element: `Si`, occu: 1, oxidation_state: 0 }],
-          xyz: [9.5, 0.5, 0.5],
-        },
-        {
-          species: [{ element: `Si`, occu: 1, oxidation_state: 0 }],
-          xyz: [0.5, 9.5, 0.5],
-        },
-        {
-          species: [{ element: `Si`, occu: 1, oxidation_state: 0 }],
-          xyz: [9.5, 9.5, 0.5],
-        },
-      ],
-    },
-    {
-      pbc: [false, false, false] as Pbc,
-      name: `no PBC`,
-      sites: [
-        {
-          species: [{ element: `Si`, occu: 1, oxidation_state: 0 }],
-          xyz: [0.5, 0.5, 0.5],
-        },
-        {
-          species: [{ element: `Si`, occu: 1, oxidation_state: 0 }],
-          xyz: [9.5, 0.5, 0.5],
-        },
-        {
-          species: [{ element: `Si`, occu: 1, oxidation_state: 0 }],
-          xyz: [0.5, 9.5, 0.5],
-        },
-        {
-          species: [{ element: `Si`, occu: 1, oxidation_state: 0 }],
-          xyz: [9.5, 9.5, 0.5],
-        },
-      ],
-    },
+    { pbc: [true, true, true] as Pbc, name: `full PBC`, sites: corner_sites },
+    { pbc: [false, false, false] as Pbc, name: `no PBC`, sites: corner_sites },
     {
       pbc: [true, true, false] as Pbc,
       name: `slab PBC (xy only)`,
-      sites: [
-        {
-          species: [{ element: `Si`, occu: 1, oxidation_state: 0 }],
-          xyz: [0.5, 0.5, 5.0],
-        },
-        {
-          species: [{ element: `Si`, occu: 1, oxidation_state: 0 }],
-          xyz: [9.5, 0.5, 5.0],
-        },
-      ],
+      sites: [make_site(`Si`, [0.5, 0.5, 5.0]), make_site(`Si`, [9.5, 0.5, 5.0])],
     },
   ])(`PBC effects: $name`, ({ pbc, sites }) => {
     expect.assertions(5)
@@ -203,24 +149,12 @@ describe(`calculate_rdf`, () => {
   })
 
   test(`different PBC settings should give different neighbor counts`, () => {
-    const sites = [
-      { species: [{ element: `Si`, occu: 1, oxidation_state: 0 }], xyz: [0.5, 0.5, 0.5] },
-      { species: [{ element: `Si`, occu: 1, oxidation_state: 0 }], xyz: [9.5, 0.5, 0.5] },
-    ]
+    const sites = [make_site(`Si`, [0.5, 0.5, 0.5]), make_site(`Si`, [9.5, 0.5, 0.5])]
     const structure = create_test_structure(10, sites)
 
-    const result_pbc = calculate_rdf(structure, {
-      cutoff: 8,
-      n_bins: 100,
-      pbc: [true, true, true],
-      auto_expand: false,
-    })
-    const result_no_pbc = calculate_rdf(structure, {
-      cutoff: 8,
-      n_bins: 100,
-      pbc: [false, false, false],
-      auto_expand: false,
-    })
+    const opts = { cutoff: 8, n_bins: 100, auto_expand: false }
+    const result_pbc = calculate_rdf(structure, { ...opts, pbc: [true, true, true] })
+    const result_no_pbc = calculate_rdf(structure, { ...opts, pbc: [false, false, false] })
 
     const sum_pbc = result_pbc.g_r.reduce((sum, val) => sum + val, 0)
     const sum_no_pbc = result_no_pbc.g_r.reduce((sum, val) => sum + val, 0)
@@ -328,22 +262,10 @@ describe(`calculate_rdf`, () => {
         [0.5, 1.5, 7.0],
       ] satisfies Matrix3x3,
       sites: [
-        {
-          species: [{ element: `Si`, occu: 1, oxidation_state: 0 }],
-          xyz: [0.0, 0.0, 0.0],
-        },
-        {
-          species: [{ element: `Si`, occu: 1, oxidation_state: 0 }],
-          xyz: [2.5, 3.0, 3.5],
-        },
-        {
-          species: [{ element: `O`, occu: 1, oxidation_state: 0 }],
-          xyz: [1.0, 1.0, 1.0],
-        },
-        {
-          species: [{ element: `O`, occu: 1, oxidation_state: 0 }],
-          xyz: [3.0, 4.0, 4.5],
-        },
+        make_site(`Si`, [0.0, 0.0, 0.0]),
+        make_site(`Si`, [2.5, 3.0, 3.5]),
+        make_site(`O`, [1.0, 1.0, 1.0]),
+        make_site(`O`, [3.0, 4.0, 4.5]),
       ],
       cutoff: 10,
       n_bins: 100,
@@ -361,16 +283,7 @@ describe(`calculate_rdf`, () => {
         [0.0, 6.0, 0.0],
         [2.0, 0.0, 7.0],
       ] satisfies Matrix3x3,
-      sites: [
-        {
-          species: [{ element: `Na`, occu: 1, oxidation_state: 0 }],
-          xyz: [0.0, 0.0, 0.0],
-        },
-        {
-          species: [{ element: `Cl`, occu: 1, oxidation_state: 0 }],
-          xyz: [2.5, 3.0, 3.5],
-        },
-      ],
+      sites: [make_site(`Na`, [0.0, 0.0, 0.0]), make_site(`Cl`, [2.5, 3.0, 3.5])],
       cutoff: 8,
       n_bins: 80,
       expected_angles: {

--- a/tests/vitest/rdf/calc-rdf.test.ts
+++ b/tests/vitest/rdf/calc-rdf.test.ts
@@ -210,7 +210,9 @@ describe(`calculate_rdf`, () => {
       center_species: `Si`,
       neighbor_species: `Si`,
     })
-    expect(all_pair.r[all_pair.g_r.findIndex((val) => val > 0)]).toBeCloseTo(1, 0)
+    const first_peak_idx = all_pair.g_r.findIndex((val) => val > 0)
+    expect(first_peak_idx).not.toBe(-1)
+    expect(all_pair.r[first_peak_idx]).toBeCloseTo(1, 0)
     expect(all_pair.g_r).toEqual(direct.g_r)
   })
 

--- a/tests/vitest/settings.test.ts
+++ b/tests/vitest/settings.test.ts
@@ -120,6 +120,12 @@ describe(`Settings`, () => {
       expect(result.scatter.point.size).toBe(DEFAULTS.scatter.point.size)
     })
 
+    test(`merges symmetry overrides while preserving symmetry defaults`, () => {
+      const result = merge({ symmetry: { symprec: 1e-2 } } as Partial<DefaultSettings>)
+      expect(result.symmetry.symprec).toBe(1e-2)
+      expect(result.symmetry.algo).toBe(DEFAULTS.symmetry.algo)
+    })
+
     test(`partial updates don't affect other sections`, () => {
       const result = merge({
         structure: { atom_radius: 2.0 },

--- a/tests/vitest/structure/Structure.test.svelte.ts
+++ b/tests/vitest/structure/Structure.test.svelte.ts
@@ -5,7 +5,7 @@ import { DEFAULTS } from '$lib/settings'
 import type { StructureHandlerData } from '$lib/structure'
 import * as exports from '$lib/structure/export'
 import { structures } from '$site/structures'
-import { mount, tick } from 'svelte'
+import { flushSync, mount, tick } from 'svelte'
 import { describe, expect, test, vi } from 'vitest'
 import {
   assert_hover_scoped_shortcut,
@@ -53,6 +53,25 @@ const create_drop_event = (files: File[]): DragEvent => {
 
 // Tests for Structure component functionality
 describe(`Structure`, () => {
+  // Regression: bond-edit identity tokens (structure_identity) were stored in
+  // deeply-proxied $state, so comparing them against the raw `structure` prop
+  // triggered state_proxy_equality_mismatch on mount. They must use $state.raw.
+  test(`mount does not emit state_proxy_equality_mismatch warning`, async () => {
+    const warns: string[] = []
+    const warn_spy = vi.spyOn(console, `warn`).mockImplementation((...args: unknown[]) => {
+      warns.push(args.map(String).join(` `))
+    })
+    mount(Structure, { target: document.body, props: { structure } })
+    flushSync()
+    await tick()
+    flushSync()
+    warn_spy.mockRestore()
+    const proxy_warns = warns.filter((warn) =>
+      /state_proxy_equality_mismatch|effect_update_depth/i.test(warn),
+    )
+    expect(proxy_warns).toEqual([])
+  })
+
   test(`open control pane when clicking toggle button`, () => {
     mount(Structure, {
       target: document.body,

--- a/tests/vitest/structure/Structure.test.svelte.ts
+++ b/tests/vitest/structure/Structure.test.svelte.ts
@@ -61,11 +61,14 @@ describe(`Structure`, () => {
     const warn_spy = vi.spyOn(console, `warn`).mockImplementation((...args: unknown[]) => {
       warns.push(args.map(String).join(` `))
     })
-    mount(Structure, { target: document.body, props: { structure } })
-    flushSync()
-    await tick()
-    flushSync()
-    warn_spy.mockRestore()
+    try {
+      mount(Structure, { target: document.body, props: { structure } })
+      flushSync()
+      await tick()
+      flushSync()
+    } finally {
+      warn_spy.mockRestore()
+    }
     const proxy_warns = warns.filter((warn) =>
       /state_proxy_equality_mismatch|effect_update_depth/i.test(warn),
     )

--- a/tests/vitest/structure/parse.test.ts
+++ b/tests/vitest/structure/parse.test.ts
@@ -147,6 +147,31 @@ describe(`POSCAR Parser`, () => {
     }
   })
 
+  test.each([
+    // [content, expected_abc, expected_xyz]: Cartesian xyz must be recomputed from wrapped abc
+    [`Test\n1.0\n10 0 0\n0 10 0\n0 0 10\nH\n1\nCartesian\n-1 0 0`, [0.9, 0, 0], [9, 0, 0]],
+    [`Test\n2.0\n5 0 0\n0 5 0\n0 0 5\nH\n1\nCartesian\n6 0 0`, [0.2, 0, 0], [2, 0, 0]],
+  ])(`should keep Cartesian xyz consistent with wrapped abc %#`, (content, abc, xyz) => {
+    const result = parse_poscar(content)
+    assert(result, `Failed to parse POSCAR`)
+    abc.forEach((val, idx) => expect(result.sites[0].abc[idx]).toBeCloseTo(val, TOL))
+    xyz.forEach((val, idx) => expect(result.sites[0].xyz[idx]).toBeCloseTo(val, TOL))
+  })
+
+  // POSCAR header edge cases: blank comment line + 3-component per-axis scaling line
+  const scale3 = `Test\n2 1 3\n1 0 0\n0 1 0\n0 0 1\nH\n1\n`
+  test.each([
+    [`\n1.0\n5 0 0\n0 5 0\n0 0 5\nSi\n1\nDirect\n0 0 0`, `Si`, [5, 5, 5], [0, 0, 0]],
+    [`${scale3}Direct\n0.5 0.5 0.5`, `H`, [2, 1, 3], [1, 0.5, 1.5]],
+    [`${scale3}Cartesian\n0.5 0.5 0.5`, `H`, [2, 1, 3], [1, 0.5, 1.5]],
+  ])(`should parse POSCAR header variant %#`, (content, element, lattice_abc, xyz) => {
+    const result = parse_poscar(content)
+    assert(result, `Failed to parse POSCAR`)
+    expect(result.sites[0].species[0].element).toBe(element)
+    expect([result.lattice?.a, result.lattice?.b, result.lattice?.c]).toEqual(lattice_abc)
+    xyz.forEach((val, idx) => expect(result.sites[0].xyz[idx]).toBeCloseTo(val, TOL))
+  })
+
   it(`keeps singular Cartesian POSCAR fractional coordinates finite`, () => {
     const result = parse_poscar(
       `Test
@@ -714,6 +739,18 @@ O2   O   0.410  0.140  0.880  1.000`
     expect(result.sites).toHaveLength(3)
     expect(result.lattice?.a).toBeCloseTo(4.916, 6)
   })
+
+  // regression: tokens.at(-1) made trailing comments break cell-parameter parsing
+  test.each([`5.4309 # angstrom`, `5.4309(5)`, `5.4309(5) # angstrom`])(
+    `should parse cell parameter line with %s`,
+    (a_value) => {
+      const result = parse_cif(
+        `data_test\n_cell_length_a ${a_value}\n_cell_length_b 4\n_cell_length_c 3\n_cell_angle_alpha 90\n_cell_angle_beta 90\n_cell_angle_gamma 90\nloop_\n_atom_site_label\n_atom_site_fract_x\n_atom_site_fract_y\n_atom_site_fract_z\nSi1 0 0 0`,
+      )
+      assert(result, `Failed to parse CIF with ${a_value}`)
+      expect(result.lattice?.a).toBeCloseTo(5.4309, 4)
+    },
+  )
 
   test(`parses P24Ru4H252C296S24N16.cif (COD 7008984) with correct totals and composition`, () => {
     const result = parse_cif(ru_p_complex_cif)
@@ -2337,6 +2374,29 @@ describe(`OPTIMADE JSON parser`, () => {
     }
   })
 
+  test.each([
+    // [species, species_at_sites, expected_elements]: highest-concentration symbol wins,
+    // 'vacancy' entries are skipped, names without species list parsed as element symbols
+    [[{ name: `Si1`, chemical_symbols: [`Si`] }], [`Si1`, `Si1`], [`Si`, `Si`]],
+    [[{ name: `A`, chemical_symbols: [`Fe`, `Ni`], concentration: [1, 3] }], [`A`], [`Ni`]],
+    [[{ name: `v`, chemical_symbols: [`vacancy`, `O`], concentration: [9, 1] }], [`v`], [`O`]],
+    [undefined, [`Fe`, `O`], [`Fe`, `O`]],
+  ])(`should resolve species_at_sites %#`, (species, species_at_sites, expected) => {
+    const result = parse_optimade_json(
+      JSON.stringify({
+        id: `test-species`,
+        type: `structures`,
+        attributes: {
+          cartesian_site_positions: species_at_sites.map((_, idx) => [idx, 0, 0]),
+          species_at_sites,
+          species, // undefined is dropped by JSON.stringify
+        },
+      }),
+    )
+    assert(result, `Failed to parse OPTIMADE JSON`)
+    expect(result.sites.map((site) => site.species[0].element)).toEqual(expected)
+  })
+
   it.each([
     {
       name: `missing required fields`,
@@ -2699,6 +2759,26 @@ describe(`OPTIMADE to Pymatgen Conversion`, () => {
     } else {
       expect(result.lattice).toBeUndefined()
     }
+  })
+
+  test(`should resolve named species through chemical_symbols`, () => {
+    const result = optimade_to_crystal({
+      id: `test-named-species`,
+      type: `structures`,
+      attributes: {
+        lattice_vectors: [
+          [5, 0, 0],
+          [0, 5, 0],
+          [0, 0, 5],
+        ],
+        cartesian_site_positions: [[0, 0, 0]],
+        species_at_sites: [`Si1`],
+        species: [{ name: `Si1`, chemical_symbols: [`Si`], mass: [28.0855] }],
+      },
+    })
+    assert(result, `Failed to convert OPTIMADE structure`)
+    expect(result.sites[0].species[0].element).toBe(`Si`)
+    expect(result.sites[0].properties.mass).toBe(28.0855)
   })
 
   it.each([

--- a/tests/vitest/structure/parse.test.ts
+++ b/tests/vitest/structure/parse.test.ts
@@ -31,7 +31,7 @@ import tio2_cif from '$site/structures/TiO2.cif?raw'
 import vasp4_format from '$site/structures/vasp4-format.poscar?raw'
 import process from 'node:process'
 import { join } from 'node:path'
-import { assert, afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest'
+import { afterEach, assert, beforeEach, describe, expect, it, test, vi } from 'vitest'
 import { get_dummy_structure, read_maybe_gz } from '../setup'
 
 // Suppress console.error for the entire test file since parse functions
@@ -147,28 +147,29 @@ describe(`POSCAR Parser`, () => {
     }
   })
 
-  test.each([
-    // [content, expected_abc, expected_xyz]: Cartesian xyz must be recomputed from wrapped abc
-    [`Test\n1.0\n10 0 0\n0 10 0\n0 0 10\nH\n1\nCartesian\n-1 0 0`, [0.9, 0, 0], [9, 0, 0]],
-    [`Test\n2.0\n5 0 0\n0 5 0\n0 0 5\nH\n1\nCartesian\n6 0 0`, [0.2, 0, 0], [2, 0, 0]],
-  ])(`should keep Cartesian xyz consistent with wrapped abc %#`, (content, abc, xyz) => {
-    const result = parse_poscar(content)
-    assert(result, `Failed to parse POSCAR`)
-    abc.forEach((val, idx) => expect(result.sites[0].abc[idx]).toBeCloseTo(val, TOL))
-    xyz.forEach((val, idx) => expect(result.sites[0].xyz[idx]).toBeCloseTo(val, TOL))
-  })
-
-  // POSCAR header edge cases: blank comment line + 3-component per-axis scaling line
+  // Edge cases: Cartesian xyz must be recomputed from wrapped abc; a blank first
+  // (comment) line and a 3-component per-axis scale line are valid POSCAR headers
   const scale3 = `Test\n2 1 3\n1 0 0\n0 1 0\n0 0 1\nH\n1\n`
+  const cubic5 = `5 0 0\n0 5 0\n0 0 5`
   test.each([
-    [`\n1.0\n5 0 0\n0 5 0\n0 0 5\nSi\n1\nDirect\n0 0 0`, `Si`, [5, 5, 5], [0, 0, 0]],
-    [`${scale3}Direct\n0.5 0.5 0.5`, `H`, [2, 1, 3], [1, 0.5, 1.5]],
-    [`${scale3}Cartesian\n0.5 0.5 0.5`, `H`, [2, 1, 3], [1, 0.5, 1.5]],
-  ])(`should parse POSCAR header variant %#`, (content, element, lattice_abc, xyz) => {
+    // [content, element, lattice_abc, site_abc, site_xyz]
+    [`Test\n1.0\n${cubic5}\nH\n1\nCartesian\n-1 0 0`, `H`, [5, 5, 5], [0.8, 0, 0], [4, 0, 0]],
+    [
+      `Test\n2.0\n${cubic5}\nH\n1\nCartesian\n6 0 0`,
+      `H`,
+      [10, 10, 10],
+      [0.2, 0, 0],
+      [2, 0, 0],
+    ],
+    [`\n1.0\n${cubic5}\nSi\n1\nDirect\n0 0 0`, `Si`, [5, 5, 5], [0, 0, 0], [0, 0, 0]],
+    [`${scale3}Direct\n0.5 0.5 0.5`, `H`, [2, 1, 3], [0.5, 0.5, 0.5], [1, 0.5, 1.5]],
+    [`${scale3}Cartesian\n0.5 0.5 0.5`, `H`, [2, 1, 3], [0.5, 0.5, 0.5], [1, 0.5, 1.5]],
+  ])(`should handle POSCAR edge case %#`, (content, element, lattice_abc, abc, xyz) => {
     const result = parse_poscar(content)
     assert(result, `Failed to parse POSCAR`)
     expect(result.sites[0].species[0].element).toBe(element)
     expect([result.lattice?.a, result.lattice?.b, result.lattice?.c]).toEqual(lattice_abc)
+    abc.forEach((val, idx) => expect(result.sites[0].abc[idx]).toBeCloseTo(val, TOL))
     xyz.forEach((val, idx) => expect(result.sites[0].xyz[idx]).toBeCloseTo(val, TOL))
   })
 
@@ -402,7 +403,9 @@ describe(`XYZ Parser`, () => {
       const lattice = latt as Matrix3x3
       for (const abc of abcs) {
         const xyz = mat3x3_vec3_multiply(transpose_3x3_matrix(lattice), abc as Vec3)
-        const content = `1\nLattice="${lattice.flat().join(` `)}"\nH ${xyz[0]} ${xyz[1]} ${xyz[2]}\n`
+        const content = `1\nLattice="${lattice.flat().join(` `)}"\nH ${
+          xyz[0]
+        } ${xyz[1]} ${xyz[2]}\n`
         const result = parse_xyz(content)
         assert(result, `Failed to parse parametric lattice`)
         assert(result.lattice, `Missing lattice`)
@@ -479,7 +482,9 @@ describe(`XYZ Parser`, () => {
       transpose_3x3_matrix(lattice as Matrix3x3),
       abc_target as Vec3,
     )
-    const content = `1\nLattice="${lattice.flat().join(` `)}"\nH ${xyz[0]} ${xyz[1]} ${xyz[2]}\n`
+    const content = `1\nLattice="${lattice.flat().join(` `)}"\nH ${xyz[0]} ${
+      xyz[1]
+    } ${xyz[2]}\n`
     const result = parse_xyz(content)
     assert(result, `Failed to parse singular lattice`)
     // Should not crash and abc should be wrapped into [0,1) and finite
@@ -631,7 +636,14 @@ describe(`CIF Parser`, () => {
       name: `quartz (hexagonal)`,
       cif: `data_quartz_alpha\n_chemical_name_mineral                 'Quartz'\n_chemical_formula_sum                  'Si O2'\n_cell_length_a                         4.916\n_cell_length_b                         4.916\n_cell_length_c                         5.405\n_cell_angle_alpha                      90\n_cell_angle_beta                       90\n_cell_angle_gamma                      120\n_space_group_name_H-M_alt              'P 31 2 1'\n_space_group_IT_number                 152\n\nloop_\n_atom_site_label\n_atom_site_type_symbol\n_atom_site_fract_x\n_atom_site_fract_y\n_atom_site_fract_z\n_atom_site_occupancy\nSi1  Si  0.470  0.000  0.000  1.000\nO1   O   0.410  0.270  0.120  1.000\nO2   O   0.410  0.140  0.880  1.000`,
       expected_sites: 3,
-      expected_lattice: { a: 4.916, b: 4.916, c: 5.405, alpha: 90, beta: 90, gamma: 120 },
+      expected_lattice: {
+        a: 4.916,
+        b: 4.916,
+        c: 5.405,
+        alpha: 90,
+        beta: 90,
+        gamma: 120,
+      },
       expected_abc: [
         { element: `Si`, abc: [0.47, 0.0, 0.0] },
         { element: `O`, abc: [0.41, 0.27, 0.12] },
@@ -767,7 +779,14 @@ O2   O   0.410  0.140  0.880  1.000`
       element_counts[element] = (element_counts[element] ?? 0) + 1
     }
 
-    expect(element_counts).toEqual({ C: 296, H: 252, N: 16, P: 24, Ru: 4, S: 24 })
+    expect(element_counts).toEqual({
+      C: 296,
+      H: 252,
+      N: 16,
+      P: 24,
+      Ru: 4,
+      S: 24,
+    })
 
     // Basic lattice sanity
     expect(Number.isFinite(result.lattice?.a as number)).toBe(true)
@@ -1613,9 +1632,7 @@ unit_cell:
     },
     {
       name: `phonopy YAML with phonon_displacements`,
-      content: `${
-        simple_phonopy_yaml
-      }\nphonon_displacements:\n- # This should be ignored for performance\n  - 0.1\n  - 0.2\n  - 0.3`,
+      content: `${simple_phonopy_yaml}\nphonon_displacements:\n- # This should be ignored for performance\n  - 0.1\n  - 0.2\n  - 0.3`,
       expected_result: `structure`,
       expected_sites: 2,
     },
@@ -1915,13 +1932,23 @@ describe(`parse_structure_file`, () => {
   describe(`comprehensive nested structure parsing`, () => {
     test.each([
       [`simple object wrapper`, { data: get_dummy_structure(`Fe`, 1, true) }],
-      [`nested object`, { results: { structure: get_dummy_structure(`Fe`, 1, true) } }],
+      [
+        `nested object`,
+        {
+          results: { structure: get_dummy_structure(`Fe`, 1, true) },
+        },
+      ],
       [`array wrapper`, [{ structure: get_dummy_structure(`Fe`, 1, true) }]],
       [
         `mixed nesting`,
         { data: [{ item: { structure: get_dummy_structure(`Fe`, 1, true) } }] },
       ],
-      [`deep nesting`, { a: { b: { c: { d: get_dummy_structure(`Fe`, 1, true) } } } }],
+      [
+        `deep nesting`,
+        {
+          a: { b: { c: { d: get_dummy_structure(`Fe`, 1, true) } } },
+        },
+      ],
       [`structure array`, { structures: [get_dummy_structure(`Fe`, 1, true)] }],
       [
         `multiple items with structure`,
@@ -1942,9 +1969,22 @@ describe(`parse_structure_file`, () => {
       [`invalid sites`, { sites: `not_an_array` }],
       [`empty sites array`, { sites: [] }],
       [`missing species`, { sites: [{ abc: [0, 0, 0] }] }],
-      [`malformed species`, { sites: [{ species: `not_array`, abc: [0, 0, 0] }] }],
+      [
+        `malformed species`,
+        {
+          sites: [{ species: `not_array`, abc: [0, 0, 0] }],
+        },
+      ],
       [`missing coordinates`, { sites: [{ species: [{ element: `H` }] }] }],
-      [`array of invalid objects`, [{ no_structure: true }, { also_invalid: true }]],
+      [
+        `array of invalid objects`,
+        [
+          { no_structure: true },
+          {
+            also_invalid: true,
+          },
+        ],
+      ],
     ])(`returns null for %s`, (_description, invalid_data) => {
       const content = JSON.stringify(invalid_data)
       const result = parse_structure_file(content, `invalid.json`)
@@ -2015,11 +2055,21 @@ describe(`parse_structure_file`, () => {
       ],
       [
         `nested in object`,
-        { structure: { sites: [{ species: [{ element: `He` }], abc: [0, 0, 0] }] } },
+        {
+          structure: {
+            sites: [{ species: [{ element: `He` }], abc: [0, 0, 0] }],
+          },
+        },
       ],
       [
         `nested in array`,
-        [{ structure: { sites: [{ species: [{ element: `Li` }], abc: [0, 0, 0] }] } }],
+        [
+          {
+            structure: {
+              sites: [{ species: [{ element: `Li` }], abc: [0, 0, 0] }],
+            },
+          },
+        ],
       ],
     ])(`parse_any_structure handles %s correctly`, (description, input) => {
       const content = JSON.stringify(input)
@@ -2068,10 +2118,19 @@ describe(`parse_structure_file`, () => {
 
     test(`finalizes direct JSON properties without sharing mutable data`, () => {
       const direct_structure = parse_poscar(na_cl_cubic)
-      if (direct_structure === null) throw new Error(`invalid fixture structure`)
+      if (direct_structure === null) {
+        throw new Error(`invalid fixture structure`)
+      }
       direct_structure.properties = {
         ...direct_structure.properties,
-        bonds: [{ site_idx_1: 0, site_idx_2: 1, order: 2, cell_shift: [1, 0, 0] }],
+        bonds: [
+          {
+            site_idx_1: 0,
+            site_idx_2: 1,
+            order: 2,
+            cell_shift: [1, 0, 0],
+          },
+        ],
         forces: [1, 2, 3],
         stability: { energy_above_hull: 0 },
       }
@@ -2379,7 +2438,17 @@ describe(`OPTIMADE JSON parser`, () => {
     // 'vacancy' entries are skipped, names without species list parsed as element symbols
     [[{ name: `Si1`, chemical_symbols: [`Si`] }], [`Si1`, `Si1`], [`Si`, `Si`]],
     [[{ name: `A`, chemical_symbols: [`Fe`, `Ni`], concentration: [1, 3] }], [`A`], [`Ni`]],
-    [[{ name: `v`, chemical_symbols: [`vacancy`, `O`], concentration: [9, 1] }], [`v`], [`O`]],
+    [
+      [
+        {
+          name: `v`,
+          chemical_symbols: [`vacancy`, `O`],
+          concentration: [9, 1],
+        },
+      ],
+      [`v`],
+      [`O`],
+    ],
     [undefined, [`Fe`, `O`], [`Fe`, `O`]],
   ])(`should resolve species_at_sites %#`, (species, species_at_sites, expected) => {
     const result = parse_optimade_json(
@@ -2400,7 +2469,11 @@ describe(`OPTIMADE JSON parser`, () => {
   it.each([
     {
       name: `missing required fields`,
-      data: { id: `test-invalid`, type: `structures`, attributes: { elements: [`Fe`] } },
+      data: {
+        id: `test-invalid`,
+        type: `structures`,
+        attributes: { elements: [`Fe`] },
+      },
       expected_error: `OPTIMADE JSON missing required position or species data`,
     },
     {
@@ -2761,26 +2834,6 @@ describe(`OPTIMADE to Pymatgen Conversion`, () => {
     }
   })
 
-  test(`should resolve named species through chemical_symbols`, () => {
-    const result = optimade_to_crystal({
-      id: `test-named-species`,
-      type: `structures`,
-      attributes: {
-        lattice_vectors: [
-          [5, 0, 0],
-          [0, 5, 0],
-          [0, 0, 5],
-        ],
-        cartesian_site_positions: [[0, 0, 0]],
-        species_at_sites: [`Si1`],
-        species: [{ name: `Si1`, chemical_symbols: [`Si`], mass: [28.0855] }],
-      },
-    })
-    assert(result, `Failed to convert OPTIMADE structure`)
-    expect(result.sites[0].species[0].element).toBe(`Si`)
-    expect(result.sites[0].properties.mass).toBe(28.0855)
-  })
-
   it.each([
     {
       name: `missing lattice vectors`,
@@ -2991,14 +3044,16 @@ describe(`OPTIMADE to Pymatgen Conversion`, () => {
     expect(result.properties?.chemical_formula_descriptive).toBe(`SiO2`)
     expect(result.properties?.nelements).toBe(2)
     expect(result.properties?.last_modified).toBe(`2023-03-11`)
-    expect(result.properties?._mp_stability).toEqual({ energy_above_hull: 0.0 })
+    expect(result.properties?._mp_stability).toEqual({
+      energy_above_hull: 0.0,
+    })
     // Verify structural fields are NOT in properties
     expect(result.properties?.lattice_vectors).toBeUndefined()
     expect(result.properties?.cartesian_site_positions).toBeUndefined()
     expect(result.properties?.species_at_sites).toBeUndefined()
   })
 
-  it(`should extract species properties (mass) to site.properties`, () => {
+  it(`should extract species properties (mass) and resolve named species`, () => {
     const optimade_structure = {
       id: `test`,
       type: `structures` as const,
@@ -3012,10 +3067,15 @@ describe(`OPTIMADE to Pymatgen Conversion`, () => {
           [0.0, 0.0, 0.0],
           [2.5, 2.5, 2.5],
         ],
-        species_at_sites: [`Fe`, `O`],
+        species_at_sites: [`Fe`, `O1`],
         species: [
           { name: `Fe`, mass: [55.845], concentration: [1.0] },
-          { name: `O`, mass: [15.999], concentration: [0.5] },
+          {
+            name: `O1`,
+            chemical_symbols: [`O`],
+            mass: [15.999],
+            concentration: [0.5],
+          },
         ],
       },
     }
@@ -3024,6 +3084,8 @@ describe(`OPTIMADE to Pymatgen Conversion`, () => {
 
     expect(result.sites[0].properties.mass).toBe(55.845)
     expect(result.sites[0].properties.concentration).toBeUndefined() // 1.0 is default, not stored
+    // named species 'O1' resolves to element O through chemical_symbols
+    expect(result.sites[1].species[0].element).toBe(`O`)
     expect(result.sites[1].properties.mass).toBe(15.999)
     expect(result.sites[1].properties.concentration).toBe(0.5)
   })
@@ -3241,14 +3303,38 @@ describe(`Coordinate Normalization`, () => {
 
   // Parametrized tests for coordinate wrapping edge cases
   test.each([
-    { abc: [-0.3, -0.7, -0.1], expected: [0.7, 0.3, 0.9], name: `negative coords` },
+    {
+      abc: [-0.3, -0.7, -0.1],
+      expected: [0.7, 0.3, 0.9],
+      name: `negative coords`,
+    },
     { abc: [1.2, 1.5, 1.0], expected: [0.2, 0.5, 0.0], name: `coords >= 1` },
-    { abc: [-0.5, 1.25, 0.75], expected: [0.5, 0.25, 0.75], name: `mixed out-of-range` },
-    { abc: [-2.3, -1.7, -0.9], expected: [0.7, 0.3, 0.1], name: `large negative` },
+    {
+      abc: [-0.5, 1.25, 0.75],
+      expected: [0.5, 0.25, 0.75],
+      name: `mixed out-of-range`,
+    },
+    {
+      abc: [-2.3, -1.7, -0.9],
+      expected: [0.7, 0.3, 0.1],
+      name: `large negative`,
+    },
     { abc: [2.3, 3.7, 1.1], expected: [0.3, 0.7, 0.1], name: `large positive` },
-    { abc: [0.25, 0.5, 0.75], expected: [0.25, 0.5, 0.75], name: `already in range` },
-    { abc: [1.0, 0.0, 0.5], expected: [0.0, 0.0, 0.5], name: `exactly 1.0 → 0` },
-    { abc: [-1.0, 0.5, 0.25], expected: [0.0, 0.5, 0.25], name: `exactly -1.0 → 0` },
+    {
+      abc: [0.25, 0.5, 0.75],
+      expected: [0.25, 0.5, 0.75],
+      name: `already in range`,
+    },
+    {
+      abc: [1.0, 0.0, 0.5],
+      expected: [0.0, 0.0, 0.5],
+      name: `exactly 1.0 → 0`,
+    },
+    {
+      abc: [-1.0, 0.5, 0.25],
+      expected: [0.0, 0.5, 0.25],
+      name: `exactly -1.0 → 0`,
+    },
   ])(`wraps $name: $abc → $expected`, ({ abc, expected }) => {
     const result = parse_any_structure(JSON.stringify(make_raw_structure(abc)), `test.json`)
     expect(result).not.toBeNull()
@@ -3272,7 +3358,9 @@ describe(`Coordinate Normalization`, () => {
     },
     {
       name: `data.materials[].structure format`,
-      wrapper: (struct: object) => ({ data: { materials: [{ structure: struct }] } }),
+      wrapper: (struct: object) => ({
+        data: { materials: [{ structure: struct }] },
+      }),
       abc: [1.5, -0.3, 0.8],
       expected_abc: [0.5, 0.7, 0.8],
       // xyz = [0.5, 0.7, 0.8] * [[5,0,0],[0,5,0],[0,0,5]] = [2.5, 3.5, 4]
@@ -3400,7 +3488,9 @@ describe(`Coordinate Normalization`, () => {
       expect_abc_in_unit_cell(site)
     }
     if (result && `lattice` in result && result.lattice) {
-      for (const site of result.sites) expect_xyz_matches_abc(site, result.lattice.matrix)
+      for (const site of result.sites) {
+        expect_xyz_matches_abc(site, result.lattice.matrix)
+      }
     }
     // Check specific wrapping: [0, -1, 0] → [0, 0, 0], [0, -1, -0.5] → [0, 0, 0.5], [0.5, -0.5, -0.25] → [0.5, 0.5, 0.75]
     expect(result?.sites[0].abc).toEqual([0, 0, 0])

--- a/tests/vitest/structure/parse.test.ts
+++ b/tests/vitest/structure/parse.test.ts
@@ -31,7 +31,7 @@ import tio2_cif from '$site/structures/TiO2.cif?raw'
 import vasp4_format from '$site/structures/vasp4-format.poscar?raw'
 import process from 'node:process'
 import { join } from 'node:path'
-import { afterEach, assert, beforeEach, describe, expect, it, test, vi } from 'vitest'
+import { assert, afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest'
 import { get_dummy_structure, read_maybe_gz } from '../setup'
 
 // Suppress console.error for the entire test file since parse functions
@@ -154,13 +154,7 @@ describe(`POSCAR Parser`, () => {
   test.each([
     // [content, element, lattice_abc, site_abc, site_xyz]
     [`Test\n1.0\n${cubic5}\nH\n1\nCartesian\n-1 0 0`, `H`, [5, 5, 5], [0.8, 0, 0], [4, 0, 0]],
-    [
-      `Test\n2.0\n${cubic5}\nH\n1\nCartesian\n6 0 0`,
-      `H`,
-      [10, 10, 10],
-      [0.2, 0, 0],
-      [2, 0, 0],
-    ],
+    [`Test\n2\n${cubic5}\nH\n1\nCartesian\n6 0 0`, `H`, [10, 10, 10], [0.2, 0, 0], [2, 0, 0]],
     [`\n1.0\n${cubic5}\nSi\n1\nDirect\n0 0 0`, `Si`, [5, 5, 5], [0, 0, 0], [0, 0, 0]],
     [`${scale3}Direct\n0.5 0.5 0.5`, `H`, [2, 1, 3], [0.5, 0.5, 0.5], [1, 0.5, 1.5]],
     [`${scale3}Cartesian\n0.5 0.5 0.5`, `H`, [2, 1, 3], [0.5, 0.5, 0.5], [1, 0.5, 1.5]],
@@ -403,9 +397,7 @@ describe(`XYZ Parser`, () => {
       const lattice = latt as Matrix3x3
       for (const abc of abcs) {
         const xyz = mat3x3_vec3_multiply(transpose_3x3_matrix(lattice), abc as Vec3)
-        const content = `1\nLattice="${lattice.flat().join(` `)}"\nH ${
-          xyz[0]
-        } ${xyz[1]} ${xyz[2]}\n`
+        const content = `1\nLattice="${lattice.flat().join(` `)}"\nH ${xyz[0]} ${xyz[1]} ${xyz[2]}\n`
         const result = parse_xyz(content)
         assert(result, `Failed to parse parametric lattice`)
         assert(result.lattice, `Missing lattice`)
@@ -482,9 +474,7 @@ describe(`XYZ Parser`, () => {
       transpose_3x3_matrix(lattice as Matrix3x3),
       abc_target as Vec3,
     )
-    const content = `1\nLattice="${lattice.flat().join(` `)}"\nH ${xyz[0]} ${
-      xyz[1]
-    } ${xyz[2]}\n`
+    const content = `1\nLattice="${lattice.flat().join(` `)}"\nH ${xyz[0]} ${xyz[1]} ${xyz[2]}\n`
     const result = parse_xyz(content)
     assert(result, `Failed to parse singular lattice`)
     // Should not crash and abc should be wrapped into [0,1) and finite
@@ -636,14 +626,7 @@ describe(`CIF Parser`, () => {
       name: `quartz (hexagonal)`,
       cif: `data_quartz_alpha\n_chemical_name_mineral                 'Quartz'\n_chemical_formula_sum                  'Si O2'\n_cell_length_a                         4.916\n_cell_length_b                         4.916\n_cell_length_c                         5.405\n_cell_angle_alpha                      90\n_cell_angle_beta                       90\n_cell_angle_gamma                      120\n_space_group_name_H-M_alt              'P 31 2 1'\n_space_group_IT_number                 152\n\nloop_\n_atom_site_label\n_atom_site_type_symbol\n_atom_site_fract_x\n_atom_site_fract_y\n_atom_site_fract_z\n_atom_site_occupancy\nSi1  Si  0.470  0.000  0.000  1.000\nO1   O   0.410  0.270  0.120  1.000\nO2   O   0.410  0.140  0.880  1.000`,
       expected_sites: 3,
-      expected_lattice: {
-        a: 4.916,
-        b: 4.916,
-        c: 5.405,
-        alpha: 90,
-        beta: 90,
-        gamma: 120,
-      },
+      expected_lattice: { a: 4.916, b: 4.916, c: 5.405, alpha: 90, beta: 90, gamma: 120 },
       expected_abc: [
         { element: `Si`, abc: [0.47, 0.0, 0.0] },
         { element: `O`, abc: [0.41, 0.27, 0.12] },
@@ -779,14 +762,7 @@ O2   O   0.410  0.140  0.880  1.000`
       element_counts[element] = (element_counts[element] ?? 0) + 1
     }
 
-    expect(element_counts).toEqual({
-      C: 296,
-      H: 252,
-      N: 16,
-      P: 24,
-      Ru: 4,
-      S: 24,
-    })
+    expect(element_counts).toEqual({ C: 296, H: 252, N: 16, P: 24, Ru: 4, S: 24 })
 
     // Basic lattice sanity
     expect(Number.isFinite(result.lattice?.a as number)).toBe(true)
@@ -1632,7 +1608,9 @@ unit_cell:
     },
     {
       name: `phonopy YAML with phonon_displacements`,
-      content: `${simple_phonopy_yaml}\nphonon_displacements:\n- # This should be ignored for performance\n  - 0.1\n  - 0.2\n  - 0.3`,
+      content: `${
+        simple_phonopy_yaml
+      }\nphonon_displacements:\n- # This should be ignored for performance\n  - 0.1\n  - 0.2\n  - 0.3`,
       expected_result: `structure`,
       expected_sites: 2,
     },
@@ -1932,23 +1910,13 @@ describe(`parse_structure_file`, () => {
   describe(`comprehensive nested structure parsing`, () => {
     test.each([
       [`simple object wrapper`, { data: get_dummy_structure(`Fe`, 1, true) }],
-      [
-        `nested object`,
-        {
-          results: { structure: get_dummy_structure(`Fe`, 1, true) },
-        },
-      ],
+      [`nested object`, { results: { structure: get_dummy_structure(`Fe`, 1, true) } }],
       [`array wrapper`, [{ structure: get_dummy_structure(`Fe`, 1, true) }]],
       [
         `mixed nesting`,
         { data: [{ item: { structure: get_dummy_structure(`Fe`, 1, true) } }] },
       ],
-      [
-        `deep nesting`,
-        {
-          a: { b: { c: { d: get_dummy_structure(`Fe`, 1, true) } } },
-        },
-      ],
+      [`deep nesting`, { a: { b: { c: { d: get_dummy_structure(`Fe`, 1, true) } } } }],
       [`structure array`, { structures: [get_dummy_structure(`Fe`, 1, true)] }],
       [
         `multiple items with structure`,
@@ -1969,22 +1937,9 @@ describe(`parse_structure_file`, () => {
       [`invalid sites`, { sites: `not_an_array` }],
       [`empty sites array`, { sites: [] }],
       [`missing species`, { sites: [{ abc: [0, 0, 0] }] }],
-      [
-        `malformed species`,
-        {
-          sites: [{ species: `not_array`, abc: [0, 0, 0] }],
-        },
-      ],
+      [`malformed species`, { sites: [{ species: `not_array`, abc: [0, 0, 0] }] }],
       [`missing coordinates`, { sites: [{ species: [{ element: `H` }] }] }],
-      [
-        `array of invalid objects`,
-        [
-          { no_structure: true },
-          {
-            also_invalid: true,
-          },
-        ],
-      ],
+      [`array of invalid objects`, [{ no_structure: true }, { also_invalid: true }]],
     ])(`returns null for %s`, (_description, invalid_data) => {
       const content = JSON.stringify(invalid_data)
       const result = parse_structure_file(content, `invalid.json`)
@@ -2055,21 +2010,11 @@ describe(`parse_structure_file`, () => {
       ],
       [
         `nested in object`,
-        {
-          structure: {
-            sites: [{ species: [{ element: `He` }], abc: [0, 0, 0] }],
-          },
-        },
+        { structure: { sites: [{ species: [{ element: `He` }], abc: [0, 0, 0] }] } },
       ],
       [
         `nested in array`,
-        [
-          {
-            structure: {
-              sites: [{ species: [{ element: `Li` }], abc: [0, 0, 0] }],
-            },
-          },
-        ],
+        [{ structure: { sites: [{ species: [{ element: `Li` }], abc: [0, 0, 0] }] } }],
       ],
     ])(`parse_any_structure handles %s correctly`, (description, input) => {
       const content = JSON.stringify(input)
@@ -2118,19 +2063,10 @@ describe(`parse_structure_file`, () => {
 
     test(`finalizes direct JSON properties without sharing mutable data`, () => {
       const direct_structure = parse_poscar(na_cl_cubic)
-      if (direct_structure === null) {
-        throw new Error(`invalid fixture structure`)
-      }
+      if (direct_structure === null) throw new Error(`invalid fixture structure`)
       direct_structure.properties = {
         ...direct_structure.properties,
-        bonds: [
-          {
-            site_idx_1: 0,
-            site_idx_2: 1,
-            order: 2,
-            cell_shift: [1, 0, 0],
-          },
-        ],
+        bonds: [{ site_idx_1: 0, site_idx_2: 1, order: 2, cell_shift: [1, 0, 0] }],
         forces: [1, 2, 3],
         stability: { energy_above_hull: 0 },
       }
@@ -2438,17 +2374,7 @@ describe(`OPTIMADE JSON parser`, () => {
     // 'vacancy' entries are skipped, names without species list parsed as element symbols
     [[{ name: `Si1`, chemical_symbols: [`Si`] }], [`Si1`, `Si1`], [`Si`, `Si`]],
     [[{ name: `A`, chemical_symbols: [`Fe`, `Ni`], concentration: [1, 3] }], [`A`], [`Ni`]],
-    [
-      [
-        {
-          name: `v`,
-          chemical_symbols: [`vacancy`, `O`],
-          concentration: [9, 1],
-        },
-      ],
-      [`v`],
-      [`O`],
-    ],
+    [[{ name: `v`, chemical_symbols: [`vacancy`, `O`], concentration: [9, 1] }], [`v`], [`O`]],
     [undefined, [`Fe`, `O`], [`Fe`, `O`]],
   ])(`should resolve species_at_sites %#`, (species, species_at_sites, expected) => {
     const result = parse_optimade_json(
@@ -2469,11 +2395,7 @@ describe(`OPTIMADE JSON parser`, () => {
   it.each([
     {
       name: `missing required fields`,
-      data: {
-        id: `test-invalid`,
-        type: `structures`,
-        attributes: { elements: [`Fe`] },
-      },
+      data: { id: `test-invalid`, type: `structures`, attributes: { elements: [`Fe`] } },
       expected_error: `OPTIMADE JSON missing required position or species data`,
     },
     {
@@ -3044,9 +2966,7 @@ describe(`OPTIMADE to Pymatgen Conversion`, () => {
     expect(result.properties?.chemical_formula_descriptive).toBe(`SiO2`)
     expect(result.properties?.nelements).toBe(2)
     expect(result.properties?.last_modified).toBe(`2023-03-11`)
-    expect(result.properties?._mp_stability).toEqual({
-      energy_above_hull: 0.0,
-    })
+    expect(result.properties?._mp_stability).toEqual({ energy_above_hull: 0.0 })
     // Verify structural fields are NOT in properties
     expect(result.properties?.lattice_vectors).toBeUndefined()
     expect(result.properties?.cartesian_site_positions).toBeUndefined()
@@ -3070,12 +2990,7 @@ describe(`OPTIMADE to Pymatgen Conversion`, () => {
         species_at_sites: [`Fe`, `O1`],
         species: [
           { name: `Fe`, mass: [55.845], concentration: [1.0] },
-          {
-            name: `O1`,
-            chemical_symbols: [`O`],
-            mass: [15.999],
-            concentration: [0.5],
-          },
+          { name: `O1`, chemical_symbols: [`O`], mass: [15.999], concentration: [0.5] },
         ],
       },
     }
@@ -3088,6 +3003,36 @@ describe(`OPTIMADE to Pymatgen Conversion`, () => {
     expect(result.sites[1].species[0].element).toBe(`O`)
     expect(result.sites[1].properties.mass).toBe(15.999)
     expect(result.sites[1].properties.concentration).toBe(0.5)
+  })
+
+  it(`picks mass/concentration for the dominant element, not index 0`, () => {
+    // Disordered site: dominant element (Ni, conc 0.7) is NOT chemical_symbols[0]
+    const optimade_structure = {
+      id: `disordered`,
+      type: `structures` as const,
+      attributes: {
+        lattice_vectors: [
+          [5, 0, 0],
+          [0, 5, 0],
+          [0, 0, 5],
+        ],
+        cartesian_site_positions: [[0, 0, 0]],
+        species_at_sites: [`D`],
+        species: [
+          {
+            name: `D`,
+            chemical_symbols: [`Fe`, `Ni`],
+            mass: [55.845, 58.693],
+            concentration: [0.3, 0.7],
+          },
+        ],
+      },
+    }
+    const result = optimade_to_crystal(optimade_structure)
+    assert(result, `Failed to convert OPTIMADE structure`)
+    expect(result.sites[0].species[0].element).toBe(`Ni`) // highest concentration wins
+    expect(result.sites[0].properties.mass).toBe(58.693) // mass[1], not mass[0]
+    expect(result.sites[0].properties.concentration).toBe(0.7) // concentration[1], not [0]
   })
 })
 
@@ -3303,38 +3248,14 @@ describe(`Coordinate Normalization`, () => {
 
   // Parametrized tests for coordinate wrapping edge cases
   test.each([
-    {
-      abc: [-0.3, -0.7, -0.1],
-      expected: [0.7, 0.3, 0.9],
-      name: `negative coords`,
-    },
+    { abc: [-0.3, -0.7, -0.1], expected: [0.7, 0.3, 0.9], name: `negative coords` },
     { abc: [1.2, 1.5, 1.0], expected: [0.2, 0.5, 0.0], name: `coords >= 1` },
-    {
-      abc: [-0.5, 1.25, 0.75],
-      expected: [0.5, 0.25, 0.75],
-      name: `mixed out-of-range`,
-    },
-    {
-      abc: [-2.3, -1.7, -0.9],
-      expected: [0.7, 0.3, 0.1],
-      name: `large negative`,
-    },
+    { abc: [-0.5, 1.25, 0.75], expected: [0.5, 0.25, 0.75], name: `mixed out-of-range` },
+    { abc: [-2.3, -1.7, -0.9], expected: [0.7, 0.3, 0.1], name: `large negative` },
     { abc: [2.3, 3.7, 1.1], expected: [0.3, 0.7, 0.1], name: `large positive` },
-    {
-      abc: [0.25, 0.5, 0.75],
-      expected: [0.25, 0.5, 0.75],
-      name: `already in range`,
-    },
-    {
-      abc: [1.0, 0.0, 0.5],
-      expected: [0.0, 0.0, 0.5],
-      name: `exactly 1.0 → 0`,
-    },
-    {
-      abc: [-1.0, 0.5, 0.25],
-      expected: [0.0, 0.5, 0.25],
-      name: `exactly -1.0 → 0`,
-    },
+    { abc: [0.25, 0.5, 0.75], expected: [0.25, 0.5, 0.75], name: `already in range` },
+    { abc: [1.0, 0.0, 0.5], expected: [0.0, 0.0, 0.5], name: `exactly 1.0 → 0` },
+    { abc: [-1.0, 0.5, 0.25], expected: [0.0, 0.5, 0.25], name: `exactly -1.0 → 0` },
   ])(`wraps $name: $abc → $expected`, ({ abc, expected }) => {
     const result = parse_any_structure(JSON.stringify(make_raw_structure(abc)), `test.json`)
     expect(result).not.toBeNull()
@@ -3358,9 +3279,7 @@ describe(`Coordinate Normalization`, () => {
     },
     {
       name: `data.materials[].structure format`,
-      wrapper: (struct: object) => ({
-        data: { materials: [{ structure: struct }] },
-      }),
+      wrapper: (struct: object) => ({ data: { materials: [{ structure: struct }] } }),
       abc: [1.5, -0.3, 0.8],
       expected_abc: [0.5, 0.7, 0.8],
       // xyz = [0.5, 0.7, 0.8] * [[5,0,0],[0,5,0],[0,0,5]] = [2.5, 3.5, 4]
@@ -3488,9 +3407,7 @@ describe(`Coordinate Normalization`, () => {
       expect_abc_in_unit_cell(site)
     }
     if (result && `lattice` in result && result.lattice) {
-      for (const site of result.sites) {
-        expect_xyz_matches_abc(site, result.lattice.matrix)
-      }
+      for (const site of result.sites) expect_xyz_matches_abc(site, result.lattice.matrix)
     }
     // Check specific wrapping: [0, -1, 0] → [0, 0, 0], [0, -1, -0.5] → [0, 0, 0.5], [0.5, -0.5, -0.25] → [0.5, 0.5, 0.75]
     expect(result?.sites[0].abc).toEqual([0, 0, 0])

--- a/tests/vitest/symmetry/moyo-integration.test.ts
+++ b/tests/vitest/symmetry/moyo-integration.test.ts
@@ -2,7 +2,12 @@
 // Uses real WASM binary to verify symmetry detection behavior
 // Note: Most symmetry tests use mocks (see index.test.ts, symmetry-utils.test.ts)
 
-import { analyze_structure_symmetry, wyckoff_positions_from_moyo } from '$lib/symmetry'
+import type { Vec3 } from '$lib/math'
+import {
+  analyze_structure_symmetry,
+  apply_symmetry_operations,
+  wyckoff_positions_from_moyo,
+} from '$lib/symmetry'
 import { structure_map } from '$site/structures'
 import { beforeAll, describe, expect, test } from 'vitest'
 import { init_moyo_for_tests } from '../setup'
@@ -55,6 +60,34 @@ describe(`moyo-wasm integration`, () => {
     })
     expect(wyckoff_positions_from_moyo(sym_data)).toHaveLength(expected_count)
   })
+
+  // Regression: moyo-wasm serializes operation.rotation as a flat 9-array in COLUMN-major
+  // order (nalgebra). A row-major read applies Wᵀ instead of W, sending atoms off-site for
+  // hexagonal/trigonal cells where W is not symmetric.
+  test.each([`mp-862690-Ac4-hexagonal`, `mp-1183089-Ac4Mg2-monoclinic`])(
+    `%s: every symmetry op maps each site onto a symmetry-equivalent site`,
+    async (id) => {
+      const structure = get_structure(id)
+      if (!(`lattice` in structure)) throw new Error(`expected periodic structure`)
+      const sym_data = await analyze_structure_symmetry(structure, { symprec: 1e-4 })
+      expect(sym_data.operations.length).toBeGreaterThan(1)
+
+      const frac_dist = (p1: Vec3, p2: Vec3) =>
+        // minimum-image distance in frac coords
+        Math.hypot(...p1.map((c1, idx) => c1 - p2[idx] - Math.round(c1 - p2[idx])))
+
+      for (const site of structure.sites) {
+        for (const image of apply_symmetry_operations(site.abc, sym_data.operations)) {
+          const on_site = structure.sites.some(
+            (other) =>
+              other.species[0]?.element === site.species[0]?.element &&
+              frac_dist(image, other.abc) < 1e-3,
+          )
+          expect(on_site, `${site.species[0]?.element} image ${image} off-site`).toBe(true)
+        }
+      }
+    },
+  )
 
   test(`highly oblique TlBiSe2 cell is handled correctly`, async () => {
     const sym_data = await analyze_structure_symmetry(

--- a/tests/vitest/symmetry/moyo-integration.test.ts
+++ b/tests/vitest/symmetry/moyo-integration.test.ts
@@ -19,6 +19,9 @@ function get_structure(id: string) {
   return structure
 }
 
+const analyze = (id: string, symprec = 1e-4) =>
+  analyze_structure_symmetry(get_structure(id), { symprec })
+
 describe(`moyo-wasm integration`, () => {
   beforeAll(init_moyo_for_tests)
 
@@ -28,10 +31,7 @@ describe(`moyo-wasm integration`, () => {
     [`mp-1183085-Ac4Mg2-orthorhombic`, [`Ac`, `Mg`]],
     [`mp-1183089-Ac4Mg2-monoclinic`, [`Ac`, `Mg`]],
   ])(`%s Wyckoff table includes expected elements`, async (id, expected) => {
-    const sym_data = await analyze_structure_symmetry(get_structure(id), {
-      symprec: 1e-4,
-    })
-    const elements = wyckoff_positions_from_moyo(sym_data).map((pos) => pos.elem)
+    const elements = wyckoff_positions_from_moyo(await analyze(id)).map((pos) => pos.elem)
     expect(elements).toEqual(expect.arrayContaining(expected))
   })
 
@@ -43,9 +43,7 @@ describe(`moyo-wasm integration`, () => {
     [`mp-862690-Ac4-hexagonal`, 194],
     [`mp-1207297-Ac2Br2O1-tetragonal`, 123],
   ])(`%s has space group %i`, async (id, expected_sg) => {
-    const sym_data = await analyze_structure_symmetry(get_structure(id), {
-      symprec: 1e-4,
-    })
+    const sym_data = await analyze(id)
     expect(sym_data.number).toBe(expected_sg)
     expect(sym_data.hm_symbol).toBeDefined()
   })
@@ -55,10 +53,7 @@ describe(`moyo-wasm integration`, () => {
     [`mp-2`, 1],
     [`mp-1234`, 2],
   ])(`%s has %i unique Wyckoff positions`, async (id, expected_count) => {
-    const sym_data = await analyze_structure_symmetry(get_structure(id), {
-      symprec: 1e-4,
-    })
-    expect(wyckoff_positions_from_moyo(sym_data)).toHaveLength(expected_count)
+    expect(wyckoff_positions_from_moyo(await analyze(id))).toHaveLength(expected_count)
   })
 
   // Regression: moyo-wasm serializes operation.rotation as a flat 9-array in COLUMN-major
@@ -68,8 +63,7 @@ describe(`moyo-wasm integration`, () => {
     `%s: every symmetry op maps each site onto a symmetry-equivalent site`,
     async (id) => {
       const structure = get_structure(id)
-      if (!(`lattice` in structure)) throw new Error(`expected periodic structure`)
-      const sym_data = await analyze_structure_symmetry(structure, { symprec: 1e-4 })
+      const sym_data = await analyze(id) // throws if structure is not periodic
       expect(sym_data.operations.length).toBeGreaterThan(1)
 
       const frac_dist = (p1: Vec3, p2: Vec3) =>
@@ -90,10 +84,7 @@ describe(`moyo-wasm integration`, () => {
   )
 
   test(`highly oblique TlBiSe2 cell is handled correctly`, async () => {
-    const sym_data = await analyze_structure_symmetry(
-      get_structure(`TlBiSe2-highly-oblique-cell`),
-      { symprec: 1e-3 },
-    )
+    const sym_data = await analyze(`TlBiSe2-highly-oblique-cell`, 1e-3)
 
     expect(sym_data.number).toBeGreaterThan(0)
     expect(sym_data.std_cell.numbers.length).toBeGreaterThan(0)

--- a/tests/vitest/table/HeatmapTable.test.svelte.ts
+++ b/tests/vitest/table/HeatmapTable.test.svelte.ts
@@ -182,6 +182,22 @@ describe(`HeatmapTable`, () => {
       expect(sorted).toEqual([`10,000`, `1,000`, `50`])
     })
 
+    it(`sorts mixed number/string columns: numbers first, desc reverses`, async () => {
+      const data = [`10`, `abc`, `9`, `def`, `2`, `a1`].map((Mixed) => ({ Mixed }))
+      const columns: Label[] = [{ label: `Mixed`, description: `` }]
+      mount(HeatmapTable, {
+        target: document.body,
+        props: { data, columns, initial_sort: `Mixed` }, // string shorthand defaults to asc
+      })
+      await tick()
+      const get_cells = () =>
+        Array.from(document.querySelectorAll(`td`)).map((cell) => cell.textContent?.trim())
+      expect(get_cells()).toEqual([`2`, `9`, `10`, `a1`, `abc`, `def`])
+      document.querySelector(`th`)?.click() // toggle to descending
+      await tick()
+      expect(get_cells()).toEqual([`def`, `abc`, `a1`, `10`, `9`, `2`])
+    })
+
     it(`respects unsortable columns`, async () => {
       const columns: Label[] = [
         { label: `Name`, sortable: true, description: `` },

--- a/tests/vitest/trajectory/parse.test.ts
+++ b/tests/vitest/trajectory/parse.test.ts
@@ -432,6 +432,20 @@ describe(`VASP XDATCAR Parser`, () => {
       `XDATCAR file too short`,
     )
   })
+
+  it(`should re-read repeated headers in variable-cell (NPT) XDATCAR`, async () => {
+    const frame = (lat_a: number, idx: number) =>
+      `frame\n1.0\n${lat_a} 0 0\n0 ${lat_a} 0\n0 0 ${lat_a}\nH\n1\nDirect configuration= ${idx}\n0.5 0.5 0.5`
+    const trajectory = await parse_trajectory_data(
+      `${frame(10, 1)}\n${frame(20, 2)}`,
+      `XDATCAR`,
+    )
+
+    expect(trajectory.frames).toHaveLength(2)
+    const structure = trajectory.frames[1].structure
+    expect(`lattice` in structure && structure.lattice.a).toBeCloseTo(20)
+    expect(structure.sites[0].xyz).toEqual([10, 10, 10])
+  })
 })
 
 describe(`LAMMPS Trajectory Format`, () => {
@@ -1007,18 +1021,56 @@ describe(`XYZ Trajectory Format`, () => {
     ])
   })
 
-  it(`should handle forces in extended XYZ format`, async () => {
-    const content = `3\nProperties=species:S:1:pos:R:3:forces:R:3\nH 0.0 0.0 0.0 0.1 0.0 0.0\nH 1.0 0.0 0.0 0.0 0.2 0.0\nH 0.0 1.0 0.0 0.0 0.0 0.3\n3\nProperties=species:S:1:pos:R:3:forces:R:3\nH 0.0 0.0 0.0 0.1 0.0 0.0\nH 1.0 0.0 0.0 0.0 0.2 0.0\nH 0.0 1.0 0.0 0.0 0.0 0.3`
-    const trajectory = await parse_trajectory_data(content, `test.extxyz`)
+  it.each<[string, string, number[][]]>([
+    // forces directly after pos, after momenta, and after a scalar column
+    [
+      `species:S:1:pos:R:3:forces:R:3`,
+      `H 0 0 0 0.1 0 0\nH 1 0 0 0 0 0.3`,
+      [
+        [0.1, 0, 0],
+        [0, 0, 0.3],
+      ],
+    ],
+    [
+      `species:S:1:pos:R:3:momenta:R:3:forces:R:3`,
+      `H 0 0 0 9.9 9.9 9.9 0.1 0.2 0.3`,
+      [[0.1, 0.2, 0.3]],
+    ],
+    [
+      `species:S:1:pos:R:3:node_energy:R:1:forces:R:3`,
+      `H 0 0 0 9.9 0.1 0.2 0.3`,
+      [[0.1, 0.2, 0.3]],
+    ],
+  ])(
+    `should read forces at Properties column offset: %s`,
+    async (properties, atom_lines, expected_forces) => {
+      const n_atoms = atom_lines.split(`\n`).length
+      const frame = `${n_atoms}\nProperties=${properties}\n${atom_lines}`
+      const trajectory = await parse_trajectory_data(`${frame}\n${frame}`, `test.extxyz`)
 
-    const metadata = trajectory.frames[0]?.metadata
-    expect(metadata?.forces).toEqual([
-      [0.1, 0.0, 0.0],
-      [0.0, 0.2, 0.0],
-      [0.0, 0.0, 0.3],
-    ])
-    expect(metadata?.force_max).toBe(0.3)
-  })
+      const metadata = trajectory.frames[0]?.metadata
+      expect(metadata?.forces).toEqual(expected_forces)
+      expect(metadata?.force_max).toBeCloseTo(
+        Math.max(...expected_forces.map((vec) => Math.hypot(...vec))),
+      )
+    },
+  )
+
+  it.each<[string, Record<string, number>]>([
+    [`frame=5`, {}], // 'e' of frame must not match energy
+    [`step=100 dt=0.5`, {}], // 'p' of step / 't' of dt must not match pressure/temperature
+    [`E = 2.0`, { energy: 2.0 }],
+    [`Temperature: 300`, { temperature: 300 }],
+  ])(
+    `should anchor comment metadata keys at word boundaries: %s`,
+    async (comment, expected) => {
+      const frame = `1\n${comment}\nH 0.0 0.0 0.0`
+      const trajectory = await parse_trajectory_data(`${frame}\n${frame}`, `test.xyz`)
+
+      const { energy, pressure, temperature } = trajectory.frames[0]?.metadata ?? {}
+      expect({ energy, pressure, temperature }).toEqual(expected)
+    },
+  )
 
   it(`should handle invalid atom counts gracefully`, async () => {
     const content = `invalid\ncomment\nH 0.0 0.0 0.0\n3\nvalid frame\nH 0.0 0.0 0.0\nH 1.0 0.0 0.0\nH 0.0 1.0 0.0`
@@ -1262,6 +1314,65 @@ describe(`Format Detection`, () => {
 
     expect(single_trajectory.metadata?.source_format).toBe(`single_xyz`)
     expect(multi_trajectory.metadata?.source_format).toBe(`xyz_trajectory`)
+  })
+
+  // Filenames from blob: object URLs (URL.createObjectURL) are UUIDs without extension,
+  // so detection must fall back to content sniffing (https://github.com/janosh/matterviz/issues/353)
+  describe(`content-based detection without filename hint`, () => {
+    const single_frame = `3\ncomment\nH 0.0 0.0 0.0\nH 1.0 0.0 0.0\nH 0.0 1.0 0.0`
+    const blob_uuid = `8a3bf2c4-d1e2-4f5a-9b8c-7d6e5f4a3b2c`
+    const lammps_content = `ITEM: TIMESTEP\n0\nITEM: NUMBER OF ATOMS\n2
+ITEM: BOX BOUNDS pp pp pp\n0.0 10.0\n0.0 10.0\n0.0 10.0
+ITEM: ATOMS id type x y z\n1 1 0.0 0.0 0.0\n2 1 5.0 0.0 0.0`
+
+    it.each([undefined, blob_uuid])(
+      `detects multi-frame XYZ content (filename=%s)`,
+      async (filename) => {
+        const multi_frame = `${single_frame}\n${single_frame}`
+        const trajectory = await parse_trajectory_data(multi_frame, filename)
+        expect(trajectory.metadata?.source_format).toBe(`xyz_trajectory`)
+        expect(trajectory.frames).toHaveLength(2)
+      },
+    )
+
+    it.each([undefined, blob_uuid])(
+      `detects single-frame XYZ content (filename=%s)`,
+      async (filename) => {
+        const trajectory = await parse_trajectory_data(single_frame, filename)
+        expect(trajectory.metadata?.source_format).toBe(`single_xyz`)
+        expect(trajectory.frames).toHaveLength(1)
+      },
+    )
+
+    it.each([
+      [`LAMMPS`, lammps_content, `lammps_trajectory`],
+      [`XDATCAR`, read_test_file(`vasp-XDATCAR.MD.gz`), `vasp_xdatcar`],
+    ])(`detects %s content without filename`, async (_label, content, expected) => {
+      const trajectory = await parse_trajectory_data(content, undefined)
+      expect(trajectory.metadata?.source_format).toBe(expected)
+    })
+
+    it.each([
+      [`HDF5`, `flame-gold-cluster-55-atoms.h5`, `hdf5_trajectory`],
+      [`ASE .traj`, `ase-LiMnO2-chgnet-relax.traj`, `ase_trajectory`],
+    ])(`detects %s binary signature without filename`, async (_label, fixture, expected) => {
+      const trajectory = await parse_trajectory_data(read_binary_test_file(fixture))
+      expect(trajectory.metadata?.source_format).toBe(expected)
+    })
+
+    it(`still respects conflicting extensions over content`, async () => {
+      // XYZ content explicitly named .json must not be sniffed as XYZ
+      const multi_frame = `${single_frame}\n${single_frame}`
+      await expect(parse_trajectory_data(multi_frame, `data.json`)).rejects.toThrow(
+        `Unsupported text format`,
+      )
+    })
+
+    it(`still rejects unparsable content without filename`, async () => {
+      await expect(parse_trajectory_data(`not a trajectory`, undefined)).rejects.toThrow(
+        `Unsupported text format`,
+      )
+    })
   })
 
   it(`should detect HDF5 signature correctly`, async () => {

--- a/tests/vitest/trajectory/streaming.test.ts
+++ b/tests/vitest/trajectory/streaming.test.ts
@@ -195,6 +195,21 @@ describe(`Trajectory Streaming`, () => {
       const frame = await loader.load_frame(data, 8)
       expect(frame?.step).toBe(8)
     })
+
+    it(`should parse Lattice and Properties-offset forces in indexed loads`, async () => {
+      const comment = `Lattice="6 0 0 0 6 0 0 0 6" Properties=species:S:1:pos:R:3:momenta:R:3:forces:R:3 energy=-1.5`
+      const frame = `1\n${comment}\nH 0.0 0.0 0.0 9.9 9.9 9.9 0.1 0.2 0.3`
+
+      const loaded = await new TrajFrameReader(`test.xyz`).load_frame(`${frame}\n${frame}`, 1)
+      const structure = loaded?.structure
+      expect(structure && `lattice` in structure && structure.lattice.matrix).toEqual([
+        [6, 0, 0],
+        [0, 6, 0],
+        [0, 0, 6],
+      ])
+      expect(loaded?.metadata?.forces).toEqual([[0.1, 0.2, 0.3]])
+      expect(loaded?.metadata?.energy).toBe(-1.5)
+    })
   })
 
   describe(`Plot Metadata Extraction`, () => {
@@ -209,6 +224,19 @@ describe(`Trajectory Streaming`, () => {
       expect(metadata[1].properties.energy).toBe(-10.3) // frame 3
       expect(metadata[0].properties.volume).toBe(100)
       expect(metadata[1].properties.volume).toBe(103) // frame 3
+    })
+
+    it.each<[string, Record<string, number>]>([
+      [`step=100 dt=0.5`, {}], // 'p' of step must not match pressure
+      [`frame=5`, {}], // 'e' of frame must not match energy
+      [`energy=-1.5 volume=100`, { energy: -1.5, volume: 100 }],
+    ])(`should anchor metadata keys at word boundaries: %s`, async (comment, expected) => {
+      const frame = `1\n${comment}\nH 0.0 0.0 0.0`
+      const loader = new TrajFrameReader(`test.xyz`)
+      const metadata = await loader.extract_plot_metadata(`${frame}\n${frame}`, {
+        sample_rate: 1,
+      })
+      expect(metadata[0].properties).toEqual(expected)
     })
 
     it(`should filter properties when requested`, async () => {

--- a/tests/vitest/trajectory/streaming.test.ts
+++ b/tests/vitest/trajectory/streaming.test.ts
@@ -209,6 +209,7 @@ describe(`Trajectory Streaming`, () => {
       ])
       expect(loaded?.metadata?.forces).toEqual([[0.1, 0.2, 0.3]])
       expect(loaded?.metadata?.energy).toBe(-1.5)
+      expect(loaded?.metadata?.volume).toBe(216) // derived from lattice (6^3), parity with eager parser
     })
   })
 

--- a/tests/vitest/xrd/calc-xrd.test.ts
+++ b/tests/vitest/xrd/calc-xrd.test.ts
@@ -1,7 +1,8 @@
 import type { Matrix3x3, Vec2, Vec3 } from '$lib/math'
+import * as math from '$lib/math'
 import type { Crystal, Pbc } from '$lib/structure'
 import { parse_structure_file } from '$lib/structure/parse'
-import { add_xrd_pattern, compute_xrd_pattern, type XrdPattern } from '$lib/xrd'
+import { add_xrd_pattern, compute_xrd_pattern, WAVELENGTHS, type XrdPattern } from '$lib/xrd'
 import fs from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
@@ -101,6 +102,18 @@ describe(`compute_xrd_pattern parity with pymatgen JSON`, () => {
       const min_match_ratio = 0.95
       expect(matched / top_indices.length).toBeGreaterThanOrEqual(min_match_ratio)
 
+      // The 20 strongest expected peaks must also match in normalized intensity (both
+      // patterns scaled to max=100). Regression for the missing Z − 41.78214·s² prefactor
+      // in the atomic scattering factor, which skewed relative peak heights (38.3 vs 51.0)
+      const top_20 = [...top_indices].sort((i1, i2) => expected.y[i2] - expected.y[i1])
+      for (const idx of top_20.slice(0, 20)) {
+        const diffs = computed.x.map((x_val) => Math.abs(x_val - expected.x[idx]))
+        const nearest = diffs.indexOf(Math.min(...diffs))
+        if (diffs[nearest] > angle_tol) continue // position check covers misses
+        const y_err = Math.abs(computed.y[nearest] - expected.y[idx])
+        expect(y_err, `y at 2θ=${expected.x[idx].toFixed(3)}`).toBeLessThanOrEqual(1)
+      }
+
       // Compare d-spacings if present, over overlapping range only
       if (expected.d_hkls && computed.d_hkls) {
         const top_d_indices = Array.from({ length: expected.y.length }, (_, idx) => idx)
@@ -168,6 +181,40 @@ describe(`compute_xrd_pattern edge cases`, () => {
       scaled_intensity_tol: 0, // include everything after scaling
     })
     expect(many_pass.x.length).toBeGreaterThan(0)
+  })
+
+  // Regression: hkl bounds from reciprocal-row norms (max_radius/|b_i| + 2) miss in-sphere
+  // reflections for skewed cells — this monoclinic cell (γ ≈ 32°) silently dropped 82 of
+  // 2132 reflections in [0°, 180°]. Correct bound uses direct rows: |h_i| ≤ R·|a_i|.
+  test(`skewed monoclinic cell enumerates every in-sphere reflection`, () => {
+    const file_name = `mp-1183089-Ac4Mg2-monoclinic.json`
+    const structure = parse_structure_file(
+      read_maybe_gz(path.join(structures_dir, file_name)),
+      file_name,
+    ) as Crystal
+    const pattern = compute_xrd_pattern(structure, {
+      wavelength: `CuKa`,
+      two_theta_range: [0, 180],
+      scaled_intensity_tol: 0, // keep every peak so multiplicities are complete
+    })
+    const total_multiplicity = (pattern.hkls ?? [])
+      .flat()
+      .reduce((sum, fam) => sum + (fam.multiplicity ?? 0), 0)
+
+    // Brute-force count with generous index bound 25 (exact bound is ≤ 11 for this cell)
+    const recip_cols = math.matrix_inverse_3x3(structure.lattice.matrix) // bᵢ as columns
+    const max_radius = 2 / WAVELENGTHS.CuKa // 2·sin(90°)/λ
+    const span = Array.from({ length: 51 }, (_, idx) => idx - 25)
+    const brute_count = span
+      .flatMap((h_idx) =>
+        span.flatMap((k_idx) =>
+          span.map((l_idx) => Math.hypot(...math.dot(recip_cols, [h_idx, k_idx, l_idx]))),
+        ),
+      )
+      .filter((g_norm) => g_norm > 0 && g_norm <= max_radius).length
+
+    expect(brute_count).toBeGreaterThan(2000) // sanity: full sphere covered
+    expect(total_multiplicity).toBe(brute_count)
   })
 
   test(`enumeration safety cap throws for pathological ranges`, () => {

--- a/tests/vitest/xrd/calc-xrd.test.ts
+++ b/tests/vitest/xrd/calc-xrd.test.ts
@@ -73,40 +73,24 @@ describe(`compute_xrd_pattern parity with pymatgen JSON`, () => {
         two_theta_range: [0, 90],
       })
 
-      // Angle tolerance (degrees)
-      const angle_tol = 5e-3
-      const d_rtol = 1e-6
-      const d_atol = 1e-6
+      const angle_tol = 5e-3 // degrees
+      const has_close = (arr: number[], target: number, tol: number) =>
+        arr.some((val) => Math.abs(val - target) <= tol)
 
-      // Compare peak positions in a set-wise manner: each expected peak should
-      // have a computed counterpart within tolerance (independent of intensity filtering)
-      const has_close = (arr: number[], target: number, tol: number): boolean => {
-        for (let idx = 0; idx < arr.length; idx++) {
-          if (Math.abs(arr[idx] - target) <= tol) return true
-        }
-        return false
-      }
-      // Focus on strongest expected peaks by intensity to avoid discrepancies from
-      // low-intensity filtering differences between implementations
-      const top_n = Math.min(200, expected.x.length)
+      // Compare peak positions set-wise over the strongest expected peaks (by intensity)
+      // to avoid discrepancies from low-intensity filtering differences between implementations
       const top_indices = Array.from({ length: expected.y.length }, (_, idx) => idx)
-        .sort((i, j) => expected.y[j] - expected.y[i])
-        .slice(0, top_n)
-        .sort((a, b) => a - b)
-      let matched = 0
-      for (let ii = 0; ii < top_indices.length; ii++) {
-        const idx = top_indices[ii]
-        const angle = expected.x[idx]
-        if (has_close(computed.x, angle, angle_tol)) matched++
-      }
-      const min_match_ratio = 0.95
-      expect(matched / top_indices.length).toBeGreaterThanOrEqual(min_match_ratio)
+        .sort((i1, i2) => expected.y[i2] - expected.y[i1])
+        .slice(0, Math.min(200, expected.x.length))
+      const matched = top_indices.filter((idx) =>
+        has_close(computed.x, expected.x[idx], angle_tol),
+      ).length
+      expect(matched / top_indices.length).toBeGreaterThanOrEqual(0.95)
 
       // The 20 strongest expected peaks must also match in normalized intensity (both
       // patterns scaled to max=100). Regression for the missing Z − 41.78214·s² prefactor
       // in the atomic scattering factor, which skewed relative peak heights (38.3 vs 51.0)
-      const top_20 = [...top_indices].sort((i1, i2) => expected.y[i2] - expected.y[i1])
-      for (const idx of top_20.slice(0, 20)) {
+      for (const idx of top_indices.slice(0, 20)) {
         const diffs = computed.x.map((x_val) => Math.abs(x_val - expected.x[idx]))
         const nearest = diffs.indexOf(Math.min(...diffs))
         if (diffs[nearest] > angle_tol) continue // position check covers misses
@@ -114,21 +98,14 @@ describe(`compute_xrd_pattern parity with pymatgen JSON`, () => {
         expect(y_err, `y at 2θ=${expected.x[idx].toFixed(3)}`).toBeLessThanOrEqual(1)
       }
 
-      // Compare d-spacings if present, over overlapping range only
-      if (expected.d_hkls && computed.d_hkls) {
-        const top_d_indices = Array.from({ length: expected.y.length }, (_, idx) => idx)
-          .sort((i, j) => expected.y[j] - expected.y[i])
-          .slice(0, Math.min(200, expected.d_hkls.length))
-          .sort((a, b) => a - b)
-        let d_matched = 0
-        for (let ii = 0; ii < top_d_indices.length; ii++) {
-          const idx = top_d_indices[ii]
-          const d_val = expected.d_hkls[idx]
-          const tol = d_atol + d_rtol * Math.abs(d_val)
-          if (has_close(computed.d_hkls, d_val, tol)) d_matched++
-        }
-        const min_d_match_ratio = 0.95
-        expect(d_matched / top_d_indices.length).toBeGreaterThanOrEqual(min_d_match_ratio)
+      // Compare d-spacings if present (fixture consistency test asserts d_hkls aligns with x)
+      const computed_d = computed.d_hkls
+      if (expected.d_hkls && computed_d) {
+        const expected_d = expected.d_hkls
+        const d_matched = top_indices.filter((idx) =>
+          has_close(computed_d, expected_d[idx], 1e-6 + 1e-6 * Math.abs(expected_d[idx])),
+        ).length
+        expect(d_matched / top_indices.length).toBeGreaterThanOrEqual(0.95)
       }
     },
   )


### PR DESCRIPTION
A sweep of independent correctness fixes spanning scientific kernels, file parsers, and plotting/UI. Each fix ships with a regression test that was confirmed to fail on the old code and pass after the fix (red→green), and the four `exclude_from_hull` arity branches and Svelte proxy-equality cases are now covered too.

### Scientific kernels
- **xrd**: add the missing `Z − 41.78214·s²·Σ` prefactor for pymatgen-style scattering params (intensities now match pymatgen fixtures); fix hkl enumeration bounds that silently dropped reflections for skewed cells.
- **thermodynamics**: fix structurally-degenerate `e_above_hull` for arity ≥ 5 (drop the redundant barycentric coordinate); respect `exclude_from_hull` in all arity branches; add elemental tie-plane fallback for elements-only ternary/quaternary references.
- **gas-thermodynamics**: apply per-atom gas corrections correctly (scale total energy by atom count).
- **symmetry / brillouin**: read moyo-wasm rotations column-major (was row-major → Wᵀ); use the correct reciprocal-space convention `Bᵀ·W⁻ᵀ·B⁻ᵀ`.
- **rdf**: keep PBC after supercell expansion (first-shell CN 5.26 → 6.0); preserve the caller's `pbc` in the all-pairs path.
- **math / marching-cubes / isosurface**: preserve area on concave coplanar merges; unwrap marching-cubes cache keys (no more cell-spanning triangles); fix trilinear interpolation off-by-one at the upper boundary.

### Parsers
- **structure**: POSCAR cartesian/abc consistency, blank comment line, per-axis scale factors; CIF trailing `#` comments; OPTIMADE species-name resolution via `chemical_symbols`.
- **trajectory**: per-frame lattice in variable-cell (NPT) XDATCAR; `Properties`-aware extxyz column offsets + forces; metadata regexes anchored to word boundaries; lattice/forces in the indexed/streaming loader.
- **composition**: throw on unbalanced parentheses (was an infinite loop freezing the tab); hydrate notation (`CuSO4·5H2O`); sub-1 stoichiometry formatting (`Li0.5` no longer renders as `Li500m`).

### Plotting / UI
- reference-line paired-endpoint clipping (negative slopes no longer mirrored); log-axis sub-decade ticks; stacked bars keyed by x value; histogram x2-axis isolation; density binning in scale space for log/arcsinh axes.
- periodic-table / heatmap log color mapping; heatmap-table mixed number/string sort; `is_color` named-color validation (via the CSS parser, no hardcoded list); SI label parsing; settings `symmetry` deep-merge.

### Svelte reactivity
- Use `$state.raw` for entry/structure identity tokens in convex-hull hover/popup and Structure bond editing to avoid `state_proxy_equality_mismatch` loops.

### Tooling
- Ignore `.claude` agent worktrees in `.gitignore` and the svelte-check hook.