### PR TITLE
Blob: URL format detection (closes #353) plus correctness fixes across io, structure, fermi-surface, convex-hull, plots, and OPTIMADE

### DIFF
--- a/src/lib/api/optimade.ts
+++ b/src/lib/api/optimade.ts
@@ -42,36 +42,38 @@ export interface OptimadeProvider {
   }
 }
 
-// Multiple CORS proxies for fallback reliability
-const CORS_PROXIES = [
-  `https://corsproxy.io/?`,
-  `https://api.allorigins.win/raw?url=`,
-  `https://cors-anywhere.herokuapp.com/`,
-  `https://thingproxy.freeboard.io/fetch/`,
-  `https://cors.bridged.cc/`,
+// CORS proxies for fallback reliability. Query-style proxies need the target URL
+// percent-encoded; path-suffix proxies need it verbatim (encoded can never succeed).
+const CORS_PROXIES: { prefix: string; encode: boolean }[] = [
+  { prefix: `https://corsproxy.io/?`, encode: true },
+  { prefix: `https://api.allorigins.win/raw?url=`, encode: true },
+  { prefix: `https://cors-anywhere.herokuapp.com/`, encode: false },
+  { prefix: `https://thingproxy.freeboard.io/fetch/`, encode: false },
+  { prefix: `https://cors.bridged.cc/`, encode: false },
 ]
 
 let cached_providers: OptimadeProvider[] | null = null
 let providers_cache_time = 0
 const CACHE_DURATION = 5 * 60 * 1000
 
-const resolved_provider_urls: Record<string, string> = {}
-let resolved_urls_cache_time = 0
+// Per-key timestamps: a shared one would let any resolution refresh every entry's TTL
+const resolved_provider_urls: Record<string, { url: string; time: number }> = {}
 const RESOLVED_URLS_CACHE_DURATION = 10 * 60 * 1000
 
 async function fetch_with_cors_proxy(url: string): Promise<Response> {
   try {
-    const direct_response = await fetch(url, {
+    // An HTTP error status (e.g. 404) is a definitive server answer — return it so
+    // callers see the real error; only thrown (network/CORS) errors warrant proxies
+    return await fetch(url, {
       headers: { Accept: `application/vnd.api+json`, 'User-Agent': `MatterViz/1.0` },
     })
-    if (direct_response.ok) return direct_response
   } catch {
     // Direct access failed, will try CORS proxies
   }
 
-  for (const proxy of CORS_PROXIES) {
+  for (const { prefix, encode } of CORS_PROXIES) {
     try {
-      const response = await fetch(`${proxy}${encodeURIComponent(url)}`, {
+      const response = await fetch(`${prefix}${encode ? encodeURIComponent(url) : url}`, {
         headers: { Accept: `application/vnd.api+json`, 'User-Agent': `MatterViz/1.0` },
       })
       if (response.ok) return response
@@ -85,11 +87,9 @@ async function fetch_with_cors_proxy(url: string): Promise<Response> {
 
 async function resolve_provider_url(provider_base_url: string): Promise<string> {
   const now = Date.now()
-  if (
-    resolved_provider_urls[provider_base_url] &&
-    now - resolved_urls_cache_time < RESOLVED_URLS_CACHE_DURATION
-  ) {
-    return resolved_provider_urls[provider_base_url]
+  const cached = resolved_provider_urls[provider_base_url]
+  if (cached && now - cached.time < RESOLVED_URLS_CACHE_DURATION) {
+    return cached.url
   }
 
   for (const endpoint of [`/links`, `/v1/links`]) {
@@ -104,18 +104,17 @@ async function resolve_provider_url(provider_base_url: string): Promise<string> 
           link.attributes.link_type === `child`,
       )
 
-      if (self_link?.attributes.base_url) {
-        resolved_provider_urls[provider_base_url] = self_link.attributes.base_url
-        resolved_urls_cache_time = now
-        return self_link.attributes.base_url
+      const url = self_link?.attributes.base_url
+      if (url) {
+        resolved_provider_urls[provider_base_url] = { url, time: now }
+        return url
       }
     } catch {
       // Try next endpoint
     }
   }
 
-  resolved_provider_urls[provider_base_url] = provider_base_url
-  resolved_urls_cache_time = now
+  resolved_provider_urls[provider_base_url] = { url: provider_base_url, time: now }
   return provider_base_url
 }
 

--- a/src/lib/convex-hull/ConvexHull2D.svelte
+++ b/src/lib/convex-hull/ConvexHull2D.svelte
@@ -493,7 +493,7 @@
   $effect(() => {
     const current_selection = helpers.current_entry(selected_entry, plot_entries)
     if (selected_entry && !current_selection) selected_entry = null
-    else if (current_selection && current_selection !== selected_entry) {
+    else if (current_selection && !helpers.same_entry(current_selection, selected_entry)) {
       selected_entry = current_selection
     }
     const current_hover = helpers.current_entry(hover_data?.entry, plot_entries)

--- a/src/lib/convex-hull/ConvexHull2D.svelte
+++ b/src/lib/convex-hull/ConvexHull2D.svelte
@@ -436,8 +436,10 @@
   const selected_scatter_point = $derived.by(() => {
     const entry = selected_entry
     if (!entry) return null
-    const idx = visible_entries.findIndex((vis_entry) => vis_entry === entry)
-    return idx !== -1 ? { series_idx: 0, point_idx: idx } : null
+    // match by entry_id (same_entry), not reference: selected_entry may be a proxied/
+    // different instance than visible_entries elements when bound to a parent $state
+    const idx = visible_entries.findIndex((vis_entry) => helpers.same_entry(vis_entry, entry))
+    return idx === -1 ? null : { series_idx: 0, point_idx: idx }
   })
 
   // Convex hull statistics - compute internally and expose via bindable prop

--- a/src/lib/convex-hull/ConvexHull3D.svelte
+++ b/src/lib/convex-hull/ConvexHull3D.svelte
@@ -436,7 +436,7 @@
     const current_selection = helpers.current_entry(selected_entry, plot_entries)
     const stale_selection = selected_entry && !current_selection
     if (stale_selection) selected_entry = null
-    else if (current_selection && current_selection !== selected_entry) {
+    else if (current_selection && !helpers.same_entry(current_selection, selected_entry)) {
       selected_entry = current_selection
     }
     const current_hover = helpers.current_entry(hover_data?.entry, plot_entries)

--- a/src/lib/convex-hull/ConvexHull4D.svelte
+++ b/src/lib/convex-hull/ConvexHull4D.svelte
@@ -340,7 +340,7 @@
     const current_selection = helpers.current_entry(selected_entry, plot_entries)
     const stale_selection = selected_entry && !current_selection
     if (stale_selection) selected_entry = null
-    else if (current_selection && current_selection !== selected_entry) {
+    else if (current_selection && !helpers.same_entry(current_selection, selected_entry)) {
       selected_entry = current_selection
     }
     const current_hover = helpers.current_entry(hover_data?.entry, plot_entries)

--- a/src/lib/convex-hull/helpers.ts
+++ b/src/lib/convex-hull/helpers.ts
@@ -176,6 +176,18 @@ export function current_entry<Entry extends { entry_id?: string }>(
   return entries.includes(entry) ? entry : null
 }
 
+// Same logical entry: same object or same entry_id. The id check is proxy-safe — a raw
+// plot entry equals its $state-proxied copy, so the selection effect doesn't reassign
+// forever (effect_update_depth_exceeded) on identity mismatch.
+export function same_entry<Entry extends { entry_id?: string }>(
+  a: Entry | null | undefined,
+  b: Entry | null | undefined,
+): boolean {
+  if (a === b) return true
+  if (!a || !b) return false
+  return a.entry_id != null && a.entry_id === b.entry_id
+}
+
 // Build a tooltip text for any phase entry (shared)
 export function build_entry_tooltip_text(entry: PhaseData): string {
   const is_element = is_unary_entry(entry)

--- a/src/lib/fermi-surface/compute.ts
+++ b/src/lib/fermi-surface/compute.ts
@@ -35,15 +35,17 @@ function catmull_rom_coeffs(t: number): [number, number, number, number] {
   return [c1, c2, c3, c4]
 }
 
-// Tricubic interpolation with cached wrap indices and precomputed coefficients
+// Tricubic interpolation with cached wrap indices and precomputed coefficients.
+// px/py/pz are the wrap periods (unique points per axis): n for periodic grids,
+// n−1 for endpoint-inclusive grids whose last point duplicates the first.
 function tricubic_interpolate(
   grid: number[][][],
   fx: number,
   fy: number,
   fz: number,
-  nx: number,
-  ny: number,
-  nz: number,
+  px: number,
+  py: number,
+  pz: number,
 ): number {
   // Get integer and fractional parts
   const ix = Math.floor(fx)
@@ -55,14 +57,13 @@ function tricubic_interpolate(
   const [cy0, cy1, cy2, cy3] = catmull_rom_coeffs(fy - iy)
   const [cz0, cz1, cz2, cz3] = catmull_rom_coeffs(fz - iz)
 
-  // Precompute wrapped indices (avoid modulo in inner loop)
-  const wrap_x = (v: number) => ((v % nx) + nx) % nx
-  const wrap_y = (v: number) => ((v % ny) + ny) % ny
-  const wrap_z = (v: number) => ((v % nz) + nz) % nz
-
-  const wx = [wrap_x(ix - 1), wrap_x(ix), wrap_x(ix + 1), wrap_x(ix + 2)]
-  const wy = [wrap_y(iy - 1), wrap_y(iy), wrap_y(iy + 1), wrap_y(iy + 2)]
-  const wz = [wrap_z(iz - 1), wrap_z(iz), wrap_z(iz + 1), wrap_z(iz + 2)]
+  // Wrapped stencil indices (modulo hoisted out of the inner loop); a zero period
+  // (single-point axis) has no neighbours, so collapse the stencil onto index 0
+  const stencil = (idx: number, period: number) =>
+    [idx - 1, idx, idx + 1, idx + 2].map((v) =>
+      period > 0 ? ((v % period) + period) % period : 0,
+    )
+  const [wx, wy, wz] = [stencil(ix, px), stencil(iy, py), stencil(iz, pz)]
 
   // Interpolate along z, then y, then x (fully inlined)
   let result = 0
@@ -86,26 +87,32 @@ function tricubic_interpolate(
   return result
 }
 
-// Upsample a 3D grid using tricubic interpolation for smoother surfaces
-function upsample_grid(grid: number[][][], factor: number): number[][][] {
+// Upsample a 3D grid with tricubic interpolation, preserving the grid convention:
+// endpoint-inclusive (BXSF, point i ↔ frac i/(n−1)) vs periodic (FRMSF, i ↔ i/n).
+// Mixing conventions rescales the surface and distorts the zone boundary.
+function upsample_grid(grid: number[][][], factor: number, periodic = false): number[][][] {
   if (factor <= 1) return grid
 
-  const nx = grid.length
-  const ny = grid[0]?.length || 0
-  const nz = grid[0]?.[0]?.length || 0
+  // Endpoint-inclusive grids carry one duplicated boundary sample per axis; the wrap
+  // period (count of unique points) doubles as the resampling span numerator
+  const endpoint = periodic ? 0 : 1
+  const dims = [grid.length, grid[0]?.length || 0, grid[0]?.[0]?.length || 0]
+  const [px, py, pz] = dims.map((n) => n - endpoint)
+  const [new_nx, new_ny, new_nz] = [px, py, pz].map((p) => Math.round(p * factor) + endpoint)
 
-  const new_nx = Math.round(nx * factor)
-  const new_ny = Math.round(ny * factor)
-  const new_nz = Math.round(nz * factor)
-
-  // Precompute fractional coordinates for each axis
-  const fx_arr = new Float64Array(new_nx)
-  const fy_arr = new Float64Array(new_ny)
-  const fz_arr = new Float64Array(new_nz)
-
-  for (let ix = 0; ix < new_nx; ix++) fx_arr[ix] = (ix / new_nx) * nx
-  for (let iy = 0; iy < new_ny; iy++) fy_arr[iy] = (iy / new_ny) * ny
-  for (let iz = 0; iz < new_nz; iz++) fz_arr[iz] = (iz / new_nz) * nz
+  // Map new index → source coordinate; a single-point axis (span 0) pins its lone
+  // output to source 0 to avoid 0/0 = NaN
+  const src_coords = (new_n: number, period: number) => {
+    const span = new_n - endpoint
+    return Float64Array.from({ length: new_n }, (_, idx) =>
+      span > 0 ? (idx / span) * period : 0,
+    )
+  }
+  const [fx_arr, fy_arr, fz_arr] = [
+    [new_nx, px],
+    [new_ny, py],
+    [new_nz, pz],
+  ].map(([new_n, period]) => src_coords(new_n, period))
 
   // Preallocate output grid
   const new_grid: number[][][] = Array(new_nx)
@@ -117,7 +124,7 @@ function upsample_grid(grid: number[][][], factor: number): number[][][] {
       const fy = fy_arr[iy]
       const iz_arr = new Float64Array(new_nz)
       for (let iz = 0; iz < new_nz; iz++) {
-        iz_arr[iz] = tricubic_interpolate(grid, fx, fy, fz_arr[iz], nx, ny, nz)
+        iz_arr[iz] = tricubic_interpolate(grid, fx, fy, fz_arr[iz], px, py, pz)
       }
       // Convert Float64Array back to regular array for compatibility
       iy_arr[iy] = Array.from(iz_arr)
@@ -163,17 +170,19 @@ export function extract_fermi_surface(
       // Check if Fermi level intersects this band
       if (!band_intersects_fermi(raw_energies, iso_value)) continue
 
+      // BXSF grids are endpoint-inclusive (store both equivalent k=0 and k=1 → false);
+      // FRMSF grids store k=i/n without the duplicated endpoint (→ true)
+      const periodic = band_data.periodic ?? false
+
       // Apply interpolation for smoother surfaces
       const energies =
         interpolation_factor > 1
-          ? upsample_grid(raw_energies, interpolation_factor)
+          ? upsample_grid(raw_energies, interpolation_factor, periodic)
           : raw_energies
 
       // Extract isosurface using marching cubes
-      // Use periodic: false because BXSF grids include both endpoints (k=0 and k=1)
-      // which are equivalent due to BZ periodicity. This matches scikit-image behavior.
       const mc_result = marching_cubes(energies, iso_value, band_data.k_lattice, {
-        periodic: false,
+        periodic,
         interpolate: true,
       })
 
@@ -201,6 +210,7 @@ export function extract_fermi_surface(
           band_data.velocities[spin_idx][band_idx],
           band_data.k_lattice,
           band_data.k_grid,
+          periodic,
         )
         isosurface.avg_velocity =
           isosurface.properties.reduce((s, v) => s + v, 0) / isosurface.properties.length
@@ -210,7 +220,7 @@ export function extract_fermi_surface(
       if (compute_dimensionality) {
         const { dimensionality, orientation } = analyze_surface_topology(
           isosurface,
-          null, // BZ data not used for topology analysis since we don't clip to Wigner-Seitz
+          band_data.k_lattice,
         )
         isosurface.dimensionality = dimensionality
         isosurface.orientation = orientation
@@ -285,28 +295,25 @@ function compute_fermi_velocities(
   velocity_grid: Vec3[][][],
   k_lattice: Matrix3x3,
   k_grid: Vec3,
+  periodic = false,
 ): number[] {
   const [nx, ny, nz] = k_grid
   const velocities: number[] = []
 
-  // Inverse of k_lattice for Cartesian to fractional conversion
-  const k_inv = math.matrix_inverse_3x3(k_lattice)
+  // Invert the marching-cubes transform cart = k_latticeᵀ·(frac − 0.5): frac =
+  // (k_latticeᵀ)⁻¹·cart + 0.5. Omitting the transpose samples wrong k-points for
+  // non-symmetric lattices; skipping the +0.5 is off by half a reciprocal cell.
+  const k_inv = math.matrix_inverse_3x3(math.transpose_3x3_matrix(k_lattice))
+  // Grid point i sits at frac i/(n−1) (endpoint-inclusive BXSF) or i/n (periodic)
+  const [sx, sy, sz] = periodic ? [nx, ny, nz] : [nx - 1, ny - 1, nz - 1]
+  // Clamp guards float jitter at the cell boundary
+  const clamp01 = (val: number) => Math.min(Math.max(val, 0), 1)
 
   for (const vertex of surface.vertices) {
-    // Convert Cartesian to fractional coordinates
-    const frac = math.mat3x3_vec3_multiply(k_inv, vertex)
-
-    // Wrap to [0, 1)
-    const wrapped: Vec3 = [
-      ((frac[0] % 1) + 1) % 1,
-      ((frac[1] % 1) + 1) % 1,
-      ((frac[2] % 1) + 1) % 1,
-    ]
-
-    // Grid indices (with interpolation)
-    const gx = wrapped[0] * nx
-    const gy = wrapped[1] * ny
-    const gz = wrapped[2] * nz
+    const frac = math.mat3x3_vec3_multiply(k_inv, vertex) // centered, in [-0.5, 0.5]
+    const gx = clamp01(frac[0] + 0.5) * sx
+    const gy = clamp01(frac[1] + 0.5) * sy
+    const gz = clamp01(frac[2] + 0.5) * sz
 
     // Trilinear interpolation of velocity
     const velocity = trilinear_interpolate_vec3(velocity_grid, gx, gy, gz)
@@ -361,16 +368,19 @@ function trilinear_interpolate_vec3(grid: Vec3[][][], x: number, y: number, z: n
 // Analyze surface topology to determine dimensionality
 function analyze_surface_topology(
   surface: Isosurface,
-  bz_data: { vertices: Vec3[] } | null,
+  k_lattice: Matrix3x3,
 ): { dimensionality: SurfaceDimensionality; orientation: Vec3 | null } {
   if (surface.vertices.length === 0) {
     return { dimensionality: `3D`, orientation: null }
   }
 
-  // Check if surface spans the full BZ in each direction
-  const bz_extent = bz_data
-    ? math.compute_bounding_box(bz_data.vertices)
-    : { min: [-1, -1, -1] as Vec3, max: [1, 1, 1] as Vec3 }
+  // Vertices live in the centered parallelepiped k_latticeᵀ·[-0.5, 0.5]³, whose bounding
+  // box along Cartesian axis j has half-extent 0.5·Σᵢ|k_lattice[i][j]| (a hardcoded box
+  // would make dimensionality depend on the absolute lattice scale)
+  const half_extent = [0, 1, 2].map(
+    (axis_idx) => 0.5 * k_lattice.reduce((sum, row) => sum + Math.abs(row[axis_idx]), 0),
+  ) as Vec3
+  const bz_extent = { min: half_extent.map((ext) => -ext) as Vec3, max: half_extent }
 
   const surface_extent = math.compute_bounding_box(surface.vertices)
 

--- a/src/lib/fermi-surface/parse.ts
+++ b/src/lib/fermi-surface/parse.ts
@@ -264,6 +264,7 @@ function parse_frmsf(content: string): BandGridData {
     fermi_energy: 0, // FRMSF typically expects Fermi level at 0
     n_bands,
     n_spins,
+    periodic: true, // FRMSF stores k=i/n with no duplicated endpoint (unlike BXSF)
   }
 }
 

--- a/src/lib/fermi-surface/types.ts
+++ b/src/lib/fermi-surface/types.ts
@@ -75,6 +75,9 @@ export interface BandGridData {
   n_bands: number
   n_spins: number // 1 or 2
   origin?: Vec3 // k-space origin (default [0,0,0])
+  // true: points sit at k=i/n with no duplicated endpoint (FRMSF); false/undefined:
+  // endpoint-inclusive grid storing both equivalent k=0 and k=1 (BXSF)
+  periodic?: boolean
 }
 
 // 2D Fermi slice data (cross-section through the BZ)

--- a/src/lib/io/decompress.ts
+++ b/src/lib/io/decompress.ts
@@ -65,7 +65,8 @@ export function decompress_file(file: File): Promise<{ content: string; filename
       () => {
         try {
           const result = reader.result
-          if (!result) throw new Error(`Failed to read file`)
+          // strict null check: empty files legitimately read as '' (falsy)
+          if (result === null) throw new Error(`Failed to read file`)
 
           if (is_supported && format) {
             if (!(result instanceof ArrayBuffer)) throw new Error(`Expected binary file data`)

--- a/src/lib/io/url-drop.ts
+++ b/src/lib/io/url-drop.ts
@@ -1,23 +1,27 @@
 import { load_binary_traj } from '$lib/trajectory/parse'
-import { decompress_data } from './decompress'
+import { decompress_data_binary } from './decompress'
 import type { FileInfo } from './types'
 
 const BINARY_EXTENSIONS = new Set(
-  `h5 hdf5 traj npz pkl dat gz gzip zip bz2 xz brml`.split(` `),
+  `h5 hdf5 traj npz pkl dat gz gzip zip bz2 xz brml raw`.split(` `),
 )
 const TEXT_EXTENSIONS = new Set(
   `xyz extxyz json cif poscar yaml yml txt md py js ts css html xml`.split(` `),
 )
 const VASP_BASENAME_RE = /^(poscar|xdatcar|contcar)$/i
+const GZ_EXT_RE = /\.(gz|gzip)$/i
 
 // Extract filename from Content-Disposition header, falling back to url_basename.
 function extract_filename(headers: Headers | undefined, fallback: string): string {
   if (!headers) return fallback
   const content_disposition_str = headers.get(`content-disposition`)
   if (!content_disposition_str) return fallback
-  const star_match = /filename\*=(?:UTF-8''|)([^;]+)/i.exec(content_disposition_str)
+  const star_match = /filename\*=([^;]+)/i.exec(content_disposition_str)
   if (star_match?.[1]) {
-    const raw = star_match[1].trim().replaceAll(/^"|"$/g, ``)
+    let raw = star_match[1].trim().replaceAll(/^"|"$/g, ``)
+    // Strip any RFC 5987 charset'language' prefix; bare values pass through unchanged
+    const ext_value_match = /^[\w!#$%&+^`{}~-]+'[\w-]*'(.*)$/.exec(raw)
+    if (ext_value_match) raw = ext_value_match[1]
     try {
       return decodeURIComponent(raw)
     } catch {
@@ -29,6 +33,26 @@ function extract_filename(headers: Headers | undefined, fallback: string): strin
   const name = plain_match?.[1]?.trim()
   if (!name) return fallback
   return name
+}
+
+const ext_of = (name: string): string => name.split(`.`).pop()?.toLowerCase() ?? ``
+
+// Whether the file inside a .gz/.gzip wrapper is a known binary format that a
+// lossy text decode would corrupt (bytes >= 0x80 → U+FFFD)
+const has_binary_inner_ext = (filename: string): boolean =>
+  BINARY_EXTENSIONS.has(ext_of(filename.replace(GZ_EXT_RE, ``)))
+
+// Gunzip a fetched payload → [content, filename] with .gz/.gzip stripped; content
+// stays an ArrayBuffer for binary inner formats, decoded string otherwise
+async function decompress_gz_payload(
+  buffer: ArrayBuffer,
+  filename: string,
+): Promise<[content: string | ArrayBuffer, filename: string]> {
+  const decompressed = await decompress_data_binary(buffer, `gzip`)
+  const content = has_binary_inner_ext(filename)
+    ? decompressed
+    : new TextDecoder().decode(decompressed)
+  return [content, filename.replace(GZ_EXT_RE, ``)]
 }
 
 // Handle URL-based file drop data by fetching content lazily
@@ -55,8 +79,10 @@ export async function load_from_url(
   url: string,
   callback: (content: string | ArrayBuffer, filename: string) => Promise<void> | void,
 ): Promise<void> {
-  const url_basename = url.split(`/`).pop() ?? url
-  const ext = url_basename.split(`.`).pop()?.toLowerCase() ?? ``
+  // Strip query string/hash before basename/extension detection so pre-signed
+  // URLs like traj.h5?X-Amz-Expires=300 still hit the right format path
+  const url_basename = url.split(/[?#]/)[0].split(`/`).pop() ?? url
+  const ext = ext_of(url_basename)
 
   if (BINARY_EXTENSIONS.has(ext)) {
     // Force binary mode for known binary files to handle GitHub Pages content-type issues
@@ -67,14 +93,14 @@ export async function load_from_url(
     // Handle gzipped files with proper content-encoding detection
     if (ext === `gz` || ext === `gzip`) {
       if (resp.headers.get(`content-encoding`) === `gzip`) {
-        // Browser automatically decompressed it, so it's text
-        return callback(await resp.text(), filename)
+        // Browser already decompressed the stored .gz (GitHub Pages-style serving), so
+        // the body is the inner file — keep binary inner formats (.h5.gz, ...) binary
+        return callback(
+          await (has_binary_inner_ext(filename) ? resp.arrayBuffer() : resp.text()),
+          filename,
+        )
       }
-      // Need to decompress manually
-      const buffer = await resp.arrayBuffer()
-      const content = await decompress_data(buffer, `gzip`)
-      // Remove .gz/.gzip extension when manually decompressing
-      return callback(content, filename.replace(/\.(gz|gzip)$/i, ``))
+      return callback(...(await decompress_gz_payload(await resp.arrayBuffer(), filename)))
     }
 
     // For H5 files, always load as binary regardless of signature
@@ -112,6 +138,10 @@ export async function load_from_url(
   let sniffed_callback_args: [content: string | ArrayBuffer, filename: string] | undefined
 
   if (!is_known_text) {
+    // Only the Range sniff is guarded (failure → plain text fetch). Once magic bytes
+    // commit to a binary format, download/decompress errors must propagate instead of
+    // falling through to a text fetch that would parse the binary bytes as garbage.
+    let sniffed: `gzip` | `binary` | null = null
     try {
       // Check for magic bytes only for unknown formats (covers extensionless URLs
       // like blob: object URLs whose basenames are UUIDs)
@@ -125,20 +155,21 @@ export async function load_from_url(
         const is_ase_traj = [0x2d, 0x20, 0x6f, 0x66, 0x20, 0x55, 0x6c, 0x6d].every(
           (byte, idx) => buf[idx] === byte,
         )
-        if (is_gzip || is_hdf5 || is_ase_traj) {
-          const resp = await fetch(url)
-          if (!resp.ok) throw new Error(`Fetch failed: ${resp.status}`)
-          const filename = extract_filename(resp.headers, url_basename)
-          const buffer = await resp.arrayBuffer()
-          // Decompress sniffed gzip since downstream parsers expect text or
-          // format-specific binary, not raw gzip bytes
-          sniffed_callback_args = is_gzip
-            ? [await decompress_data(buffer, `gzip`), filename.replace(/\.(gz|gzip)$/i, ``)]
-            : [buffer, filename]
-        }
+        if (is_gzip) sniffed = `gzip`
+        else if (is_hdf5 || is_ase_traj) sniffed = `binary`
       }
     } catch {
-      // Fall through to text fetch if HEAD request fails
+      // Fall through to text fetch if the Range HEAD request fails
+    }
+
+    if (sniffed) {
+      const resp = await fetch(url)
+      if (!resp.ok) throw new Error(`Fetch failed: ${resp.status}`)
+      const filename = extract_filename(resp.headers, url_basename)
+      const buffer = await resp.arrayBuffer()
+      // Gunzip sniffed gzip — downstream parsers can't handle raw gzip bytes
+      sniffed_callback_args =
+        sniffed === `gzip` ? await decompress_gz_payload(buffer, filename) : [buffer, filename]
     }
   }
 

--- a/src/lib/io/url-drop.ts
+++ b/src/lib/io/url-drop.ts
@@ -100,10 +100,9 @@ export async function load_from_url(
       return callback(buffer, filename)
     }
 
-    if (resp.headers.get(`content-encoding`) === `gzip`) {
-      return callback(await resp.text(), filename)
-    }
-
+    // Content-Encoding is transparent transport compression: fetch already
+    // decompressed the body, so binary formats (npz, pkl, brml, ...) must still
+    // be read as ArrayBuffer — .text() would corrupt them via lossy UTF-8 decode
     return callback(await resp.arrayBuffer(), filename)
   }
 

--- a/src/lib/plot/box/BoxPlot.svelte
+++ b/src/lib/plot/box/BoxPlot.svelte
@@ -309,7 +309,11 @@
       // NaN pixels + LOG_EPS range pollution. Clamp the grid to the smallest positive sample.
       if ((is_secondary(box_item.series) ? val_axis2 : val_axis).scale_type === `log`) {
         const min_pos = samples.reduce((min, val) => (val > 0 && val < min ? val : min), Infinity)
-        clip = [Math.max(clip?.[0] ?? -Infinity, min_pos), clip?.[1] ?? null]
+        // Guard: no positive samples → min_pos is Infinity; leave clip unchanged so the KDE
+        // never receives a non-finite lower bound
+        if (Number.isFinite(min_pos)) {
+          clip = [Math.max(clip?.[0] ?? -Infinity, min_pos), clip?.[1] ?? null]
+        }
       }
       map.set(
         box_item.idx,

--- a/src/lib/plot/box/BoxPlot.svelte
+++ b/src/lib/plot/box/BoxPlot.svelte
@@ -298,21 +298,37 @@
   // KDE per visible violin series, keyed by series index (bandwidth from the full sample)
   let violin_kdes = $derived.by(() => {
     const map = new SvelteMap<number, KdeResult>()
+    const [val_axis, val_axis2] = orientation === `vertical`
+      ? [y_axis, y2_axis]
+      : [x_axis, x2_axis]
     for (const box_item of visible_boxes) {
       if (!draws_violin(box_item.series)) continue
+      const samples = box_item.series.y ?? []
+      let clip = box_item.series.clip ?? kde_clip
+      // On a log value axis the KDE grid tail (data_min - cut*bandwidth) is usually <= 0 →
+      // NaN pixels + LOG_EPS range pollution. Clamp the grid to the smallest positive sample.
+      if ((is_secondary(box_item.series) ? val_axis2 : val_axis).scale_type === `log`) {
+        const min_pos = samples.reduce((min, val) => (val > 0 && val < min ? val : min), Infinity)
+        clip = [Math.max(clip?.[0] ?? -Infinity, min_pos), clip?.[1] ?? null]
+      }
       map.set(
         box_item.idx,
-        gaussian_kde(box_item.series.y ?? [], {
+        gaussian_kde(samples, {
           bandwidth: box_item.series.bandwidth ?? bandwidth,
           n_points: kde_points,
           cut: kde_cut,
-          clip: box_item.series.clip ?? kde_clip,
+          clip,
           max_samples: kde_max_samples,
         }),
       )
     }
     return map
   })
+
+  // The horizontal category pixel axis is inverted, so flip the half-violin side to keep
+  // `positive` meaning "above the center line" (vertical/`both` pass through unchanged)
+  const to_screen_side = (eff_side: ViolinSide, vertical: boolean): ViolinSide =>
+    vertical || eff_side === `both` ? eff_side : eff_side === `positive` ? `negative` : `positive`
 
   // Peak density per violin, computed once on data change (avoids spreading kde.density into
   // Math.max — unsafe for large kde_points — and re-deriving it on every render/hover).
@@ -335,8 +351,10 @@
   // Collect value-axis points (whiskers, quartiles, outliers, KDE tails) for auto-range
   const value_points = (boxes: Box[]): { x: number; y: number }[] =>
     boxes.flatMap((box_item) => {
-      const { whisker_low, whisker_high, q1, q3, median, outliers } = box_item.stats
+      const { whisker_low, whisker_high, q1, q3, median, mean, outliers } = box_item.stats
       const vals = [whisker_low, whisker_high, q1, q3, median]
+      // keep the drawn mean line in range even when hidden outliers drag it past the whiskers
+      if (show_mean) vals.push(mean)
       // outliers are sorted ascending; auto-range only needs their extremes (avoids
       // spreading a potentially huge array as call args)
       if (show_outliers && outliers.length > 0) {
@@ -1183,9 +1201,10 @@
               {#if kde && max_density > 0}
                 {@const grid_px = kde.grid.map((g_val) => val_scale(g_val))}
                 {@const offsets = kde.density.map((den) => (den / max_density) * violin_half)}
+                {@const screen_side = to_screen_side(eff_side, vertical)}
                 <path
                   class="violin-area"
-                  d={violin_path(grid_px, offsets, c_center, eff_side, pt)}
+                  d={violin_path(grid_px, offsets, c_center, screen_side, pt)}
                   fill={color}
                   fill-opacity={violin_state.opacity}
                   stroke={color}

--- a/src/lib/plot/sankey/sankey.ts
+++ b/src/lib/plot/sankey/sankey.ts
@@ -165,7 +165,9 @@ export function compute_sankey_layout<Metadata = Record<string, unknown>>(
     iterations = 6,
   } = opts
 
-  if (!(width > 0) || !(height > 0) || data.nodes.length === 0 || data.links.length === 0)
+  // All-zero link values would make d3-sankey divide by zero (NaN ribbon paths)
+  const has_flow = data.links.some((link) => link.value > 0)
+  if (!(width > 0) || !(height > 0) || data.nodes.length === 0 || !has_flow)
     return { nodes: [], links: [] }
 
   // Resolve ids -> indices and clone into fresh objects (d3 mutates these).

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -57,7 +57,7 @@
   import { get_property_colors } from './atom-properties'
   import AtomLegend from './AtomLegend.svelte'
   import CellSelect from './CellSelect.svelte'
-  import { BOND_ORDER_OPTIONS, merge_bond_edits } from './bonding'
+  import { BOND_ORDER_OPTIONS, merge_bond_edits, remap_bonds_after_deletion } from './bonding'
   import type { StructureHandlerData } from './index'
   import { MAX_SELECTED_SITES } from './measure'
   import { normalize_fractional_coords, parse_any_structure } from './parse'
@@ -1226,9 +1226,17 @@
           const to_delete = scene_to_structure_indices(selected_sites, true)
           const n_deleted = to_delete.size
           clear_selection()
+          // Remap explicit bond metadata so surviving bonds track shifted site indices
+          const old_bonds = structure.properties?.bonds
           structure = {
             ...structure,
             sites: structure.sites.filter((_, idx) => !to_delete.has(idx)),
+            ...(old_bonds && {
+              properties: {
+                ...structure.properties,
+                bonds: remap_bonds_after_deletion(old_bonds, to_delete),
+              },
+            }),
           }
           // Clear per-site overrides since indices shifted after deletion
           if (site_radius_overrides?.size > 0) site_radius_overrides.clear()

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -1226,7 +1226,9 @@
           const to_delete = scene_to_structure_indices(selected_sites, true)
           const n_deleted = to_delete.size
           clear_selection()
-          // Remap explicit bond metadata so surviving bonds track shifted site indices
+          // Remap explicit bond metadata so surviving bonds track shifted site indices.
+          // structure_with_bonds prefers the bindable `bonds` prop, so remap that too.
+          if (bonds !== undefined) bonds = remap_bonds_after_deletion(bonds, to_delete)
           const old_bonds = structure.properties?.bonds
           structure = {
             ...structure,

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -2095,7 +2095,7 @@
         ] as Vec3}
               {@const direct = math.euclidean_dist(pos_i, pos_j)}
               {@const pbc = lattice
-          ? measure.distance_pbc(pos_i, pos_j, lattice.matrix)
+          ? measure.distance_pbc(pos_i, pos_j, lattice.matrix, undefined, lattice.pbc)
           : direct}
               {@const differ = lattice ? Math.abs(pbc - direct) > 1e-6 : false}
               <extras.HTML center position={midpoint}>
@@ -2124,8 +2124,10 @@
               }
                 {@const site_a = structure.sites[idx_a]}
                 {@const site_b = structure.sites[idx_b]}
-                {@const v1 = measure.displacement_pbc(center.xyz, site_a.xyz, lattice?.matrix)}
-                {@const v2 = measure.displacement_pbc(center.xyz, site_b.xyz, lattice?.matrix)}
+                {@const disp = (to: Vec3) =>
+            measure.displacement_pbc(center.xyz, to, lattice?.matrix, undefined, lattice?.pbc)}
+                {@const v1 = disp(site_a.xyz)}
+                {@const v2 = disp(site_b.xyz)}
                 {@const n1 = Math.hypot(v1[0], v1[1], v1[2])}
                 {@const n2 = Math.hypot(v2[0], v2[1], v2[2])}
                 {@const angle_deg = measure.angle_between_vectors(v1, v2, `degrees`)}

--- a/src/lib/structure/bonding.ts
+++ b/src/lib/structure/bonding.ts
@@ -73,6 +73,24 @@ export const get_bond_key = (idx_1: number, idx_2: number, cell_shift?: Vec3): s
   )}`
 }
 
+// Remap explicit bond metadata after site deletion: drop bonds touching deleted
+// sites and shift each surviving index down by the number of deleted indices below it.
+export function remap_bonds_after_deletion(
+  bonds: readonly StructureBond[],
+  deleted_indices: ReadonlySet<number>,
+): StructureBond[] {
+  const shift = (idx: number) => idx - [...deleted_indices].filter((del) => del < idx).length
+  return bonds
+    .filter(
+      (bond) => !deleted_indices.has(bond.site_idx_1) && !deleted_indices.has(bond.site_idx_2),
+    )
+    .map((bond) => ({
+      ...bond,
+      site_idx_1: shift(bond.site_idx_1),
+      site_idx_2: shift(bond.site_idx_2),
+    }))
+}
+
 export type BondEditState = {
   added_bonds: StructureBond[]
   removed_bonds: StructureBond[]

--- a/src/lib/structure/bonding.ts
+++ b/src/lib/structure/bonding.ts
@@ -79,7 +79,18 @@ export function remap_bonds_after_deletion(
   bonds: readonly StructureBond[],
   deleted_indices: ReadonlySet<number>,
 ): StructureBond[] {
-  const shift = (idx: number) => idx - [...deleted_indices].filter((del) => del < idx).length
+  // Sort the deleted indices once; shift each surviving index down by the count of deleted
+  // indices below it via binary search (O(log m) per lookup vs re-filtering the set each call).
+  const sorted = [...deleted_indices].sort((idx_a, idx_b) => idx_a - idx_b)
+  const shift = (idx: number) => {
+    let [lo, hi] = [0, sorted.length]
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1
+      if (sorted[mid] < idx) lo = mid + 1
+      else hi = mid
+    }
+    return idx - lo // lo == count of deleted indices < idx
+  }
   return bonds
     .filter(
       (bond) => !deleted_indices.has(bond.site_idx_1) && !deleted_indices.has(bond.site_idx_2),
@@ -551,24 +562,26 @@ export function get_bond_render_matrices(
 ): Float32Array[] {
   const order = bond.bond_order ?? 1
   const gap = bond_thickness * 1.8
-  const offsets_and_scales: [number, number][] =
-    order === 2
-      ? [
-          [-gap / 2, 0.65],
-          [gap / 2, 0.65],
-        ]
-      : order === 3
-        ? [
-            [-gap, 0.55],
-            [0, 0.55],
-            [gap, 0.55],
-          ]
-        : order === 1.5 || order === `aromatic`
-          ? [
-              [-gap / 2, 0.75],
-              [gap / 2, 0.4],
-            ]
-          : []
+  // Parallel cylinder [offset, radius_scale] pairs per bond order; empty → a single
+  // full-width bond (handled by the fallback below)
+  let offsets_and_scales: [number, number][] = []
+  if (order === 2)
+    offsets_and_scales = [
+      [-gap / 2, 0.65],
+      [gap / 2, 0.65],
+    ]
+  else if (order === 3)
+    offsets_and_scales = [
+      [-gap, 0.55],
+      [0, 0.55],
+      [gap, 0.55],
+    ]
+  else if (order === 1.5 || order === `aromatic`) {
+    offsets_and_scales = [
+      [-gap / 2, 0.75],
+      [gap / 2, 0.4],
+    ]
+  }
   return offsets_and_scales.length === 0
     ? [bond.transform_matrix]
     : offsets_and_scales.map(([offset, radius_scale]) =>

--- a/src/lib/structure/export.ts
+++ b/src/lib/structure/export.ts
@@ -545,7 +545,8 @@ export function structure_to_cif_str(structure?: AnyStructure): string {
     const symmetry = structure.symmetry as Record<string, unknown>
     const { space_group_number, space_group_symbol } = symmetry
     if (typeof space_group_symbol === `string` && space_group_symbol) {
-      lines.push(`_space_group_name_H-M_alt ${space_group_symbol}`)
+      // Quote H-M symbols: their spaces (e.g. 'F m -3 m') would break CIF tokenization
+      lines.push(`_space_group_name_H-M_alt '${space_group_symbol}'`)
     }
     if (
       (typeof space_group_number === `number` || typeof space_group_number === `string`) &&
@@ -556,6 +557,10 @@ export function structure_to_cif_str(structure?: AnyStructure): string {
   }
 
   lines.push(``)
+
+  // Explicit identity-only symmetry-ops loop (like pymatgen's CifWriter): sites are the
+  // full P1 list, so without it parsers would re-apply the H-M ops and multiply sites
+  lines.push(`loop_`, `_symmetry_equiv_pos_as_xyz`, `  'x, y, z'`, ``)
 
   // Atom site loop header
   lines.push(`loop_`)
@@ -570,37 +575,32 @@ export function structure_to_cif_str(structure?: AnyStructure): string {
   const cart_to_frac =
     lattice.matrix?.length === 3 ? math.create_cart_to_frac(lattice.matrix) : null
 
-  // Atom sites
+  // Atom sites: one row per species entry so disordered (multi-species) sites
+  // keep every component with its own occupancy instead of only species[0]
   for (let idx = 0; idx < structure.sites.length; idx++) {
     const site = structure.sites[idx]
     if (!site) continue // Skip if site is undefined
 
-    // Extract element symbol from species
-    let element_symbol = `X` // default fallback
-    let occupancy = 1
-    if (site.species && Array.isArray(site.species) && site.species.length > 0) {
-      const first_species = site.species[0]
-      if (first_species && `element` in first_species && first_species.element) {
-        element_symbol = first_species.element
-        occupancy = first_species?.occu ?? 1
-      }
-    }
-
     // Get fractional coordinates
     let frac_coords: number[]
-    if (site.abc && Array.isArray(site.abc) && site.abc.length >= 3) {
+    if (Array.isArray(site.abc) && site.abc.length >= 3) {
       frac_coords = site.abc.slice(0, 3)
     } else if (site.xyz?.length >= 3 && cart_to_frac) {
       frac_coords = cart_to_frac(site.xyz)
     } else throw new Error(`No valid coordinates found for site ${idx}`)
+    const coords_str = frac_coords.map((coord) => coord.toFixed(8)).join(` `)
 
-    // Format: label element_symbol x y z
-    const label = site.label || `${element_symbol}${idx + 1}`
-    lines.push(
-      `${label} ${element_symbol} ${frac_coords[0].toFixed(8)} ${frac_coords[1].toFixed(
-        8,
-      )} ${frac_coords[2].toFixed(8)} ${occupancy.toFixed(8)}`,
-    )
+    const species_list = site.species?.length ? site.species : [{ element: `X`, occu: 1 }]
+    for (const [spec_idx, species] of species_list.entries()) {
+      const elem = species?.element || `X`
+      // Row format: label element x y z occupancy. Labels must be unique per row,
+      // so disordered sites get a per-species suffix.
+      const label =
+        species_list.length > 1
+          ? `${elem}${idx + 1}_${spec_idx}`
+          : site.label || `${elem}${idx + 1}`
+      lines.push(`${label} ${elem} ${coords_str} ${(species?.occu ?? 1).toFixed(8)}`)
+    }
   }
 
   return lines.join(`\n`)

--- a/src/lib/structure/measure.ts
+++ b/src/lib/structure/measure.ts
@@ -2,25 +2,34 @@
 
 import type { LatticeConverters, Matrix3x3, Vec3 } from '$lib/math'
 import { min_image_displacement, subtract } from '$lib/math'
+import type { Pbc } from './pbc'
 
 export type AngleMode = `degrees` | `radians`
 
 export const MAX_SELECTED_SITES = 8
 
 // Calculate minimum image displacement between two points under PBC
-// If lattice_matrix is null/undefined, returns Euclidean displacement
+// If lattice_matrix is null/undefined, returns Euclidean displacement.
+// pbc flags disable wrapping along non-periodic axes (e.g. slab vacuum directions).
 export function displacement_pbc(
   from: Vec3,
   to: Vec3,
   lattice_matrix: Matrix3x3 | null | undefined,
   converters?: LatticeConverters,
+  pbc?: Pbc,
 ): Vec3 {
   if (!lattice_matrix) return subtract(to, from)
-  return min_image_displacement(from, to, lattice_matrix, converters)
+  return min_image_displacement(from, to, lattice_matrix, converters, pbc)
 }
 
-export function distance_pbc(a: Vec3, b: Vec3, lattice_matrix: Matrix3x3): number {
-  const [dx, dy, dz] = displacement_pbc(a, b, lattice_matrix)
+export function distance_pbc(
+  a: Vec3,
+  b: Vec3,
+  lattice_matrix: Matrix3x3,
+  converters?: LatticeConverters,
+  pbc?: Pbc,
+): number {
+  const [dx, dy, dz] = displacement_pbc(a, b, lattice_matrix, converters, pbc)
   return Math.hypot(dx, dy, dz)
 }
 

--- a/src/lib/structure/parse.ts
+++ b/src/lib/structure/parse.ts
@@ -155,6 +155,10 @@ function resolve_optimade_element(
     if (!best || conc > best.conc) best = { symbol, conc, sym_idx }
   }
   if (best) return { symbol: best.symbol, sym_idx: best.sym_idx }
+  // Fallback: the name may be an element with a trailing atom index (e.g. 'O1');
+  // element symbols never contain digits, so stripping them is safe
+  const stripped = species_name.replace(/\d+$/, ``)
+  if (is_known_element_symbol(stripped)) return { symbol: stripped, sym_idx: -1 }
   return { symbol: validate_element_symbol(species_name, index), sym_idx: -1 }
 }
 

--- a/src/lib/structure/parse.ts
+++ b/src/lib/structure/parse.ts
@@ -1248,6 +1248,19 @@ export function normalize_fractional_coords(structure: ParsedStructure): ParsedS
   return { ...structure, sites: normalized_sites }
 }
 
+// Detect a structure inside already-stringified JSON (OPTIMADE or pymatgen/nested).
+// Throws if `content` isn't valid JSON; returns null if it holds no known structure.
+const detect_json_structure = (content: string): ParsedStructure | null => {
+  const parsed = JSON.parse(content)
+  if (is_optimade_raw(parsed)) {
+    const result = parse_optimade_from_raw(parsed)
+    if (result) return result
+  }
+  // Otherwise try parsing as pymatgen/nested structure JSON
+  const structure = find_structure_in_json(parsed)
+  return structure ? normalize_fractional_coords(structure) : null
+}
+
 // Auto-detect file format and parse accordingly
 export function parse_structure_file(
   content: string,
@@ -1269,24 +1282,16 @@ export function parse_structure_file(
     // CIF files
     if (ext === `cif`) return parse_cif(content)
 
-    // JSON files - try OPTIMADE JSON structure format first, then pymatgen
+    // JSON files - extension is authoritative, so failures return null
     if (ext === `json`) {
       try {
-        // Parse once, reuse for detection and parsing
-        const parsed = JSON.parse(content)
-        if (is_optimade_raw(parsed)) {
-          const result = parse_optimade_from_raw(parsed)
-          if (result) return result
-        }
-        // Otherwise, try to parse as pymatgen/nested structure JSON
-        const structure = find_structure_in_json(parsed)
-        if (structure) return normalize_fractional_coords(structure)
+        const result = detect_json_structure(content)
+        if (result) return result
         console.error(`JSON file does not contain a valid structure format`)
-        return null
       } catch (error) {
         console.error(`Error parsing JSON file:`, error)
-        return null
       }
+      return null
     }
 
     // YAML files (phonopy)
@@ -1302,16 +1307,8 @@ export function parse_structure_file(
   // JSON detection must come before the line-count guard: minified JSON
   // (e.g. fetched via extensionless blob: object URLs) is a single line.
   try {
-    const parsed = JSON.parse(content)
-    if (is_optimade_raw(parsed)) {
-      const result = parse_optimade_from_raw(parsed)
-      if (result) return result
-    }
-    // Otherwise try parsing as regular JSON structure
-    const structure = find_structure_in_json(parsed)
-    if (structure) {
-      return normalize_fractional_coords(structure)
-    }
+    const result = detect_json_structure(content)
+    if (result) return result
   } catch {
     // Not JSON, continue with other format detection
   }

--- a/src/lib/structure/parse.ts
+++ b/src/lib/structure/parse.ts
@@ -1298,15 +1298,9 @@ export function parse_structure_file(
     }
   }
 
-  // Try to auto-detect based on content
-  const lines = content.trim().split(/\r?\n/)
-
-  if (lines.length < 2) {
-    console.error(`File too short to determine format`)
-    return null
-  }
-
-  // JSON format detection: try to parse as JSON first
+  // Try to auto-detect based on content.
+  // JSON detection must come before the line-count guard: minified JSON
+  // (e.g. fetched via extensionless blob: object URLs) is a single line.
   try {
     const parsed = JSON.parse(content)
     if (is_optimade_raw(parsed)) {
@@ -1320,6 +1314,13 @@ export function parse_structure_file(
     }
   } catch {
     // Not JSON, continue with other format detection
+  }
+
+  const lines = content.trim().split(/\r?\n/)
+
+  if (lines.length < 2) {
+    console.error(`File too short to determine format`)
+    return null
   }
 
   // XYZ format detection: first line should be a number, second line is comment

--- a/src/lib/structure/pbc.ts
+++ b/src/lib/structure/pbc.ts
@@ -62,12 +62,16 @@ export function find_image_atoms(
     return vec_len > 0 ? PHYSICAL_TOLERANCE / vec_len : 0.05
   })
 
+  // Respect per-axis periodicity: no images across non-periodic (vacuum) directions
+  const pbc: Pbc = structure.lattice.pbc ?? [true, true, true]
+
   for (const [idx, site] of structure.sites.entries()) {
     // Find edge dimensions and translation directions
     const edge_dims: { dim: number; direction: number }[] = []
 
     // Find boundary dimensions
     for (let dim = 0; dim < 3; dim++) {
+      if (!pbc[dim]) continue
       const coord = site.abc[dim]
       const dim_tolerance = tolerances[dim]
       if (Math.abs(coord) < dim_tolerance) edge_dims.push({ dim, direction: 1 })

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -624,6 +624,9 @@
         // Read file content directly
         const content = await read_file_content(file)
         await load_trajectory_data(content, file.name)
+        // Don't fall through: drops from IDEs/file managers often also carry a
+        // text/plain payload (the file path) which would clobber the loaded data
+        return
       }
 
       // Check for plain text data (fallback)

--- a/tests/vitest/api/optimade.test.ts
+++ b/tests/vitest/api/optimade.test.ts
@@ -2,8 +2,9 @@ import {
   decode_structure_id,
   detect_provider_from_slug,
   encode_structure_id,
+  fetch_optimade_providers,
 } from '$lib/api/optimade'
-import { describe, expect, test } from 'vitest'
+import { afterEach, describe, expect, test, vi } from 'vitest'
 import { MOCK_PROVIDERS } from '../../fixtures/optimade-mocks'
 
 describe(`OPTIMADE API utilities`, () => {
@@ -79,5 +80,35 @@ describe(`OPTIMADE API utilities`, () => {
   ])(`should return empty string for %s`, (slug) => {
     const provider = detect_provider_from_slug(slug, MOCK_PROVIDERS)
     expect(provider).toBe(``)
+  })
+})
+
+describe(`fetch_with_cors_proxy behavior (via fetch_optimade_providers)`, () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  test(`HTTP error status from direct fetch surfaces instead of hammering proxies`, async () => {
+    // A 404 is a definitive server answer — return it as-is, not masked by 5 proxy attempts
+    const mock_fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: () => Promise.reject(new Error(`no body`)),
+    })
+    vi.stubGlobal(`fetch`, mock_fetch)
+    await expect(fetch_optimade_providers()).rejects.toThrow(`no body`)
+    expect(mock_fetch).toHaveBeenCalledTimes(1) // no proxy fallback
+  })
+
+  test(`path-suffix proxies receive the raw URL, query proxies the encoded one`, async () => {
+    // Network failure (thrown) triggers the proxy fallback chain
+    const mock_fetch = vi.fn().mockRejectedValue(new TypeError(`Failed to fetch`))
+    vi.stubGlobal(`fetch`, mock_fetch)
+    await expect(fetch_optimade_providers()).rejects.toThrow(`All CORS proxies failed`)
+    const urls = mock_fetch.mock.calls.map(([url]) => url as string)
+    const target = `https://providers.optimade.org/v1/links`
+    expect(urls[0]).toBe(target) // direct attempt first
+    // Query-style proxies must percent-encode the target; path-suffix proxies must not
+    expect(urls.some((url) => url.endsWith(encodeURIComponent(target)))).toBe(true)
+    expect(urls).toContain(`https://cors-anywhere.herokuapp.com/${target}`)
+    expect(urls).toContain(`https://thingproxy.freeboard.io/fetch/${target}`)
   })
 })

--- a/tests/vitest/convex-hull/ConvexHullSelectionHarness.svelte
+++ b/tests/vitest/convex-hull/ConvexHullSelectionHarness.svelte
@@ -32,7 +32,10 @@
   let entries = $state.raw(entries_for(`old`))
   let stable_entries = $state.raw<ConvexHullEntry[]>([])
   let unstable_entries = $state.raw<ConvexHullEntry[]>([])
-  let selected_entry = $state.raw<ConvexHullEntry | null>(null)
+  // Plain (deeply-proxied) $state, matching how the demo binds selected_entry: the
+  // component writing a raw plot entry back through this binding re-proxies it, which
+  // used to loop the selection effect forever (raw !== proxy → effect_update_depth_exceeded)
+  let selected_entry = $state<ConvexHullEntry | null>(null)
 </script>
 
 <button

--- a/tests/vitest/fermi-surface/compute-conventions.test.ts
+++ b/tests/vitest/fermi-surface/compute-conventions.test.ts
@@ -64,13 +64,13 @@ describe(`fermi-surface grid/lattice conventions`, () => {
   // field v=[fx,0,0] must sample to exactly iso everywhere. Hexagonal catches a missing
   // transpose; off-center iso catches wrap/centering errors.
   test.each([
-    [`identity`, IDENTITY, 0.5],
-    [`identity`, IDENTITY, 0.25],
-    [`hexagonal`, HEXAGONAL, 0.5],
-    [`hexagonal`, HEXAGONAL, 0.25],
+    { name: `identity`, k_lattice: IDENTITY, iso: 0.5 },
+    { name: `identity`, k_lattice: IDENTITY, iso: 0.25 },
+    { name: `hexagonal`, k_lattice: HEXAGONAL, iso: 0.5 },
+    { name: `hexagonal`, k_lattice: HEXAGONAL, iso: 0.25 },
   ])(
-    `velocities sample the true k-point (%s lattice, plane at fx=%d)`,
-    (_lat, k_lattice, iso) => {
+    `velocities sample the true k-point ($name lattice, plane at fx=$iso)`,
+    ({ k_lattice, iso }) => {
       const band_data = make_band_data(21, (fx) => fx, {
         k_lattice,
         velocity_fn: (fx) => [fx, 0, 0],

--- a/tests/vitest/fermi-surface/compute-conventions.test.ts
+++ b/tests/vitest/fermi-surface/compute-conventions.test.ts
@@ -1,0 +1,134 @@
+// Regression tests for grid/lattice convention bugs in fermi-surface extraction:
+// velocity cart→frac must invert the marching-cubes transform (transpose + de-center),
+// resampling/extraction must respect endpoint-inclusive (BXSF) vs periodic (FRMSF)
+// grids, and the BZ extent must derive from k_lattice (not a hardcoded [-1,1]³ box).
+import { extract_fermi_surface } from '$lib/fermi-surface/compute'
+import { parse_fermi_file } from '$lib/fermi-surface/parse'
+import type { BandGridData } from '$lib/fermi-surface/types'
+import type { Matrix3x3, Vec3 } from '$lib/math'
+import { describe, expect, test } from 'vitest'
+
+const scaled = (scale: number): Matrix3x3 => [
+  [scale, 0, 0],
+  [0, scale, 0],
+  [0, 0, scale],
+]
+const IDENTITY = scaled(1)
+// k_latticeᵀ ≠ k_lattice exposes a missing transpose in cart→frac conversion
+const HEXAGONAL: Matrix3x3 = [
+  [1, 0, 0],
+  [-0.5, Math.sqrt(3) / 2, 0],
+  [0, 0, 1],
+]
+
+// n³ grid of fn(frac coords); denom n−1 = endpoint-inclusive BXSF (point i ↔ i/(n−1)),
+// denom n = periodic FRMSF (i ↔ i/n, no duplicated endpoint)
+const build_grid = <Val>(
+  n: number,
+  denom: number,
+  fn: (fx: number, fy: number, fz: number) => Val,
+) =>
+  Array.from({ length: n }, (_x, ix) =>
+    Array.from({ length: n }, (_y, iy) =>
+      Array.from({ length: n }, (_z, iz) => fn(ix / denom, iy / denom, iz / denom)),
+    ),
+  )
+
+const make_band_data = (
+  n: number,
+  energy_fn: (fx: number, fy: number, fz: number) => number,
+  opts: {
+    k_lattice?: Matrix3x3
+    periodic?: boolean
+    velocity_fn?: (fx: number, fy: number, fz: number) => Vec3
+  } = {},
+): BandGridData => {
+  const { k_lattice = IDENTITY, periodic, velocity_fn } = opts
+  const denom = periodic ? n : n - 1
+  return {
+    energies: [[build_grid(n, denom, energy_fn)]],
+    ...(velocity_fn && { velocities: [[build_grid(n, denom, velocity_fn)]] }),
+    ...(periodic && { periodic }),
+    k_grid: [n, n, n],
+    k_lattice,
+    fermi_energy: 0,
+    n_bands: 1,
+    n_spins: 1,
+  }
+}
+
+const sphere = (fx: number, fy: number, fz: number) => Math.hypot(fx - 0.5, fy - 0.5, fz - 0.5)
+
+describe(`fermi-surface grid/lattice conventions`, () => {
+  // Planar isosurface at fx=iso: every vertex sits at grid frac_x=iso, so a velocity
+  // field v=[fx,0,0] must sample to exactly iso everywhere. Hexagonal catches a missing
+  // transpose; off-center iso catches wrap/centering errors.
+  test.each([
+    [`identity`, IDENTITY, 0.5],
+    [`identity`, IDENTITY, 0.25],
+    [`hexagonal`, HEXAGONAL, 0.5],
+    [`hexagonal`, HEXAGONAL, 0.25],
+  ])(
+    `velocities sample the true k-point (%s lattice, plane at fx=%d)`,
+    (_lat, k_lattice, iso) => {
+      const band_data = make_band_data(21, (fx) => fx, {
+        k_lattice,
+        velocity_fn: (fx) => [fx, 0, 0],
+      })
+      const result = extract_fermi_surface(band_data, { mu: iso, compute_velocities: true })
+      const props = result.isosurfaces[0]?.properties ?? []
+      expect(props.length).toBeGreaterThan(0)
+      for (const vel of props) expect(vel).toBeCloseTo(iso, 2)
+    },
+  )
+
+  // Sphere of radius 0.3 around frac (0.5,0.5,0.5) must keep its radius through
+  // extraction and upsampling — a mixed-up grid convention rescales it by ~n/(n−1)
+  test.each([
+    [`endpoint-inclusive (BXSF)`, false, 1],
+    [`endpoint-inclusive (BXSF), 2x upsampled`, false, 2],
+    [`periodic (FRMSF)`, true, 1],
+    [`periodic (FRMSF), 2x upsampled`, true, 2],
+  ])(`sphere keeps its radius: %s`, (_label, periodic, interpolation_factor) => {
+    const band_data = make_band_data(20, sphere, { periodic })
+    const { isosurfaces } = extract_fermi_surface(band_data, { mu: 0.3, interpolation_factor })
+    const verts = isosurfaces[0].vertices
+    const mean_radius = verts.reduce((sum, vec) => sum + Math.hypot(...vec), 0) / verts.length
+    expect(mean_radius).toBeCloseTo(0.3, 2)
+  })
+
+  test(`single-point endpoint-inclusive axis upsamples without NaN/crash`, () => {
+    // [1][n][n] grid: px = 0, so unguarded resampling computes 0/0 = NaN and the
+    // tricubic wrap (v % 0) indexes grid[NaN] → crash. A single x-plane has no cubes
+    // to march, so the expected output is simply no surfaces.
+    const n = 6
+    const band_data: BandGridData = {
+      energies: [[[build_grid(n, n - 1, (_fx, fy, fz) => Math.hypot(fy - 0.5, fz - 0.5))[0]]]],
+      k_grid: [1, n, n],
+      k_lattice: IDENTITY,
+      fermi_energy: 0.3,
+      n_bands: 1,
+      n_spins: 1,
+    }
+    expect(extract_fermi_surface(band_data, { interpolation_factor: 2 }).isosurfaces).toEqual(
+      [],
+    )
+  })
+
+  // Full-BZ cylinder along z (open surface spanning one axis ⇒ 2D sheet); classification
+  // must be invariant under pure rescaling of k_lattice
+  test.each([1, 2, 0.8])(`full-BZ cylinder is 2D at lattice scale %d`, (scale) => {
+    const band_data = make_band_data(21, (fx, fy) => Math.hypot(fx - 0.5, fy - 0.5), {
+      k_lattice: scaled(scale),
+    })
+    const result = extract_fermi_surface(band_data, { mu: 0.3, compute_dimensionality: true })
+    expect(result.isosurfaces[0].dimensionality).toBe(`2D`)
+    expect(result.isosurfaces[0].orientation).toEqual([0, 0, 1])
+  })
+
+  test(`parse_frmsf marks the grid as periodic`, () => {
+    const energies = Array.from({ length: 64 }, (_, idx) => (idx % 2 ? 1 : -1))
+    const frmsf = [`4 4 4`, `1`, `1`, `1 0 0`, `0 1 0`, `0 0 1`, ...energies].join(`\n`)
+    expect((parse_fermi_file(frmsf, `bands.frmsf`) as BandGridData).periodic).toBe(true)
+  })
+})

--- a/tests/vitest/io/decompress.test.ts
+++ b/tests/vitest/io/decompress.test.ts
@@ -1,0 +1,8 @@
+import { decompress_file } from '$lib/io/decompress'
+import { expect, test } from 'vitest'
+
+test(`decompress_file resolves empty (0-byte) files to empty content`, async () => {
+  // FileReader returns '' for empty text files, which is falsy but valid
+  const result = await decompress_file(new File([], `empty.txt`))
+  expect(result).toEqual({ content: ``, filename: `empty.txt` })
+})

--- a/tests/vitest/io/index.test.ts
+++ b/tests/vitest/io/index.test.ts
@@ -490,26 +490,33 @@ describe(`load_from_url`, () => {
   })
 
   describe(`non-gzip binary files with content-encoding`, () => {
-    test(`gzip content-encoding on non-.gz URL returns text`, async () => {
-      const mock_response = new Response(`decompressed content`, {
+    test(`gzip content-encoding on binary extension stays ArrayBuffer`, async () => {
+      // Content-Encoding is transparent: fetch auto-decompresses, so the body is
+      // the original binary and must not be lossily decoded to text
+      const payload = new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0xff, 0xfe, 0x00, 0x80])
+      const mock_response = new Response(payload, {
         headers: {
           'content-encoding': `gzip`,
-          'content-type': `text/plain`,
+          'content-type': `application/octet-stream`,
         },
+      })
+      Object.defineProperty(mock_response, `arrayBuffer`, {
+        value: () => Promise.resolve(payload.buffer),
       })
       globalThis.fetch = vi.fn().mockResolvedValue(mock_response)
 
       let received_content: string | ArrayBuffer | null = null
       let received_filename: string | null = null
       await load_from_url(
-        `https://example.com/data.npz`, // binary extension but with gzip content-encoding
+        `https://example.com/data.npz`, // binary extension with gzip content-encoding
         (content, filename) => {
           received_content = content
           received_filename = filename
         },
       )
 
-      expect(typeof received_content).toBe(`string`)
+      expect(received_content).toBeInstanceOf(ArrayBuffer)
+      expect(new Uint8Array(received_content as unknown as ArrayBuffer)).toEqual(payload)
       expect(received_filename).toBe(`data.npz`)
     })
   })

--- a/tests/vitest/io/index.test.ts
+++ b/tests/vitest/io/index.test.ts
@@ -3,13 +3,20 @@ import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 globalThis.fetch = vi.fn()
 
-// decompress_data is a static import in url-drop.ts, so the gzip test below can't mock it via a
-// dynamic import. Mock it through the module registry (hoisted) instead, keeping the other real
-// exports so unrelated decompress paths are unaffected.
-const { mock_decompress } = vi.hoisted(() => ({ mock_decompress: vi.fn() }))
+// decompress helpers are static imports in url-drop.ts, so the gzip tests below can't mock them
+// via a dynamic import. Mock them through the module registry (hoisted) instead, keeping the
+// other real exports so unrelated decompress paths are unaffected.
+const { mock_decompress, mock_decompress_binary } = vi.hoisted(() => ({
+  mock_decompress: vi.fn(),
+  mock_decompress_binary: vi.fn(),
+}))
 vi.mock(`$lib/io/decompress`, async (import_original) => {
   const actual = await import_original<Record<string, unknown>>()
-  return { ...actual, decompress_data: mock_decompress }
+  return {
+    ...actual,
+    decompress_data: mock_decompress,
+    decompress_data_binary: mock_decompress_binary,
+  }
 })
 
 describe(`handle_url_drop`, () => {
@@ -117,6 +124,7 @@ describe(`load_from_url`, () => {
     [`https://example.com/model.npz`, `model.npz`],
     [`https://example.com/data.pkl`, `data.pkl`],
     [`https://example.com/output.dat`, `output.dat`],
+    [`https://example.com/scan.raw`, `scan.raw`], // Bruker/Rigaku XRD binary
   ])(`binary extensions %s`, async (url, expected_filename) => {
     const { received_content, received_filename } = await load_test_url(
       url,
@@ -155,45 +163,65 @@ describe(`load_from_url`, () => {
     expect(globalThis.fetch).toHaveBeenCalledTimes(1) // Only one fetch for known text formats
   })
 
-  test(`gzip files with content-encoding are handled as text`, async () => {
-    const mock_response = new Response(`decompressed content`, {
-      headers: { 'content-encoding': `gzip` },
-    })
-    globalThis.fetch = vi.fn().mockResolvedValue(mock_response)
-
-    let received_content: string | ArrayBuffer | null = null
-    let received_filename: string | null = null
-
-    await load_from_url(`https://example.com/file.xyz.gz`, (content, filename) => {
-      received_content = content
-      received_filename = filename
-    })
-
-    expect(typeof received_content).toBe(`string`)
-    expect(received_content).toBe(`decompressed content`)
-    expect(received_filename).toBe(`file.xyz.gz`)
+  // content-encoding gzip: browser already decompressed the stored .gz, so the body is
+  // the inner file — text formats arrive as string, binary inner formats (.h5.gz) as
+  // ArrayBuffer that a text decode would corrupt
+  test.each([
+    [`file.xyz.gz`, `decompressed content`],
+    [`data.h5.gz`, new Uint8Array([0x89, 0x48, 0x44, 0x46]).buffer],
+  ] as const)(`content-encoding gzip body passes through: %s`, async (name, body) => {
+    const { received_content, received_filename } = await load_test_url(
+      `https://example.com/${name}`,
+      body,
+      { 'content-encoding': `gzip` },
+    )
+    expect(received_content).toBe(body)
+    expect(received_filename).toBe(name)
   })
 
-  test(`gzip files without content-encoding are decompressed`, async () => {
-    mock_decompress.mockResolvedValue(`decompressed content`)
+  // No content-encoding: the .gz body is gunzipped manually, the .gz suffix stripped
+  // from the filename, and binary inner formats (.h5.gz) stay ArrayBuffer
+  test.each([
+    [`file.xyz.gz`, `file.xyz`, `string`],
+    [`x.h5.gz`, `x.h5`, `binary`],
+  ] as const)(`manual gunzip: %s -> %s (%s)`, async (name, expected_name, kind) => {
+    const inner = new TextEncoder().encode(`inner bytes`).buffer
+    mock_decompress_binary.mockResolvedValue(inner)
+    const { received_content, received_filename } = await load_test_url(
+      `https://example.com/${name}`,
+      new ArrayBuffer(8),
+      { 'content-type': `application/octet-stream` },
+    )
+    expect(mock_decompress_binary).toHaveBeenCalledWith(new ArrayBuffer(8), `gzip`)
+    expect(received_content).toBe(kind === `string` ? `inner bytes` : inner)
+    expect(received_filename).toBe(expected_name)
+  })
 
-    const mock_response = create_mock_response(new ArrayBuffer(8), {
-      'content-type': `application/octet-stream`,
-    })
-    globalThis.fetch = vi.fn().mockResolvedValue(mock_response)
+  test(`propagates decompress errors instead of falling through to a text fetch`, async () => {
+    // Once magic bytes commit to gzip, a decompress failure must throw rather than be
+    // swallowed and re-fetched as text (which would parse the binary bytes as garbage)
+    mock_decompress_binary.mockRejectedValue(new Error(`corrupt gzip`))
+    const gzip_header = new Uint8Array([0x1f, 0x8b, ...Array(14).fill(0)]).buffer
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(create_mock_response(gzip_header, {}))
+      .mockResolvedValue(create_mock_response(new ArrayBuffer(8), {}))
 
-    let received_content: string | ArrayBuffer | null = null
-    let received_filename: string | null = null
+    await expect(load_from_url(`https://example.com/blob-uuid`, () => {})).rejects.toThrow(
+      `corrupt gzip`,
+    )
+  })
 
-    await load_from_url(`https://example.com/file.xyz.gz`, (content, filename) => {
-      received_content = content
-      received_filename = filename
-    })
-
-    expect(typeof received_content).toBe(`string`)
-    expect(received_content).toBe(`decompressed content`)
-    expect(received_filename).toBe(`file.xyz`)
-    expect(mock_decompress).toHaveBeenCalledWith(new ArrayBuffer(8), `gzip`)
+  test(`query string and hash are stripped before extension detection`, async () => {
+    // Pre-signed URLs like traj.h5?X-Amz-Expires=300 must still hit the binary
+    // path and not leak the query string into the callback filename
+    const { received_content, received_filename } = await load_test_url(
+      `https://example.com/data.h5?sig=abc`,
+      new ArrayBuffer(8),
+      { 'content-type': `application/octet-stream` },
+    )
+    expect(received_content).toBeInstanceOf(ArrayBuffer)
+    expect(received_filename).toBe(`data.h5`)
   })
 
   test.each([
@@ -273,14 +301,24 @@ describe(`load_from_url`, () => {
     },
   )
 
-  test(`sniffed gzip without .gz extension is decompressed`, async () => {
-    mock_decompress.mockResolvedValue(`decompressed content`)
-    const header = new Uint8Array([0x1f, 0x8b, ...Array(14).fill(0)])
+  // Sniffed gzip magic on a URL without .gz extension is decompressed; a binary inner
+  // extension from Content-Disposition (relax.traj.gz) keeps the payload an ArrayBuffer
+  test.each([
+    [`data.bin`, `string`, {}],
+    [
+      `relax.traj`,
+      `binary`,
+      { 'content-disposition': `attachment; filename="relax.traj.gz"` },
+    ],
+  ] as const)(`sniffed gzip -> %s (%s)`, async (expected_name, kind, headers) => {
+    const inner = new TextEncoder().encode(`inner bytes`).buffer
+    mock_decompress_binary.mockResolvedValue(inner)
+    const gzip_header = new Uint8Array([0x1f, 0x8b, ...Array(14).fill(0)]).buffer
     const full_body = new ArrayBuffer(100)
     globalThis.fetch = vi
       .fn()
-      .mockResolvedValueOnce(create_mock_response(header.buffer, {}))
-      .mockResolvedValueOnce(create_mock_response(full_body, {}))
+      .mockResolvedValueOnce(create_mock_response(gzip_header, {}))
+      .mockResolvedValueOnce(create_mock_response(full_body, headers))
 
     let received_content: string | ArrayBuffer | null = null
     let received_filename: string | null = null
@@ -289,9 +327,9 @@ describe(`load_from_url`, () => {
       received_filename = filename
     })
 
-    expect(received_content).toBe(`decompressed content`)
-    expect(received_filename).toBe(`data.bin`)
-    expect(mock_decompress).toHaveBeenCalledWith(full_body, `gzip`)
+    expect(received_content).toBe(kind === `string` ? `inner bytes` : inner)
+    expect(received_filename).toBe(expected_name)
+    expect(mock_decompress_binary).toHaveBeenCalledWith(full_body, `gzip`)
   })
 
   test(`blob: object URL with text content passes UUID basename to callback`, async () => {
@@ -407,6 +445,19 @@ describe(`load_from_url`, () => {
         `filename*=UTF-8''invalid%ZZencoding.xyz`,
         `invalid%ZZencoding.xyz`,
         `invalid percent-encoding returns raw value`,
+      ],
+      // RFC 5987 grammar is charset'language'value — strip the full prefix
+      [
+        `filename*=UTF-8'en'na%C3%AFve.cif`,
+        `naïve.cif`,
+        `RFC 5987 filename* with charset and language tag`,
+      ],
+      // Non-UTF-8 charset prefix must still be stripped; %FC is invalid UTF-8
+      // so decodeURIComponent fails and the raw (prefix-stripped) value is kept
+      [
+        `filename*=iso-8859-1''f%FCr.txt`,
+        `f%FCr.txt`,
+        `RFC 5987 filename* with non-UTF-8 charset`,
       ],
     ])(`%s -> %s (%s)`, async (disposition, expected, _desc) => {
       const mock_response = new Response(`content`, {

--- a/tests/vitest/plot/BoxPlot.test.ts
+++ b/tests/vitest/plot/BoxPlot.test.ts
@@ -78,6 +78,24 @@ describe(`BoxPlot`, () => {
     expect(plot.querySelectorAll(`.value-label`)).toHaveLength(2)
   })
 
+  test(`show_mean keeps the mean line inside the plot even when outliers are hidden`, async () => {
+    // heavy outlier drags mean (~1004) far above whisker_high (~9); with outliers
+    // hidden, the mean used to be excluded from the auto-range and rendered off-plot
+    const plot = await mount_sized_box_plot({
+      series: [{ y: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10_000], label: `skewed` }],
+      show_mean: true,
+      show_outliers: false,
+    })
+    // the dashed line is the mean glyph (median/whiskers/caps are solid)
+    const mean_line = [...plot.querySelectorAll(`.box-series line`)].find((line) =>
+      line.hasAttribute(`stroke-dasharray`),
+    )
+    expect(mean_line).toBeDefined()
+    const mean_y = Number(mean_line?.getAttribute(`y1`))
+    expect(mean_y).toBeGreaterThanOrEqual(0) // was ≈ -27000 before the fix
+    expect(mean_y).toBeLessThanOrEqual(300)
+  })
+
   test(`a far outlier expands the value-axis range`, async () => {
     // value_points must reach the extreme outliers, not just the whiskers. The component
     // pushes only the sorted outlier extremes (outliers[0]/[last]) so this also stays safe

--- a/tests/vitest/plot/Violin.test.ts
+++ b/tests/vitest/plot/Violin.test.ts
@@ -10,6 +10,15 @@ const dist = (n: number, center = 0, spread = 1): number[] =>
     (_, idx) => center + spread * Math.sin(idx * 1.7) + (idx % 5) * 0.1,
   )
 
+// Extract alternating x,y pixel coords from a violin path ("Mx,yLx,y...Z")
+const path_coords = (d: string): { xs: number[]; ys: number[] } => {
+  const nums = (d.match(/-?\d+(?:\.\d+)?(?:e[+-]?\d+)?/gi) ?? []).map(Number)
+  return {
+    xs: nums.filter((_, idx) => idx % 2 === 0),
+    ys: nums.filter((_, idx) => idx % 2 === 1),
+  }
+}
+
 async function mount_violin(
   props: Partial<ComponentProps<typeof Violin>>,
 ): Promise<HTMLElement> {
@@ -52,4 +61,50 @@ describe(`Violin`, () => {
     expect(plot.querySelectorAll(`.violin-area`)).toHaveLength(2)
     expect(plot.querySelector(`.x-label`)?.textContent).toBe(`Value`)
   })
+
+  test(`log value axis clamps KDE grid to positive support (finite path, no range pollution)`, async () => {
+    const plot = await mount_violin({
+      series: [{ y: [0.5, 1, 1.5, 2, 3, 4, 6, 8, 10, 15], label: `A` }],
+      y_axis: { scale_type: `log` },
+    })
+    const path = plot.querySelector(`.violin-area`)?.getAttribute(`d`) ?? ``
+    // unclamped, the KDE grid tail (≈ -4.5) mapped to NaN pixels (invisible violin)
+    expect(path.length).toBeGreaterThan(0)
+    expect(path).not.toContain(`NaN`)
+    const { ys } = path_coords(path)
+    // a LOG_EPS-polluted auto-range (~10 decades) squashed the violin to span ≈ 35px
+    expect(Math.max(...ys) - Math.min(...ys)).toBeGreaterThan(100)
+  })
+
+  // side=positive must hug "above the center line" (horizontal, smaller screen y) /
+  // "right of it" (vertical, larger screen x) — the horizontal category pixel axis
+  // is inverted, so the rendered side flips
+  test.each([
+    [`horizontal`, -1],
+    [`vertical`, 1],
+  ] as const)(
+    `side=positive draws the violin hump on the positive side (%s)`,
+    async (orientation, sign) => {
+      const plot = await mount_violin({
+        series: [{ y: dist(80, 5, 1), label: `A` }],
+        orientation,
+        side: `positive`,
+        kind: `violin+box`,
+      })
+      // whisker segments run along the value axis at the category center
+      const [c1, c2] = orientation === `horizontal` ? [`y1`, `y2`] : [`x1`, `x2`]
+      const whisker = [...plot.querySelectorAll(`.box-series line`)].find(
+        (ln) => ln.getAttribute(c1) === ln.getAttribute(c2),
+      )
+      const center = Number(whisker?.getAttribute(c1))
+      expect(Number.isFinite(center)).toBe(true)
+      const { xs, ys } = path_coords(
+        plot.querySelector(`.violin-area`)?.getAttribute(`d`) ?? ``,
+      )
+      // signed offsets from the center line: hump on the positive side, inner edge on it
+      const deltas = (orientation === `horizontal` ? ys : xs).map((px) => (px - center) * sign)
+      expect(Math.max(...deltas)).toBeGreaterThan(5)
+      expect(Math.min(...deltas)).toBeGreaterThanOrEqual(-1)
+    },
+  )
 })

--- a/tests/vitest/plot/sankey-layout.test.ts
+++ b/tests/vitest/plot/sankey-layout.test.ts
@@ -124,10 +124,32 @@ describe(`compute_sankey_layout`, () => {
   })
 
   test.each([
-    [{ nodes: [], links: [] } as SankeyData],
-    [tri], // valid data but zero size -> empty
-  ])(`returns empty layout for degenerate input %#`, (data) => {
-    expect(compute_sankey_layout(data, { width: 0, height: 0 }).nodes).toEqual([])
+    [{ nodes: [], links: [] } as SankeyData, { width: 0, height: 0 }],
+    [tri, { width: 0, height: 0 }], // valid data but zero size -> empty
+    // all-zero link values would divide by zero in d3-sankey (NaN ribbon paths)
+    [
+      {
+        nodes: [{ label: `A` }, { label: `B` }],
+        links: [{ source: 0, target: 1, value: 0 }],
+      } as SankeyData,
+      dims,
+    ],
+  ])(`returns empty layout for degenerate input %#`, (data, size) => {
+    expect(compute_sankey_layout(data, size).nodes).toEqual([])
+  })
+
+  test(`a zero-value link among positive links keeps the layout finite`, () => {
+    const data: SankeyData = {
+      nodes: [{ label: `A` }, { label: `B` }, { label: `C` }],
+      links: [
+        { source: 0, target: 2, value: 1 },
+        { source: 1, target: 2, value: 0 },
+      ],
+    }
+    const { nodes, links } = compute_sankey_layout(data, dims)
+    expect(nodes).toHaveLength(3)
+    expect(nodes.every((nd) => Number.isFinite(nd.y0) && Number.isFinite(nd.y1))).toBe(true)
+    for (const link of links) expect(link.path).not.toContain(`NaN`)
   })
 
   test(`warns when node labels collide and no ids are set`, () => {

--- a/tests/vitest/structure/bonding.test.ts
+++ b/tests/vitest/structure/bonding.test.ts
@@ -1155,3 +1155,27 @@ test(`electroneg_ratio ignores weak bonds for closest neighbor penalty`, () => {
   expect(na_na).toBeUndefined()
   expect(na_cl).toBeDefined()
 })
+
+describe(`remap_bonds_after_deletion`, () => {
+  const bond = (
+    site_idx_1: number,
+    site_idx_2: number,
+    extra: Partial<StructureBond> = {},
+  ): StructureBond => ({ site_idx_1, site_idx_2, order: 1, ...extra })
+
+  const shifted: Partial<StructureBond> = { order: 2, cell_shift: [1, 0, 0] }
+  test.each([
+    [`decrements indices past deleted site`, [bond(1, 2)], [0], [bond(0, 1)]],
+    [`drops bonds touching deleted sites`, [bond(0, 2)], [2], []],
+    [
+      `mixed drop and shift`, // only the 3-4 bond survives, shifted down by 2
+      [bond(0, 1), bond(1, 3), bond(3, 4), bond(2, 4)],
+      [1, 2],
+      [bond(1, 2)],
+    ],
+    [`no deletions is a no-op`, [bond(0, 1), bond(1, 2)], [], [bond(0, 1), bond(1, 2)]],
+    [`preserves order and cell_shift`, [bond(2, 3, shifted)], [0], [bond(1, 2, shifted)]],
+  ])(`%s`, (_desc, bonds, deleted, expected) => {
+    expect(bonding.remap_bonds_after_deletion(bonds, new Set(deleted))).toEqual(expected)
+  })
+})

--- a/tests/vitest/structure/export.test.ts
+++ b/tests/vitest/structure/export.test.ts
@@ -885,8 +885,8 @@ describe(`Export functionality`, () => {
         sites: [
           {
             species: [
-              { element: `Cu`, occu: 0.5, oxidation_state: 0 },
-              { element: `Au`, occu: 0.5, oxidation_state: 0 },
+              { element: `Cu`, occu: 0.7, oxidation_state: 0 },
+              { element: `Au`, occu: 0.3, oxidation_state: 0 },
             ],
             abc: [0.25, 0.25, 0.25],
             xyz: [2.5, 2.5, 2.5],
@@ -899,17 +899,25 @@ describe(`Export functionality`, () => {
       const atom_rows = cif_content
         .split(`\n`)
         .filter((line) => /^\S+ (Cu|Au) /.test(line.trim()))
-      // both species rows carry the site's coords, each with its own occupancy
       expect(atom_rows).toHaveLength(2)
-      for (const row of atom_rows) {
-        expect(row).toContain(`0.25000000`)
-        expect(row).toContain(`0.50000000`)
-      }
 
-      // Round-trip: both partial occupancies survive parsing
+      // each element's row carries the site coords and its OWN occupancy (col order:
+      // label element x y z occupancy) — distinct occupancies catch a swapped assignment
+      const cif_occ = (element: string): number => {
+        const row = atom_rows.find((line) => line.trim().split(/\s+/)[1] === element)
+        if (!row) throw new Error(`missing CIF row for ${element}`)
+        const cols = row.trim().split(/\s+/)
+        expect(cols.slice(2, 5)).toEqual([`0.25000000`, `0.25000000`, `0.25000000`])
+        return Number(cols.at(-1))
+      }
+      expect(cif_occ(`Cu`)).toBeCloseTo(0.7, 8)
+      expect(cif_occ(`Au`)).toBeCloseTo(0.3, 8)
+
+      // Round-trip: each element keeps its own partial occupancy through parse_cif
       const species = parse_cif(cif_content)?.sites.flatMap((site) => site.species) ?? []
       expect(species.map((sp) => sp.element).sort()).toEqual([`Au`, `Cu`])
-      expect(species.reduce((sum, sp) => sum + sp.occu, 0)).toBeCloseTo(1, 8)
+      expect(species.find((sp) => sp.element === `Cu`)?.occu).toBeCloseTo(0.7, 8)
+      expect(species.find((sp) => sp.element === `Au`)?.occu).toBeCloseTo(0.3, 8)
     })
 
     it.each([

--- a/tests/vitest/structure/export.test.ts
+++ b/tests/vitest/structure/export.test.ts
@@ -859,45 +859,57 @@ describe(`Export functionality`, () => {
       }
     })
 
-    it(`exports CIF with space group information`, () => {
-      const structure_with_symmetry: AnyStructure = {
-        id: `test_symmetry`,
+    it(`exports CIF with quoted H-M symbol, IT number, and identity symmetry ops loop`, () => {
+      const structure: AnyStructure = {
+        ...simple_structure,
+        // @ts-expect-error - symmetry is not on AnyStructure but read by the CIF exporter
+        symmetry: { space_group_symbol: `F m -3 m`, space_group_number: 225 },
+      }
+      const lines = structure_to_cif_str(structure)
+        .split(`\n`)
+        .map((line) => line.trim())
+
+      // Unquoted multi-word H-M symbols would break CIF tokenization downstream
+      expect(lines).toContain(`_space_group_name_H-M_alt 'F m -3 m'`)
+      expect(lines).toContain(`_space_group_IT_number 225`)
+      // Identity ops loop prevents parsers (e.g. pymatgen) from re-applying the 192
+      // Fm-3m operators to the already-P1-expanded sites
+      const ops_idx = lines.indexOf(`_symmetry_equiv_pos_as_xyz`)
+      expect(lines[ops_idx - 1]).toBe(`loop_`)
+      expect(lines[ops_idx + 1]).toBe(`'x, y, z'`)
+    })
+
+    it(`exports one CIF row per species on disordered sites and round-trips`, () => {
+      const disordered: AnyStructure = {
+        ...simple_structure,
         sites: [
           {
-            species: [{ element: `H`, occu: 1, oxidation_state: 0 }],
-            abc: [0.0, 0.0, 0.0],
-            xyz: [0.0, 0.0, 0.0],
-            label: `H1`,
+            species: [
+              { element: `Cu`, occu: 0.5, oxidation_state: 0 },
+              { element: `Au`, occu: 0.5, oxidation_state: 0 },
+            ],
+            abc: [0.25, 0.25, 0.25],
+            xyz: [2.5, 2.5, 2.5],
+            label: `Cu1`,
             properties: {},
           },
         ],
-        lattice: {
-          matrix: [
-            [2.0, 0.0, 0.0],
-            [0.0, 2.0, 0.0],
-            [0.0, 0.0, 2.0],
-          ],
-          pbc: [true, true, true],
-          a: 2,
-          b: 2,
-          c: 2,
-          alpha: 90,
-          beta: 90,
-          gamma: 90,
-          volume: 8,
-        },
-        // @ts-expect-error - test symmetry property
-        symmetry: {
-          space_group_symbol: `P1`,
-          space_group_number: 1,
-        },
+      }
+      const cif_content = structure_to_cif_str(disordered)
+      const atom_rows = cif_content
+        .split(`\n`)
+        .filter((line) => /^\S+ (Cu|Au) /.test(line.trim()))
+      // both species rows carry the site's coords, each with its own occupancy
+      expect(atom_rows).toHaveLength(2)
+      for (const row of atom_rows) {
+        expect(row).toContain(`0.25000000`)
+        expect(row).toContain(`0.50000000`)
       }
 
-      const cif_content = structure_to_cif_str(structure_with_symmetry)
-      const lines = cif_content.split(`\n`)
-
-      expect(lines).toContain(`_space_group_name_H-M_alt P1`)
-      expect(lines).toContain(`_space_group_IT_number 1`)
+      // Round-trip: both partial occupancies survive parsing
+      const species = parse_cif(cif_content)?.sites.flatMap((site) => site.species) ?? []
+      expect(species.map((sp) => sp.element).sort()).toEqual([`Au`, `Cu`])
+      expect(species.reduce((sum, sp) => sum + sp.occu, 0)).toBeCloseTo(1, 8)
     })
 
     it.each([

--- a/tests/vitest/structure/measure.test.ts
+++ b/tests/vitest/structure/measure.test.ts
@@ -42,6 +42,24 @@ describe(`measure: distances`, () => {
       expect(displacement_pbc(from, to, lattice_matrix)).toEqual([3, 5, 5])
     },
   )
+
+  test(`pbc flags disable wrapping along vacuum axes (slabs)`, () => {
+    const lat = cubic(10)
+    // Slab with vacuum along z: distance must NOT wrap across the vacuum gap
+    expect(
+      distance_pbc([0, 0, 1], [0, 0, 9], lat, undefined, [true, true, false]),
+    ).toBeCloseTo(8, 12)
+    // Fully periodic: wraps to the minimum image distance of 2
+    expect(distance_pbc([0, 0, 1], [0, 0, 9], lat)).toBeCloseTo(2, 12)
+
+    const disp = displacement_pbc([0, 0, 1], [0, 0, 9], lat, undefined, [true, true, false])
+    expect(disp[2]).toBeCloseTo(8, 12)
+    // Periodic axes still wrap with mixed pbc
+    const disp_xy = displacement_pbc([1, 1, 1], [9, 9, 9], lat, undefined, [true, true, false])
+    expect(disp_xy[0]).toBeCloseTo(-2, 12)
+    expect(disp_xy[1]).toBeCloseTo(-2, 12)
+    expect(disp_xy[2]).toBeCloseTo(8, 12)
+  })
 })
 
 describe(`measure: angles`, () => {

--- a/tests/vitest/structure/parse.test.ts
+++ b/tests/vitest/structure/parse.test.ts
@@ -1733,6 +1733,28 @@ unit_cell:
 })
 
 describe(`parse_structure_file`, () => {
+  // Filenames from blob: object URLs (URL.createObjectURL) are extensionless UUIDs,
+  // so format detection must fall back to content sniffing — same bug class as
+  // https://github.com/janosh/matterviz/issues/353 for trajectories
+  test.each([
+    [`CIF`, `Li10GeP2S12.cif`],
+    [`POSCAR`, `BaTiO3-tetragonal.poscar`],
+    [`pymatgen JSON`, `mp-1.json`],
+    [`extxyz`, `quartz.extxyz`],
+    [`phonopy YAML`, `BeO-zw12zc18p-phono3py.yaml.gz`],
+  ])(`detects %s content with blob-URL UUID filename`, (_label, fixture) => {
+    const content = read_maybe_gz(`./src/site/structures/${fixture}`)
+    const result = parse_structure_file(content, `8a3bf2c4-d1e2-4f5a-9b8c-7d6e5f4a3b2c`)
+    expect(result, `failed to content-detect ${fixture}`).not.toBeNull()
+    expect(result?.sites.length).toBeGreaterThan(0)
+  })
+
+  test(`still trusts conflicting extension over content`, () => {
+    // CIF content explicitly named .json must not be sniffed as CIF
+    const content = read_maybe_gz(`./src/site/structures/Li10GeP2S12.cif`)
+    expect(parse_structure_file(content, `data.json`)).toBeNull()
+  })
+
   test(`parses nested JSON structure correctly`, () => {
     // Read the actual test file
     const content = read_maybe_gz(`./src/site/structures/${hea_hcp_filename}`)

--- a/tests/vitest/structure/pbc.test.ts
+++ b/tests/vitest/structure/pbc.test.ts
@@ -959,3 +959,24 @@ describe(`wrap_to_unit_cell`, () => {
     }
   })
 })
+
+describe(`find_image_atoms respects lattice.pbc`, () => {
+  test(`skips image generation along non-periodic axes (slab)`, () => {
+    // Corner atom in a fully periodic cell generates images along all 3 dims
+    const periodic = make_crystal(5, [[`Na`, [0, 0, 0]]])
+    const periodic_images = find_image_atoms(periodic)
+    expect(periodic_images).toHaveLength(7) // 2^3 - 1 corner images
+
+    // Slab with vacuum along z: no image may be shifted along z
+    const slab = make_crystal(5, [[`Na`, [0, 0, 0]]], { pbc: [true, true, false] })
+    const slab_images = find_image_atoms(slab)
+    expect(slab_images).toHaveLength(3) // 2^2 - 1 in-plane images
+    for (const [, , img_abc] of slab_images) expect(img_abc[2]).toBe(0)
+
+    // Fully non-periodic: no images at all
+    const molecule_like = make_crystal(5, [[`Na`, [0, 0, 0]]], {
+      pbc: [false, false, false],
+    })
+    expect(find_image_atoms(molecule_like)).toHaveLength(0)
+  })
+})

--- a/tests/vitest/trajectory/data-url.test.ts
+++ b/tests/vitest/trajectory/data-url.test.ts
@@ -1,0 +1,79 @@
+// Regression tests for loading trajectories via the data_url prop
+// (https://github.com/janosh/matterviz/issues/353): blob: object URLs from
+// URL.createObjectURL have extensionless UUID basenames, so format detection
+// must fall back to content sniffing instead of failing with
+// "Unsupported text format".
+import type { TrajHandlerData } from '$lib/trajectory'
+import Trajectory from '$lib/trajectory/Trajectory.svelte'
+import { mount, unmount } from 'svelte'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+const MULTI_FRAME_XYZ = `2\nStep 1\nH 0.0 0.0 0.0\nH 0.0 0.0 0.74
+2\nStep 2\nH 0.0 0.0 0.0\nH 0.0 0.0 0.78`
+const BLOB_URL = `blob:http://localhost:5173/8a3bf2c4-d1e2-4f5a-9b8c-7d6e5f4a3b2c`
+
+// Fresh response per fetch call since load_from_url may fetch twice (magic-byte
+// sniff via Range request, then full body)
+const mock_fetch_text = (content: string) =>
+  vi.fn().mockImplementation(() =>
+    Promise.resolve({
+      ok: true,
+      headers: new Headers(),
+      text: () => Promise.resolve(content),
+      arrayBuffer: () => Promise.resolve(new TextEncoder().encode(content).buffer),
+    }),
+  )
+
+const mounted: ReturnType<typeof mount>[] = []
+afterEach(() => {
+  for (const app of mounted.splice(0)) void unmount(app)
+})
+
+describe(`Trajectory data_url loading`, () => {
+  test(`loads multi-frame XYZ from blob: URL with UUID basename`, async () => {
+    globalThis.fetch = mock_fetch_text(MULTI_FRAME_XYZ)
+
+    let load_data: TrajHandlerData | undefined
+    let error_data: TrajHandlerData | undefined
+    mounted.push(
+      mount(Trajectory, {
+        target: document.body,
+        props: {
+          data_url: BLOB_URL,
+          display_mode: `structure`,
+          show_controls: `never`,
+          on_file_load: (data: TrajHandlerData) => (load_data = data),
+          on_error: (data: TrajHandlerData) => (error_data = data),
+        },
+      }),
+    )
+
+    await vi.waitFor(() => expect(load_data).toBeDefined())
+    expect(error_data).toBeUndefined()
+    expect(load_data?.frame_count).toBe(2)
+    expect(load_data?.filename).toBe(`8a3bf2c4-d1e2-4f5a-9b8c-7d6e5f4a3b2c`)
+    expect(load_data?.trajectory?.metadata?.source_format).toBe(`xyz_trajectory`)
+  })
+
+  test(`still reports error for unparsable blob: URL content`, async () => {
+    globalThis.fetch = mock_fetch_text(`not a trajectory in any format`)
+
+    let load_data: TrajHandlerData | undefined
+    let error_data: TrajHandlerData | undefined
+    mounted.push(
+      mount(Trajectory, {
+        target: document.body,
+        props: {
+          data_url: BLOB_URL,
+          display_mode: `structure`,
+          show_controls: `never`,
+          on_file_load: (data: TrajHandlerData) => (load_data = data),
+          on_error: (data: TrajHandlerData) => (error_data = data),
+        },
+      }),
+    )
+
+    await vi.waitFor(() => expect(error_data).toBeDefined())
+    expect(load_data).toBeUndefined()
+  })
+})

--- a/tests/vitest/trajectory/file-drop.test.ts
+++ b/tests/vitest/trajectory/file-drop.test.ts
@@ -1,0 +1,60 @@
+// Regression: a single OS/IDE drag often carries BOTH a File and a text/plain
+// payload (e.g. the file path). The text/plain fallback must not run after a
+// file was successfully loaded, else it clobbers the trajectory with a parse error.
+import type { TrajHandlerData } from '$lib/trajectory'
+import Trajectory from '$lib/trajectory/Trajectory.svelte'
+import { mount, unmount } from 'svelte'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+const MULTI_FRAME_XYZ = `2\nStep 1\nH 0.0 0.0 0.0\nH 0.0 0.0 0.74
+2\nStep 2\nH 0.0 0.0 0.0\nH 0.0 0.0 0.78`
+
+const create_drop_event = (files: File[], text_plain = ``): DragEvent => {
+  const drag_event = new DragEvent(`drop`, { bubbles: true })
+  const data_transfer = {
+    files: Object.assign(files, { item: (idx: number) => files[idx] ?? null }) as FileList,
+    getData: (type: string) => (type === `text/plain` ? text_plain : ``),
+    dropEffect: `copy` as const,
+    effectAllowed: `copy` as const,
+    items: [] as unknown as DataTransferItemList,
+    types: [] as readonly string[],
+    clearData: () => {},
+    setData: () => {},
+    setDragImage: () => {},
+  }
+  Object.defineProperty(drag_event, `dataTransfer`, { value: data_transfer })
+  return drag_event
+}
+
+const mounted: ReturnType<typeof mount>[] = []
+afterEach(() => {
+  for (const app of mounted.splice(0)) void unmount(app)
+})
+
+describe(`Trajectory file drop`, () => {
+  test(`text/plain payload alongside a dropped file does not clobber the load`, async () => {
+    let load_data: TrajHandlerData | undefined
+    let error_data: TrajHandlerData | undefined
+    mounted.push(
+      mount(Trajectory, {
+        target: document.body,
+        props: {
+          display_mode: `structure`,
+          show_controls: `never`,
+          on_file_load: (data: TrajHandlerData) => (load_data = data),
+          on_error: (data: TrajHandlerData) => (error_data = data),
+        },
+      }),
+    )
+
+    const file = new File([MULTI_FRAME_XYZ], `test.xyz`, { type: `text/plain` })
+    const viewer = document.querySelector(`.trajectory`) as HTMLElement
+    // IDE/file-manager drags also set text/plain to the source path
+    viewer.dispatchEvent(create_drop_event([file], `/home/user/test.xyz`))
+
+    await vi.waitFor(() => expect(load_data).toBeDefined())
+    expect(load_data?.frame_count).toBe(2)
+    expect(load_data?.filename).toBe(`test.xyz`)
+    expect(error_data).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Closes #353.

Started as the blob: URL format-detection fix and grew into a broader correctness sweep on this branch. Each behavior change ships with a red→green regression test.

## Blob: URL / format detection (closes #353)
- `io/url-drop`: content/magic-byte sniffing for extensionless `blob:` URLs (UUID basenames); read gzip `Content-Encoding` responses as `ArrayBuffer` (binary-safe, no lossy UTF-8 decode); restrict the Range-sniff `try/catch` to the HEAD sniff so the committed download/`decompress` errors propagate instead of silently falling through to a text fetch; strip query string/hash before extension detection (pre-signed URLs).
- `structure/parse`: JSON detection runs before the line-count guard so minified single-line JSON (e.g. pymatgen `mp-1.json`) content-detects without a filename hint; `detect_json_structure` helper dedupes the extension- and content-based paths.
- `trajectory/Trajectory`: indexed parsers own their `frame_loader`; `orig_data` retained only when a loader exists; drop handler returns after a file loads so a co-carried `text/plain` payload can't clobber it.
- `io/decompress`: strict null check (empty files legitimately read as `''`).

## Additional correctness fixes (each with regression tests)
- **OPTIMADE**: `resolve_optimade_element` returns the chosen `chemical_symbols` index so `mass`/`concentration` match the dominant element (not hard-coded `[0]`), and strips a trailing atom-index suffix (`O1` → `O`); per-key resolved-URL cache TTLs; query- vs path-style CORS proxy encoding; surface direct HTTP error statuses instead of masking behind "all proxies failed".
- **convex-hull**: proxy-safe `same_entry()` so selecting an entry bound to a parent plain `$state` no longer loops forever (`effect_update_depth_exceeded`) — fixes the click-to-select page freeze.
- **fermi-surface**: guard upsampling of single-point endpoint-inclusive axes (no `0/0` NaN / `grid[NaN]` crash); honor the FRMSF periodic grid convention; invert the marching-cubes transform (transpose + de-center) when sampling velocities; derive the BZ extent from `k_lattice` instead of a hardcoded box.
- **plots**: clamp violin KDE grid to positive support on log axes, include the mean line in auto-range, flip the violin side on the inverted horizontal axis; sankey degrades to an empty layout when all link values are 0 (avoids d3 divide-by-zero).
- **structure**: PBC-aware distance/displacement measurements; remap explicit bond metadata after site deletion; CIF export emits one row per disordered species (with occupancy) plus an explicit identity `_symmetry_equiv_pos_as_xyz` loop.
- **structure export**: quote multi-word space-group names in CIF output.

Note: scope is broader than the original blob-URL fix — these were bundled here at the author's request rather than split into separate PRs.