### PR TITLE
Plot correctness and rendering fixes across components

### DIFF
--- a/extensions/vscode/tests/detect.test.ts
+++ b/extensions/vscode/tests/detect.test.ts
@@ -132,11 +132,7 @@ describe(`detect_view_type`, () => {
     [
       `dos (phonon)`,
       `dos`,
-      {
-        type: `phonon`,
-        frequencies: [0, 100, 200],
-        densities: [[0.1, 0.2, 0.3]],
-      },
+      { type: `phonon`, frequencies: [0, 100, 200], densities: [[0.1, 0.2, 0.3]] },
     ],
     [`band_structure (pymatgen)`, `band_structure`, pymatgen_bands],
     [
@@ -356,14 +352,7 @@ describe(`detect_view_type`, () => {
         temperature_range: [300, 1500],
       },
     ],
-    [
-      `column table with unequal lengths`,
-      null,
-      {
-        col_a: [1, 2, 3],
-        col_b: [4, 5],
-      },
-    ],
+    [`column table with unequal lengths`, null, { col_a: [1, 2, 3], col_b: [4, 5] }],
     [
       `row table with inconsistent keys`,
       null,

--- a/src/lib/composition/PieChart.svelte
+++ b/src/lib/composition/PieChart.svelte
@@ -291,9 +291,15 @@
   .pie-segment.interactive:focus {
     outline: none;
   }
+  svg {
+    /* very thin slices place their labels outside the pie at 1.2x the outer radius,
+    past the square viewBox - the default svg overflow: hidden would clip them */
+    overflow: visible;
+  }
   foreignobject {
     pointer-events: none;
     transition: all 0.2s ease;
+    overflow: visible;
   }
   foreignobject.hovered {
     font-weight: 700;
@@ -307,9 +313,6 @@
     height: 100%;
     transition: all 0.2s ease;
     white-space: nowrap;
-  }
-  foreignobject {
-    overflow: visible;
   }
   .pie-label.hovered {
     font-weight: 700;

--- a/src/lib/convex-hull/ConvexHull4D.svelte
+++ b/src/lib/convex-hull/ConvexHull4D.svelte
@@ -629,11 +629,8 @@
       for (let idx = 0; idx < 4; idx++) {
         const vx = vertices[idx]
         // Direction from centroid to vertex
-        const dir = {
-          x: vx.x - centroid.x,
-          y: vx.y - centroid.y,
-          z: vx.z - centroid.z,
-        }
+        const { x: cx, y: cy, z: cz } = centroid
+        const dir = { x: vx.x - cx, y: vx.y - cy, z: vx.z - cz }
         const len = Math.hypot(dir.x, dir.y, dir.z) || 1
         const label_pos = {
           x: vx.x + (dir.x / len) * distance,

--- a/src/lib/phase-diagram/IsobaricBinaryPhaseDiagram.svelte
+++ b/src/lib/phase-diagram/IsobaricBinaryPhaseDiagram.svelte
@@ -9,6 +9,7 @@
   import { compute_bounding_box_2d, polygon_centroid, type Vec2 } from '$lib/math'
   import type { AxisConfig } from '$lib/plot'
   import { constrain_tooltip_position } from '$lib/plot/core/layout'
+  import { unique_id } from '$lib/plot/core/utils'
   import { scaleLinear } from 'd3-scale'
   import type { ComponentProps, Snippet } from 'svelte'
   import type { HTMLAttributes } from 'svelte/elements'
@@ -123,6 +124,11 @@
   // Shared icon/toggle styling for controls and export panes
   const pane_icon_style = `width: 14px; height: 14px`
   const pane_toggle_props = { style: `padding: 0` }
+
+  // Instance-unique prefix for gradient ids: region ids come from user data (e.g.
+  // 'liquid'), so two diagrams on one page would otherwise cross-reference each
+  // other's gradients (first-in-document wins, with that instance's pixel coords)
+  const gradient_uid = unique_id(`pd-gradient`)
 
   // Rebuild diagram data when diagram_input changes ($derived auto-recomputes)
   const rebuilt_data = $derived.by(() => {
@@ -619,7 +625,7 @@
         {#each transformed_regions as region (region.id)}
           {#if region.gradient}
             <linearGradient
-              id="gradient-{region.id}"
+              id="{gradient_uid}-{region.id}"
               x1={region.x_min}
               x2={region.x_max}
               y1="0"
@@ -661,7 +667,7 @@
           <path
             d={region.svg_path}
             fill={region.gradient
-            ? `url(#gradient-${region.id})`
+            ? `url(#${gradient_uid}-${region.id})`
             : (region.color || get_phase_color(region.name))}
             stroke="none"
             class:hovered={hovered_region?.id === region.id}

--- a/src/lib/plot/bar/BarPlot.svelte
+++ b/src/lib/plot/bar/BarPlot.svelte
@@ -38,16 +38,17 @@
   } from '$lib/plot'
   import type { AxisChangeState } from '$lib/plot/core/axis-utils'
   import { create_axis_change_handler } from '$lib/plot/core/axis-utils'
-  import { process_prop } from '$lib/plot/core/data-transform'
   import {
     create_dimension_tracker,
     create_hover_lock,
   } from '$lib/plot/core/hover-lock.svelte'
+  import { create_legend_visibility } from '$lib/plot/core/utils/series-visibility'
   import {
     get_relative_coords,
-    pan_range,
+    MIN_TOUCH_DISTANCE_PIXELS,
+    pan_range_by_pixels,
     PINCH_ZOOM_THRESHOLD,
-    pixels_to_data_delta,
+    zoom_range_by_factor,
   } from '$lib/plot/core/interactions'
   import type { IndexedRefLine } from '$lib/plot/core/reference-line'
   import { group_ref_lines_by_z, index_ref_lines } from '$lib/plot/core/reference-line'
@@ -56,17 +57,15 @@
     create_scale,
     create_size_scale,
     generate_ticks,
-    get_nice_data_range,
     get_tick_label,
   } from '$lib/plot/core/scales'
-  import { DEFAULT_MARKERS, get_scale_type_name } from '$lib/plot/core/types'
+  import { DEFAULT_MARKERS } from '$lib/plot/core/types'
   import { DEFAULTS } from '$lib/settings'
   import { extent } from 'd3-array'
   import type { Snippet } from 'svelte'
-  import { untrack } from 'svelte'
+  import { onDestroy, untrack } from 'svelte'
   import type { HTMLAttributes } from 'svelte/elements'
   import { Tween, type TweenOptions } from 'svelte/motion'
-  import { SvelteMap } from 'svelte/reactivity'
   import {
     build_obstacles_norm,
     clip_bar,
@@ -86,6 +85,14 @@
   import { unique_id } from '$lib/plot/core/utils'
   import ZeroLines from '$lib/plot/core/components/ZeroLines.svelte'
   import ZoomRect from '$lib/plot/core/components/ZoomRect.svelte'
+  import {
+    compute_bar_auto_ranges,
+    compute_group_info,
+    compute_stacked_offsets,
+    normalize_categorical,
+  } from './data'
+  import { compute_bar_rect, compute_line_points } from './geometry'
+  import type { LineSeriesPoint as BarLineSeriesPoint } from './geometry'
 
   // Handler props for line marker events (extends BarHandlerProps with point-specific data)
   interface LineMarkerHandlerProps extends BarHandlerProps<Metadata> {
@@ -93,27 +100,17 @@
   }
 
   // Extended point type with computed screen coordinates (used internally for rendering)
-  type LineSeriesPoint = InternalPoint<Metadata> & {
-    x: number // Screen x coordinate
-    y: number // Screen y coordinate
-    data_x: number // Original data x value
-    data_y: number // Original data y value
-    idx: number // Index in series
-  }
+  type LineSeriesPoint = BarLineSeriesPoint<Metadata>
 
   let {
     series = $bindable([]),
     orientation = $bindable(`vertical`),
     mode = $bindable(`overlay`),
     x_axis = $bindable({}),
-    x2_axis = $bindable({}),
+    x2_axis: x2_axis_prop = $bindable({}),
     y_axis = $bindable({}),
-    y2_axis = $bindable({}),
+    y2_axis: y2_axis_prop = $bindable({}),
     display = $bindable(DEFAULTS.bar.display),
-    x_range = [null, null],
-    x2_range = [null, null],
-    y_range = [null, null],
-    y2_range = [null, null],
     range_padding = 0.05,
     padding = { t: 20, b: 60, l: 60, r: 20 },
     legend = {},
@@ -223,24 +220,26 @@
   // Initialize bar, line, y2_axis with defaults - using $derived for reactivity
   let bar_state = $derived({ ...DEFAULTS.bar.bar, ...bar })
   let line_state = $derived({ ...DEFAULTS.bar.line, ...line })
-  y2_axis = {
+  // Merge secondary-axis defaults as deriveds instead of assigning back into the
+  // $bindable props (which would push library defaults into the parent's bound state)
+  let y2_axis = $derived({
     format: ``,
     scale_type: `linear`,
     ticks: 5,
     label_shift: { y: 60 },
     tick: { label: { shift: { x: 0, y: 0 } } }, // base offset handled in rendering
     range: [null, null],
-    ...y2_axis,
-  }
-  x2_axis = {
+    ...y2_axis_prop,
+  } as typeof y2_axis_prop)
+  let x2_axis = $derived({
     format: ``,
     scale_type: `linear`,
     ticks: 5,
     label_shift: { x: 0, y: 40 },
     tick: { label: { shift: { x: 0, y: 0 } } },
     range: [null, null],
-    ...x2_axis,
-  }
+    ...x2_axis_prop,
+  } as typeof x2_axis_prop)
 
   let [width, height] = $state([0, 0])
   let wrapper: HTMLDivElement | undefined = $state()
@@ -257,19 +256,10 @@
   let indexed_ref_lines = $derived(index_ref_lines(ref_lines))
   let ref_lines_by_z = $derived(group_ref_lines_by_z(indexed_ref_lines))
 
-  // === Categorical Normalization ===
-  // Internal type with guaranteed numeric x (for downstream scale/rendering code)
-  type NumericBarSeries = Omit<BarSeries<Metadata>, `x`> & { x: readonly number[] }
-
-  let is_categorical = $derived(
-    series.some((srs) => srs.x.some((val) => typeof val === `string`)),
-  )
-
-  let category_list = $derived.by(() => {
-    if (!is_categorical) return [] as string[]
-    if (x_axis.categories?.length) return [...x_axis.categories]
-    return [...new Set(series.flatMap((srs) => srs.x.map(String)))]
-  })
+  // === Categorical Normalization (string x values -> integer indices, see ./data) ===
+  let cat_norm = $derived(normalize_categorical(series, x_axis.categories))
+  let category_list = $derived(cat_norm.category_list)
+  let internal_series = $derived(cat_norm.internal_series)
 
   let category_indices = $derived(
     category_list.length > 0 ? category_list.map((_, idx) => idx) : null,
@@ -285,39 +275,6 @@
     return step <= 1
       ? category_indices
       : category_indices.filter((_, idx) => idx % step === 0)
-  })
-
-  let internal_series = $derived.by<NumericBarSeries[]>(() => {
-    // safe: when !category_indices, all x values are numeric (is_categorical is false)
-    if (!category_indices) return series as unknown as NumericBarSeries[]
-    return series.map((srs) => {
-      const orig_map = new Map(srs.x.map((val, idx) => [String(val), idx]))
-      if (orig_map.size < srs.x.length) {
-        console.warn(
-          `BarPlot: series "${
-            srs.label ?? `?`
-          }" has duplicate x values — last occurrence wins`,
-        )
-      }
-      // Resolve original index for each category (undefined if series lacks it)
-      const orig_indices = category_list.map((cat) => orig_map.get(cat))
-      const remap = <T>(arr: readonly T[] | null | undefined, fallback: T): T[] =>
-        orig_indices.map((oi) => oi != null ? (arr?.[oi] ?? fallback) : fallback)
-      const bw_arr = Array.isArray(srs.bar_width) ? srs.bar_width : null
-      const meta_arr = Array.isArray(srs.metadata) ? srs.metadata : null
-      return {
-        ...srs,
-        x: category_indices,
-        y: remap(srs.y, srs.render_mode === `line` ? NaN : 0),
-        labels: remap(srs.labels, null),
-        metadata: orig_indices.map((oi) =>
-          oi != null ? (meta_arr ? meta_arr[oi] : srs.metadata) : undefined
-        ) as Metadata[],
-        ...(bw_arr ? { bar_width: remap(bw_arr, 0.5) } : {}),
-        ...(srs.color_values ? { color_values: remap(srs.color_values, null) } : {}),
-        ...(srs.size_values ? { size_values: remap(srs.size_values, null) } : {}),
-      } as NumericBarSeries
-    })
   })
 
   // Compute auto ranges from visible series
@@ -336,124 +293,26 @@
     visible_series.filter((srs) => srs.x_axis === `x2`),
   )
 
-  let auto_ranges = $derived.by(() => {
-    // Calculate separate ranges for y1 and y2 axes
-    const calc_y_range = (
-      series_list: typeof visible_series,
-      y_limit: typeof y_range,
-      scale_type: ScaleType,
-    ) => {
-      let points = series_list.flatMap((srs) =>
-        srs.x.map((x_val, idx) => ({ x: x_val, y: srs.y[idx] }))
-      )
-
-      // In stacked mode, calculate stacked totals for accurate range (only for bars on the same axis)
-      if (mode === `stacked`) {
-        const stacked_totals = new SvelteMap<number, { pos: number; neg: number }>()
-
-        // Only include visible bar series (not lines) in stacking
-        series_list
-          .filter((srs) => srs.render_mode !== `line`)
-          .forEach((srs) =>
-            srs.x.forEach((x_val, idx) => {
-              const y_val = srs.y[idx] ?? 0
-              const totals = stacked_totals.get(x_val) ?? { pos: 0, neg: 0 }
-              if (y_val >= 0) totals.pos += y_val
-              else totals.neg += y_val
-              stacked_totals.set(x_val, totals)
-            })
-          )
-
-        // Replace points with stacked totals + line series (which don't stack)
-        points = [
-          ...Array.from(stacked_totals).flatMap(([x_val, { pos, neg }]) => [
-            ...(pos > 0 ? [{ x: x_val, y: pos }] : []),
-            ...(neg < 0 ? [{ x: x_val, y: neg }] : []),
-          ]),
-          ...series_list
-            .filter((srs) => srs.render_mode === `line`)
-            .flatMap((srs) =>
-              srs.x.map((x_val, idx) => ({ x: x_val, y: srs.y[idx] }))
-            ),
-        ]
-      }
-
-      if (points.length === 0) return [0, 1]
-
-      let computed_y_range = get_nice_data_range(
-        points,
-        (pt) => pt.y,
-        y_limit,
-        scale_type,
-        range_padding,
-        false,
-      )
-
-      // For bar plots, ensure the value axis starts at 0 unless there are negative values
-      // Only apply zero-clamping for linear and arcsinh scales (not log)
-      const type_name = get_scale_type_name(scale_type)
-      if (type_name === `linear` || type_name === `arcsinh`) {
-        const has_negative = points.some((pt) => pt.y < 0)
-        const has_positive = points.some((pt) => pt.y > 0)
-
-        // Only adjust if no explicit y_range is set
-        if (y_limit?.[0] == null && y_limit?.[1] == null) {
-          if (has_positive && !has_negative) computed_y_range = [0, computed_y_range[1]]
-          else if (has_negative && !has_positive) computed_y_range = [computed_y_range[0], 0]
-        }
-      }
-
-      return computed_y_range
-    }
-
-    // Get x values split by axis for range calculation
-    // For categorical data, use fixed range centered on integer indices
-    let x_auto_range: number[]
-    if (category_list.length > 0) {
-      x_auto_range = [-0.5, category_list.length - 0.5]
-    } else {
-      const x1_x_points = visible_series
-        .filter((srs) => (srs.x_axis ?? `x1`) === `x1`)
-        .flatMap((srs) => srs.x.map((x_val) => ({ x: x_val, y: 0 })))
-      x_auto_range = x1_x_points.length > 0
-        ? get_nice_data_range(
-          x1_x_points,
-          (pt) => pt.x,
-          x_range,
-          x_axis.scale_type ?? `linear`,
-          range_padding,
-          x_axis.format?.startsWith(`%`) || false,
-        )
-        : [0, 1]
-    }
-
-    const x2_x_points = x2_series.flatMap((srs) =>
-      srs.x.map((x_val) => ({ x: x_val, y: 0 }))
-    )
-    const x2_scale_type = x2_axis.scale_type ?? `linear`
-    const x2_auto_range = x2_x_points.length > 0
-      ? get_nice_data_range(
-        x2_x_points,
-        (pt) => pt.x,
-        x2_range,
-        x2_scale_type,
-        range_padding,
-        x2_axis.format?.startsWith(`%`) || false,
-      )
-      : [0, 1]
-
-    const y1_range = calc_y_range(y1_series, y_range, y_axis.scale_type ?? `linear`)
-    const y2_auto_range = calc_y_range(
-      y2_series,
-      y2_range,
-      y2_axis.scale_type ?? `linear`,
-    )
-
-    // Map data ranges to axis ranges depending on orientation
-    return orientation === `horizontal`
-      ? ({ x: y1_range, x2: x2_auto_range, y: x_auto_range, y2: y2_auto_range })
-      : ({ x: x_auto_range, x2: x2_auto_range, y: y1_range, y2: y2_auto_range })
-  })
+  let auto_ranges = $derived(compute_bar_auto_ranges({
+    visible_series,
+    y1_series,
+    y2_series,
+    x2_series,
+    mode,
+    orientation,
+    range_padding,
+    category_count: category_list.length,
+    x_range: x_axis.range ?? [null, null],
+    x_scale_type: x_axis.scale_type ?? `linear`,
+    x_is_time: x_axis.format?.startsWith(`%`) || false,
+    x2_range: x2_axis.range ?? [null, null],
+    x2_scale_type: x2_axis.scale_type ?? `linear`,
+    x2_is_time: x2_axis.format?.startsWith(`%`) || false,
+    y_range: y_axis.range ?? [null, null],
+    y_scale_type: y_axis.scale_type ?? `linear`,
+    y2_range: y2_axis.range ?? [null, null],
+    y2_scale_type: y2_axis.scale_type ?? `linear`,
+  }))
 
   // Initialize and current ranges
   let ranges = $state<{
@@ -798,8 +657,8 @@
         // Update axis ranges to trigger reactivity and prevent effect from overriding
         x_axis = { ...x_axis, range: [Math.min(xr1, xr2), Math.max(xr1, xr2)] }
         if (x2_series.length > 0 && Number.isFinite(x2r1) && Number.isFinite(x2r2)) {
-          x2_axis = {
-            ...x2_axis,
+          x2_axis_prop = {
+            ...x2_axis_prop,
             range: [Math.min(x2r1, x2r2), Math.max(x2r1, x2r2)],
           }
         }
@@ -807,7 +666,10 @@
         // gate on y2 series presence (like x2): the y2 scale is a [0, 1] sentinel
         // otherwise, so inverting would store a phantom range in the bindable prop
         if (y2_series.length > 0) {
-          y2_axis = { ...y2_axis, range: [Math.min(y2_1, y2_2), Math.max(y2_1, y2_2)] }
+          y2_axis_prop = {
+            ...y2_axis_prop,
+            range: [Math.min(y2_1, y2_2), Math.max(y2_1, y2_2)],
+          }
         }
       }
     }
@@ -817,40 +679,30 @@
     document.body.style.cursor = `default`
   }
 
-  // Pan drag handlers
+  // Pan/zoom all four axes from an interaction-start snapshot, each in its own
+  // scale's transform space (log axes pan by a constant factor, linear by a shift)
+  const pan_all_axes = (init: InitialRanges, dx_px: number, dy_px: number) => {
+    ranges.current.x = pan_range_by_pixels(init.initial_x_range, dx_px, chart_width, x_axis.scale_type)
+    ranges.current.x2 = pan_range_by_pixels(init.initial_x2_range, dx_px, chart_width, x2_axis.scale_type)
+    ranges.current.y = pan_range_by_pixels(init.initial_y_range, dy_px, chart_height, y_axis.scale_type)
+    ranges.current.y2 = pan_range_by_pixels(init.initial_y2_range, dy_px, chart_height, y2_axis.scale_type)
+  }
+  const zoom_all_axes = (init: InitialRanges, factor: number) => {
+    ranges.current.x = zoom_range_by_factor(init.initial_x_range, factor, x_axis.scale_type)
+    ranges.current.x2 = zoom_range_by_factor(init.initial_x2_range, factor, x2_axis.scale_type)
+    ranges.current.y = zoom_range_by_factor(init.initial_y_range, factor, y_axis.scale_type)
+    ranges.current.y2 = zoom_range_by_factor(init.initial_y2_range, factor, y2_axis.scale_type)
+  }
+
+  // Pan drag handler (drag direction inverted on x for natural pan feel)
   const on_pan_move = (evt: MouseEvent) => {
     if (!pan_drag_state) return
-    const dx = evt.clientX - pan_drag_state.start.x
-    const dy = evt.clientY - pan_drag_state.start.y
-
-    // Convert pixel delta to data delta (note: drag direction is inverted for natural pan feel)
     const sensitivity = pan?.drag_sensitivity ?? 1
-
-    const x_delta = pixels_to_data_delta(
-      -dx * sensitivity,
-      pan_drag_state.initial_x_range,
-      chart_width,
+    pan_all_axes(
+      pan_drag_state,
+      -(evt.clientX - pan_drag_state.start.x) * sensitivity,
+      (evt.clientY - pan_drag_state.start.y) * sensitivity,
     )
-    const x2_delta = pixels_to_data_delta(
-      -dx * sensitivity,
-      pan_drag_state.initial_x2_range,
-      chart_width,
-    )
-    const y_delta = pixels_to_data_delta(
-      dy * sensitivity,
-      pan_drag_state.initial_y_range,
-      chart_height,
-    )
-    const y2_delta = pixels_to_data_delta(
-      dy * sensitivity,
-      pan_drag_state.initial_y2_range,
-      chart_height,
-    )
-
-    ranges.current.x = pan_range(pan_drag_state.initial_x_range, x_delta)
-    ranges.current.x2 = pan_range(pan_drag_state.initial_x2_range, x2_delta)
-    ranges.current.y = pan_range(pan_drag_state.initial_y_range, y_delta)
-    ranges.current.y2 = pan_range(pan_drag_state.initial_y2_range, y2_delta)
   }
 
   const on_pan_end = () => {
@@ -859,6 +711,20 @@
     window.removeEventListener(`mousemove`, on_pan_move)
     window.removeEventListener(`mouseup`, on_pan_end)
   }
+
+  // Tear down any window listeners + cursor override if the component unmounts mid-drag
+  // (mouseup/panend would otherwise never fire, leaking listeners and a stuck cursor).
+  // onDestroy also runs during SSR teardown, where window/document don't exist.
+  onDestroy(() => {
+    if (typeof window === `undefined`) return
+    window.removeEventListener(`mousemove`, on_window_mouse_move)
+    window.removeEventListener(`mouseup`, on_window_mouse_up)
+    window.removeEventListener(`mousemove`, on_pan_move)
+    window.removeEventListener(`mouseup`, on_pan_end)
+    drag_state = { start: null, current: null, bounds: null }
+    pan_drag_state = null
+    document.body.style.cursor = ``
+  })
 
   function handle_mouse_down(evt: MouseEvent) {
     const coords = get_relative_coords(evt)
@@ -902,34 +768,15 @@
 
     const sensitivity = pan?.wheel_sensitivity ?? 1
 
-    // Determine pan direction based on wheel delta
-    const x_delta = pixels_to_data_delta(
-      evt.deltaX * sensitivity,
-      ranges.current.x,
-      chart_width,
-    )
-    const x2_delta = pixels_to_data_delta(
-      evt.deltaX * sensitivity,
-      ranges.current.x2,
-      chart_width,
-    )
-    const y_delta = pixels_to_data_delta(
-      evt.deltaY * sensitivity,
-      ranges.current.y,
-      chart_height,
-    )
-    const y2_delta = pixels_to_data_delta(
-      evt.deltaY * sensitivity,
-      ranges.current.y2,
-      chart_height,
-    )
-
+    // Pan along the dominant wheel direction
     if (Math.abs(evt.deltaX) > Math.abs(evt.deltaY)) {
-      ranges.current.x = pan_range(ranges.current.x, x_delta)
-      ranges.current.x2 = pan_range(ranges.current.x2, x2_delta)
+      const dx = evt.deltaX * sensitivity
+      ranges.current.x = pan_range_by_pixels(ranges.current.x, dx, chart_width, x_axis.scale_type)
+      ranges.current.x2 = pan_range_by_pixels(ranges.current.x2, dx, chart_width, x2_axis.scale_type)
     } else {
-      ranges.current.y = pan_range(ranges.current.y, y_delta)
-      ranges.current.y2 = pan_range(ranges.current.y2, y2_delta)
+      const dy = evt.deltaY * sensitivity
+      ranges.current.y = pan_range_by_pixels(ranges.current.y, dy, chart_height, y_axis.scale_type)
+      ranges.current.y2 = pan_range_by_pixels(ranges.current.y2, dy, chart_height, y2_axis.scale_type)
     }
   }
 
@@ -967,74 +814,17 @@
 
     // Calculate pinch scale (curr/start so spread = zoom out, pinch = zoom in)
     const start_dist = Math.hypot(s2.x - s1.x, s2.y - s1.y)
-    // Guard against zero-distance pinch to avoid Infinity scale
-    if (start_dist < Number.EPSILON) return
+    // ignore near-coincident touches so curr_dist / start_dist can't blow up the scale
+    if (start_dist < MIN_TOUCH_DISTANCE_PIXELS) return
     const curr_dist = Math.hypot(t2.clientX - t1.clientX, t2.clientY - t1.clientY)
     const scale = curr_dist / start_dist
 
     // If scale changed significantly, treat as pinch-zoom
     // Also guard against scale being too small to avoid division by zero
+    // Pinch zoom about the view center (spread = zoom in, pinch = zoom out)
     if (Math.abs(scale - 1) > PINCH_ZOOM_THRESHOLD && scale > Number.EPSILON) {
-      // Pinch zoom centered on gesture center
-      // Divide by scale so spread (scale > 1) = smaller span (zoom in)
-      const x_span = touch_state.initial_x_range[1] - touch_state.initial_x_range[0]
-      const x2_span = touch_state.initial_x2_range[1] -
-        touch_state.initial_x2_range[0]
-      const y_span = touch_state.initial_y_range[1] - touch_state.initial_y_range[0]
-      const y2_span = touch_state.initial_y2_range[1] -
-        touch_state.initial_y2_range[0]
-      const x_center =
-        (touch_state.initial_x_range[0] + touch_state.initial_x_range[1]) / 2
-      const x2_center =
-        (touch_state.initial_x2_range[0] + touch_state.initial_x2_range[1]) / 2
-      const y_center =
-        (touch_state.initial_y_range[0] + touch_state.initial_y_range[1]) / 2
-      const y2_center =
-        (touch_state.initial_y2_range[0] + touch_state.initial_y2_range[1]) / 2
-
-      ranges.current.x = [
-        x_center - x_span / scale / 2,
-        x_center + x_span / scale / 2,
-      ]
-      ranges.current.x2 = [
-        x2_center - x2_span / scale / 2,
-        x2_center + x2_span / scale / 2,
-      ]
-      ranges.current.y = [
-        y_center - y_span / scale / 2,
-        y_center + y_span / scale / 2,
-      ]
-      ranges.current.y2 = [
-        y2_center - y2_span / scale / 2,
-        y2_center + y2_span / scale / 2,
-      ]
-    } else {
-      // Pan
-      const x_delta = pixels_to_data_delta(
-        -dx,
-        touch_state.initial_x_range,
-        chart_width,
-      )
-      const x2_delta = pixels_to_data_delta(
-        -dx,
-        touch_state.initial_x2_range,
-        chart_width,
-      )
-      const y_delta = pixels_to_data_delta(
-        dy,
-        touch_state.initial_y_range,
-        chart_height,
-      )
-      const y2_delta = pixels_to_data_delta(
-        dy,
-        touch_state.initial_y2_range,
-        chart_height,
-      )
-      ranges.current.x = pan_range(touch_state.initial_x_range, x_delta)
-      ranges.current.x2 = pan_range(touch_state.initial_x2_range, x2_delta)
-      ranges.current.y = pan_range(touch_state.initial_y_range, y_delta)
-      ranges.current.y2 = pan_range(touch_state.initial_y2_range, y2_delta)
-    }
+      zoom_all_axes(touch_state, scale)
+    } else pan_all_axes(touch_state, -dx, dy)
   }
 
   function handle_touch_end() {
@@ -1098,30 +888,7 @@
     })
   )
 
-  function toggle_series_visibility(series_idx: number) {
-    if (series_idx >= 0 && series_idx < series.length) {
-      series = series.map((srs, idx) =>
-        idx === series_idx ? { ...srs, visible: !(srs.visible ?? true) } : srs
-      )
-    }
-  }
-
-  function toggle_group_visibility(_group_name: string, series_indices: number[]) {
-    // Filter to valid indices upfront (consistent with shared toggle_group_visibility)
-    const valid_indices = series_indices.filter((idx) =>
-      idx >= 0 && idx < series.length
-    )
-    if (valid_indices.length === 0) return
-
-    const idx_set = new Set(valid_indices)
-    // Check if all series in the group are currently visible
-    const all_visible = valid_indices.every((idx) => series[idx].visible ?? true)
-    // Toggle: if all visible, hide all; otherwise show all
-    const new_visibility = !all_visible
-    series = series.map((srs, idx) =>
-      idx_set.has(idx) ? { ...srs, visible: new_visibility } : srs
-    )
-  }
+  const legend_vis = create_legend_visibility(() => series, (next) => (series = next))
 
   // Collect bar and line positions for legend placement
   let bar_points_for_placement = $derived.by(() => {
@@ -1289,34 +1056,10 @@
     }
 
   // Stack offsets (only for bar series in stacked mode, grouped by y-axis)
-  let stacked_offsets = $derived.by(() => {
-    if (mode !== `stacked`) return [] as number[][]
-    const offsets = internal_series.map((srs) => Array.from(srs.x, () => 0))
-    // Cumulative totals keyed by axis/sign/x value so series with misaligned x grids
-    // stack on the correct baseline (matching stacked_totals in auto_ranges)
-    const acc = new SvelteMap<string, number>()
-    internal_series.forEach((srs, series_idx) => {
-      if (!(srs?.visible ?? true) || srs.render_mode === `line`) return
-      srs.x.forEach((x_val, bar_idx) => {
-        const y_val = srs.y[bar_idx] ?? 0
-        const key = `${srs.y_axis === `y2` ? `y2` : `y1`}:${y_val >= 0 ? `+` : `-`}:${x_val}`
-        offsets[series_idx][bar_idx] = acc.get(key) ?? 0
-        acc.set(key, (acc.get(key) ?? 0) + y_val)
-      })
-    })
-    return offsets
-  })
+  let stacked_offsets = $derived(compute_stacked_offsets(internal_series, mode))
 
   // Calculate group positions for grouped mode (side-by-side bars)
-  let group_info = $derived.by(() => {
-    if (mode !== `grouped`) return { bar_series_count: 0, bar_series_indices: [] }
-    const bar_series_indices = internal_series
-      .map((srs, idx) =>
-        (srs?.visible ?? true) && srs.render_mode !== `line` ? idx : -1
-      )
-      .filter((idx) => idx >= 0)
-    return { bar_series_count: bar_series_indices.length, bar_series_indices }
-  })
+  let group_info = $derived(compute_group_info(internal_series, mode))
 
   // Set theme-aware background when entering fullscreen
   $effect(() => {
@@ -1334,9 +1077,9 @@
     set_axis: (axis, config) => {
       // Spread into existing state to preserve merged type structure
       if (axis === `x`) x_axis = { ...x_axis, ...config }
-      else if (axis === `x2`) x2_axis = { ...x2_axis, ...config }
+      else if (axis === `x2`) x2_axis_prop = { ...x2_axis_prop, ...config }
       else if (axis === `y`) y_axis = { ...y_axis, ...config }
-      else y2_axis = { ...y2_axis, ...config }
+      else y2_axis_prop = { ...y2_axis_prop, ...config }
     },
     get_series: () => series,
     set_series: (new_series) => (series = new_series),
@@ -1447,9 +1190,9 @@
         ranges.current.y2 = [...ranges.initial.y2] as [number, number]
         // Also reset axis props so future data changes recalculate auto ranges
         x_axis = { ...x_axis, range: [null, null] }
-        x2_axis = { ...x2_axis, range: [null, null] }
+        x2_axis_prop = { ...x2_axis_prop, range: [null, null] }
         y_axis = { ...y_axis, range: [null, null] }
-        y2_axis = { ...y2_axis, range: [null, null] }
+        y2_axis_prop = { ...y2_axis_prop, range: [null, null] }
       }}
       onmouseleave={() => {
         hovered = false
@@ -1461,6 +1204,7 @@
       ontouchstart={handle_touch_start}
       ontouchmove={handle_touch_move}
       ontouchend={handle_touch_end}
+      ontouchcancel={handle_touch_end}
       style:cursor={pan_drag_state
       ? `grabbing`
       : shift_held && pan?.enabled !== false
@@ -1494,6 +1238,7 @@
         ticks={ticks.x as number[]}
         place={scales.x}
         axis={x_axis}
+        domain={ranges.current.x as Vec2}
         {pad}
         {width}
         {height}
@@ -1514,6 +1259,7 @@
           ticks={ticks.x2 as number[]}
           place={scales.x2}
           axis={x2_axis}
+          domain={ranges.current.x2 as Vec2}
           {pad}
           {width}
           {height}
@@ -1532,6 +1278,7 @@
         ticks={ticks.y as number[]}
         place={scales.y}
         axis={y_axis}
+        domain={ranges.current.y as Vec2}
         {pad}
         {width}
         {height}
@@ -1559,6 +1306,7 @@
           ticks={ticks.y2 as number[]}
           place={scales.y2}
           axis={y2_axis}
+          domain={ranges.current.y2 as Vec2}
           {pad}
           {width}
           {height}
@@ -1637,42 +1385,14 @@
             series_markers === `line+points`}
                 {@const show_points = series_markers === `points` ||
             series_markers === `line+points`}
-                {@const points = srs.x.map((x_val, idx) => {
-            const y_val = srs.y[idx]
-            // Lines don't stack - they show absolute values (useful for totals/trends)
-            const plot_x = orientation === `vertical`
-              ? x_scale(x_val)
-              : x_scale(y_val)
-            const plot_y = orientation === `vertical`
-              ? y_scale(y_val)
-              : scales.y(x_val)
-            // Create internal point with all needed data
-            const color_value = srs.color_values?.[idx] ?? null
-            const size_value = srs.size_values?.[idx] ?? null
-            const point_style = process_prop(srs.point_style, idx)
-            const point_hover = process_prop(srs.point_hover, idx)
-            const point_label = process_prop(srs.point_label, idx)
-            const point_offset = process_prop(srs.point_offset, idx)
-            const metadata = Array.isArray(srs.metadata)
-              ? srs.metadata[idx]
-              : srs.metadata
-            return {
-              x: plot_x,
-              y: plot_y,
-              data_x: x_val,
-              data_y: y_val,
-              idx,
-              color_value,
-              size_value,
-              point_style,
-              point_hover,
-              point_label,
-              point_offset,
-              metadata,
-              series_idx,
-              point_idx: idx,
-            } as LineSeriesPoint
-          }).filter((pt) => isFinite(pt.x) && isFinite(pt.y))}
+                {@const points = compute_line_points({
+            series: srs,
+            series_idx,
+            orientation,
+            x_scale,
+            y_scale,
+            cat_y_scale: scales.y,
+          })}
                 {@const polyline_str = show_line && points.length > 1
             ? points.map((pt) => `${pt.x},${pt.y}`).join(` `)
             : ``}
@@ -1837,37 +1557,24 @@
                   {@const bar_width_val = Array.isArray(srs.bar_width)
             ? (srs.bar_width[bar_idx] ?? 0.5)
             : (srs.bar_width ?? 0.5)}
-                  {@const half = mode === `grouped` && group_info.bar_series_count > 1
-            ? bar_width_val / (2 * group_info.bar_series_count)
-            : bar_width_val / 2}
-                  {@const calculate_group_offset = (idx: number) => {
-            const position = group_info.bar_series_indices.indexOf(idx)
-            const offset = position - (group_info.bar_series_count - 1) / 2
-            return offset * (bar_width_val / group_info.bar_series_count)
-          }}
-                  {@const group_offset = mode === `grouped` && group_info.bar_series_count > 1
-            ? calculate_group_offset(series_idx)
-            : 0}
                   {@const is_vertical = orientation === `vertical`}
-                  {@const cat_val = x_val}
-                  {@const val = y_val}
-                  {@const use_y2 = srs.y_axis === `y2`}
-                  {@const y_scale = use_y2 ? scales.y2 : scales.y}
-                  {@const use_x2_bar = srs.x_axis === `x2`}
-                  {@const x_scale_bar = use_x2_bar ? scales.x2 : scales.x}
+                  {@const x_scale_bar = srs.x_axis === `x2` ? scales.x2 : scales.x}
                   {@const [cat_scale, val_scale] = is_vertical
-            ? [x_scale_bar, y_scale]
+            ? [x_scale_bar, srs.y_axis === `y2` ? scales.y2 : scales.y]
             : [scales.y, x_scale_bar]}
-                  {@const c0 = cat_scale(cat_val + group_offset - half)}
-                  {@const c1 = cat_scale(cat_val + group_offset + half)}
-                  {@const v0 = val_scale(base)}
-                  {@const v1 = val_scale(base + val)}
-                  {@const [rect_x, rect_y] = is_vertical
-            ? [Math.min(c0, c1), Math.min(v0, v1)]
-            : [Math.min(v0, v1), Math.min(c0, c1)]}
-                  {@const [rect_w, rect_h] = is_vertical
-            ? [Math.max(1, Math.abs(c1 - c0)), Math.max(0, Math.abs(v1 - v0))]
-            : [Math.max(1, Math.abs(v1 - v0)), Math.max(0, Math.abs(c1 - c0))]}
+                  {@const { c0, c1, v0, v1, rect_x, rect_y, rect_w, rect_h } =
+            compute_bar_rect({
+              cat_val: x_val,
+              val: y_val,
+              base,
+              bar_width_val,
+              series_idx,
+              mode,
+              orientation,
+              group_info,
+              cat_scale,
+              val_scale,
+            })}
                   {#if (is_vertical ? rect_h : rect_w) > 0}
                     <path
                       d={bar_path(
@@ -1947,8 +1654,9 @@
         bind:root_element={legend_element}
         {...legend}
         series_data={legend_data}
-        on_toggle={legend?.on_toggle || toggle_series_visibility}
-        on_group_toggle={legend?.on_group_toggle || toggle_group_visibility}
+        on_toggle={legend?.on_toggle ?? legend_vis.on_toggle}
+        on_group_toggle={legend?.on_group_toggle ?? legend_vis.on_group_toggle}
+        on_double_click={legend?.on_double_click ?? legend_vis.on_double_click}
         on_hover_change={legend_hover.set_locked}
         on_item_hover={(item) =>
           (hovered_legend_series_idx = item != null && item.series_idx >= 0
@@ -2025,9 +1733,9 @@
         bind:orientation
         bind:mode
         bind:x_axis
-        bind:x2_axis
+        bind:x2_axis={x2_axis_prop}
         bind:y_axis
-        bind:y2_axis
+        bind:y2_axis={y2_axis_prop}
         bind:display
         auto_x_range={auto_ranges.x as Vec2}
         auto_x2_range={auto_ranges.x2 as Vec2}
@@ -2071,8 +1779,10 @@
     background: var(--barplot-fullscreen-bg, var(--barplot-bg, var(--plot-bg)));
     max-height: none !important;
     overflow: hidden;
-    /* Add padding to prevent titles from being cropped at top */
-    padding-top: var(--plot-fullscreen-padding-top, 2em);
+    /* border-top (not padding-top): bind:clientHeight includes padding but excludes
+    borders - padding made the chart overflow + clip its bottom 2em (x-axis title) */
+    border-top: var(--plot-fullscreen-padding-top, 2em) solid
+      var(--barplot-fullscreen-bg, var(--barplot-bg, var(--plot-bg, transparent)));
     box-sizing: border-box;
   }
   .header-controls {

--- a/src/lib/plot/bar/BarPlot.svelte
+++ b/src/lib/plot/bar/BarPlot.svelte
@@ -37,7 +37,7 @@
     ScatterPoint,
   } from '$lib/plot'
   import type { AxisChangeState } from '$lib/plot/core/axis-utils'
-  import { create_axis_change_handler } from '$lib/plot/core/axis-utils'
+  import { create_axis_loader } from '$lib/plot/core/axis-utils'
   import {
     create_dimension_tracker,
     create_hover_lock,
@@ -49,6 +49,7 @@
     MIN_TOUCH_DISTANCE_PIXELS,
     pan_range_by_pixels,
     PINCH_ZOOM_THRESHOLD,
+    remove_drag_listeners,
     resolve_axis_ranges,
     sorted_range,
     to_epoch_num,
@@ -79,7 +80,6 @@
   } from '$lib/plot/core/auto-place'
   import {
     calc_auto_padding,
-    constrain_tooltip_position,
     filter_padding,
     LABEL_GAP_DEFAULT,
     y2_axis_label_x,
@@ -231,7 +231,7 @@
     format: ``,
     scale_type: `linear`,
     ticks: 5,
-    label_shift: { y: 60 },
+    label_shift: { x: 0, y: 0 }, // y2 title stays vertically centered (x pos set by y2_axis_label_x)
     tick: { label: { shift: { x: 0, y: 0 } } }, // base offset handled in rendering
     range: [null, null],
     ...y2_axis_prop,
@@ -678,14 +678,9 @@
   // (mouseup/panend would otherwise never fire, leaking listeners and a stuck cursor).
   // onDestroy also runs during SSR teardown, where window/document don't exist.
   onDestroy(() => {
-    if (typeof window === `undefined`) return
-    window.removeEventListener(`mousemove`, on_window_mouse_move)
-    window.removeEventListener(`mouseup`, on_window_mouse_up)
-    window.removeEventListener(`mousemove`, on_pan_move)
-    window.removeEventListener(`mouseup`, on_pan_end)
+    remove_drag_listeners([on_window_mouse_move, on_pan_move], [on_window_mouse_up, on_pan_end])
     drag_state = { start: null, current: null, bounds: null }
     pan_drag_state = null
-    document.body.style.cursor = ``
   })
 
   function handle_mouse_down(evt: MouseEvent) {
@@ -940,7 +935,6 @@
 
   // Tooltip state
   let hover_info = $state<BarHandlerProps<Metadata> | null>(null)
-  let tooltip_el = $state<HTMLDivElement | undefined>()
 
   function get_bar_data(
     series_idx: number,
@@ -1049,32 +1043,12 @@
     set_loading: (axis) => (axis_loading = axis),
   }
 
-  // Create shared handler bound to this component's state
-  // Using $derived so handler updates when callback props change
-  const handle_axis_change = $derived(create_axis_change_handler(
+  // Shared handler + one-shot auto-load bound to this component's state
+  const { handle_axis_change, try_auto_load } = create_axis_loader(
     axis_state,
-    data_loader,
-    on_axis_change,
-    on_error,
-  ))
-
-  let auto_load_attempted = false // prevent infinite retries on failure
-
-  // Auto-load data if series is empty but options exist (runs once)
-  $effect(() => {
-    if (series.length === 0 && data_loader && !auto_load_attempted) {
-      // Check x-axis first, then y-axis
-      if (x_axis.options?.length) {
-        auto_load_attempted = true
-        const first_key = x_axis.selected_key ?? x_axis.options[0].key
-        handle_axis_change(`x`, first_key).catch(() => {})
-      } else if (y_axis.options?.length) {
-        auto_load_attempted = true
-        const first_key = y_axis.selected_key ?? y_axis.options[0].key
-        handle_axis_change(`y`, first_key).catch(() => {})
-      }
-    }
-  })
+    () => ({ data_loader, on_axis_change, on_error }),
+  )
+  $effect(try_auto_load)
 </script>
 
 {#snippet ref_lines_layer(lines: IndexedRefLine[])}
@@ -1638,21 +1612,13 @@
       {@const cy = (hover_info.active_y_axis === `y2` ? scales.y2 : scales.y)(
       hover_info.orient_y,
     )}
-      {@const tooltip_pos = constrain_tooltip_position(
-      cx,
-      cy,
-      tooltip_el?.offsetWidth ?? 140,
-      tooltip_el?.offsetHeight ?? 50,
-      width,
-      height,
-      { offset_x: 10, offset_y: 5 },
-    )}
       <PlotTooltip
-        x={tooltip_pos.x}
-        y={tooltip_pos.y}
-        offset={{ x: 0, y: 0 }}
+        x={cx}
+        y={cy}
+        offset={{ x: 10, y: 5 }}
+        constrain_to={{ width, height }}
+        fallback_size={{ width: 140, height: 50 }}
         bg_color={hover_info.color}
-        bind:wrapper={tooltip_el}
       >
         {#if tooltip}
           {@render tooltip({ ...hover_info, fullscreen })}

--- a/src/lib/plot/bar/BarPlot.svelte
+++ b/src/lib/plot/bar/BarPlot.svelte
@@ -44,10 +44,14 @@
   } from '$lib/plot/core/hover-lock.svelte'
   import { create_legend_visibility } from '$lib/plot/core/utils/series-visibility'
   import {
+    axis_ranges_equal,
     get_relative_coords,
     MIN_TOUCH_DISTANCE_PIXELS,
     pan_range_by_pixels,
     PINCH_ZOOM_THRESHOLD,
+    resolve_axis_ranges,
+    sorted_range,
+    to_epoch_num,
     zoom_range_by_factor,
   } from '$lib/plot/core/interactions'
   import type { IndexedRefLine } from '$lib/plot/core/reference-line'
@@ -78,6 +82,7 @@
     constrain_tooltip_position,
     filter_padding,
     LABEL_GAP_DEFAULT,
+    y2_axis_label_x,
     measure_max_tick_width,
   } from '$lib/plot/core/layout'
   import PlotTooltip from '$lib/plot/core/components/PlotTooltip.svelte'
@@ -324,43 +329,16 @@
   })
 
   $effect(() => { // handle x_axis.range / x2_axis.range / y_axis.range / y2_axis.range changes
-    const new_x = [
-      x_axis.range?.[0] ?? auto_ranges.x[0],
-      x_axis.range?.[1] ?? auto_ranges.x[1],
-    ] as Vec2
-    const new_x2 = [
-      x2_axis.range?.[0] ?? auto_ranges.x2[0],
-      x2_axis.range?.[1] ?? auto_ranges.x2[1],
-    ] as Vec2
-    const new_y = [
-      y_axis.range?.[0] ?? auto_ranges.y[0],
-      y_axis.range?.[1] ?? auto_ranges.y[1],
-    ] as Vec2
-    const new_y2 = [
-      y2_axis.range?.[0] ?? auto_ranges.y2[0],
-      y2_axis.range?.[1] ?? auto_ranges.y2[1],
-    ] as Vec2
-    // Skip transient non-finite ranges (e.g. before data/size is ready): writing NaN
-    // would both break scales and make the comparison below never settle (NaN !== NaN).
-    if (![...new_x, ...new_x2, ...new_y, ...new_y2].every(Number.isFinite)) return
+    // resolve_axis_ranges returns null for transient non-finite bounds (skip: writing
+    // NaN breaks scales and, since NaN !== NaN, loops the effect)
+    const next = resolve_axis_ranges({ x: x_axis, x2: x2_axis, y: y_axis, y2: y2_axis }, auto_ranges)
+    if (!next) return
     // Only update if the initial (data-driven) ranges changed, not when user pans.
     // untrack the read of `ranges` so the assignment below can't re-trigger this effect
     // (reading + writing the same state otherwise causes effect_update_depth_exceeded).
     const init = untrack(() => ranges.initial)
-    if (
-      init.x[0] !== new_x[0] ||
-      init.x[1] !== new_x[1] ||
-      init.x2[0] !== new_x2[0] ||
-      init.x2[1] !== new_x2[1] ||
-      init.y[0] !== new_y[0] ||
-      init.y[1] !== new_y[1] ||
-      init.y2[0] !== new_y2[0] ||
-      init.y2[1] !== new_y2[1]
-    ) {
-      ranges = {
-        initial: { x: new_x, x2: new_x2, y: new_y, y2: new_y2 },
-        current: { x: new_x, x2: new_x2, y: new_y, y2: new_y2 },
-      }
+    if (!axis_ranges_equal(init, next)) {
+      ranges = { initial: { ...next }, current: { ...next } }
     }
   })
 
@@ -639,37 +617,21 @@
       const dx = Math.abs(drag_state.start.x - drag_state.current.x)
       const dy = Math.abs(drag_state.start.y - drag_state.current.y)
 
-      let xr1: number, xr2: number
-      if (x1_raw instanceof Date && x2_raw instanceof Date) {
-        ;[xr1, xr2] = [x1_raw.getTime(), x2_raw.getTime()]
-      } else if (typeof x1_raw === `number` && typeof x2_raw === `number`) {
-        ;[xr1, xr2] = [x1_raw, x2_raw]
-      } else [xr1, xr2] = [NaN, NaN] // bail: mixed types
-
-      let x2r1: number, x2r2: number
-      if (x2a_1_raw instanceof Date && x2a_2_raw instanceof Date) {
-        ;[x2r1, x2r2] = [x2a_1_raw.getTime(), x2a_2_raw.getTime()]
-      } else if (typeof x2a_1_raw === `number` && typeof x2a_2_raw === `number`) {
-        ;[x2r1, x2r2] = [x2a_1_raw, x2a_2_raw]
-      } else [x2r1, x2r2] = [NaN, NaN]
+      // Same scale inverts both coords, so each pair is all-number or all-Date
+      const [xr1, xr2] = [to_epoch_num(x1_raw), to_epoch_num(x2_raw)]
+      const [x2r1, x2r2] = [to_epoch_num(x2a_1_raw), to_epoch_num(x2a_2_raw)]
 
       if (dx > 5 && dy > 5 && Number.isFinite(xr1) && Number.isFinite(xr2)) {
         // Update axis ranges to trigger reactivity and prevent effect from overriding
-        x_axis = { ...x_axis, range: [Math.min(xr1, xr2), Math.max(xr1, xr2)] }
+        x_axis = { ...x_axis, range: sorted_range(xr1, xr2) }
         if (x2_series.length > 0 && Number.isFinite(x2r1) && Number.isFinite(x2r2)) {
-          x2_axis_prop = {
-            ...x2_axis_prop,
-            range: [Math.min(x2r1, x2r2), Math.max(x2r1, x2r2)],
-          }
+          x2_axis_prop = { ...x2_axis_prop, range: sorted_range(x2r1, x2r2) }
         }
-        y_axis = { ...y_axis, range: [Math.min(y1, y2), Math.max(y1, y2)] }
+        y_axis = { ...y_axis, range: sorted_range(y1, y2) }
         // gate on y2 series presence (like x2): the y2 scale is a [0, 1] sentinel
         // otherwise, so inverting would store a phantom range in the bindable prop
         if (y2_series.length > 0) {
-          y2_axis_prop = {
-            ...y2_axis_prop,
-            range: [Math.min(y2_1, y2_2), Math.max(y2_1, y2_2)],
-          }
+          y2_axis_prop = { ...y2_axis_prop, range: sorted_range(y2_1, y2_2) }
         }
       }
     }
@@ -1298,9 +1260,6 @@
       <!-- Y2-axis (Right) -->
       <!-- Note: y2 axis is only supported for vertical orientation. Implementing x2 for horizontal mode requires additional complexity. -->
       {#if y2_series.length > 0 && orientation === `vertical`}
-        {@const y2_inside = y2_axis.tick?.label?.inside ?? false}
-        {@const y2_tick_shift = y2_inside ? 0 : (y2_axis.tick?.label?.shift?.x ?? 0) + 8}
-        {@const y2_tick_width = y2_inside ? 0 : tick_label_widths.y2_max}
         <PlotAxis
           side="y2"
           ticks={ticks.y2 as number[]}
@@ -1312,8 +1271,7 @@
           {height}
           show_grid={display.y2_grid}
           tick_label={(tick) => get_tick_label(tick, y2_axis.ticks)}
-          label_x={width - pad.r + y2_tick_shift + y2_tick_width + LABEL_GAP_DEFAULT +
-          (y2_axis.label_shift?.x ?? 0)}
+          label_x={y2_axis_label_x(y2_axis, width, pad.r, tick_label_widths.y2_max)}
           label_y={pad.t + chart_height / 2 + (y2_axis.label_shift?.y ?? 0)}
           axis_loading={axis_loading === `y2`}
           on_axis_change={(key) => handle_axis_change(`y2`, key)}

--- a/src/lib/plot/bar/BarPlot.svelte
+++ b/src/lib/plot/bar/BarPlot.svelte
@@ -275,6 +275,18 @@
     category_list.length > 0 ? category_list.map((_, idx) => idx) : null,
   )
 
+  // Thin categorical tick labels + grid lines when many categories would overlap.
+  // Bars still render for every category (this only reduces drawn ticks/labels/grid).
+  let cat_tick_indices = $derived.by<number[]>(() => {
+    if (!category_indices) return []
+    const axis_px = (orientation === `horizontal` ? height : width) || 0
+    const max_ticks = Math.max(1, Math.floor(axis_px / 28)) // ~28px per category label
+    const step = Math.ceil(category_indices.length / max_ticks)
+    return step <= 1
+      ? category_indices
+      : category_indices.filter((_, idx) => idx % step === 0)
+  })
+
   let internal_series = $derived.by<NumericBarSeries[]>(() => {
     // safe: when !category_indices, all x values are numeric (is_categorical is false)
     if (!category_indices) return series as unknown as NumericBarSeries[]
@@ -469,17 +481,22 @@
       y2_axis.range?.[0] ?? auto_ranges.y2[0],
       y2_axis.range?.[1] ?? auto_ranges.y2[1],
     ] as Vec2
-    // Only update if the initial (data-driven) ranges changed, not when user pans
-    // Comparing against initial preserves user's pan/zoom state
+    // Skip transient non-finite ranges (e.g. before data/size is ready): writing NaN
+    // would both break scales and make the comparison below never settle (NaN !== NaN).
+    if (![...new_x, ...new_x2, ...new_y, ...new_y2].every(Number.isFinite)) return
+    // Only update if the initial (data-driven) ranges changed, not when user pans.
+    // untrack the read of `ranges` so the assignment below can't re-trigger this effect
+    // (reading + writing the same state otherwise causes effect_update_depth_exceeded).
+    const init = untrack(() => ranges.initial)
     if (
-      ranges.initial.x[0] !== new_x[0] ||
-      ranges.initial.x[1] !== new_x[1] ||
-      ranges.initial.x2[0] !== new_x2[0] ||
-      ranges.initial.x2[1] !== new_x2[1] ||
-      ranges.initial.y[0] !== new_y[0] ||
-      ranges.initial.y[1] !== new_y[1] ||
-      ranges.initial.y2[0] !== new_y2[0] ||
-      ranges.initial.y2[1] !== new_y2[1]
+      init.x[0] !== new_x[0] ||
+      init.x[1] !== new_x[1] ||
+      init.x2[0] !== new_x2[0] ||
+      init.x2[1] !== new_x2[1] ||
+      init.y[0] !== new_y[0] ||
+      init.y[1] !== new_y[1] ||
+      init.y2[0] !== new_y2[0] ||
+      init.y2[1] !== new_y2[1]
     ) {
       ranges = {
         initial: { x: new_x, x2: new_x2, y: new_y, y2: new_y2 },
@@ -678,7 +695,7 @@
   // Ticks
   let ticks = $derived({
     x: width && height
-      ? (category_indices && cat_axis === `x` ? category_indices : generate_ticks(
+      ? (category_indices && cat_axis === `x` ? cat_tick_indices : generate_ticks(
         ranges.current.x,
         x_axis.scale_type ?? `linear`,
         x_axis.ticks,
@@ -687,7 +704,7 @@
       ))
       : [],
     y: width && height
-      ? (category_indices && cat_axis === `y` ? category_indices : generate_ticks(
+      ? (category_indices && cat_axis === `y` ? cat_tick_indices : generate_ticks(
         ranges.current.y,
         y_axis.scale_type ?? `linear`,
         y_axis.ticks,
@@ -787,7 +804,11 @@
           }
         }
         y_axis = { ...y_axis, range: [Math.min(y1, y2), Math.max(y1, y2)] }
-        y2_axis = { ...y2_axis, range: [Math.min(y2_1, y2_2), Math.max(y2_1, y2_2)] }
+        // gate on y2 series presence (like x2): the y2 scale is a [0, 1] sentinel
+        // otherwise, so inverting would store a phantom range in the bindable prop
+        if (y2_series.length > 0) {
+          y2_axis = { ...y2_axis, range: [Math.min(y2_1, y2_2), Math.max(y2_1, y2_2)] }
+        }
       }
     }
     drag_state = { start: null, current: null, bounds: null }
@@ -1558,7 +1579,10 @@
         </clipPath>
       </defs>
 
-      <!-- Clipped content: zero lines, bars, and lines -->
+      <!-- Chart content is clipped in two groups so reference lines can interleave
+           at their z positions while staying outside the chart clip: each line still
+           self-clips to the plot area inside ReferenceLine, only its annotation text
+           is allowed to overflow the plot edges. -->
       <g clip-path="url(#{clip_path_id})">
         <ZeroLines
           {display}
@@ -1582,11 +1606,12 @@
           {height}
           {pad}
         />
+      </g>
 
-        <!-- Reference lines: below lines -->
-        {@render ref_lines_layer(ref_lines_by_z.below_lines)}
+      {@render ref_lines_layer(ref_lines_by_z.below_lines)}
 
-        <!-- Bars and Lines -->
+      <!-- Bars and Lines -->
+      <g clip-path="url(#{clip_path_id})">
         {#each internal_series as srs, series_idx (srs?.id ?? series_idx)}
           {#if srs?.visible ?? true}
             {@const is_line = srs.render_mode === `line`}
@@ -1900,13 +1925,10 @@
             </g>
           {/if}
         {/each}
-
-        <!-- Reference lines: below points -->
-        {@render ref_lines_layer(ref_lines_by_z.below_points)}
-
-        <!-- Reference lines: above all -->
-        {@render ref_lines_layer(ref_lines_by_z.above_all)}
       </g>
+
+      {@render ref_lines_layer(ref_lines_by_z.below_points)}
+      {@render ref_lines_layer(ref_lines_by_z.above_all)}
     </svg>
 
     <!-- Legend -->

--- a/src/lib/plot/bar/data.ts
+++ b/src/lib/plot/bar/data.ts
@@ -28,10 +28,8 @@ export function normalize_categorical<Metadata = Record<string, unknown>>(
 
   if (category_list.length === 0) {
     // safe: when no categories were found, all x values are numeric
-    return {
-      category_list,
-      internal_series: series as unknown as NumericBarSeries<Metadata>[],
-    }
+    const internal_series = series as NumericBarSeries<Metadata>[]
+    return { category_list, internal_series }
   }
 
   const category_indices = category_list.map((_, idx) => idx)
@@ -46,6 +44,12 @@ export function normalize_categorical<Metadata = Record<string, unknown>>(
     const orig_indices = category_list.map((cat) => orig_map.get(cat))
     const remap = <T>(arr: readonly T[] | null | undefined, fallback: T): T[] =>
       orig_indices.map((oi) => (oi != null ? (arr?.[oi] ?? fallback) : fallback))
+    // Reorder a per-point prop that may be a single value (broadcast, left as-is) or an
+    // array (must follow the category reordering, else point styles misalign with bars)
+    const remap_per_point = <T>(prop: T[] | T | undefined): T[] | T | undefined =>
+      Array.isArray(prop)
+        ? (orig_indices.map((oi) => (oi != null ? prop[oi] : undefined)) as T[])
+        : prop
     const bw_arr = Array.isArray(srs.bar_width) ? srs.bar_width : null
     const meta_arr = Array.isArray(srs.metadata) ? srs.metadata : null
     return {
@@ -56,6 +60,10 @@ export function normalize_categorical<Metadata = Record<string, unknown>>(
       metadata: orig_indices.map((oi) =>
         oi != null ? (meta_arr ? meta_arr[oi] : srs.metadata) : undefined,
       ) as Metadata[],
+      point_style: remap_per_point(srs.point_style),
+      point_hover: remap_per_point(srs.point_hover),
+      point_label: remap_per_point(srs.point_label),
+      point_offset: remap_per_point(srs.point_offset),
       ...(bw_arr ? { bar_width: remap(bw_arr, 0.5) } : {}),
       ...(srs.color_values ? { color_values: remap(srs.color_values, null) } : {}),
       ...(srs.size_values ? { size_values: remap(srs.size_values, null) } : {}),

--- a/src/lib/plot/bar/data.ts
+++ b/src/lib/plot/bar/data.ts
@@ -1,0 +1,239 @@
+// Pure data-shaping logic for BarPlot: categorical x-value normalization,
+// auto-range computation (incl. stacked totals + zero-clamping), stacked-bar
+// offsets and grouped-bar layout info. Extracted from BarPlot.svelte so the
+// math is unit-testable without mounting the component.
+
+import { get_nice_data_range } from '$lib/plot/core/scales'
+import type { BarMode, BarSeries, Orientation, ScaleType } from '$lib/plot/core/types'
+import { get_scale_type_name } from '$lib/plot/core/types'
+
+// Internal series shape with guaranteed numeric x (string categories mapped to integer indices)
+export type NumericBarSeries<Metadata = Record<string, unknown>> = Omit<
+  BarSeries<Metadata>,
+  `x`
+> & { x: readonly number[] }
+
+// Map string x values (categories) to integer indices shared across all series.
+// Numeric-only input is passed through unchanged (same array identity).
+export function normalize_categorical<Metadata = Record<string, unknown>>(
+  series: readonly BarSeries<Metadata>[],
+  explicit_categories?: readonly string[],
+): { category_list: string[]; internal_series: NumericBarSeries<Metadata>[] } {
+  const is_categorical = series.some((srs) => srs.x.some((val) => typeof val === `string`))
+  const category_list = !is_categorical
+    ? []
+    : explicit_categories?.length
+      ? [...explicit_categories]
+      : [...new Set(series.flatMap((srs) => srs.x.map(String)))]
+
+  if (category_list.length === 0) {
+    // safe: when no categories were found, all x values are numeric
+    return {
+      category_list,
+      internal_series: series as unknown as NumericBarSeries<Metadata>[],
+    }
+  }
+
+  const category_indices = category_list.map((_, idx) => idx)
+  const internal_series = series.map((srs) => {
+    const orig_map = new Map(srs.x.map((val, idx) => [String(val), idx]))
+    if (orig_map.size < srs.x.length) {
+      console.warn(
+        `BarPlot: series "${srs.label ?? `?`}" has duplicate x values — last occurrence wins`,
+      )
+    }
+    // Resolve original index for each category (undefined if series lacks it)
+    const orig_indices = category_list.map((cat) => orig_map.get(cat))
+    const remap = <T>(arr: readonly T[] | null | undefined, fallback: T): T[] =>
+      orig_indices.map((oi) => (oi != null ? (arr?.[oi] ?? fallback) : fallback))
+    const bw_arr = Array.isArray(srs.bar_width) ? srs.bar_width : null
+    const meta_arr = Array.isArray(srs.metadata) ? srs.metadata : null
+    return {
+      ...srs,
+      x: category_indices,
+      y: remap(srs.y, srs.render_mode === `line` ? NaN : 0),
+      labels: remap(srs.labels, null),
+      metadata: orig_indices.map((oi) =>
+        oi != null ? (meta_arr ? meta_arr[oi] : srs.metadata) : undefined,
+      ) as Metadata[],
+      ...(bw_arr ? { bar_width: remap(bw_arr, 0.5) } : {}),
+      ...(srs.color_values ? { color_values: remap(srs.color_values, null) } : {}),
+      ...(srs.size_values ? { size_values: remap(srs.size_values, null) } : {}),
+    } as NumericBarSeries<Metadata>
+  })
+  return { category_list, internal_series }
+}
+
+export interface BarAutoRangeOpts<Metadata = Record<string, unknown>> {
+  visible_series: readonly NumericBarSeries<Metadata>[]
+  y1_series: readonly NumericBarSeries<Metadata>[]
+  y2_series: readonly NumericBarSeries<Metadata>[]
+  x2_series: readonly NumericBarSeries<Metadata>[]
+  mode: BarMode
+  orientation: Orientation
+  range_padding: number
+  category_count: number // > 0 fixes the category axis to [-0.5, count - 0.5]
+  x_range: [number | null, number | null]
+  x_scale_type: ScaleType
+  x_is_time: boolean
+  x2_range: [number | null, number | null]
+  x2_scale_type: ScaleType
+  x2_is_time: boolean
+  y_range: [number | null, number | null]
+  y_scale_type: ScaleType
+  y2_range: [number | null, number | null]
+  y2_scale_type: ScaleType
+}
+
+// Compute data-driven axis ranges for all four axes. In stacked mode the value
+// range covers per-x stacked totals (positive and negative stacks separately);
+// for linear/arcsinh scales the value axis is clamped to include 0 when all
+// values share one sign and no explicit range is set.
+export function compute_bar_auto_ranges<Metadata = Record<string, unknown>>(
+  opts: BarAutoRangeOpts<Metadata>,
+): { x: number[]; x2: number[]; y: number[]; y2: number[] } {
+  const { visible_series, mode, orientation, range_padding, category_count } = opts
+
+  const calc_y_range = (
+    series_list: readonly NumericBarSeries<Metadata>[],
+    y_limit: [number | null, number | null],
+    scale_type: ScaleType,
+  ) => {
+    let points = series_list.flatMap((srs) =>
+      srs.x.map((x_val, idx) => ({ x: x_val, y: srs.y[idx] })),
+    )
+
+    // In stacked mode, calculate stacked totals for accurate range (only for bars on the same axis)
+    if (mode === `stacked`) {
+      const stacked_totals = new Map<number, { pos: number; neg: number }>()
+
+      // Only include visible bar series (not lines) in stacking
+      series_list
+        .filter((srs) => srs.render_mode !== `line`)
+        .forEach((srs) =>
+          srs.x.forEach((x_val, idx) => {
+            const y_val = srs.y[idx] ?? 0
+            const totals = stacked_totals.get(x_val) ?? { pos: 0, neg: 0 }
+            if (y_val >= 0) totals.pos += y_val
+            else totals.neg += y_val
+            stacked_totals.set(x_val, totals)
+          }),
+        )
+
+      // Replace points with stacked totals + line series (which don't stack)
+      points = [
+        ...Array.from(stacked_totals).flatMap(([x_val, { pos, neg }]) => [
+          ...(pos > 0 ? [{ x: x_val, y: pos }] : []),
+          ...(neg < 0 ? [{ x: x_val, y: neg }] : []),
+        ]),
+        ...series_list
+          .filter((srs) => srs.render_mode === `line`)
+          .flatMap((srs) => srs.x.map((x_val, idx) => ({ x: x_val, y: srs.y[idx] }))),
+      ]
+    }
+
+    if (points.length === 0) return [0, 1]
+
+    let computed_y_range = get_nice_data_range(
+      points,
+      (pt) => pt.y,
+      y_limit,
+      scale_type,
+      range_padding,
+      false,
+    )
+
+    // Bar value axes include 0 when all values share one sign - unless an explicit
+    // range is set or the scale is log (where 0 is invalid)
+    const type_name = get_scale_type_name(scale_type)
+    if (
+      (type_name === `linear` || type_name === `arcsinh`) &&
+      y_limit[0] == null &&
+      y_limit[1] == null
+    ) {
+      const has_negative = points.some((pt) => pt.y < 0)
+      const has_positive = points.some((pt) => pt.y > 0)
+      if (has_positive && !has_negative) computed_y_range = [0, computed_y_range[1]]
+      else if (has_negative && !has_positive) computed_y_range = [computed_y_range[0], 0]
+    }
+
+    return computed_y_range
+  }
+
+  const calc_x_range = (
+    series_list: readonly NumericBarSeries<Metadata>[],
+    limit: [number | null, number | null],
+    scale_type: ScaleType,
+    is_time: boolean,
+  ) => {
+    const points = series_list.flatMap((srs) => srs.x.map((x_val) => ({ x: x_val, y: 0 })))
+    if (points.length === 0) return [0, 1]
+    return get_nice_data_range(points, (pt) => pt.x, limit, scale_type, range_padding, is_time)
+  }
+
+  // Categorical x axes use a fixed range centered on integer indices
+  const x_auto_range =
+    category_count > 0
+      ? [-0.5, category_count - 0.5]
+      : calc_x_range(
+          visible_series.filter((srs) => (srs.x_axis ?? `x1`) === `x1`),
+          opts.x_range,
+          opts.x_scale_type,
+          opts.x_is_time,
+        )
+  const x2_auto_range = calc_x_range(
+    opts.x2_series,
+    opts.x2_range,
+    opts.x2_scale_type,
+    opts.x2_is_time,
+  )
+
+  const y1_range = calc_y_range(opts.y1_series, opts.y_range, opts.y_scale_type)
+  const y2_auto_range = calc_y_range(opts.y2_series, opts.y2_range, opts.y2_scale_type)
+
+  // Map data ranges to axis ranges depending on orientation
+  return orientation === `horizontal`
+    ? { x: y1_range, x2: x2_auto_range, y: x_auto_range, y2: y2_auto_range }
+    : { x: x_auto_range, x2: x2_auto_range, y: y1_range, y2: y2_auto_range }
+}
+
+// Stack offsets indexed by [original series idx][bar idx] (only bar series in
+// stacked mode contribute; hidden and line series get all-zero rows).
+export function compute_stacked_offsets<Metadata = Record<string, unknown>>(
+  internal_series: readonly NumericBarSeries<Metadata>[],
+  mode: BarMode,
+): number[][] {
+  if (mode !== `stacked`) return []
+  const offsets = internal_series.map((srs) => Array.from(srs.x, () => 0))
+  // Cumulative totals keyed by axis/sign/x value so series with misaligned x grids
+  // stack on the correct baseline (matching stacked totals in compute_bar_auto_ranges)
+  const acc = new Map<string, number>()
+  internal_series.forEach((srs, series_idx) => {
+    if (!(srs?.visible ?? true) || srs.render_mode === `line`) return
+    srs.x.forEach((x_val, bar_idx) => {
+      const y_val = srs.y[bar_idx] ?? 0
+      const key = `${srs.y_axis === `y2` ? `y2` : `y1`}:${y_val >= 0 ? `+` : `-`}:${x_val}`
+      offsets[series_idx][bar_idx] = acc.get(key) ?? 0
+      acc.set(key, (acc.get(key) ?? 0) + y_val)
+    })
+  })
+  return offsets
+}
+
+export interface GroupInfo {
+  bar_series_count: number
+  bar_series_indices: number[] // original indices into internal_series of visible bar series
+}
+
+// Group positions for grouped mode (side-by-side bars). Indices are original
+// series indices so hidden/line series don't shift visible bars' slots.
+export function compute_group_info<Metadata = Record<string, unknown>>(
+  internal_series: readonly NumericBarSeries<Metadata>[],
+  mode: BarMode,
+): GroupInfo {
+  if (mode !== `grouped`) return { bar_series_count: 0, bar_series_indices: [] }
+  const bar_series_indices = internal_series
+    .map((srs, idx) => ((srs?.visible ?? true) && srs.render_mode !== `line` ? idx : -1))
+    .filter((idx) => idx >= 0)
+  return { bar_series_count: bar_series_indices.length, bar_series_indices }
+}

--- a/src/lib/plot/bar/geometry.ts
+++ b/src/lib/plot/bar/geometry.ts
@@ -1,0 +1,103 @@
+// Pure screen-space geometry for BarPlot rendering: line-series point
+// construction and per-bar rect computation. Extracted from BarPlot.svelte's
+// template so the coordinate math is unit-testable.
+
+import { process_prop } from '$lib/plot/core/data-transform'
+import type { BarMode, InternalPoint, Orientation } from '$lib/plot/core/types'
+import type { GroupInfo, NumericBarSeries } from './data'
+
+// Point with computed screen coordinates plus original data values
+export type LineSeriesPoint<Metadata = Record<string, unknown>> = InternalPoint<Metadata> & {
+  x: number // Screen x coordinate
+  y: number // Screen y coordinate
+  data_x: number // Original data x value
+  data_y: number // Original data y value
+  idx: number // Index in series
+}
+
+// Build screen-space points for a line series (lines don't stack - they show
+// absolute values). Non-finite points (NaN/Infinity coords) are dropped.
+export function compute_line_points<Metadata = Record<string, unknown>>(opts: {
+  series: NumericBarSeries<Metadata>
+  series_idx: number
+  orientation: Orientation
+  x_scale: (val: number) => number // the series' x scale (x or x2); carries values in horizontal mode
+  y_scale: (val: number) => number // the series' y scale (y or y2)
+  cat_y_scale: (val: number) => number // primary y scale (carries categories in horizontal mode)
+}): LineSeriesPoint<Metadata>[] {
+  const { series: srs, series_idx, orientation, x_scale, y_scale, cat_y_scale } = opts
+  return srs.x
+    .map((x_val, idx) => {
+      const y_val = srs.y[idx]
+      const plot_x = orientation === `vertical` ? x_scale(x_val) : x_scale(y_val)
+      const plot_y = orientation === `vertical` ? y_scale(y_val) : cat_y_scale(x_val)
+      const metadata = Array.isArray(srs.metadata) ? srs.metadata[idx] : srs.metadata
+      return {
+        x: plot_x,
+        y: plot_y,
+        data_x: x_val,
+        data_y: y_val,
+        idx,
+        color_value: srs.color_values?.[idx] ?? null,
+        size_value: srs.size_values?.[idx] ?? null,
+        point_style: process_prop(srs.point_style, idx),
+        point_hover: process_prop(srs.point_hover, idx),
+        point_label: process_prop(srs.point_label, idx),
+        point_offset: process_prop(srs.point_offset, idx),
+        metadata,
+        series_idx,
+        point_idx: idx,
+      } as LineSeriesPoint<Metadata>
+    })
+    .filter((pt) => isFinite(pt.x) && isFinite(pt.y))
+}
+
+export interface BarRect {
+  c0: number // category-axis screen coord of bar start
+  c1: number // category-axis screen coord of bar end
+  v0: number // value-axis screen coord of bar base
+  v1: number // value-axis screen coord of bar tip
+  rect_x: number
+  rect_y: number
+  rect_w: number
+  rect_h: number
+}
+
+// Screen-space rect for one bar: category extent (c0/c1) from bar width +
+// grouped offset, value extent (v0/v1) from stacked base to base + value.
+// Rects get min 1px width so thin bars stay visible.
+export function compute_bar_rect(opts: {
+  cat_val: number
+  val: number
+  base: number // stacked baseline in data units (0 unless stacked)
+  bar_width_val: number
+  series_idx: number
+  mode: BarMode
+  orientation: Orientation
+  group_info: GroupInfo
+  cat_scale: (val: number) => number
+  val_scale: (val: number) => number
+}): BarRect {
+  const { cat_val, val, base, bar_width_val, series_idx, mode, group_info } = opts
+  const { cat_scale, val_scale } = opts
+  const is_vertical = opts.orientation === `vertical`
+  const grouped = mode === `grouped` && group_info.bar_series_count > 1
+  const half = grouped ? bar_width_val / (2 * group_info.bar_series_count) : bar_width_val / 2
+  // Offset uses the series' slot among visible bar series (original-index lookup)
+  const group_offset = grouped
+    ? (group_info.bar_series_indices.indexOf(series_idx) -
+        (group_info.bar_series_count - 1) / 2) *
+      (bar_width_val / group_info.bar_series_count)
+    : 0
+  const c0 = cat_scale(cat_val + group_offset - half)
+  const c1 = cat_scale(cat_val + group_offset + half)
+  const v0 = val_scale(base)
+  const v1 = val_scale(base + val)
+  const [rect_x, rect_y] = is_vertical
+    ? [Math.min(c0, c1), Math.min(v0, v1)]
+    : [Math.min(v0, v1), Math.min(c0, c1)]
+  const [rect_w, rect_h] = is_vertical
+    ? [Math.max(1, Math.abs(c1 - c0)), Math.max(0, Math.abs(v1 - v0))]
+    : [Math.max(1, Math.abs(v1 - v0)), Math.max(0, Math.abs(c1 - c0))]
+  return { c0, c1, v0, v1, rect_x, rect_y, rect_w, rect_h }
+}

--- a/src/lib/plot/box/BoxPlot.svelte
+++ b/src/lib/plot/box/BoxPlot.svelte
@@ -39,16 +39,14 @@
   } from '$lib/plot/core/auto-place'
   import { compute_box_stats } from '$lib/plot/box/box-plot'
   import { gaussian_kde, type KdeResult } from '$lib/plot/box/kde'
-  import {
-    create_dimension_tracker,
-    create_hover_lock,
-  } from '$lib/plot/core/hover-lock.svelte'
+  import { create_dimension_tracker, create_hover_lock } from '$lib/plot/core/hover-lock.svelte'
+  import { create_legend_visibility } from '$lib/plot/core/utils/series-visibility'
   import {
     get_relative_coords,
     MIN_TOUCH_DISTANCE_PIXELS,
-    pan_range,
+    pan_range_by_pixels,
     PINCH_ZOOM_THRESHOLD,
-    pixels_to_data_delta,
+    zoom_range_by_factor,
   } from '$lib/plot/core/interactions'
   import {
     calc_auto_padding,
@@ -114,14 +112,10 @@
     series = $bindable([]),
     orientation = $bindable(`vertical`),
     x_axis = $bindable({}),
-    x2_axis = $bindable({}),
+    x2_axis: x2_axis_prop = $bindable({}),
     y_axis = $bindable({}),
-    y2_axis = $bindable({}),
+    y2_axis: y2_axis_prop = $bindable({}),
     display = $bindable(DEFAULTS.box.display),
-    x_range = [null, null],
-    x2_range = [null, null],
-    y_range = [null, null],
-    y2_range = [null, null],
     range_padding = 0.05,
     padding = { t: 20, b: 60, l: 60, r: 20 },
     legend = {},
@@ -218,8 +212,26 @@
   let outlier_state = $derived({ ...DEFAULTS.box.outlier, ...outlier_style })
   let violin_state = $derived({ ...DEFAULTS.box.violin, ...violin_style })
 
-  y2_axis = { format: ``, scale_type: `linear`, ticks: 5, range: [null, null], ...y2_axis }
-  x2_axis = { format: ``, scale_type: `linear`, ticks: 5, range: [null, null], ...x2_axis }
+  // Merge secondary-axis defaults as deriveds instead of assigning back into the
+  // $bindable props (which would push library defaults into the parent's bound state)
+  let y2_axis = $derived(
+    {
+      format: ``,
+      scale_type: `linear`,
+      ticks: 5,
+      range: [null, null],
+      ...y2_axis_prop,
+    } as typeof y2_axis_prop,
+  )
+  let x2_axis = $derived(
+    {
+      format: ``,
+      scale_type: `linear`,
+      ticks: 5,
+      range: [null, null],
+      ...x2_axis_prop,
+    } as typeof x2_axis_prop,
+  )
 
   let [width, height] = $state([0, 0])
   let wrapper: HTMLDivElement | undefined = $state()
@@ -377,7 +389,7 @@
     const primary_boxes = visible_boxes.filter((box_item) => !is_secondary(box_item.series))
     const calc_value_range = (
       boxes: Box[],
-      limit: typeof y_range,
+      limit: [number | null, number | null],
       scale_type: ScaleType,
     ): Vec2 => {
       const pts = value_points(boxes)
@@ -387,12 +399,12 @@
     const vertical = orientation === `vertical`
     const value_primary = calc_value_range(
       primary_boxes,
-      vertical ? y_range : x_range,
+      (vertical ? y_axis.range : x_axis.range) ?? [null, null],
       (vertical ? y_axis.scale_type : x_axis.scale_type) ?? `linear`,
     )
     const value_secondary = calc_value_range(
       secondary_boxes,
-      vertical ? y2_range : x2_range,
+      (vertical ? y2_axis.range : x2_axis.range) ?? [null, null],
       (vertical ? y2_axis.scale_type : x2_axis.scale_type) ?? `linear`,
     )
 
@@ -623,13 +635,19 @@
       if (dx > 5 && dy > 5 && Number.isFinite(x1) && Number.isFinite(x2)) {
         x_axis = { ...x_axis, range: [Math.min(x1, x2), Math.max(x1, x2)] }
         if (has_secondary && Number.isFinite(x2_1) && Number.isFinite(x2_2)) {
-          x2_axis = { ...x2_axis, range: [Math.min(x2_1, x2_2), Math.max(x2_1, x2_2)] }
+          x2_axis_prop = {
+            ...x2_axis_prop,
+            range: [Math.min(x2_1, x2_2), Math.max(x2_1, x2_2)],
+          }
         }
         y_axis = { ...y_axis, range: [Math.min(y1, y2), Math.max(y1, y2)] }
         // gate on secondary series presence (like x2): the y2 scale is a sentinel
         // otherwise, so inverting would store a phantom range in the bindable prop
         if (has_secondary && Number.isFinite(y2_1) && Number.isFinite(y2_2)) {
-          y2_axis = { ...y2_axis, range: [Math.min(y2_1, y2_2), Math.max(y2_1, y2_2)] }
+          y2_axis_prop = {
+            ...y2_axis_prop,
+            range: [Math.min(y2_1, y2_2), Math.max(y2_1, y2_2)],
+          }
         }
       }
     }
@@ -639,19 +657,30 @@
     document.body.style.cursor = `default`
   }
 
+  // Pan/zoom all four axes from an interaction-start snapshot, each in its own
+  // scale's transform space (log axes pan by a constant factor, linear by a shift)
+  const pan_all_axes = (init: InitialRanges, dx_px: number, dy_px: number) => {
+    ranges.current.x = pan_range_by_pixels(init.initial_x_range, dx_px, chart_width, x_axis.scale_type)
+    ranges.current.x2 = pan_range_by_pixels(init.initial_x2_range, dx_px, chart_width, x2_axis.scale_type)
+    ranges.current.y = pan_range_by_pixels(init.initial_y_range, dy_px, chart_height, y_axis.scale_type)
+    ranges.current.y2 = pan_range_by_pixels(init.initial_y2_range, dy_px, chart_height, y2_axis.scale_type)
+  }
+  const zoom_all_axes = (init: InitialRanges, factor: number) => {
+    ranges.current.x = zoom_range_by_factor(init.initial_x_range, factor, x_axis.scale_type)
+    ranges.current.x2 = zoom_range_by_factor(init.initial_x2_range, factor, x2_axis.scale_type)
+    ranges.current.y = zoom_range_by_factor(init.initial_y_range, factor, y_axis.scale_type)
+    ranges.current.y2 = zoom_range_by_factor(init.initial_y2_range, factor, y2_axis.scale_type)
+  }
+
+  // Pan drag handler (drag direction inverted on x for natural pan feel)
   const on_pan_move = (evt: MouseEvent) => {
     if (!pan_drag_state) return
-    const dx = evt.clientX - pan_drag_state.start.x
-    const dy = evt.clientY - pan_drag_state.start.y
     const sensitivity = pan?.drag_sensitivity ?? 1
-    const x_delta = pixels_to_data_delta(-dx * sensitivity, pan_drag_state.initial_x_range, chart_width)
-    const x2_delta = pixels_to_data_delta(-dx * sensitivity, pan_drag_state.initial_x2_range, chart_width)
-    const y_delta = pixels_to_data_delta(dy * sensitivity, pan_drag_state.initial_y_range, chart_height)
-    const y2_delta = pixels_to_data_delta(dy * sensitivity, pan_drag_state.initial_y2_range, chart_height)
-    ranges.current.x = pan_range(pan_drag_state.initial_x_range, x_delta)
-    ranges.current.x2 = pan_range(pan_drag_state.initial_x2_range, x2_delta)
-    ranges.current.y = pan_range(pan_drag_state.initial_y_range, y_delta)
-    ranges.current.y2 = pan_range(pan_drag_state.initial_y2_range, y2_delta)
+    pan_all_axes(
+      pan_drag_state,
+      -(evt.clientX - pan_drag_state.start.x) * sensitivity,
+      (evt.clientY - pan_drag_state.start.y) * sensitivity,
+    )
   }
   const on_pan_end = () => {
     pan_drag_state = null
@@ -703,16 +732,14 @@
     if (!pan_enabled || !is_focused || !shift_held) return
     evt.preventDefault()
     const sensitivity = pan?.wheel_sensitivity ?? 1
-    const x_delta = pixels_to_data_delta(evt.deltaX * sensitivity, ranges.current.x, chart_width)
-    const x2_delta = pixels_to_data_delta(evt.deltaX * sensitivity, ranges.current.x2, chart_width)
-    const y_delta = pixels_to_data_delta(evt.deltaY * sensitivity, ranges.current.y, chart_height)
-    const y2_delta = pixels_to_data_delta(evt.deltaY * sensitivity, ranges.current.y2, chart_height)
     if (Math.abs(evt.deltaX) > Math.abs(evt.deltaY)) {
-      ranges.current.x = pan_range(ranges.current.x, x_delta)
-      ranges.current.x2 = pan_range(ranges.current.x2, x2_delta)
+      const dx = evt.deltaX * sensitivity
+      ranges.current.x = pan_range_by_pixels(ranges.current.x, dx, chart_width, x_axis.scale_type)
+      ranges.current.x2 = pan_range_by_pixels(ranges.current.x2, dx, chart_width, x2_axis.scale_type)
     } else {
-      ranges.current.y = pan_range(ranges.current.y, y_delta)
-      ranges.current.y2 = pan_range(ranges.current.y2, y2_delta)
+      const dy = evt.deltaY * sensitivity
+      ranges.current.y = pan_range_by_pixels(ranges.current.y, dy, chart_height, y_axis.scale_type)
+      ranges.current.y2 = pan_range_by_pixels(ranges.current.y2, dy, chart_height, y2_axis.scale_type)
     }
   }
 
@@ -743,34 +770,10 @@
     if (start_dist < MIN_TOUCH_DISTANCE_PIXELS) return
     const curr_dist = Math.hypot(t2.clientX - t1.clientX, t2.clientY - t1.clientY)
     const scale = curr_dist / start_dist
+    // Pinch zoom about the view center (spread = zoom in, pinch = zoom out)
     if (Math.abs(scale - 1) > PINCH_ZOOM_THRESHOLD && scale > Number.EPSILON) {
-      const zoom = (rng: Vec2): Vec2 => {
-        const span = rng[1] - rng[0]
-        const center = (rng[0] + rng[1]) / 2
-        return [center - span / scale / 2, center + span / scale / 2]
-      }
-      ranges.current.x = zoom(touch_state.initial_x_range)
-      ranges.current.x2 = zoom(touch_state.initial_x2_range)
-      ranges.current.y = zoom(touch_state.initial_y_range)
-      ranges.current.y2 = zoom(touch_state.initial_y2_range)
-    } else {
-      ranges.current.x = pan_range(
-        touch_state.initial_x_range,
-        pixels_to_data_delta(-dx, touch_state.initial_x_range, chart_width),
-      )
-      ranges.current.x2 = pan_range(
-        touch_state.initial_x2_range,
-        pixels_to_data_delta(-dx, touch_state.initial_x2_range, chart_width),
-      )
-      ranges.current.y = pan_range(
-        touch_state.initial_y_range,
-        pixels_to_data_delta(dy, touch_state.initial_y_range, chart_height),
-      )
-      ranges.current.y2 = pan_range(
-        touch_state.initial_y2_range,
-        pixels_to_data_delta(dy, touch_state.initial_y2_range, chart_height),
-      )
-    }
+      zoom_all_axes(touch_state, scale)
+    } else pan_all_axes(touch_state, -dx, dy)
   }
   const handle_touch_end = () => (touch_state = null)
 
@@ -785,22 +788,7 @@
     })),
   )
 
-  function toggle_series_visibility(series_idx: number) {
-    if (series_idx >= 0 && series_idx < series.length) {
-      series = series.map((srs, idx) =>
-        idx === series_idx ? { ...srs, visible: !(srs.visible ?? true) } : srs
-      )
-    }
-  }
-  function toggle_group_visibility(_group: string, indices: number[]) {
-    const valid = indices.filter((idx) => idx >= 0 && idx < series.length)
-    if (valid.length === 0) return
-    const idx_set = new Set(valid)
-    const all_visible = valid.every((idx) => series[idx].visible ?? true)
-    series = series.map((srs, idx) =>
-      idx_set.has(idx) ? { ...srs, visible: !all_visible } : srs
-    )
-  }
+  const legend_vis = create_legend_visibility(() => series, (next) => (series = next))
 
   let box_points_for_placement = $derived.by(() => {
     if (!width || !height || visible_boxes.length === 0) return []
@@ -1003,9 +991,9 @@
         ranges.current.y = [...ranges.initial.y] as Vec2
         ranges.current.y2 = [...ranges.initial.y2] as Vec2
         x_axis = { ...x_axis, range: [null, null] }
-        x2_axis = { ...x2_axis, range: [null, null] }
+        x2_axis_prop = { ...x2_axis_prop, range: [null, null] }
         y_axis = { ...y_axis, range: [null, null] }
-        y2_axis = { ...y2_axis, range: [null, null] }
+        y2_axis_prop = { ...y2_axis_prop, range: [null, null] }
       }}
       onmouseleave={() => {
         hovered = false
@@ -1048,6 +1036,7 @@
         ticks={ticks.x as number[]}
         place={scales.x}
         axis={x_axis}
+        domain={ranges.current.x as Vec2}
         {pad}
         {width}
         {height}
@@ -1065,6 +1054,7 @@
           ticks={ticks.x2 as number[]}
           place={scales.x2}
           axis={x2_axis}
+          domain={ranges.current.x2 as Vec2}
           {pad}
           {width}
           {height}
@@ -1080,6 +1070,7 @@
         ticks={ticks.y as number[]}
         place={scales.y}
         axis={y_axis}
+        domain={ranges.current.y as Vec2}
         {pad}
         {width}
         {height}
@@ -1103,6 +1094,7 @@
           ticks={ticks.y2 as number[]}
           place={scales.y2}
           axis={y2_axis}
+          domain={ranges.current.y2 as Vec2}
           {pad}
           {width}
           {height}
@@ -1335,8 +1327,9 @@
         bind:root_element={legend_element}
         {...legend}
         series_data={legend_data}
-        on_toggle={legend?.on_toggle || toggle_series_visibility}
-        on_group_toggle={legend?.on_group_toggle || toggle_group_visibility}
+        on_toggle={legend?.on_toggle ?? legend_vis.on_toggle}
+        on_group_toggle={legend?.on_group_toggle ?? legend_vis.on_group_toggle}
+        on_double_click={legend?.on_double_click ?? legend_vis.on_double_click}
         on_hover_change={legend_hover.set_locked}
         on_item_hover={(item) =>
           (hovered_legend_series_idx = item != null && item.series_idx >= 0
@@ -1410,9 +1403,9 @@
         bind:kind
         bind:side
         bind:x_axis
-        bind:x2_axis
+        bind:x2_axis={x2_axis_prop}
         bind:y_axis
-        bind:y2_axis
+        bind:y2_axis={y2_axis_prop}
         bind:display
         auto_x_range={auto_ranges.x as Vec2}
         auto_x2_range={auto_ranges.x2 as Vec2}
@@ -1454,7 +1447,10 @@
     background: var(--boxplot-fullscreen-bg, var(--boxplot-bg, var(--plot-bg)));
     max-height: none !important;
     overflow: hidden;
-    padding-top: var(--plot-fullscreen-padding-top, 2em);
+    /* border-top (not padding-top): bind:clientHeight includes padding but excludes
+    borders - padding made the chart overflow + clip its bottom 2em (x-axis title) */
+    border-top: var(--plot-fullscreen-padding-top, 2em) solid
+      var(--boxplot-fullscreen-bg, var(--boxplot-bg, var(--plot-bg, transparent)));
     box-sizing: border-box;
   }
   .header-controls {

--- a/src/lib/plot/box/BoxPlot.svelte
+++ b/src/lib/plot/box/BoxPlot.svelte
@@ -47,13 +47,13 @@
     MIN_TOUCH_DISTANCE_PIXELS,
     pan_range_by_pixels,
     PINCH_ZOOM_THRESHOLD,
+    remove_drag_listeners,
     resolve_axis_ranges,
     sorted_range,
     zoom_range_by_factor,
   } from '$lib/plot/core/interactions'
   import {
     calc_auto_padding,
-    constrain_tooltip_position,
     filter_padding,
     LABEL_GAP_DEFAULT,
     y2_axis_label_x,
@@ -546,10 +546,7 @@
     if (user_ticks != null && typeof user_ticks === `object` && !Array.isArray(user_ticks)) {
       return user_ticks
     }
-    return Object.fromEntries(slot_list.map((cat, idx) => [idx, cat])) as Record<
-      number,
-      string
-    >
+    return Object.fromEntries(slot_list.map((cat, idx) => [idx, cat]))
   })
 
   let ticks = $derived({
@@ -623,13 +620,20 @@
       const dy = Math.abs(drag_state.start.y - drag_state.current.y)
       if (dx > 5 && dy > 5 && Number.isFinite(x1) && Number.isFinite(x2)) {
         x_axis = { ...x_axis, range: sorted_range(x1, x2) }
-        if (has_secondary && Number.isFinite(x2_1) && Number.isFinite(x2_2)) {
+        // the secondary value axis is x2 only in horizontal mode, y2 only in vertical
+        // (is_secondary keys off orientation); writing the off-orientation axis would
+        // store a phantom range from its [0, 1] sentinel scale into the bound prop
+        if (
+          has_secondary && orientation === `horizontal` &&
+          Number.isFinite(x2_1) && Number.isFinite(x2_2)
+        ) {
           x2_axis_prop = { ...x2_axis_prop, range: sorted_range(x2_1, x2_2) }
         }
         y_axis = { ...y_axis, range: sorted_range(y1, y2) }
-        // gate on secondary series presence (like x2): the y2 scale is a sentinel
-        // otherwise, so inverting would store a phantom range in the bindable prop
-        if (has_secondary && Number.isFinite(y2_1) && Number.isFinite(y2_2)) {
+        if (
+          has_secondary && orientation === `vertical` &&
+          Number.isFinite(y2_1) && Number.isFinite(y2_2)
+        ) {
           y2_axis_prop = { ...y2_axis_prop, range: sorted_range(y2_1, y2_2) }
         }
       }
@@ -676,14 +680,9 @@
   // (mouseup/panend would otherwise never fire, leaking listeners and a stuck cursor).
   // onDestroy also runs during SSR teardown, where window/document don't exist.
   onDestroy(() => {
-    if (typeof window === `undefined`) return
-    window.removeEventListener(`mousemove`, on_window_mouse_move)
-    window.removeEventListener(`mouseup`, on_window_mouse_up)
-    window.removeEventListener(`mousemove`, on_pan_move)
-    window.removeEventListener(`mouseup`, on_pan_end)
+    remove_drag_listeners([on_window_mouse_move, on_pan_move], [on_window_mouse_up, on_pan_end])
     drag_state = { start: null, current: null, bounds: null }
     pan_drag_state = null
-    document.body.style.cursor = ``
   })
 
   function handle_mouse_down(evt: MouseEvent) {
@@ -827,7 +826,6 @@
 
   // === Tooltip / hover ===
   let hover_info = $state<BoxHover | null>(null)
-  let tooltip_el = $state<HTMLDivElement | undefined>()
 
   function get_box_data(box_item: Box, color: string): BoxHover {
     const vertical = orientation === `vertical`
@@ -1322,21 +1320,13 @@
     {/if}
 
     {#if hover_info && hovered}
-      {@const tooltip_pos = constrain_tooltip_position(
-      hover_info.cx,
-      hover_info.cy,
-      tooltip_el?.offsetWidth ?? 140,
-      tooltip_el?.offsetHeight ?? 50,
-      width,
-      height,
-      { offset_x: 10, offset_y: 5 },
-    )}
       <PlotTooltip
-        x={tooltip_pos.x}
-        y={tooltip_pos.y}
-        offset={{ x: 0, y: 0 }}
+        x={hover_info.cx}
+        y={hover_info.cy}
+        offset={{ x: 10, y: 5 }}
+        constrain_to={{ width, height }}
+        fallback_size={{ width: 140, height: 50 }}
         bg_color={hover_info.color}
-        bind:wrapper={tooltip_el}
       >
         {#if tooltip}
           {@render tooltip({ ...hover_info, fullscreen })}

--- a/src/lib/plot/box/BoxPlot.svelte
+++ b/src/lib/plot/box/BoxPlot.svelte
@@ -42,10 +42,13 @@
   import { create_dimension_tracker, create_hover_lock } from '$lib/plot/core/hover-lock.svelte'
   import { create_legend_visibility } from '$lib/plot/core/utils/series-visibility'
   import {
+    axis_ranges_equal,
     get_relative_coords,
     MIN_TOUCH_DISTANCE_PIXELS,
     pan_range_by_pixels,
     PINCH_ZOOM_THRESHOLD,
+    resolve_axis_ranges,
+    sorted_range,
     zoom_range_by_factor,
   } from '$lib/plot/core/interactions'
   import {
@@ -53,6 +56,7 @@
     constrain_tooltip_position,
     filter_padding,
     LABEL_GAP_DEFAULT,
+    y2_axis_label_x,
     measure_max_tick_width,
   } from '$lib/plot/core/layout'
   import { LOG_EPS } from '$lib/math'
@@ -422,30 +426,15 @@
   })
 
   $effect(() => { // sync ranges from axis.range overrides / auto ranges
-    const resolve_range = (
-      axis: { range?: [number | null, number | null] },
-      auto: Vec2,
-    ): Vec2 => [axis.range?.[0] ?? auto[0], axis.range?.[1] ?? auto[1]]
-    const new_x = resolve_range(x_axis, auto_ranges.x)
-    const new_x2 = resolve_range(x2_axis, auto_ranges.x2)
-    const new_y = resolve_range(y_axis, auto_ranges.y)
-    const new_y2 = resolve_range(y2_axis, auto_ranges.y2)
-    // Skip transient non-finite ranges: writing NaN breaks scales and makes the
-    // comparison below never settle (NaN !== NaN), causing an infinite effect loop.
-    if (![...new_x, ...new_x2, ...new_y, ...new_y2].every(Number.isFinite)) return
+    // resolve_axis_ranges returns null for transient non-finite bounds (skip: writing
+    // NaN breaks scales and, since NaN !== NaN, loops the effect)
+    const next = resolve_axis_ranges({ x: x_axis, x2: x2_axis, y: y_axis, y2: y2_axis }, auto_ranges)
+    if (!next) return
     // untrack the read of `ranges` so the assignment can't re-trigger this effect
     // (reading + writing the same state otherwise causes effect_update_depth_exceeded).
     const init = untrack(() => ranges.initial)
-    if (
-      init.x[0] !== new_x[0] || init.x[1] !== new_x[1] ||
-      init.x2[0] !== new_x2[0] || init.x2[1] !== new_x2[1] ||
-      init.y[0] !== new_y[0] || init.y[1] !== new_y[1] ||
-      init.y2[0] !== new_y2[0] || init.y2[1] !== new_y2[1]
-    ) {
-      ranges = {
-        initial: { x: new_x, x2: new_x2, y: new_y, y2: new_y2 },
-        current: { x: new_x, x2: new_x2, y: new_y, y2: new_y2 },
-      }
+    if (!axis_ranges_equal(init, next)) {
+      ranges = { initial: { ...next }, current: { ...next } }
     }
   })
 
@@ -633,21 +622,15 @@
       const dx = Math.abs(drag_state.start.x - drag_state.current.x)
       const dy = Math.abs(drag_state.start.y - drag_state.current.y)
       if (dx > 5 && dy > 5 && Number.isFinite(x1) && Number.isFinite(x2)) {
-        x_axis = { ...x_axis, range: [Math.min(x1, x2), Math.max(x1, x2)] }
+        x_axis = { ...x_axis, range: sorted_range(x1, x2) }
         if (has_secondary && Number.isFinite(x2_1) && Number.isFinite(x2_2)) {
-          x2_axis_prop = {
-            ...x2_axis_prop,
-            range: [Math.min(x2_1, x2_2), Math.max(x2_1, x2_2)],
-          }
+          x2_axis_prop = { ...x2_axis_prop, range: sorted_range(x2_1, x2_2) }
         }
-        y_axis = { ...y_axis, range: [Math.min(y1, y2), Math.max(y1, y2)] }
+        y_axis = { ...y_axis, range: sorted_range(y1, y2) }
         // gate on secondary series presence (like x2): the y2 scale is a sentinel
         // otherwise, so inverting would store a phantom range in the bindable prop
         if (has_secondary && Number.isFinite(y2_1) && Number.isFinite(y2_2)) {
-          y2_axis_prop = {
-            ...y2_axis_prop,
-            range: [Math.min(y2_1, y2_2), Math.max(y2_1, y2_2)],
-          }
+          y2_axis_prop = { ...y2_axis_prop, range: sorted_range(y2_1, y2_2) }
         }
       }
     }
@@ -1086,9 +1069,6 @@
       />
 
       {#if has_secondary && orientation === `vertical`}
-        {@const y2_inside = y2_axis.tick?.label?.inside ?? false}
-        {@const y2_tick_shift = y2_inside ? 0 : (y2_axis.tick?.label?.shift?.x ?? 0) + 8}
-        {@const y2_tick_width = y2_inside ? 0 : tick_label_widths.y2_max}
         <PlotAxis
           side="y2"
           ticks={ticks.y2 as number[]}
@@ -1100,8 +1080,7 @@
           {height}
           show_grid={display.y2_grid}
           tick_label={(tick) => get_tick_label(tick, y2_axis.ticks)}
-          label_x={width - pad.r + y2_tick_shift + y2_tick_width + LABEL_GAP_DEFAULT +
-          (y2_axis.label_shift?.x ?? 0)}
+          label_x={y2_axis_label_x(y2_axis, width, pad.r, tick_label_widths.y2_max)}
           label_y={pad.t + chart_height / 2 + (y2_axis.label_shift?.y ?? 0)}
         />
       {/if}

--- a/src/lib/plot/box/BoxPlot.svelte
+++ b/src/lib/plot/box/BoxPlot.svelte
@@ -57,6 +57,7 @@
     LABEL_GAP_DEFAULT,
     measure_max_tick_width,
   } from '$lib/plot/core/layout'
+  import { LOG_EPS } from '$lib/math'
   import type { IndexedRefLine } from '$lib/plot/core/reference-line'
   import { group_ref_lines_by_z, index_ref_lines } from '$lib/plot/core/reference-line'
   import {
@@ -417,11 +418,17 @@
     const new_x2 = resolve_range(x2_axis, auto_ranges.x2)
     const new_y = resolve_range(y_axis, auto_ranges.y)
     const new_y2 = resolve_range(y2_axis, auto_ranges.y2)
+    // Skip transient non-finite ranges: writing NaN breaks scales and makes the
+    // comparison below never settle (NaN !== NaN), causing an infinite effect loop.
+    if (![...new_x, ...new_x2, ...new_y, ...new_y2].every(Number.isFinite)) return
+    // untrack the read of `ranges` so the assignment can't re-trigger this effect
+    // (reading + writing the same state otherwise causes effect_update_depth_exceeded).
+    const init = untrack(() => ranges.initial)
     if (
-      ranges.initial.x[0] !== new_x[0] || ranges.initial.x[1] !== new_x[1] ||
-      ranges.initial.x2[0] !== new_x2[0] || ranges.initial.x2[1] !== new_x2[1] ||
-      ranges.initial.y[0] !== new_y[0] || ranges.initial.y[1] !== new_y[1] ||
-      ranges.initial.y2[0] !== new_y2[0] || ranges.initial.y2[1] !== new_y2[1]
+      init.x[0] !== new_x[0] || init.x[1] !== new_x[1] ||
+      init.x2[0] !== new_x2[0] || init.x2[1] !== new_x2[1] ||
+      init.y[0] !== new_y[0] || init.y[1] !== new_y[1] ||
+      init.y2[0] !== new_y2[0] || init.y2[1] !== new_y2[1]
     ) {
       ranges = {
         initial: { x: new_x, x2: new_x2, y: new_y, y2: new_y2 },
@@ -517,6 +524,20 @@
     y2: create_scale(y2_axis.scale_type ?? `linear`, ranges.current.y2, [height - pad.b, pad.t]),
   })
 
+  // Value scale for a box (vertical -> y/y2, horizontal -> x/x2), made log-safe: on a
+  // log value axis, stats at values <= 0 (whisker_low is often exactly 0; negative
+  // outliers) have no finite pixel. Clamp to LOG_EPS so whiskers/boxes/labels draw
+  // toward the plot edge (the clip group crops the overshoot) instead of NaN coords.
+  const box_val_scale = (srs: BoxPlotSeries<Metadata>): (val: number) => number => {
+    const vertical = orientation === `vertical`
+    const secondary = is_secondary(srs)
+    const scale = vertical
+      ? (secondary ? scales.y2 : scales.y)
+      : (secondary ? scales.x2 : scales.x)
+    const axis = vertical ? (secondary ? y2_axis : y_axis) : (secondary ? x2_axis : x_axis)
+    return axis.scale_type === `log` ? (val) => scale(Math.max(val, LOG_EPS)) : scale
+  }
+
   // Categorical tick labels (slot index -> category name) unless user provides a label mapping
   let effective_cat_ticks = $derived.by(() => {
     if (slot_list.length === 0) return undefined
@@ -605,7 +626,11 @@
           x2_axis = { ...x2_axis, range: [Math.min(x2_1, x2_2), Math.max(x2_1, x2_2)] }
         }
         y_axis = { ...y_axis, range: [Math.min(y1, y2), Math.max(y1, y2)] }
-        y2_axis = { ...y2_axis, range: [Math.min(y2_1, y2_2), Math.max(y2_1, y2_2)] }
+        // gate on secondary series presence (like x2): the y2 scale is a sentinel
+        // otherwise, so inverting would store a phantom range in the bindable prop
+        if (has_secondary && Number.isFinite(y2_1) && Number.isFinite(y2_2)) {
+          y2_axis = { ...y2_axis, range: [Math.min(y2_1, y2_2), Math.max(y2_1, y2_2)] }
+        }
       }
     }
     drag_state = { start: null, current: null, bounds: null }
@@ -782,10 +807,7 @@
     const vertical = orientation === `vertical`
     return visible_boxes
       .map((box_item) => {
-        const secondary = is_secondary(box_item.series)
-        const val_scale = vertical
-          ? (secondary ? scales.y2 : scales.y)
-          : (secondary ? scales.x2 : scales.x)
+        const val_scale = box_val_scale(box_item.series)
         const cat_scale = vertical ? scales.x : scales.y
         const cc = cat_scale(box_item.slot)
         const vc = val_scale(box_item.stats.median)
@@ -838,10 +860,7 @@
 
   function get_box_data(box_item: Box, color: string): BoxHover {
     const vertical = orientation === `vertical`
-    const secondary = is_secondary(box_item.series)
-    const val_scale = vertical
-      ? (secondary ? scales.y2 : scales.y)
-      : (secondary ? scales.x2 : scales.x)
+    const val_scale = box_val_scale(box_item.series)
     const cat_scale = vertical ? scales.x : scales.y
     const cc = cat_scale(box_item.slot)
     const v_hi = val_scale(box_item.stats.whisker_high)
@@ -1101,6 +1120,10 @@
         </clipPath>
       </defs>
 
+      <!-- Chart content is clipped in two groups so reference lines can interleave
+           at their z positions while staying outside the chart clip: each line still
+           self-clips to the plot area inside ReferenceLine, only its annotation text
+           is allowed to overflow the plot edges. -->
       <g clip-path="url(#{clip_path_id})">
         <ZeroLines
           {display}
@@ -1122,19 +1145,18 @@
           {height}
           {pad}
         />
+      </g>
 
-        {@render ref_lines_layer(ref_lines_by_z.below_lines)}
+      {@render ref_lines_layer(ref_lines_by_z.below_lines)}
 
-        <!-- Boxes -->
+      <!-- Boxes -->
+      <g clip-path="url(#{clip_path_id})">
         {#each visible_boxes as box_item (box_item.series.id ?? box_item.idx)}
           {@const stats = box_item.stats}
           {#if Number.isFinite(stats.median)}
             {@const vertical = orientation === `vertical`}
-            {@const secondary = is_secondary(box_item.series)}
             {@const cat_scale = vertical ? scales.x : scales.y}
-            {@const val_scale = vertical
-            ? (secondary ? scales.y2 : scales.y)
-            : (secondary ? scales.x2 : scales.x)}
+            {@const val_scale = box_val_scale(box_item.series)}
             {@const color = box_color(box_item.idx)}
             {@const draw_box = draws_box(box_item.series)}
             {@const kde = violin_kdes.get(box_item.idx)}
@@ -1292,10 +1314,10 @@
             </g>
           {/if}
         {/each}
-
-        {@render ref_lines_layer(ref_lines_by_z.below_points)}
-        {@render ref_lines_layer(ref_lines_by_z.above_all)}
       </g>
+
+      {@render ref_lines_layer(ref_lines_by_z.below_points)}
+      {@render ref_lines_layer(ref_lines_by_z.above_all)}
     </svg>
 
     {#if legend && should_show_legend}

--- a/src/lib/plot/box/box-plot.ts
+++ b/src/lib/plot/box/box-plot.ts
@@ -3,7 +3,59 @@
 
 import { ascending } from 'd3-array'
 import { quantile_unordered } from '$lib/plot/box/quantile'
-import type { WhiskerMode } from '$lib/plot/core/types'
+import type { HandlerProps } from '$lib/plot/core/types'
+
+// === Box plot types ===
+// How box plot whiskers are computed from a raw distribution
+export type WhiskerMode = `tukey` | `minmax` | `percentile` | `std`
+
+// Which glyph(s) to draw per series: a box, a violin (KDE density), or both
+export type ViolinKind = `box` | `violin` | `violin+box`
+// Which half of the category slot a violin occupies (for one-sided / split violins)
+export type ViolinSide = `both` | `positive` | `negative`
+// Bandwidth selector for the KDE (a number, or a rule-of-thumb name)
+export type BandwidthOption = number | `silverman` | `scott`
+
+// One box/violin in a BoxPlot, summarizing a single raw distribution (y)
+export interface BoxPlotSeries<Metadata = Record<string, unknown>> {
+  id?: string | number // Optional stable identifier (used for keying)
+  y: readonly number[] // raw distribution for THIS box (quantiles/KDE computed internally)
+  label?: string // category label (axis tick + legend + tooltip title)
+  color?: string
+  box_width?: number // fraction of the category slot (0..1), default from settings
+  visible?: boolean
+  // Group name for organizing legend items (same semantics as BarSeries.legend_group)
+  legend_group?: string
+  metadata?: Metadata
+  // Specify which x-axis to use: 'x1' (bottom, default) or 'x2' (top)
+  x_axis?: `x1` | `x2`
+  // Specify which y-axis to use: 'y1' (left, default) or 'y2' (right)
+  y_axis?: `y1` | `y2`
+  // Per-series whisker overrides (else fall back to component-level props)
+  whisker_mode?: WhiskerMode
+  whisker_range?: number
+  whisker_percentiles?: [number, number]
+  // Violin overrides (else fall back to component-level props)
+  kind?: ViolinKind // 'box' (default), 'violin', or 'violin+box'
+  side?: ViolinSide // 'both' (default), 'positive', or 'negative'
+  bandwidth?: BandwidthOption
+  violin_width?: number // fraction of the category slot
+  clip?: [number | null, number | null] // hard KDE bounds (e.g. [0, null] for RMSD)
+  // Series sharing a `category` occupy the same slot (for split/grouped violins).
+  // When omitted, each series gets its own slot (default box/violin behavior).
+  category?: string
+}
+
+export interface BoxHandlerProps<
+  Metadata = Record<string, unknown>,
+> extends HandlerProps<Metadata> {
+  box_idx: number
+  stats: BoxStats
+  color: string
+  category_label?: string
+  active_y_axis: `y1` | `y2`
+  active_x_axis: `x1` | `x2`
+}
 
 // Summary statistics for a single box, in data units.
 export interface BoxStats {

--- a/src/lib/plot/core/axis-utils.ts
+++ b/src/lib/plot/core/axis-utils.ts
@@ -123,6 +123,38 @@ export const create_axis_change_handler =
     }
   }
 
+// Bundle axis change handler with one-shot auto-load of the first axis option.
+// get_props keeps callback props fresh; try_auto_load reads series/axis configs
+// through state getters so a component `$effect(try_auto_load)` tracks them reactively.
+export function create_axis_loader<T extends DataSeries | BarSeries>(
+  state: AxisChangeState<T>,
+  get_props: () => {
+    data_loader?: DataLoaderFn<Record<string, unknown>, T>
+    on_axis_change?: (axis: AxisType, key: string, new_series: T[]) => void
+    on_error?: (error: AxisLoadError) => void
+  },
+) {
+  let auto_load_attempted = false // prevent infinite retries on failure
+  const handle_axis_change = (axis: AxisType, key: string) => {
+    const { data_loader, on_axis_change, on_error } = get_props()
+    return create_axis_change_handler(state, data_loader, on_axis_change, on_error)(axis, key)
+  }
+  // Auto-load data if series is empty but options exist (runs once, x-axis first then y)
+  const try_auto_load = () => {
+    if (state.get_series().length > 0 || !get_props().data_loader || auto_load_attempted)
+      return
+    for (const axis of [`x`, `y`] as const) {
+      const config = state.get_axis(axis)
+      if (config.options?.length) {
+        auto_load_attempted = true
+        handle_axis_change(axis, config.selected_key ?? config.options[0].key).catch(() => {})
+        return
+      }
+    }
+  }
+  return { handle_axis_change, try_auto_load }
+}
+
 // Constants for axis label foreignObject positioning (all values in px)
 // Use minimal dimensions - overflow: visible handles any dropdown expansion
 export const AXIS_LABEL_CONTAINER = {

--- a/src/lib/plot/core/components/ColorScaleSelect.svelte
+++ b/src/lib/plot/core/components/ColorScaleSelect.svelte
@@ -48,7 +48,7 @@
       tick_labels={0}
       title_side="left"
       wrapper_style="width: 100%;"
-      title_style="width: 6em; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; text-align: left;"
+      title_style="width: 6em; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; text-align: left; font-size: 0.9rem;"
       {...colorbar}
     />
   {/snippet}

--- a/src/lib/plot/core/components/PlotLegend.svelte
+++ b/src/lib/plot/core/components/PlotLegend.svelte
@@ -461,6 +461,10 @@
     font-size: var(--plot-legend-font-size, 0.8em);
     max-width: var(--plot-legend-max-width);
     width: fit-content;
+    /* cap height so legends with many series don't overflow the plot; scroll the rest.
+    % resolves against the (position: relative) plot wrapper's height. */
+    max-height: var(--plot-legend-max-height, 80%);
+    overflow-y: auto;
     z-index: var(--plot-legend-z-index, 2);
     box-sizing: border-box;
   }

--- a/src/lib/plot/core/components/PlotTooltip.svelte
+++ b/src/lib/plot/core/components/PlotTooltip.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { luminance } from '$lib/colors'
+  import { constrain_tooltip_position } from '$lib/plot/core/layout'
   import type { Snippet } from 'svelte'
   import type { HTMLAttributes } from 'svelte/elements'
 
@@ -9,6 +10,8 @@
     bg_color,
     offset = { x: 6, y: 0 },
     fixed = false,
+    constrain_to,
+    fallback_size,
     wrapper = $bindable(),
     children,
     ...rest
@@ -18,6 +21,8 @@
     bg_color?: string | null
     offset?: { x: number; y: number }
     fixed?: boolean // Use position: fixed (for viewport coords) vs absolute
+    constrain_to?: { width: number; height: number } // flip/clamp within these bounds (offset consumed by constraining)
+    fallback_size?: { width: number; height: number } // size estimate before first measure
     wrapper?: HTMLDivElement // Bindable reference for measuring tooltip size
     children: Snippet
   } = $props()
@@ -29,6 +34,17 @@
 
   // For fixed positioning (viewport coords), flip to opposite side when near viewport edges
   const pos = $derived.by(() => {
+    if (constrain_to) {
+      return constrain_tooltip_position(
+        x,
+        y,
+        wrapper?.offsetWidth ?? fallback_size?.width ?? 0,
+        wrapper?.offsetHeight ?? fallback_size?.height ?? 0,
+        constrain_to.width,
+        constrain_to.height,
+        { offset_x: offset.x, offset_y: offset.y },
+      )
+    }
     const raw_x = x + offset.x
     const raw_y = y + offset.y
     if (!fixed) return { x: raw_x, y: raw_y }

--- a/src/lib/plot/core/data-cleaning.ts
+++ b/src/lib/plot/core/data-cleaning.ts
@@ -1,19 +1,102 @@
 // Data cleaning utilities for plot data
 // Detects oscillations, enforces physical bounds, and handles multi-dimensional datasets
 
+import type { Vec2 } from '$lib/math'
+import type { DataSeries } from '$lib/plot/core/types'
 import { apply_gaussian_smearing } from '$lib/spectral/helpers'
-import type {
-  CleaningConfig,
-  CleaningQuality,
-  CleaningResult,
-  DataSeries,
-  InstabilityResult,
-  InvalidValueMode,
-  LocalOutlierConfig,
-  LocalOutlierResult,
-  PhysicalBounds,
-  SmoothingConfig,
-} from '$lib/plot/core/types'
+
+// --- Data Cleaning Types ---
+
+// Oscillation detection weights (all default to 1.0)
+export interface OscillationWeights {
+  derivative_variance?: number // Weight for derivative variance method
+  amplitude_growth?: number // Weight for exponential amplitude growth
+  sign_changes?: number // Weight for derivative sign change frequency
+}
+
+// How to handle invalid values (NaN, Infinity)
+export type InvalidValueMode = `remove` | `propagate` | `interpolate`
+
+// Truncation strategy when instability detected
+export type TruncationMode = `hard_cut` | `mark_unstable`
+
+// Physical bounds configuration
+export interface PhysicalBounds {
+  min?: number | ((x: number) => number) // Static or x-dependent minimum
+  max?: number | ((x: number) => number) // Static or x-dependent maximum
+  mode?: `clamp` | `filter` | `null` // How to handle violations
+}
+
+// Smoothing algorithm configuration (discriminated union for type safety)
+export type SmoothingConfig =
+  | { type: `moving_avg`; window: number }
+  | { type: `savgol`; window: number; polynomial_order?: number } // window must be odd
+  | { type: `gaussian`; sigma: number } // sigma controls Gaussian kernel width
+
+// Local outlier detection config (sliding window approach)
+export interface LocalOutlierConfig {
+  window_half?: number // Points on each side for local context (default: 7)
+  mad_threshold?: number // MADs from local median to flag outlier (default: 2.0)
+  max_iterations?: number // Iterative passes to catch clustered outliers (default: 5)
+}
+
+// Result of local outlier detection
+export interface LocalOutlierResult {
+  kept_indices: number[]
+  removed_indices: number[]
+  iterations_used: number
+}
+
+// Main cleaning configuration
+export interface CleaningConfig {
+  // Oscillation detection
+  oscillation_threshold?: number // Combined score threshold (default: 3.0)
+  oscillation_weights?: OscillationWeights // Method weights
+  window_size?: number // Rolling window for detection (default: 5)
+
+  // Data handling
+  invalid_values?: InvalidValueMode // NaN/Infinity handling (default: 'remove')
+  bounds?: PhysicalBounds // Physical constraints
+  smooth?: SmoothingConfig // Optional smoothing
+  local_outliers?: LocalOutlierConfig // Local sliding window outlier removal
+
+  // Truncation
+  truncation_mode?: TruncationMode // 'hard_cut' or 'mark_unstable' (default: 'mark_unstable')
+
+  // Performance
+  in_place?: boolean // Mutate input arrays (default: true)
+}
+
+// Quality report from cleaning operation
+export interface CleaningQuality {
+  points_removed: number
+  invalid_values_found: number // NaN/Infinity count
+  oscillation_detected: boolean
+  oscillation_score?: number // Combined weighted score
+  bounds_violations: number
+  outliers_removed?: number // Count of local outliers removed
+  stable_range?: Vec2 // [start_x, end_x] if mark_unstable mode
+  truncated_at_x?: number // x value if hard_cut mode
+}
+
+// Result of a cleaning operation
+export interface CleaningResult<T = DataSeries> {
+  series: T // Cleaned data (same ref if in_place)
+  quality: CleaningQuality
+}
+
+// Instability detection result
+export interface InstabilityResult {
+  detected: boolean
+  onset_index: number
+  onset_x: number
+  combined_score: number
+  method_scores: {
+    derivative_variance: number
+    amplitude_growth: number
+    sign_changes: number
+  }
+}
 
 // Default configuration values
 const DEFAULT_WINDOW_SIZE = 5

--- a/src/lib/plot/core/interactions.ts
+++ b/src/lib/plot/core/interactions.ts
@@ -103,10 +103,9 @@ function axis_transform(scale_type: ScaleType | undefined): {
   }
   if (name === `arcsinh`) {
     const threshold = get_arcsinh_threshold(scale_type)
-    return {
-      to: (val) => Math.asinh(val / threshold),
-      from: (val) => Math.sinh(val) * threshold,
-    }
+    const to = (val: number) => Math.asinh(val / threshold)
+    const from = (val: number) => Math.sinh(val) * threshold
+    return { to, from }
   }
   return { to: (val) => val, from: (val) => val }
 }
@@ -134,6 +133,8 @@ export function zoom_range_by_factor(
   factor: number,
   scale_type?: ScaleType,
 ): Vec2 {
+  // Guard invalid factors (0/negative/NaN) that would emit Infinity/NaN into axis state
+  if (!Number.isFinite(factor) || factor <= 0) return range
   const { to, from } = axis_transform(scale_type)
   const [t0, t1] = [to(range[0]), to(range[1])]
   const center = (t0 + t1) / 2
@@ -144,6 +145,23 @@ export function zoom_range_by_factor(
 // Coerce a scale.invert result (number, or Date for time scales) to an epoch number
 export const to_epoch_num = (val: number | Date): number =>
   val instanceof Date ? val.getTime() : val
+
+// Remove window drag/pan listeners and reset the body cursor. Call from onDestroy:
+// a component unmounting mid-drag would otherwise leak its listeners and leave the
+// cursor stuck (the mouseup that normally cleans up never fires after unmount).
+export function remove_drag_listeners(
+  move_handlers: ((evt: MouseEvent) => void)[],
+  up_handlers: ((evt: MouseEvent) => void)[],
+): void {
+  if (typeof window === `undefined`) return
+  for (const handler of move_handlers) {
+    window.removeEventListener(`mousemove`, handler as EventListener)
+  }
+  for (const handler of up_handlers) {
+    window.removeEventListener(`mouseup`, handler as EventListener)
+  }
+  document.body.style.cursor = ``
+}
 
 // Sorted [min, max] from two scalar bounds (rect-zoom inverts drag start/end,
 // which arrive in either order depending on drag direction)

--- a/src/lib/plot/core/interactions.ts
+++ b/src/lib/plot/core/interactions.ts
@@ -1,5 +1,5 @@
 import { LOG_EPS, type Point2D, type Vec2 } from '$lib/math'
-import type { ScaleType, Y2SyncConfig, Y2SyncMode } from '$lib/plot/core/types'
+import type { AxisRanges, ScaleType, Y2SyncConfig, Y2SyncMode } from '$lib/plot/core/types'
 import { get_arcsinh_threshold, get_scale_type_name } from '$lib/plot/core/types'
 
 // Get coordinates of a mouse event relative to an element (the event's
@@ -139,6 +139,62 @@ export function zoom_range_by_factor(
   const center = (t0 + t1) / 2
   const half_span = (t1 - t0) / factor / 2
   return [from(center - half_span), from(center + half_span)]
+}
+
+// Coerce a scale.invert result (number, or Date for time scales) to an epoch number
+export const to_epoch_num = (val: number | Date): number =>
+  val instanceof Date ? val.getTime() : val
+
+// Sorted [min, max] from two scalar bounds (rect-zoom inverts drag start/end,
+// which arrive in either order depending on drag direction)
+export const sorted_range = (a: number, b: number): Vec2 => [Math.min(a, b), Math.max(a, b)]
+
+// Strict per-bound equality of two [min, max] ranges
+export const vec2_equal = (a: Vec2, b: Vec2): boolean => a[0] === b[0] && a[1] === b[1]
+
+// True when all four axis ranges match. The range-sync effects use this to skip
+// no-op writes that would otherwise re-trigger the effect and loop.
+export const axis_ranges_equal = (a: AxisRanges, b: AxisRanges): boolean =>
+  vec2_equal(a.x, b.x) &&
+  vec2_equal(a.x2, b.x2) &&
+  vec2_equal(a.y, b.y) &&
+  vec2_equal(a.y2, b.y2)
+
+type AxisRangeOverride = { range?: [number | null, number | null] }
+type AutoRanges = {
+  x: readonly number[]
+  x2: readonly number[]
+  y: readonly number[]
+  y2: readonly number[]
+}
+
+// Merge each axis's explicit range over its auto range (per-bound: a null bound
+// falls back to the auto value). Returns null if any resolved bound is non-finite so
+// the caller can skip the sync - writing NaN breaks scales and, since NaN !== NaN,
+// makes the change comparison never settle (an infinite effect loop).
+export function resolve_axis_ranges(
+  axes: {
+    x: AxisRangeOverride
+    x2: AxisRangeOverride
+    y: AxisRangeOverride
+    y2: AxisRangeOverride
+  },
+  auto: AutoRanges,
+): AxisRanges | null {
+  const resolve = (axis: AxisRangeOverride, fallback: readonly number[]): Vec2 => [
+    axis.range?.[0] ?? fallback[0],
+    axis.range?.[1] ?? fallback[1],
+  ]
+  const next: AxisRanges = {
+    x: resolve(axes.x, auto.x),
+    x2: resolve(axes.x2, auto.x2),
+    y: resolve(axes.y, auto.y),
+    y2: resolve(axes.y2, auto.y2),
+  }
+  for (const [lo, hi] of [next.x, next.x2, next.y, next.y2]) {
+    if (!Number.isFinite(lo) || !Number.isFinite(hi)) return null
+  }
+  return next
 }
 
 // Threshold for distinguishing pinch-zoom from pan in touch gestures

--- a/src/lib/plot/core/interactions.ts
+++ b/src/lib/plot/core/interactions.ts
@@ -1,5 +1,6 @@
-import type { Point2D, Vec2 } from '$lib/math'
-import type { Y2SyncConfig, Y2SyncMode } from '$lib/plot/core/types'
+import { LOG_EPS, type Point2D, type Vec2 } from '$lib/math'
+import type { ScaleType, Y2SyncConfig, Y2SyncMode } from '$lib/plot/core/types'
+import { get_arcsinh_threshold, get_scale_type_name } from '$lib/plot/core/types'
 
 // Get coordinates of a mouse event relative to an element (the event's
 // currentTarget by default; pass `element` when the handler is delegated and the
@@ -86,21 +87,58 @@ export function sync_y2_range(y1_range: Vec2, y2_base_range: Vec2, sync: Y2SyncC
   return y2_base_range
 }
 
-// Shift a range by a delta amount (no bounds constraint for free panning)
-export const pan_range = (current: Vec2, delta: number): Vec2 => [
-  current[0] + delta,
-  current[1] + delta,
-]
+// Forward/inverse transform pair mapping an axis's data values onto its visual
+// metric (the space where equal pixel steps are equal steps; identity for
+// linear/time). Pan and pinch must be uniform in *screen* space - doing the math
+// linearly on a log axis stretches one end of the view and shifts past zero into
+// an all-NaN domain. log clamps at LOG_EPS so a non-positive bound (stale explicit
+// range) recovers instead of propagating -Infinity.
+function axis_transform(scale_type: ScaleType | undefined): {
+  to: (val: number) => number
+  from: (val: number) => number
+} {
+  const name = get_scale_type_name(scale_type)
+  if (name === `log`) {
+    return { to: (val) => Math.log(Math.max(val, LOG_EPS)), from: Math.exp }
+  }
+  if (name === `arcsinh`) {
+    const threshold = get_arcsinh_threshold(scale_type)
+    return {
+      to: (val) => Math.asinh(val / threshold),
+      from: (val) => Math.sinh(val) * threshold,
+    }
+  }
+  return { to: (val) => val, from: (val) => val }
+}
 
-// Convert pixel delta to data delta using current data range and pixel range
-export function pixels_to_data_delta(
+// Pan a range by a pixel delta, uniformly in screen space: linear axes shift by a
+// constant amount, log axes by a constant factor (which also can't cross zero).
+// `pixel_span` is the plot's pixel extent along the axis.
+export function pan_range_by_pixels(
+  range: Vec2,
   pixel_delta: number,
-  data_range: Vec2,
-  pixel_range: number,
-): number {
-  if (pixel_range === 0) return 0
-  const data_span = data_range[1] - data_range[0]
-  return (pixel_delta / pixel_range) * data_span
+  pixel_span: number,
+  scale_type?: ScaleType,
+): Vec2 {
+  if (pixel_span === 0) return range
+  const { to, from } = axis_transform(scale_type)
+  const [t0, t1] = [to(range[0]), to(range[1])]
+  const t_delta = (pixel_delta / pixel_span) * (t1 - t0)
+  return [from(t0 + t_delta), from(t1 + t_delta)]
+}
+
+// Zoom a range about its screen-space center by `factor` (pinch: >1 zooms in).
+// On log axes the fixed point is the geometric mean - the visual center.
+export function zoom_range_by_factor(
+  range: Vec2,
+  factor: number,
+  scale_type?: ScaleType,
+): Vec2 {
+  const { to, from } = axis_transform(scale_type)
+  const [t0, t1] = [to(range[0]), to(range[1])]
+  const center = (t0 + t1) / 2
+  const half_span = (t1 - t0) / factor / 2
+  return [from(center - half_span), from(center + half_span)]
 }
 
 // Threshold for distinguishing pinch-zoom from pan in touch gestures

--- a/src/lib/plot/core/layout.ts
+++ b/src/lib/plot/core/layout.ts
@@ -7,6 +7,20 @@ export type Sides = { t?: number; b?: number; l?: number; r?: number }
 // Default gap between tick labels and axis labels
 export const LABEL_GAP_DEFAULT = 30
 
+// X position for a right-side (y2) axis label: past the plot edge plus tick shift and
+// measured tick-label width (both zero when tick labels render inside the plot)
+export function y2_axis_label_x(
+  axis: AxisConfig,
+  width: number,
+  pad_r: number,
+  max_tick_width: number,
+): number {
+  const inside = axis.tick?.label?.inside ?? false
+  const tick_shift = inside ? 0 : (axis.tick?.label?.shift?.x ?? 0) + 8
+  const label_offset = (inside ? 0 : max_tick_width) + LABEL_GAP_DEFAULT + (axis.label_shift?.x ?? 0)
+  return width - pad_r + tick_shift + label_offset
+}
+
 // Filter undefined values from padding to prevent overriding defaults when spreading
 // Guards against undefined/null padding inputs (common for optional props)
 export const filter_padding = (

--- a/src/lib/plot/core/layout.ts
+++ b/src/lib/plot/core/layout.ts
@@ -284,10 +284,9 @@ export function sample_series_obstacle_points(
       const n_samples = Math.floor(Math.hypot(point.x - prev.x, point.y - prev.y) / step)
       for (let idx = 1; idx < n_samples; idx++) {
         const frac = idx / n_samples
-        obstacles.push({
-          x: prev.x + (point.x - prev.x) * frac,
-          y: prev.y + (point.y - prev.y) * frac,
-        })
+        const x = prev.x + (point.x - prev.x) * frac
+        const y = prev.y + (point.y - prev.y) * frac
+        obstacles.push({ x, y })
       }
     }
     prev = point

--- a/src/lib/plot/core/layout.ts
+++ b/src/lib/plot/core/layout.ts
@@ -17,7 +17,8 @@ export function y2_axis_label_x(
 ): number {
   const inside = axis.tick?.label?.inside ?? false
   const tick_shift = inside ? 0 : (axis.tick?.label?.shift?.x ?? 0) + 8
-  const label_offset = (inside ? 0 : max_tick_width) + LABEL_GAP_DEFAULT + (axis.label_shift?.x ?? 0)
+  const label_offset =
+    (inside ? 0 : max_tick_width) + LABEL_GAP_DEFAULT + (axis.label_shift?.x ?? 0)
   return width - pad_r + tick_shift + label_offset
 }
 

--- a/src/lib/plot/core/layout.ts
+++ b/src/lib/plot/core/layout.ts
@@ -398,8 +398,9 @@ export function compute_element_placement(
 
       // Corner preference: use element's actual corner (not center) for distance
       // This ensures a wide element at the left edge gets proper corner credit
-      const elem_right = cand_x + element_size.width
-      const elem_bottom = cand_y + element_size.height
+      // (measured footprint, same as cand_rect — not the element_size fallback)
+      const elem_right = cand_x + elem_width
+      const elem_bottom = cand_y + elem_height
 
       // Distance from element's matching corner to each plot corner
       const min_corner_dist = Math.min(

--- a/src/lib/plot/core/scales.ts
+++ b/src/lib/plot/core/scales.ts
@@ -254,8 +254,13 @@ export function create_scale(
   const type_name = get_scale_type_name(scale_type)
 
   if (type_name === `log`) {
+    // Clamp BOTH ends to the positive floor: panning shifts ranges linearly, so a
+    // log axis panned past zero can arrive with max <= 0 — an unclamped max makes
+    // every scale output (and invert) NaN, blanking the chart and polluting axis
+    // ranges. A clamped degenerate domain just renders flat and stays recoverable.
+    const lo = Math.max(min_val, math.LOG_EPS)
     return scaleLog()
-      .domain([Math.max(min_val, math.LOG_EPS), max_val])
+      .domain([lo, Math.max(max_val, lo)])
       .range(output_range)
   }
   if (type_name === `arcsinh`) {

--- a/src/lib/plot/core/types.ts
+++ b/src/lib/plot/core/types.ts
@@ -64,6 +64,9 @@ export type InitialRanges = {
   initial_y2_range: Vec2
 }
 
+// Current [min, max] range of each of the four axes
+export type AxisRanges = { x: Vec2; x2: Vec2; y: Vec2; y2: Vec2 }
+
 export type Point<Metadata = Record<string, unknown>> = {
   x: number
   y: number

--- a/src/lib/plot/core/types.ts
+++ b/src/lib/plot/core/types.ts
@@ -757,7 +757,7 @@ export type Corner = (typeof CORNER_CELLS)[number]
 export const DEFAULT_GRID_STYLE = {
   stroke: `var(--border-color, gray)`,
   'stroke-dasharray': `4`,
-  'stroke-width': `1`,
+  'stroke-width': `0.5`,
 } as const
 
 export const DEFAULT_MARKERS = `line+points` as const

--- a/src/lib/plot/core/types.ts
+++ b/src/lib/plot/core/types.ts
@@ -1,17 +1,58 @@
 import type { D3SymbolName } from '$lib/labels'
 import type { Point2D, Point3D, Vec2, Vec3 } from '$lib/math'
-// type-only circular import (sunburst.ts imports from this file) - erased at runtime
-import type { PositionedArc } from '$lib/plot/sunburst/sunburst'
 import type DraggablePane from '$lib/overlays/DraggablePane.svelte'
 import type { ComponentProps, Snippet } from 'svelte'
 import type { HTMLAttributes } from 'svelte/elements'
 import type { TweenOptions } from 'svelte/motion'
-import type { BoxStats } from '$lib/plot/box/box-plot'
 import type { Sides } from '$lib/plot/core/layout'
 import type PlotLegend from '$lib/plot/core/components/PlotLegend.svelte'
 import type { TicksOption } from '$lib/plot/core/scales'
 
 export type { TweenOptions } from 'svelte/motion'
+
+// Chart-family types live next to their chart code; re-exported here (type-only,
+// erased at runtime) so existing `$lib/plot/core/types` import paths keep working.
+export type {
+  BandwidthOption,
+  BoxHandlerProps,
+  BoxPlotSeries,
+  ViolinKind,
+  ViolinSide,
+  WhiskerMode,
+} from '$lib/plot/box/box-plot'
+export type {
+  CleaningConfig,
+  CleaningQuality,
+  CleaningResult,
+  InstabilityResult,
+  InvalidValueMode,
+  LocalOutlierConfig,
+  LocalOutlierResult,
+  OscillationWeights,
+  PhysicalBounds,
+  SmoothingConfig,
+  TruncationMode,
+} from '$lib/plot/core/data-cleaning'
+export type {
+  SankeyData,
+  SankeyHandlerProps,
+  SankeyLink,
+  SankeyLinkColorMode,
+  SankeyLinkHandlerProps,
+  SankeyNode,
+  SankeyNodeAlign,
+  SankeyNodeHandlerProps,
+  SankeyOrientation,
+} from '$lib/plot/sankey/sankey-types'
+export type {
+  SunburstLabelRotation,
+  SunburstLabelText,
+  SunburstNode,
+  SunburstNodeHandlerProps,
+  SunburstShape,
+  SunburstSort,
+  SunburstValueMode,
+} from '$lib/plot/sunburst/sunburst'
 
 export type XyShift = { x?: number; y?: number } // For optional shift/offset values
 
@@ -344,147 +385,6 @@ export type UserContentProps = {
 export type Orientation = `vertical` | `horizontal`
 export type BarMode = `overlay` | `stacked` | `grouped`
 
-// How box plot whiskers are computed from a raw distribution
-export type WhiskerMode = `tukey` | `minmax` | `percentile` | `std`
-
-// Which glyph(s) to draw per series: a box, a violin (KDE density), or both
-export type ViolinKind = `box` | `violin` | `violin+box`
-// Which half of the category slot a violin occupies (for one-sided / split violins)
-export type ViolinSide = `both` | `positive` | `negative`
-// Bandwidth selector for the KDE (a number, or a rule-of-thumb name)
-export type BandwidthOption = number | `silverman` | `scott`
-
-// One box/violin in a BoxPlot, summarizing a single raw distribution (y)
-export interface BoxPlotSeries<Metadata = Record<string, unknown>> {
-  id?: string | number // Optional stable identifier (used for keying)
-  y: readonly number[] // raw distribution for THIS box (quantiles/KDE computed internally)
-  label?: string // category label (axis tick + legend + tooltip title)
-  color?: string
-  box_width?: number // fraction of the category slot (0..1), default from settings
-  visible?: boolean
-  // Group name for organizing legend items (same semantics as BarSeries.legend_group)
-  legend_group?: string
-  metadata?: Metadata
-  // Specify which x-axis to use: 'x1' (bottom, default) or 'x2' (top)
-  x_axis?: `x1` | `x2`
-  // Specify which y-axis to use: 'y1' (left, default) or 'y2' (right)
-  y_axis?: `y1` | `y2`
-  // Per-series whisker overrides (else fall back to component-level props)
-  whisker_mode?: WhiskerMode
-  whisker_range?: number
-  whisker_percentiles?: [number, number]
-  // Violin overrides (else fall back to component-level props)
-  kind?: ViolinKind // 'box' (default), 'violin', or 'violin+box'
-  side?: ViolinSide // 'both' (default), 'positive', or 'negative'
-  bandwidth?: BandwidthOption
-  violin_width?: number // fraction of the category slot
-  clip?: [number | null, number | null] // hard KDE bounds (e.g. [0, null] for RMSD)
-  // Series sharing a `category` occupy the same slot (for split/grouped violins).
-  // When omitted, each series gets its own slot (default box/violin behavior).
-  category?: string
-}
-
-export interface BoxHandlerProps<
-  Metadata = Record<string, unknown>,
-> extends HandlerProps<Metadata> {
-  box_idx: number
-  stats: BoxStats
-  color: string
-  category_label?: string
-  active_y_axis: `y1` | `y2`
-  active_x_axis: `x1` | `x2`
-}
-
-// === Sankey diagram ===
-// Flow direction: 'horizontal' = columns left->right, 'vertical' = columns top->bottom
-export type SankeyOrientation = `horizontal` | `vertical`
-// Maps to d3-sankey alignment functions (sankeyLeft/Right/Center/Justify)
-export type SankeyNodeAlign = `left` | `right` | `center` | `justify`
-// How each link ribbon derives its color when no explicit link.color is set
-export type SankeyLinkColorMode = `source` | `target` | `gradient` | `static`
-
-export interface SankeyNode<Metadata = Record<string, unknown>> {
-  id?: string | number // stable id (defaults to array index); referenced by links
-  label?: string
-  color?: string // defaults to cycled DEFAULT_SERIES_COLORS
-  metadata?: Metadata
-}
-
-export interface SankeyLink<Metadata = Record<string, unknown>> {
-  source: number | string // node id, or zero-based index into nodes
-  target: number | string // node id, or zero-based index into nodes
-  value: number // flow magnitude (controls ribbon thickness)
-  color?: string // overrides link_color_mode for this link
-  label?: string
-  metadata?: Metadata
-}
-
-export interface SankeyData<Metadata = Record<string, unknown>> {
-  nodes: SankeyNode<Metadata>[]
-  links: SankeyLink<Metadata>[]
-}
-
-export interface SankeyNodeHandlerProps<Metadata = Record<string, unknown>> {
-  type: `node`
-  node_idx: number
-  id: string | number
-  label?: string
-  value: number // sum of incoming/outgoing link values
-  color: string
-  metadata?: Metadata
-}
-
-export interface SankeyLinkHandlerProps<Metadata = Record<string, unknown>> {
-  type: `link`
-  link_idx: number
-  source_idx: number
-  target_idx: number
-  source_label?: string
-  target_label?: string
-  value: number
-  color: string
-  metadata?: Metadata
-}
-
-export type SankeyHandlerProps<Metadata = Record<string, unknown>> =
-  | SankeyNodeHandlerProps<Metadata>
-  | SankeyLinkHandlerProps<Metadata>
-
-// === Sunburst chart ===
-// How node values are interpreted (plotly `branchvalues` semantics):
-// 'leaf-sum'  - parent values ignored, computed as sum of leaf values (d3 .sum default)
-// 'total'     - every node's value is authoritative; children should sum <= parent
-//               (plotly branchvalues='total'; a shortfall leaves an angular gap)
-// 'remainder' - a node's own value is added on top of its children's sum
-export type SunburstValueMode = `leaf-sum` | `total` | `remainder`
-// Arc label orientation: 'auto' picks radial/tangential per arc based on available space
-export type SunburstLabelRotation = `auto` | `radial` | `tangential` | `horizontal`
-// Sibling ordering: 'none' preserves input order (e.g. spacegroup number order)
-export type SunburstSort = `descending` | `ascending` | `none`
-// What arc labels display (plotly textinfo equivalent); percent is of the root total
-export type SunburstLabelText = `label` | `value` | `percent` | `label+value` | `label+percent`
-// Chart geometry: polar rings (sunburst) or stacked horizontal rows (icicle)
-export type SunburstShape = `sunburst` | `icicle`
-
-export interface SunburstNode<Metadata = Record<string, unknown>> {
-  id?: string | number // stable id (defaults to slash-joined label path, e.g. "cubic/Fm-3m")
-  label?: string
-  value?: number // required on leaves ('leaf-sum') / authoritative on all nodes ('total')
-  color?: string // explicit color, inherited by descendants without their own
-  children?: SunburstNode<Metadata>[]
-  metadata?: Metadata
-}
-
-// Event payload for hover/click/zoom callbacks: a PositionedArc minus its geometry
-// (screen coords are an implementation detail), plus the resolved parent id
-export interface SunburstNodeHandlerProps<Metadata = Record<string, unknown>> extends Omit<
-  PositionedArc<Metadata>,
-  `x0` | `x1` | `y0` | `y1` | `subtree_end` | `parent_idx`
-> {
-  type: `node`
-  parent_id: string | number | null
-}
-
 export interface BarSeries<Metadata = Record<string, unknown>> {
   id?: string | number // Optional stable identifier for the series (used for keying)
   x: readonly (number | string)[]
@@ -710,11 +610,6 @@ export interface PlotControlsProps extends PlotConfig {
 // Base props shared across plot components (non-bindable props only)
 // Components should declare x_axis, y_axis, display, etc. as $bindable() grouped configs
 export interface BasePlotProps {
-  // Axis limits (non-bindable - used for auto-range calculation)
-  x_range?: [number | null, number | null]
-  x2_range?: [number | null, number | null]
-  y_range?: [number | null, number | null]
-  y2_range?: [number | null, number | null]
   range_padding?: number // Factor to pad auto-detected ranges before nicing (e.g. 0.05 = 5%)
   padding?: Sides
   // State
@@ -1197,96 +1092,3 @@ export type RefPlane = RefPlaneBase &
     | { type: `normal`; normal: Vec3; point: Vec3 }
     | { type: `points`; p1: Vec3; p2: Vec3; p3: Vec3 } // plane through 3 points
   )
-
-// --- Data Cleaning Types ---
-
-// Oscillation detection weights (all default to 1.0)
-export interface OscillationWeights {
-  derivative_variance?: number // Weight for derivative variance method
-  amplitude_growth?: number // Weight for exponential amplitude growth
-  sign_changes?: number // Weight for derivative sign change frequency
-}
-
-// How to handle invalid values (NaN, Infinity)
-export type InvalidValueMode = `remove` | `propagate` | `interpolate`
-
-// Truncation strategy when instability detected
-export type TruncationMode = `hard_cut` | `mark_unstable`
-
-// Physical bounds configuration
-export interface PhysicalBounds {
-  min?: number | ((x: number) => number) // Static or x-dependent minimum
-  max?: number | ((x: number) => number) // Static or x-dependent maximum
-  mode?: `clamp` | `filter` | `null` // How to handle violations
-}
-
-// Smoothing algorithm configuration (discriminated union for type safety)
-export type SmoothingConfig =
-  | { type: `moving_avg`; window: number }
-  | { type: `savgol`; window: number; polynomial_order?: number } // window must be odd
-  | { type: `gaussian`; sigma: number } // sigma controls Gaussian kernel width
-
-// Local outlier detection config (sliding window approach)
-export interface LocalOutlierConfig {
-  window_half?: number // Points on each side for local context (default: 7)
-  mad_threshold?: number // MADs from local median to flag outlier (default: 2.0)
-  max_iterations?: number // Iterative passes to catch clustered outliers (default: 5)
-}
-
-// Result of local outlier detection
-export interface LocalOutlierResult {
-  kept_indices: number[]
-  removed_indices: number[]
-  iterations_used: number
-}
-
-// Main cleaning configuration
-export interface CleaningConfig {
-  // Oscillation detection
-  oscillation_threshold?: number // Combined score threshold (default: 3.0)
-  oscillation_weights?: OscillationWeights // Method weights
-  window_size?: number // Rolling window for detection (default: 5)
-
-  // Data handling
-  invalid_values?: InvalidValueMode // NaN/Infinity handling (default: 'remove')
-  bounds?: PhysicalBounds // Physical constraints
-  smooth?: SmoothingConfig // Optional smoothing
-  local_outliers?: LocalOutlierConfig // Local sliding window outlier removal
-
-  // Truncation
-  truncation_mode?: TruncationMode // 'hard_cut' or 'mark_unstable' (default: 'mark_unstable')
-
-  // Performance
-  in_place?: boolean // Mutate input arrays (default: true)
-}
-
-// Quality report from cleaning operation
-export interface CleaningQuality {
-  points_removed: number
-  invalid_values_found: number // NaN/Infinity count
-  oscillation_detected: boolean
-  oscillation_score?: number // Combined weighted score
-  bounds_violations: number
-  outliers_removed?: number // Count of local outliers removed
-  stable_range?: Vec2 // [start_x, end_x] if mark_unstable mode
-  truncated_at_x?: number // x value if hard_cut mode
-}
-
-// Result of a cleaning operation
-export interface CleaningResult<T = DataSeries> {
-  series: T // Cleaned data (same ref if in_place)
-  quality: CleaningQuality
-}
-
-// Instability detection result
-export interface InstabilityResult {
-  detected: boolean
-  onset_index: number
-  onset_x: number
-  combined_score: number
-  method_scores: {
-    derivative_variance: number
-    amplitude_growth: number
-    sign_changes: number
-  }
-}

--- a/src/lib/plot/core/utils/series-visibility.ts
+++ b/src/lib/plot/core/utils/series-visibility.ts
@@ -1,43 +1,61 @@
-import type { DataSeries } from '$lib/plot/core/types'
-
 export type StrRecord = Record<string, unknown>
 
-type SeriesSource = [string, string, string, unknown, unknown]
+// Minimal series shape the visibility helpers need - generic over the concrete series
+// type (DataSeries, BarSeries, BoxPlotSeries, ...) so toggled arrays keep their type
+type VisSeries = {
+  label?: string | null
+  unit?: string
+  y_axis?: string
+  visible?: boolean
+  x?: unknown
+  y?: unknown
+}
+
+type SeriesSource = [string, string, string, ...unknown[]]
 
 export type SeriesVisibilitySnapshot = {
   visibility: boolean[]
   source: SeriesSource[]
 }
 
-const series_source = <Metadata extends StrRecord = StrRecord>(
-  series: DataSeries<Metadata>[],
-  length = series.length,
-): SeriesSource[] =>
+// Length + first/last element: a by-value signature for x/y data. Deliberately NOT
+// array identity: inside components those are $state proxies whose identity changes
+// when the series prop is reassigned (e.g. by the isolate itself), which made the
+// snapshot reject itself and permanently broke restore-from-isolation.
+const data_sig = (arr: unknown): unknown[] =>
+  Array.isArray(arr) ? [arr.length, arr[0], arr[arr.length - 1]] : [arr]
+
+const series_source = (series: VisSeries[], length = series.length): SeriesSource[] =>
   series
     .slice(0, length)
-    .map((srs) => [srs.label ?? ``, srs.unit ?? ``, srs.y_axis ?? ``, srs.x, srs.y])
+    .map((srs) => [
+      srs.label ?? ``,
+      srs.unit ?? ``,
+      srs.y_axis ?? ``,
+      ...data_sig(srs.x),
+      ...data_sig(srs.y),
+    ])
 
 const same_series_source = (
   series: SeriesSource[],
   snapshot_series: SeriesSource[],
 ): boolean =>
   series.length === snapshot_series.length &&
-  series.every((source, idx) =>
-    source.every((part, part_idx) => Object.is(part, snapshot_series[idx][part_idx])),
+  series.every(
+    (source, idx) =>
+      source.length === snapshot_series[idx].length &&
+      source.every((part, part_idx) => Object.is(part, snapshot_series[idx][part_idx])),
   )
 
-export function have_compatible_units<Metadata extends StrRecord = StrRecord>(
-  series1: DataSeries<Metadata>,
-  series2: DataSeries<Metadata>,
-): boolean {
+export function have_compatible_units(series1: VisSeries, series2: VisSeries): boolean {
   if (!series1.unit || !series2.unit) return true
   return series1.unit === series2.unit
 }
 
-export function toggle_series_visibility<Metadata extends StrRecord = StrRecord>(
-  series: DataSeries<Metadata>[],
+export function toggle_series_visibility<Series extends VisSeries>(
+  series: Series[],
   series_idx: number,
-): DataSeries<Metadata>[] {
+): Series[] {
   if (series_idx < 0 || series_idx >= series.length || !series[series_idx]) return series
 
   const toggled = series[series_idx]
@@ -60,10 +78,10 @@ export function toggle_series_visibility<Metadata extends StrRecord = StrRecord>
   })
 }
 
-export function toggle_group_visibility<Metadata extends StrRecord = StrRecord>(
-  series: DataSeries<Metadata>[],
+export function toggle_group_visibility<Series extends VisSeries>(
+  series: Series[],
   series_indices: number[],
-): DataSeries<Metadata>[] {
+): Series[] {
   // Filter to valid indices upfront
   const valid_indices = series_indices.filter((idx) => idx >= 0 && idx < series.length)
   if (valid_indices.length === 0) return series
@@ -81,12 +99,12 @@ export function toggle_group_visibility<Metadata extends StrRecord = StrRecord>(
   )
 }
 
-export function handle_legend_double_click<Metadata extends StrRecord = StrRecord>(
-  series: DataSeries<Metadata>[],
+export function handle_legend_double_click<Series extends VisSeries>(
+  series: Series[],
   idx: number,
   prev_snapshot: SeriesVisibilitySnapshot | null,
 ): {
-  series: DataSeries<Metadata>[]
+  series: Series[]
   prev_visibility: SeriesVisibilitySnapshot | null
 } {
   if (idx < 0 || idx >= series.length) {
@@ -136,5 +154,29 @@ export function handle_legend_double_click<Metadata extends StrRecord = StrRecor
       return (srs.visible ?? true) !== in_group ? { ...srs, visible: in_group } : srs
     }),
     prev_visibility: new_prev,
+  }
+}
+
+// Bundle the three legend visibility handlers (click toggle, group toggle,
+// double-click isolate/restore) around a series accessor pair. Owns the
+// isolate/restore snapshot internally so components don't each carry it.
+export function create_legend_visibility<Series extends VisSeries>(
+  get_series: () => Series[],
+  set_series: (series: Series[]) => void,
+): {
+  on_toggle: (series_idx: number) => void
+  on_group_toggle: (group_name: string, series_indices: number[]) => void
+  on_double_click: (series_idx: number) => void
+} {
+  let prev_visibility: SeriesVisibilitySnapshot | null = null
+  return {
+    on_toggle: (series_idx) => set_series(toggle_series_visibility(get_series(), series_idx)),
+    on_group_toggle: (_group_name, series_indices) =>
+      set_series(toggle_group_visibility(get_series(), series_indices)),
+    on_double_click: (series_idx) => {
+      const result = handle_legend_double_click(get_series(), series_idx, prev_visibility)
+      set_series(result.series)
+      prev_visibility = result.prev_visibility
+    },
   }
 }

--- a/src/lib/plot/core/utils/series-visibility.ts
+++ b/src/lib/plot/core/utils/series-visibility.ts
@@ -1,5 +1,3 @@
-export type StrRecord = Record<string, unknown>
-
 // Minimal series shape the visibility helpers need - generic over the concrete series
 // type (DataSeries, BarSeries, BoxPlotSeries, ...) so toggled arrays keep their type
 type VisSeries = {

--- a/src/lib/plot/histogram/Histogram.svelte
+++ b/src/lib/plot/histogram/Histogram.svelte
@@ -30,6 +30,9 @@
     MIN_TOUCH_DISTANCE_PIXELS,
     pan_range_by_pixels,
     PINCH_ZOOM_THRESHOLD,
+    resolve_axis_ranges,
+    sorted_range,
+    vec2_equal,
     zoom_range_by_factor,
   } from '$lib/plot/core/interactions'
   import {
@@ -37,6 +40,7 @@
     constrain_tooltip_position,
     filter_padding,
     LABEL_GAP_DEFAULT,
+    y2_axis_label_x,
     measure_max_tick_width,
   } from '$lib/plot/core/layout'
   import {
@@ -363,48 +367,21 @@
   })
 
   $effect(() => {
-    // Support one-sided range pinning: merge user range with auto range for null values
-    const new_x: [number, number] = final_x_axis.range
-      ? [
-        final_x_axis.range[0] ?? auto_ranges.x[0],
-        final_x_axis.range[1] ?? auto_ranges.x[1],
-      ]
-      : auto_ranges.x
-    const new_x2: [number, number] = final_x2_axis.range
-      ? [
-        final_x2_axis.range[0] ?? auto_ranges.x2[0],
-        final_x2_axis.range[1] ?? auto_ranges.x2[1],
-      ]
-      : auto_ranges.x2
-    const new_y: [number, number] = final_y_axis.range
-      ? [
-        final_y_axis.range[0] ?? auto_ranges.y[0],
-        final_y_axis.range[1] ?? auto_ranges.y[1],
-      ]
-      : auto_ranges.y
-    const new_y2: [number, number] = final_y2_axis.range
-      ? [
-        final_y2_axis.range[0] ?? auto_ranges.y2[0],
-        final_y2_axis.range[1] ?? auto_ranges.y2[1],
-      ]
-      : auto_ranges.y2
-
-    // Skip transient non-finite ranges: writing NaN breaks scales and makes the
-    // comparison below never settle (NaN !== NaN), causing an infinite effect loop.
-    if (![...new_x, ...new_x2, ...new_y, ...new_y2].every(Number.isFinite)) return
-    // Only update if the initial (data-driven) ranges changed, not when user pans.
+    // Supports one-sided range pinning (null bounds fall back to auto); returns null
+    // for transient non-finite bounds (skip: writing NaN breaks scales and loops here)
+    const next = resolve_axis_ranges(
+      { x: final_x_axis, x2: final_x2_axis, y: final_y_axis, y2: final_y2_axis },
+      auto_ranges,
+    )
+    if (!next) return
+    // Update only changed axes (preserving each unchanged axis's panned current view).
     // untrack the reads of `ranges` so the writes below can't re-trigger this effect
     // (reading + writing the same state otherwise causes effect_update_depth_exceeded).
     const init = untrack(() => ranges.initial)
-    const x_changed = new_x[0] !== init.x[0] || new_x[1] !== init.x[1]
-    const x2_changed = new_x2[0] !== init.x2[0] || new_x2[1] !== init.x2[1]
-    const y_changed = new_y[0] !== init.y[0] || new_y[1] !== init.y[1]
-    const y2_changed = new_y2[0] !== init.y2[0] || new_y2[1] !== init.y2[1]
-
-    if (x_changed) [ranges.initial.x, ranges.current.x] = [new_x, new_x]
-    if (x2_changed) [ranges.initial.x2, ranges.current.x2] = [new_x2, new_x2]
-    if (y_changed) [ranges.initial.y, ranges.current.y] = [new_y, new_y]
-    if (y2_changed) [ranges.initial.y2, ranges.current.y2] = [new_y2, new_y2]
+    if (!vec2_equal(init.x, next.x)) [ranges.initial.x, ranges.current.x] = [next.x, next.x]
+    if (!vec2_equal(init.x2, next.x2)) [ranges.initial.x2, ranges.current.x2] = [next.x2, next.x2]
+    if (!vec2_equal(init.y, next.y)) [ranges.initial.y, ranges.current.y] = [next.y, next.y]
+    if (!vec2_equal(init.y2, next.y2)) [ranges.initial.y2, ranges.current.y2] = [next.y2, next.y2]
   })
 
   // Layout: dynamic padding based on tick label widths
@@ -718,27 +695,15 @@
       const dy = Math.abs(drag_state.start.y - drag_state.current.y)
       if (dx > 5 && dy > 5) {
         // Update axis ranges to trigger reactivity and prevent effect from overriding
-        x_axis = {
-          ...x_axis,
-          range: [Math.min(start_x, end_x), Math.max(start_x, end_x)],
-        }
+        x_axis = { ...x_axis, range: sorted_range(start_x, end_x) }
         if (x2_series.length > 0) {
-          x2_axis = {
-            ...x2_axis,
-            range: [Math.min(start_x2, end_x2), Math.max(start_x2, end_x2)],
-          }
+          x2_axis = { ...x2_axis, range: sorted_range(start_x2, end_x2) }
         }
-        y_axis = {
-          ...y_axis,
-          range: [Math.min(start_y, end_y), Math.max(start_y, end_y)],
-        }
+        y_axis = { ...y_axis, range: sorted_range(start_y, end_y) }
         // gate on y2 series presence (like x2): the y2 scale is a [0, 1] sentinel
         // otherwise, so inverting would store a phantom range in the bindable prop
         if (y2_series.length > 0) {
-          y2_axis = {
-            ...y2_axis,
-            range: [Math.min(start_y2, end_y2), Math.max(start_y2, end_y2)],
-          }
+          y2_axis = { ...y2_axis, range: sorted_range(start_y2, end_y2) }
         }
       }
     }
@@ -1217,9 +1182,6 @@
 
     <!-- Y2-axis (Right) -->
     {#if y2_series.length > 0}
-      {@const y2_inside = final_y2_axis.tick?.label?.inside ?? false}
-      {@const y2_tick_shift = y2_inside ? 0 : (final_y2_axis.tick?.label?.shift?.x ?? 0) + 8}
-      {@const y2_tick_width = y2_inside ? 0 : tick_label_widths.y2_max}
       <PlotAxis
         side="y2"
         ticks={ticks.y2 as number[]}
@@ -1231,8 +1193,7 @@
         {height}
         show_grid={display.y2_grid}
         tick_label={(tick) => get_tick_label(tick, final_y2_axis.ticks)}
-        label_x={width - pad.r + y2_tick_shift + y2_tick_width + LABEL_GAP_DEFAULT +
-        (final_y2_axis.label_shift?.x ?? 0)}
+        label_x={y2_axis_label_x(final_y2_axis, width, pad.r, tick_label_widths.y2_max)}
         label_y={pad.t + (height - pad.t - pad.b) / 2 + (final_y2_axis.label_shift?.y ?? 0)}
         axis_loading={axis_loading === `y2`}
         on_axis_change={(key) => handle_axis_change(`y2`, key)}

--- a/src/lib/plot/histogram/Histogram.svelte
+++ b/src/lib/plot/histogram/Histogram.svelte
@@ -24,11 +24,13 @@
     create_dimension_tracker,
     create_hover_lock,
   } from '$lib/plot/core/hover-lock.svelte'
+  import { create_legend_visibility } from '$lib/plot/core/utils/series-visibility'
   import {
     get_relative_coords,
-    pan_range,
+    MIN_TOUCH_DISTANCE_PIXELS,
+    pan_range_by_pixels,
     PINCH_ZOOM_THRESHOLD,
-    pixels_to_data_delta,
+    zoom_range_by_factor,
   } from '$lib/plot/core/interactions'
   import {
     calc_auto_padding,
@@ -66,7 +68,7 @@
   import { DEFAULTS } from '$lib/settings'
   import { bin, max } from 'd3-array'
   import type { Snippet } from 'svelte'
-  import { untrack } from 'svelte'
+  import { onDestroy, untrack } from 'svelte'
   import type { HTMLAttributes } from 'svelte/elements'
   import { Tween } from 'svelte/motion'
   import type { Vec2 } from '$lib/math'
@@ -81,10 +83,6 @@
     y_axis: y_axis_init = {},
     y2_axis: y2_axis_init = {},
     display: display_init = DEFAULTS.histogram.display,
-    x_range = [null, null],
-    x2_range = [null, null],
-    y_range = [null, null],
-    y2_range = [null, null],
     range_padding = 0.05,
     padding = { t: 20, b: 60, l: 60, r: 20 },
     bins = $bindable(100),
@@ -275,7 +273,7 @@
     const auto_x = get_nice_data_range(
       x1_values.map((val) => ({ x: val, y: 0 })),
       ({ x }) => x,
-      x_range,
+      final_x_axis.range ?? [null, null],
       final_x_axis.scale_type ?? `linear`,
       range_padding,
       false,
@@ -286,7 +284,7 @@
       ? get_nice_data_range(
         x2_values.map((val) => ({ x: val, y: 0 })),
         ({ x }) => x,
-        x2_range,
+        final_x2_axis.range ?? [null, null],
         final_x2_axis.scale_type ?? `linear`,
         range_padding,
         false,
@@ -296,7 +294,7 @@
     // Calculate y-range for a specific set of series
     const calc_y_range = (
       series_list: typeof selected_series,
-      y_limit: typeof y_range,
+      y_limit: [number | null, number | null],
       scale_type: ScaleType,
     ): Vec2 => {
       const type_name = get_scale_type_name(scale_type)
@@ -336,12 +334,12 @@
 
     const y1_range = calc_y_range(
       y1_series,
-      y_range,
+      final_y_axis.range ?? [null, null],
       final_y_axis.scale_type ?? `linear`,
     )
     const y2_auto_range = calc_y_range(
       y2_series,
-      y2_range,
+      final_y2_axis.range ?? [null, null],
       final_y2_axis.scale_type ?? `linear`,
     )
 
@@ -762,42 +760,33 @@
     document.body.style.cursor = `default`
   }
 
-  // Pan drag handlers
+  // Pan/zoom all four axes from an interaction-start snapshot, each in its own
+  // scale's transform space (log axes pan by a constant factor, linear by a shift).
+  // Plot dims clamped to 1px so degenerate containers can't produce Infinity deltas.
+  const pan_all_axes = (init: InitialRanges, dx_px: number, dy_px: number) => {
+    const plot_width = Math.max(1, width - pad.l - pad.r)
+    const plot_height = Math.max(1, height - pad.t - pad.b)
+    ranges.current.x = pan_range_by_pixels(init.initial_x_range, dx_px, plot_width, final_x_axis.scale_type)
+    ranges.current.x2 = pan_range_by_pixels(init.initial_x2_range, dx_px, plot_width, final_x2_axis.scale_type)
+    ranges.current.y = pan_range_by_pixels(init.initial_y_range, dy_px, plot_height, final_y_axis.scale_type)
+    ranges.current.y2 = pan_range_by_pixels(init.initial_y2_range, dy_px, plot_height, final_y2_axis.scale_type)
+  }
+  const zoom_all_axes = (init: InitialRanges, factor: number) => {
+    ranges.current.x = zoom_range_by_factor(init.initial_x_range, factor, final_x_axis.scale_type)
+    ranges.current.x2 = zoom_range_by_factor(init.initial_x2_range, factor, final_x2_axis.scale_type)
+    ranges.current.y = zoom_range_by_factor(init.initial_y_range, factor, final_y_axis.scale_type)
+    ranges.current.y2 = zoom_range_by_factor(init.initial_y2_range, factor, final_y2_axis.scale_type)
+  }
+
+  // Pan drag handler (drag direction inverted on x for natural pan feel)
   const on_pan_move = (evt: MouseEvent) => {
     if (!pan_drag_state) return
-    const dx = evt.clientX - pan_drag_state.start.x
-    const dy = evt.clientY - pan_drag_state.start.y
-
-    // Convert pixel delta to data delta (note: drag direction is inverted for natural pan feel)
-    const plot_width = width - pad.l - pad.r
-    const plot_height = height - pad.t - pad.b
     const sensitivity = pan?.drag_sensitivity ?? 1
-
-    const x_delta = pixels_to_data_delta(
-      -dx * sensitivity,
-      pan_drag_state.initial_x_range,
-      plot_width,
+    pan_all_axes(
+      pan_drag_state,
+      -(evt.clientX - pan_drag_state.start.x) * sensitivity,
+      (evt.clientY - pan_drag_state.start.y) * sensitivity,
     )
-    const x2_delta = pixels_to_data_delta(
-      -dx * sensitivity,
-      pan_drag_state.initial_x2_range,
-      plot_width,
-    )
-    const y_delta = pixels_to_data_delta(
-      dy * sensitivity,
-      pan_drag_state.initial_y_range,
-      plot_height,
-    )
-    const y2_delta = pixels_to_data_delta(
-      dy * sensitivity,
-      pan_drag_state.initial_y2_range,
-      plot_height,
-    )
-
-    ranges.current.x = pan_range(pan_drag_state.initial_x_range, x_delta)
-    ranges.current.x2 = pan_range(pan_drag_state.initial_x2_range, x2_delta)
-    ranges.current.y = pan_range(pan_drag_state.initial_y_range, y_delta)
-    ranges.current.y2 = pan_range(pan_drag_state.initial_y2_range, y2_delta)
   }
 
   const on_pan_end = () => {
@@ -806,6 +795,20 @@
     window.removeEventListener(`mousemove`, on_pan_move)
     window.removeEventListener(`mouseup`, on_pan_end)
   }
+
+  // Tear down any window listeners + cursor override if the component unmounts mid-drag
+  // (mouseup/panend would otherwise never fire, leaking listeners and a stuck cursor).
+  // onDestroy also runs during SSR teardown, where window/document don't exist.
+  onDestroy(() => {
+    if (typeof window === `undefined`) return
+    window.removeEventListener(`mousemove`, on_window_mouse_move)
+    window.removeEventListener(`mouseup`, on_window_mouse_up)
+    window.removeEventListener(`mousemove`, on_pan_move)
+    window.removeEventListener(`mouseup`, on_pan_end)
+    drag_state = { start: null, current: null, bounds: null }
+    pan_drag_state = null
+    document.body.style.cursor = ``
+  })
 
   function handle_mouse_down(evt: MouseEvent) {
     const coords = get_relative_coords(evt)
@@ -852,34 +855,15 @@
     const plot_height = Math.max(1, height - pad.t - pad.b)
     const sensitivity = pan?.wheel_sensitivity ?? 1
 
-    // Determine pan direction based on wheel delta
-    const x_delta = pixels_to_data_delta(
-      evt.deltaX * sensitivity,
-      ranges.current.x,
-      plot_width,
-    )
-    const x2_delta = pixels_to_data_delta(
-      evt.deltaX * sensitivity,
-      ranges.current.x2,
-      plot_width,
-    )
-    const y_delta = pixels_to_data_delta(
-      evt.deltaY * sensitivity,
-      ranges.current.y,
-      plot_height,
-    )
-    const y2_delta = pixels_to_data_delta(
-      evt.deltaY * sensitivity,
-      ranges.current.y2,
-      plot_height,
-    )
-
+    // Pan along the dominant wheel direction
     if (Math.abs(evt.deltaX) > Math.abs(evt.deltaY)) {
-      ranges.current.x = pan_range(ranges.current.x, x_delta)
-      ranges.current.x2 = pan_range(ranges.current.x2, x2_delta)
+      const dx = evt.deltaX * sensitivity
+      ranges.current.x = pan_range_by_pixels(ranges.current.x, dx, plot_width, final_x_axis.scale_type)
+      ranges.current.x2 = pan_range_by_pixels(ranges.current.x2, dx, plot_width, final_x2_axis.scale_type)
     } else {
-      ranges.current.y = pan_range(ranges.current.y, y_delta)
-      ranges.current.y2 = pan_range(ranges.current.y2, y2_delta)
+      const dy = evt.deltaY * sensitivity
+      ranges.current.y = pan_range_by_pixels(ranges.current.y, dy, plot_height, final_y_axis.scale_type)
+      ranges.current.y2 = pan_range_by_pixels(ranges.current.y2, dy, plot_height, final_y2_axis.scale_type)
     }
   }
 
@@ -917,78 +901,15 @@
 
     // Calculate pinch scale (curr/start so spread = zoom out, pinch = zoom in)
     const start_dist = Math.hypot(s2.x - s1.x, s2.y - s1.y)
-    // Guard against zero-distance pinch to avoid Infinity scale
-    if (start_dist < Number.EPSILON) return
+    // ignore near-coincident touches so curr_dist / start_dist can't blow up the scale
+    if (start_dist < MIN_TOUCH_DISTANCE_PIXELS) return
     const curr_dist = Math.hypot(t2.clientX - t1.clientX, t2.clientY - t1.clientY)
     const scale = curr_dist / start_dist
 
-    // Clamp to at least 1 to avoid Infinity deltas when padding equals container size
-    const plot_width = Math.max(1, width - pad.l - pad.r)
-    const plot_height = Math.max(1, height - pad.t - pad.b)
-
-    // If scale changed significantly, treat as pinch-zoom
-    // Also guard against scale being too small to avoid division by zero
+    // Pinch zoom about the view center (spread = zoom in, pinch = zoom out)
     if (Math.abs(scale - 1) > PINCH_ZOOM_THRESHOLD && scale > Number.EPSILON) {
-      // Pinch zoom centered on gesture center
-      // Divide by scale so spread (scale > 1) = smaller span (zoom in)
-      const x_span = touch_state.initial_x_range[1] - touch_state.initial_x_range[0]
-      const x2_span = touch_state.initial_x2_range[1] -
-        touch_state.initial_x2_range[0]
-      const y_span = touch_state.initial_y_range[1] - touch_state.initial_y_range[0]
-      const y2_span = touch_state.initial_y2_range[1] -
-        touch_state.initial_y2_range[0]
-      const x_center =
-        (touch_state.initial_x_range[0] + touch_state.initial_x_range[1]) / 2
-      const x2_center =
-        (touch_state.initial_x2_range[0] + touch_state.initial_x2_range[1]) / 2
-      const y_center =
-        (touch_state.initial_y_range[0] + touch_state.initial_y_range[1]) / 2
-      const y2_center =
-        (touch_state.initial_y2_range[0] + touch_state.initial_y2_range[1]) / 2
-
-      ranges.current.x = [
-        x_center - x_span / scale / 2,
-        x_center + x_span / scale / 2,
-      ]
-      ranges.current.x2 = [
-        x2_center - x2_span / scale / 2,
-        x2_center + x2_span / scale / 2,
-      ]
-      ranges.current.y = [
-        y_center - y_span / scale / 2,
-        y_center + y_span / scale / 2,
-      ]
-      ranges.current.y2 = [
-        y2_center - y2_span / scale / 2,
-        y2_center + y2_span / scale / 2,
-      ]
-    } else {
-      // Pan
-      const x_delta = pixels_to_data_delta(
-        -dx,
-        touch_state.initial_x_range,
-        plot_width,
-      )
-      const x2_delta = pixels_to_data_delta(
-        -dx,
-        touch_state.initial_x2_range,
-        plot_width,
-      )
-      const y_delta = pixels_to_data_delta(
-        dy,
-        touch_state.initial_y_range,
-        plot_height,
-      )
-      const y2_delta = pixels_to_data_delta(
-        dy,
-        touch_state.initial_y2_range,
-        plot_height,
-      )
-      ranges.current.x = pan_range(touch_state.initial_x_range, x_delta)
-      ranges.current.x2 = pan_range(touch_state.initial_x2_range, x2_delta)
-      ranges.current.y = pan_range(touch_state.initial_y_range, y_delta)
-      ranges.current.y2 = pan_range(touch_state.initial_y2_range, y2_delta)
-    }
+      zoom_all_axes(touch_state, scale)
+    } else pan_all_axes(touch_state, -dx, dy)
   }
 
   function handle_touch_end() {
@@ -1038,16 +959,7 @@
     on_bar_hover?.({ value, count, property, event: evt })
   }
 
-  function toggle_series_visibility(series_idx: number) {
-    if (series_idx >= 0 && series_idx < series.length) {
-      // Toggle series visibility
-      series = series.map((srs: DataSeries, idx: number) => {
-        if (idx === series_idx) return { ...srs, visible: !(srs.visible ?? true) }
-        return srs
-      })
-      ;(legend?.on_toggle || on_series_toggle)(series_idx)
-    }
-  }
+  const legend_vis = create_legend_visibility(() => series, (next) => (series = next))
 
   // Set theme-aware background when entering fullscreen
   $effect(() => {
@@ -1183,6 +1095,7 @@
     ontouchstart={handle_touch_start}
     ontouchmove={handle_touch_move}
     ontouchend={handle_touch_end}
+    ontouchcancel={handle_touch_end}
     style:cursor={pan_drag_state
     ? `grabbing`
     : shift_held && pan?.enabled !== false
@@ -1248,6 +1161,7 @@
       ticks={ticks.x as number[]}
       place={scales.x}
       axis={final_x_axis}
+      domain={ranges.current.x as Vec2}
       {pad}
       {width}
       {height}
@@ -1266,6 +1180,7 @@
         ticks={ticks.x2 as number[]}
         place={scales.x2}
         axis={final_x2_axis}
+        domain={ranges.current.x2 as Vec2}
         {pad}
         {width}
         {height}
@@ -1284,6 +1199,7 @@
       ticks={ticks.y as number[]}
       place={scales.y}
       axis={final_y_axis}
+      domain={ranges.current.y as Vec2}
       {pad}
       {width}
       {height}
@@ -1309,6 +1225,7 @@
         ticks={ticks.y2 as number[]}
         place={scales.y2}
         axis={final_y2_axis}
+        domain={ranges.current.y2 as Vec2}
         {pad}
         {width}
         {height}
@@ -1470,7 +1387,12 @@
       bind:root_element={legend_element}
       {...legend}
       series_data={legend_data}
-      on_toggle={legend?.on_toggle || toggle_series_visibility}
+      on_toggle={legend?.on_toggle ?? ((series_idx: number) => {
+        if (series_idx < 0 || series_idx >= series.length) return
+        legend_vis.on_toggle(series_idx)
+        on_series_toggle(series_idx)
+      })}
+      on_double_click={legend?.on_double_click ?? legend_vis.on_double_click}
       on_hover_change={legend_hover.set_locked}
       on_item_hover={(item) =>
         (hovered_legend_series_idx = item != null && item.series_idx >= 0
@@ -1518,8 +1440,10 @@
     background: var(--histogram-fullscreen-bg, var(--histogram-bg, var(--plot-bg)));
     max-height: none !important;
     overflow: hidden;
-    /* Add padding to prevent titles from being cropped at top */
-    padding-top: var(--plot-fullscreen-padding-top, 2em);
+    /* border-top (not padding-top): bind:clientHeight includes padding but excludes
+    borders - padding made the chart overflow + clip its bottom 2em (x-axis title) */
+    border-top: var(--plot-fullscreen-padding-top, 2em) solid
+      var(--histogram-fullscreen-bg, var(--histogram-bg, var(--plot-bg, transparent)));
     box-sizing: border-box;
   }
   .header-controls {

--- a/src/lib/plot/histogram/Histogram.svelte
+++ b/src/lib/plot/histogram/Histogram.svelte
@@ -391,16 +391,17 @@
       ]
       : auto_ranges.y2
 
-    // Only update if the initial (data-driven) ranges changed, not when user pans
-    // Comparing against initial preserves user's pan/zoom state
-    const x_changed = new_x[0] !== ranges.initial.x[0] ||
-      new_x[1] !== ranges.initial.x[1]
-    const x2_changed = new_x2[0] !== ranges.initial.x2[0] ||
-      new_x2[1] !== ranges.initial.x2[1]
-    const y_changed = new_y[0] !== ranges.initial.y[0] ||
-      new_y[1] !== ranges.initial.y[1]
-    const y2_changed = new_y2[0] !== ranges.initial.y2[0] ||
-      new_y2[1] !== ranges.initial.y2[1]
+    // Skip transient non-finite ranges: writing NaN breaks scales and makes the
+    // comparison below never settle (NaN !== NaN), causing an infinite effect loop.
+    if (![...new_x, ...new_x2, ...new_y, ...new_y2].every(Number.isFinite)) return
+    // Only update if the initial (data-driven) ranges changed, not when user pans.
+    // untrack the reads of `ranges` so the writes below can't re-trigger this effect
+    // (reading + writing the same state otherwise causes effect_update_depth_exceeded).
+    const init = untrack(() => ranges.initial)
+    const x_changed = new_x[0] !== init.x[0] || new_x[1] !== init.x[1]
+    const x2_changed = new_x2[0] !== init.x2[0] || new_x2[1] !== init.x2[1]
+    const y_changed = new_y[0] !== init.y[0] || new_y[1] !== init.y[1]
+    const y2_changed = new_y2[0] !== init.y2[0] || new_y2[1] !== init.y2[1]
 
     if (x_changed) [ranges.initial.x, ranges.current.x] = [new_x, new_x]
     if (x2_changed) [ranges.initial.x2, ranges.current.x2] = [new_x2, new_x2]
@@ -733,9 +734,13 @@
           ...y_axis,
           range: [Math.min(start_y, end_y), Math.max(start_y, end_y)],
         }
-        y2_axis = {
-          ...y2_axis,
-          range: [Math.min(start_y2, end_y2), Math.max(start_y2, end_y2)],
+        // gate on y2 series presence (like x2): the y2 scale is a [0, 1] sentinel
+        // otherwise, so inverting would store a phantom range in the bindable prop
+        if (y2_series.length > 0) {
+          y2_axis = {
+            ...y2_axis,
+            range: [Math.min(start_y2, end_y2), Math.max(start_y2, end_y2)],
+          }
         }
       }
     }
@@ -1326,6 +1331,7 @@
       <g
         class="histogram-series"
         data-series-idx={series_idx}
+        clip-path="url(#{clip_path_id})"
         opacity={hovered_legend_series_idx !== null &&
             hovered_legend_series_idx !== series_idx
           ? 0.25

--- a/src/lib/plot/histogram/Histogram.svelte
+++ b/src/lib/plot/histogram/Histogram.svelte
@@ -18,7 +18,7 @@
     ReferenceLine,
   } from '$lib/plot'
   import type { AxisChangeState } from '$lib/plot/core/axis-utils'
-  import { AXIS_DEFAULTS, create_axis_change_handler } from '$lib/plot/core/axis-utils'
+  import { AXIS_DEFAULTS, create_axis_loader } from '$lib/plot/core/axis-utils'
   import { extract_series_color, prepare_legend_data } from '$lib/plot/core/data-transform'
   import {
     create_dimension_tracker,
@@ -30,6 +30,7 @@
     MIN_TOUCH_DISTANCE_PIXELS,
     pan_range_by_pixels,
     PINCH_ZOOM_THRESHOLD,
+    remove_drag_listeners,
     resolve_axis_ranges,
     sorted_range,
     vec2_equal,
@@ -37,7 +38,6 @@
   } from '$lib/plot/core/interactions'
   import {
     calc_auto_padding,
-    constrain_tooltip_position,
     filter_padding,
     LABEL_GAP_DEFAULT,
     y2_axis_label_x,
@@ -175,10 +175,10 @@
     ...x2_axis_init,
   })))
   let y_axis = $state(untrack(() => ({ ...axis_state_defaults, ...y_axis_init })))
-  // y2-axis needs different default label_shift for right-side positioning
+  // y2 title stays vertically centered; its x position is computed by y2_axis_label_x
   let y2_axis = $state(untrack(() => ({
     ...axis_state_defaults,
-    label_shift: { x: 0, y: 60 },
+    label_shift: { x: 0, y: 0 },
     ...y2_axis_init,
   })))
   let display = $state(
@@ -208,7 +208,6 @@
   // Compute ref_lines with index and group by z-index (using shared utilities)
   let indexed_ref_lines = $derived(index_ref_lines(ref_lines))
   let ref_lines_by_z = $derived(group_ref_lines_by_z(indexed_ref_lines))
-  let tooltip_el = $state<HTMLDivElement | undefined>()
   let drag_state = $state<{
     start: { x: number; y: number } | null
     current: { x: number; y: number } | null
@@ -765,14 +764,9 @@
   // (mouseup/panend would otherwise never fire, leaking listeners and a stuck cursor).
   // onDestroy also runs during SSR teardown, where window/document don't exist.
   onDestroy(() => {
-    if (typeof window === `undefined`) return
-    window.removeEventListener(`mousemove`, on_window_mouse_move)
-    window.removeEventListener(`mouseup`, on_window_mouse_up)
-    window.removeEventListener(`mousemove`, on_pan_move)
-    window.removeEventListener(`mouseup`, on_pan_end)
+    remove_drag_listeners([on_window_mouse_move, on_pan_move], [on_window_mouse_up, on_pan_end])
     drag_state = { start: null, current: null, bounds: null }
     pan_drag_state = null
-    document.body.style.cursor = ``
   })
 
   function handle_mouse_down(evt: MouseEvent) {
@@ -952,32 +946,12 @@
     set_loading: (axis) => (axis_loading = axis),
   }
 
-  // Create shared handler bound to this component's state
-  // Using $derived so handler updates when callback props change
-  const handle_axis_change = $derived(create_axis_change_handler(
+  // Shared handler + one-shot auto-load bound to this component's state
+  const { handle_axis_change, try_auto_load } = create_axis_loader(
     axis_state,
-    data_loader,
-    on_axis_change,
-    on_error,
-  ))
-
-  let auto_load_attempted = false // prevent infinite retries on failure
-
-  // Auto-load data if series is empty but options exist (runs once)
-  $effect(() => {
-    if (series.length === 0 && data_loader && !auto_load_attempted) {
-      // Check x-axis first, then y-axis
-      if (x_axis.options?.length) {
-        auto_load_attempted = true
-        const first_key = x_axis.selected_key ?? x_axis.options[0].key
-        handle_axis_change(`x`, first_key).catch(() => {})
-      } else if (y_axis.options?.length) {
-        auto_load_attempted = true
-        const first_key = y_axis.selected_key ?? y_axis.options[0].key
-        handle_axis_change(`y`, first_key).catch(() => {})
-      }
-    }
-  })
+    () => ({ data_loader, on_axis_change, on_error }),
+  )
+  $effect(try_auto_load)
 </script>
 
 {#snippet ref_lines_layer(lines: IndexedRefLine[])}
@@ -1276,20 +1250,12 @@
     {@const { value, count, property, active_y_axis, active_x_axis } = hover_info}
     {@const tooltip_x = (active_x_axis === `x2` ? scales.x2 : scales.x)(value)}
     {@const tooltip_y = (active_y_axis === `y2` ? scales.y2 : scales.y)(count)}
-    {@const tooltip_pos = constrain_tooltip_position(
-      tooltip_x,
-      tooltip_y,
-      tooltip_el?.offsetWidth ?? 120,
-      tooltip_el?.offsetHeight ?? (mode === `overlay` ? 60 : 40),
-      width,
-      height,
-      { offset_x: 5, offset_y: -10 },
-    )}
     <PlotTooltip
-      x={tooltip_pos.x}
-      y={tooltip_pos.y}
-      offset={{ x: 0, y: 0 }}
-      bind:wrapper={tooltip_el}
+      x={tooltip_x}
+      y={tooltip_y}
+      offset={{ x: 5, y: -10 }}
+      constrain_to={{ width, height }}
+      fallback_size={{ width: 120, height: mode === `overlay` ? 60 : 40 }}
     >
       {#if tooltip}
         {@render tooltip({ ...hover_info, fullscreen })}

--- a/src/lib/plot/sankey/Sankey.svelte
+++ b/src/lib/plot/sankey/Sankey.svelte
@@ -639,7 +639,10 @@
     background: var(--sankey-fullscreen-bg, var(--sankey-bg, var(--plot-bg)));
     max-height: none !important;
     overflow: hidden;
-    padding-top: var(--plot-fullscreen-padding-top, 2em);
+    /* border-top (not padding-top): bind:clientHeight includes padding but excludes
+    borders - padding made the chart overflow + clip its bottom 2em (x-axis title) */
+    border-top: var(--plot-fullscreen-padding-top, 2em) solid
+      var(--sankey-fullscreen-bg, var(--sankey-bg, var(--plot-bg, transparent)));
     box-sizing: border-box;
   }
   .header-controls {

--- a/src/lib/plot/sankey/index.ts
+++ b/src/lib/plot/sankey/index.ts
@@ -1,3 +1,4 @@
 export * from './sankey'
+export type * from './sankey-types'
 export { default as Sankey } from './Sankey.svelte'
 export { default as SankeyControls } from './SankeyControls.svelte'

--- a/src/lib/plot/sankey/sankey-types.ts
+++ b/src/lib/plot/sankey/sankey-types.ts
@@ -1,0 +1,57 @@
+// === Sankey diagram types ===
+// Public input/event types for the Sankey component; layout-result types
+// (PositionedNode/PositionedLink) live in sankey.ts next to the layout math.
+
+// Flow direction: 'horizontal' = columns left->right, 'vertical' = columns top->bottom
+export type SankeyOrientation = `horizontal` | `vertical`
+// Maps to d3-sankey alignment functions (sankeyLeft/Right/Center/Justify)
+export type SankeyNodeAlign = `left` | `right` | `center` | `justify`
+// How each link ribbon derives its color when no explicit link.color is set
+export type SankeyLinkColorMode = `source` | `target` | `gradient` | `static`
+
+export interface SankeyNode<Metadata = Record<string, unknown>> {
+  id?: string | number // stable id (defaults to array index); referenced by links
+  label?: string
+  color?: string // defaults to cycled DEFAULT_SERIES_COLORS
+  metadata?: Metadata
+}
+
+export interface SankeyLink<Metadata = Record<string, unknown>> {
+  source: number | string // node id, or zero-based index into nodes
+  target: number | string // node id, or zero-based index into nodes
+  value: number // flow magnitude (controls ribbon thickness)
+  color?: string // overrides link_color_mode for this link
+  label?: string
+  metadata?: Metadata
+}
+
+export interface SankeyData<Metadata = Record<string, unknown>> {
+  nodes: SankeyNode<Metadata>[]
+  links: SankeyLink<Metadata>[]
+}
+
+export interface SankeyNodeHandlerProps<Metadata = Record<string, unknown>> {
+  type: `node`
+  node_idx: number
+  id: string | number
+  label?: string
+  value: number // sum of incoming/outgoing link values
+  color: string
+  metadata?: Metadata
+}
+
+export interface SankeyLinkHandlerProps<Metadata = Record<string, unknown>> {
+  type: `link`
+  link_idx: number
+  source_idx: number
+  target_idx: number
+  source_label?: string
+  target_label?: string
+  value: number
+  color: string
+  metadata?: Metadata
+}
+
+export type SankeyHandlerProps<Metadata = Record<string, unknown>> =
+  | SankeyNodeHandlerProps<Metadata>
+  | SankeyLinkHandlerProps<Metadata>

--- a/src/lib/plot/scatter-3d/ScatterPlot3D.svelte
+++ b/src/lib/plot/scatter-3d/ScatterPlot3D.svelte
@@ -462,8 +462,10 @@
     border-radius: 0;
     max-height: none !important;
     overflow: hidden;
-    /* Add padding to prevent titles from being cropped at top */
-    padding-top: var(--plot-fullscreen-padding-top, 2em);
+    /* border-top (not padding-top): bind:clientHeight includes padding but excludes
+    borders - padding made the chart overflow + clip its bottom 2em (x-axis title) */
+    border-top: var(--plot-fullscreen-padding-top, 2em) solid
+      var(--scatter3d-bg, var(--plot-bg, transparent));
     box-sizing: border-box;
   }
   /* Threlte Canvas container needs flex: 1 to fill available space in flex layout

--- a/src/lib/plot/scatter/BinnedScatterPlot.svelte
+++ b/src/lib/plot/scatter/BinnedScatterPlot.svelte
@@ -1014,7 +1014,10 @@
     margin: 0;
     max-height: none !important;
     overflow: hidden;
-    padding-top: var(--plot-fullscreen-padding-top, 2em);
+    /* border-top (not padding-top): bind:clientHeight includes padding but excludes
+    borders - padding made the chart overflow + clip its bottom 2em (x-axis title) */
+    border-top: var(--plot-fullscreen-padding-top, 2em) solid
+      var(--binned-scatter-fullscreen-bg, var(--binned-scatter-bg, var(--plot-bg, Canvas)));
     position: fixed;
     top: 0;
     width: 100vw !important;

--- a/src/lib/plot/scatter/BinnedScatterPlot.svelte
+++ b/src/lib/plot/scatter/BinnedScatterPlot.svelte
@@ -199,6 +199,9 @@
   function set_auto_range() {
     const next_x_range = axis_range(x_axis, auto_ranges.x)
     const next_y_range = axis_range(y_axis, auto_ranges.y)
+    // Skip non-finite ranges (e.g. a NaN bound in an axis range prop): NaN !== NaN
+    // means same_range never settles, looping until effect_update_depth_exceeded
+    if (![...next_x_range, ...next_y_range].every(Number.isFinite)) return
     if (!same_range(x_range, next_x_range)) x_range = next_x_range
     if (!same_range(y_range, next_y_range)) y_range = next_y_range
   }

--- a/src/lib/plot/scatter/ScatterPlot.svelte
+++ b/src/lib/plot/scatter/ScatterPlot.svelte
@@ -54,7 +54,7 @@
     place_decorations,
   } from '$lib/plot/core/auto-place'
   import type { AxisChangeState } from '$lib/plot/core/axis-utils'
-  import { AXIS_DEFAULTS, create_axis_change_handler } from '$lib/plot/core/axis-utils'
+  import { AXIS_DEFAULTS, create_axis_loader } from '$lib/plot/core/axis-utils'
   import { get_series_color, get_series_symbol } from '$lib/plot/core/data-transform'
   import {
     create_dimension_tracker,
@@ -88,6 +88,7 @@
     normalize_y2_sync,
     pan_range_by_pixels,
     PINCH_ZOOM_THRESHOLD,
+    remove_drag_listeners,
     sorted_range,
     sync_y2_range,
     to_epoch_num,
@@ -96,7 +97,6 @@
   import type { Rect, Sides } from '$lib/plot/core/layout'
   import {
     calc_auto_padding,
-    constrain_tooltip_position,
     filter_padding,
     LABEL_GAP_DEFAULT,
     y2_axis_label_x,
@@ -381,9 +381,6 @@
     legend_hover.cleanup()
     colorbar_hover.cleanup()
   })
-
-  // Tooltip element reference for dynamic sizing
-  let tooltip_el = $state<HTMLDivElement | undefined>()
 
   // Module-level constants to avoid repeated allocations
   // Create and categorize points in a single pass (instead of 3 separate iterations)
@@ -1227,16 +1224,11 @@
   // (mouseup/panend would otherwise never fire, leaking listeners and a stuck cursor).
   // onDestroy also runs during SSR teardown, where window/document don't exist.
   onDestroy(() => {
-    if (typeof window === `undefined`) return
-    window.removeEventListener(`mousemove`, on_window_mouse_move)
-    window.removeEventListener(`mouseup`, on_window_mouse_up)
-    window.removeEventListener(`mousemove`, on_pan_move)
-    window.removeEventListener(`mouseup`, on_pan_end)
+    remove_drag_listeners([on_window_mouse_move, on_pan_move], [on_window_mouse_up, on_pan_end])
     drag_start_coords = null
     drag_current_coords = null
     svg_bounding_box = null
     pan_drag_state = null
-    document.body.style.cursor = ``
   })
 
   function handle_mouse_down(evt: MouseEvent) {
@@ -1595,32 +1587,12 @@
     set_loading: (axis) => (axis_loading = axis),
   }
 
-  // Create shared handler bound to this component's state
-  // Using $derived so handler updates when callback props change
-  const handle_axis_change = $derived(create_axis_change_handler(
+  // Shared handler + one-shot auto-load bound to this component's state
+  const { handle_axis_change, try_auto_load } = create_axis_loader(
     axis_state,
-    data_loader,
-    on_axis_change,
-    on_error,
-  ))
-
-  let auto_load_attempted = false // prevent infinite retries on failure
-
-  // Auto-load data if series is empty but options exist (runs once)
-  $effect(() => {
-    if (series.length === 0 && data_loader && !auto_load_attempted) {
-      // Check x-axis first, then y-axis
-      if (x_axis.options?.length) {
-        auto_load_attempted = true
-        const first_key = x_axis.selected_key ?? x_axis.options[0].key
-        handle_axis_change(`x`, first_key).catch(() => {})
-      } else if (y_axis.options?.length) {
-        auto_load_attempted = true
-        const first_key = y_axis.selected_key ?? y_axis.options[0].key
-        handle_axis_change(`y`, first_key).catch(() => {})
-      }
-    }
-  })
+    () => ({ data_loader, on_axis_change, on_error }),
+  )
+  $effect(try_auto_load)
 </script>
 
 {#snippet fill_regions_layer(fills: typeof computed_fills)}
@@ -2101,21 +2073,13 @@
       series_with_ids[series_idx],
       color_scale_fn,
     )}
-      {@const tooltip_pos = constrain_tooltip_position(
-      handler_props.cx,
-      handler_props.cy,
-      tooltip_el?.offsetWidth ?? 120,
-      tooltip_el?.offsetHeight ?? 50,
-      width,
-      height,
-      { offset_x: 10, offset_y: 5 },
-    )}
       <PlotTooltip
-        x={tooltip_pos.x}
-        y={tooltip_pos.y}
-        offset={{ x: 0, y: 0 }}
+        x={handler_props.cx}
+        y={handler_props.cy}
+        offset={{ x: 10, y: 5 }}
+        constrain_to={{ width, height }}
+        fallback_size={{ width: 120, height: 50 }}
         bg_color={tooltip_bg_color}
-        bind:wrapper={tooltip_el}
       >
         {#if tooltip}
           {@render tooltip(handler_props)}

--- a/src/lib/plot/scatter/ScatterPlot.svelte
+++ b/src/lib/plot/scatter/ScatterPlot.svelte
@@ -647,7 +647,14 @@
       if (result.changed) initial_y2_range = result.range
       // Apply sync if enabled, otherwise use expanded range (or keep current if unchanged)
       if (y2_sync_config.mode !== `none`) {
-        zoom_y2_range = sync_y2_range(zoom_y_range, initial_y2_range, y2_sync_config)
+        // untrack the read of zoom_y_range: this effect also writes it (fresh array per
+        // run when y.explicit), so a tracked read would loop until
+        // effect_update_depth_exceeded. Pan/zoom handlers sync y2 themselves.
+        zoom_y2_range = sync_y2_range(
+          untrack(() => zoom_y_range),
+          initial_y2_range,
+          y2_sync_config,
+        )
       } else if (result.changed) {
         zoom_y2_range = result.range
       }
@@ -1398,7 +1405,6 @@
         next_y_range[0] !== next_y_range[1]
       ) {
         // Update axis ranges to trigger reactivity (like BarPlot/Histogram do)
-        // Y2 sync is handled by the effect that reacts to y_axis changes
         x_axis = { ...x_axis, range: next_x_range }
         y_axis = { ...y_axis, range: next_y_range }
 
@@ -1415,6 +1421,17 @@
           x2_axis = {
             ...x2_axis,
             range: [Math.min(x2_a, x2_b), Math.max(x2_a, x2_b)],
+          }
+        }
+
+        // Y2 axis: when sync is enabled the y_axis effect derives y2; with sync 'none'
+        // y2 must zoom from the rect directly (parity with BarPlot/Histogram/BoxPlot)
+        if (y2_points.length > 0 && y2_sync_config.mode === `none`) {
+          const y2_a = y2_scale_fn.invert(drag_start_coords.y)
+          const y2_b = y2_scale_fn.invert(drag_current_coords.y)
+          y2_axis = {
+            ...y2_axis,
+            range: [Math.min(y2_a, y2_b), Math.max(y2_a, y2_b)],
           }
         }
       }

--- a/src/lib/plot/scatter/ScatterPlot.svelte
+++ b/src/lib/plot/scatter/ScatterPlot.svelte
@@ -3,8 +3,7 @@
   generics="Metadata extends Record<string, unknown> = Record<string, unknown>"
 >
   import type { D3ColorSchemeName, D3InterpolateName } from '$lib/colors'
-  import type { D3SymbolName } from '$lib/labels'
-  import { format_value, symbol_names } from '$lib/labels'
+  import { format_value } from '$lib/labels'
   import { sanitize_html } from '$lib/sanitize'
   import { FullscreenToggle, set_fullscreen_bg } from '$lib/layout'
   import type { Point2D, Vec2 } from '$lib/math'
@@ -56,11 +55,7 @@
   } from '$lib/plot/core/auto-place'
   import type { AxisChangeState } from '$lib/plot/core/axis-utils'
   import { AXIS_DEFAULTS, create_axis_change_handler } from '$lib/plot/core/axis-utils'
-  import {
-    get_series_color,
-    get_series_symbol,
-    process_prop,
-  } from '$lib/plot/core/data-transform'
+  import { get_series_color, get_series_symbol } from '$lib/plot/core/data-transform'
   import {
     create_dimension_tracker,
     create_hover_lock,
@@ -71,17 +66,12 @@
     is_time_scale,
   } from '$lib/plot/core/types'
   import { compute_label_positions } from '$lib/plot/core/utils/label-placement'
-  import type { SeriesVisibilitySnapshot } from '$lib/plot/core/utils/series-visibility'
-  import {
-    handle_legend_double_click,
-    toggle_group_visibility,
-    toggle_series_visibility,
-  } from '$lib/plot/core/utils/series-visibility'
+  import { create_legend_visibility } from '$lib/plot/core/utils/series-visibility'
   import { DEFAULTS } from '$lib/settings'
   import { extent } from 'd3-array'
   import { scaleTime } from 'd3-scale'
   import type { ComponentProps, Snippet } from 'svelte'
-  import { untrack } from 'svelte'
+  import { onDestroy, untrack } from 'svelte'
   import type { HTMLAttributes } from 'svelte/elements'
   import { Tween, type TweenOptions } from 'svelte/motion'
   import { SvelteSet } from 'svelte/reactivity'
@@ -90,16 +80,16 @@
     compute_fill_segments,
     convert_error_band_to_fill_region,
     generate_fill_path,
-    is_fill_gradient,
   } from '$lib/plot/core/fill-utils'
   import {
     expand_range_if_needed,
     get_relative_coords,
+    MIN_TOUCH_DISTANCE_PIXELS,
     normalize_y2_sync,
-    pan_range,
+    pan_range_by_pixels,
     PINCH_ZOOM_THRESHOLD,
-    pixels_to_data_delta,
     sync_y2_range,
+    zoom_range_by_factor,
   } from '$lib/plot/core/interactions'
   import type { Rect, Sides } from '$lib/plot/core/layout'
   import {
@@ -121,9 +111,11 @@
     get_nice_data_range,
   } from '$lib/plot/core/scales'
   import { resolve_line_tween, unique_id } from '$lib/plot/core/utils'
-
-  const in_range = (val: number | null | undefined, lo: number, hi: number) =>
-    val != null && !isNaN(val) && val >= Math.min(lo, hi) && val <= Math.max(lo, hi)
+  import {
+    build_legend_data,
+    filter_series_to_ranges,
+    pick_tooltip_bg,
+  } from './scatter-data'
 
   let {
     series = $bindable([]),
@@ -314,7 +306,7 @@
   let zoom_x2_range = $state<[number, number]>([0, 1])
   let zoom_y_range = $state<[number, number]>([0, 1])
   let zoom_y2_range = $state<[number, number]>([0, 1])
-  let prev_series_visibility: SeriesVisibilitySnapshot | null = $state(null)
+  const legend_vis = create_legend_visibility(() => series, (next) => (series = next))
 
   // Y2 axis sync configuration
   let y2_sync_config = $derived(normalize_y2_sync(y2_axis?.sync))
@@ -727,78 +719,12 @@
 
   // Filter series data to only include points within bounds and augment with internal data
   let filtered_series = $derived(
-    series_with_ids
-      .map((data_series: DataSeries<Metadata>, series_idx): DataSeries<Metadata> => {
-        // Handle null/undefined series first
-        if (!data_series) {
-          return {
-            x: [],
-            y: [],
-            visible: true,
-            filtered_data: [],
-            _id: series_idx,
-            orig_series_idx: series_idx,
-          }
-        }
-
-        // Handle explicitly hidden series
-        if (!(data_series.visible ?? true)) {
-          return {
-            ...data_series,
-            visible: false,
-            filtered_data: [],
-            orig_series_idx: series_idx,
-          }
-        }
-
-        const { x: xs, y: ys, color_values, size_values, ...series_rest } = data_series
-
-        // Process points internally, adding properties beyond the base Point type
-        const processed_points: InternalPoint<Metadata>[] = xs.map(
-          (x_val: number, point_idx: number) => ({
-            x: x_val,
-            y: ys[point_idx],
-            color_value: color_values?.[point_idx],
-            metadata: process_prop(series_rest.metadata, point_idx) as Metadata | undefined,
-            point_style: process_prop(series_rest.point_style, point_idx),
-            point_hover: process_prop(series_rest.point_hover, point_idx),
-            point_label: process_prop(series_rest.point_label, point_idx),
-            point_offset: process_prop(series_rest.point_offset, point_idx),
-            series_idx,
-            point_idx,
-            size_value: size_values?.[point_idx],
-          }),
-        )
-
-        // Filter to points within the plot bounds (handles inverted ranges like [3.5, 1.4])
-        // Determine which ranges to use based on series axis properties
-        const [series_x_min, series_x_max] = (data_series.x_axis ?? `x1`) === `x2`
-          ? [x2_min, x2_max]
-          : [x_min, x_max]
-        const [series_y_min, series_y_max] = (data_series.y_axis ?? `y1`) === `y2`
-          ? [y2_min, y2_max]
-          : [y_min, y_max]
-
-        const filtered_data_with_extras = processed_points.filter(
-          ({ x, y }) =>
-            in_range(x, series_x_min, series_x_max) &&
-            in_range(y, series_y_min, series_y_max),
-        )
-
-        // Return structure consistent with DataSeries but acknowledge internal data structure (filtered_data)
-        return {
-          ...data_series,
-          visible: true, // Mark series as visible here
-          filtered_data: filtered_data_with_extras,
-          orig_series_idx: series_idx, // Store original index for auto-cycling colors/symbols
-        }
-      })
-      // Filter series end up completely empty after point filtering
-      .filter((
-        srs,
-      ): srs is DataSeries<Metadata> & { filtered_data: InternalPoint<Metadata>[] } =>
-        (srs.filtered_data?.length ?? 0) > 0
-      ),
+    filter_series_to_ranges(series_with_ids, {
+      x: [x_min, x_max],
+      x2: [x2_min, x2_max],
+      y: [y_min, y_max],
+      y2: [y2_min, y2_max],
+    }),
   )
 
   // Tally line series/points to budget path-morph tweens (see resolve_line_tween).
@@ -842,14 +768,6 @@
     }
     return points
   })
-
-  // Explicitly define the type for display_style matching PlotLegend expectations
-  type LegendDisplayStyle = {
-    symbol_type?: D3SymbolName
-    symbol_color?: string
-    line_color?: string
-    line_dash?: string
-  }
 
   const fill_hover_key = (
     source_type: `fill_region` | `error_band`,
@@ -965,161 +883,9 @@
   })
 
   // Prepare data needed for the legend component
-  let legend_data = $derived.by(() => {
-    const items = series_with_ids.map(
-      (data_series: DataSeries & { _id?: string | number }, series_idx: number) => {
-        const is_visible = data_series?.visible ?? true
-        // Prefer top-level label, fallback to metadata label
-        const explicit_label = data_series?.label ??
-          (typeof data_series?.metadata === `object` &&
-              data_series.metadata !== null &&
-              `label` in data_series.metadata &&
-              typeof data_series.metadata.label === `string`
-            ? data_series.metadata.label
-            : null)
-        // Use explicit label or generate default
-        const label = explicit_label ?? `Series ${series_idx + 1}`
-        const has_explicit_label = explicit_label != null
-
-        // Use series-specific defaults for auto-differentiation
-        const series_default_color = get_series_color(series_idx)
-        const series_default_symbol = get_series_symbol(series_idx)
-
-        const display_style: LegendDisplayStyle = {
-          symbol_type: series_default_symbol,
-          symbol_color: series_default_color,
-          line_color: series_default_color,
-        }
-        const series_markers = data_series?.markers ?? DEFAULT_MARKERS
-
-        // Check point_style (could be object or array)
-        const first_point_style = Array.isArray(data_series?.point_style)
-          ? data_series.point_style[0]
-          : data_series?.point_style
-
-        if (series_markers?.includes(`points`)) {
-          if (first_point_style) {
-            // Use explicit symbol_type if provided and valid, otherwise keep series default
-            if (
-              typeof first_point_style.symbol_type === `string` &&
-              symbol_names.includes(first_point_style.symbol_type as D3SymbolName)
-            ) {
-              display_style.symbol_type = first_point_style
-                .symbol_type as D3SymbolName
-            }
-
-            // Use explicit fill color if provided
-            if (first_point_style.fill) {
-              display_style.symbol_color = first_point_style.fill
-            }
-            if (first_point_style.stroke) {
-              // Use stroke color if fill is none or transparent
-              if (
-                !display_style.symbol_color ||
-                display_style.symbol_color === `none` ||
-                display_style.symbol_color.startsWith(`rgba(`, 0) // Check if transparent
-              ) display_style.symbol_color = first_point_style.stroke
-            }
-          }
-          // else: keep series-specific defaults for symbol_type and symbol_color
-        } else {
-          // If no points marker, explicitly remove marker style for legend
-          display_style.symbol_type = undefined
-          display_style.symbol_color = undefined
-        }
-
-        // Check line_style
-        if (series_markers?.includes(`line`)) {
-          // Prefer explicit line stroke, then other explicit colors, then series default
-          let legend_line_color = data_series?.line_style?.stroke
-          if (!legend_line_color) {
-            // Try color scale if available
-            const first_cv = Array.isArray(data_series?.color_values)
-              ? data_series?.color_values?.find((color_val: number | null) =>
-                color_val != null
-              )
-              : undefined
-            legend_line_color =
-              (first_cv != null ? color_scale_fn(first_cv) : undefined) ||
-              first_point_style?.fill ||
-              first_point_style?.stroke ||
-              series_default_color
-          }
-          display_style.line_color = legend_line_color
-          display_style.line_dash = data_series?.line_style?.line_dash
-        } else {
-          // If no line marker, explicitly remove line style for legend
-          display_style.line_dash = undefined
-          display_style.line_color = undefined
-        }
-
-        return {
-          series_idx,
-          label,
-          visible: is_visible,
-          display_style,
-          has_explicit_label,
-          legend_group: data_series?.legend_group,
-        }
-      },
-    )
-
-    // Deduplicate by label+legend_group - keep first occurrence of each unique combination
-    const seen_labels = new SvelteSet<string>()
-    const series_items = items.filter(
-      (
-        legend_item: {
-          label: string
-          series_idx: number
-          visible: boolean
-          display_style: LegendDisplayStyle
-          has_explicit_label: boolean
-          legend_group?: string
-        },
-      ) => {
-        // Use label+group as unique key (group may be undefined)
-        const unique_key = `${legend_item.legend_group ?? ``}::${legend_item.label}`
-        if (seen_labels.has(unique_key)) return false
-        seen_labels.add(unique_key)
-        return true
-      },
-    )
-
-    // Add fill region items to legend (deduplicated using same key format as series)
-    const fill_items = computed_fills
-      .filter((fill) => fill.show_in_legend !== false && fill.label)
-      .filter((fill) => {
-        // Use same composite key as series: legend_group::label
-        const unique_key = `${fill.legend_group ?? ``}::${fill.label ?? ``}`
-        if (seen_labels.has(unique_key)) return false
-        seen_labels.add(unique_key)
-        return true
-      })
-      .map((fill) => {
-        // Pass gradient for swatch rendering, or solid color as fallback
-        const fill_gradient = is_fill_gradient(fill.fill) ? fill.fill : undefined
-        const fill_color = typeof fill.fill === `string` ? fill.fill : undefined
-
-        return {
-          series_idx: -1, // Not a series
-          fill_idx: fill.idx,
-          fill_source_type: fill.source_type,
-          fill_source_idx: fill.source_idx,
-          item_type: `fill` as const,
-          label: fill.label ?? ``,
-          visible: fill.visible !== false,
-          legend_group: fill.legend_group,
-          display_style: {
-            fill_color,
-            fill_opacity: fill.fill_opacity ?? 0.3,
-            edge_color: fill.edge_upper?.color,
-            fill_gradient,
-          },
-        }
-      })
-
-    return [...series_items, ...fill_items]
-  })
+  let legend_data = $derived(
+    build_legend_data(series_with_ids, computed_fills, color_scale_fn),
+  )
 
   // Group fills by z-index for ordered rendering (single pass instead of 4 filters)
   let fills_by_z = $derived.by(() => {
@@ -1446,45 +1212,38 @@
     document.body.style.cursor = `default`
   }
 
-  // Pan drag handlers
-  const on_pan_move = (evt: MouseEvent) => {
-    if (!pan_drag_state) return
-    const dx = evt.clientX - pan_drag_state.start.x
-    const dy = evt.clientY - pan_drag_state.start.y
-
-    // Convert pixel delta to data delta (note: drag direction is inverted for natural pan feel)
-    // Clamp to at least 1 to avoid Infinity deltas when padding equals container size
+  // Pan/zoom all four axes from an interaction-start snapshot, each in its own
+  // scale's transform space (log axes pan by a constant factor, linear by a shift).
+  // Plot dims clamped to 1px so degenerate containers can't produce Infinity deltas.
+  const pan_all_axes = (init: InitialRanges, dx_px: number, dy_px: number) => {
     const plot_width = Math.max(1, width - pad.l - pad.r)
     const plot_height = Math.max(1, height - pad.t - pad.b)
-    const sensitivity = pan?.drag_sensitivity ?? 1
-
-    const x_delta = pixels_to_data_delta(
-      -dx * sensitivity,
-      pan_drag_state.initial_x_range,
-      plot_width,
-    )
-    const x2_delta = pixels_to_data_delta(
-      -dx * sensitivity,
-      pan_drag_state.initial_x2_range,
-      plot_width,
-    )
-    const y_delta = pixels_to_data_delta(
-      dy * sensitivity,
-      pan_drag_state.initial_y_range,
-      plot_height,
-    )
-    const y2_delta = pixels_to_data_delta(
-      dy * sensitivity,
-      pan_drag_state.initial_y2_range,
-      plot_height,
-    )
-
-    zoom_x_range = pan_range(pan_drag_state.initial_x_range, x_delta)
-    zoom_x2_range = pan_range(pan_drag_state.initial_x2_range, x2_delta)
-    zoom_y_range = pan_range(pan_drag_state.initial_y_range, y_delta)
+    zoom_x_range = pan_range_by_pixels(init.initial_x_range, dx_px, plot_width, final_x_axis.scale_type)
+    zoom_x2_range = pan_range_by_pixels(init.initial_x2_range, dx_px, plot_width, final_x2_axis.scale_type)
+    zoom_y_range = pan_range_by_pixels(init.initial_y_range, dy_px, plot_height, final_y_axis.scale_type)
     zoom_y2_range = get_synced_y2(
       zoom_y_range,
-      pan_range(pan_drag_state.initial_y2_range, y2_delta),
+      pan_range_by_pixels(init.initial_y2_range, dy_px, plot_height, final_y2_axis.scale_type),
+    )
+  }
+  const zoom_all_axes = (init: InitialRanges, factor: number) => {
+    zoom_x_range = zoom_range_by_factor(init.initial_x_range, factor, final_x_axis.scale_type)
+    zoom_x2_range = zoom_range_by_factor(init.initial_x2_range, factor, final_x2_axis.scale_type)
+    zoom_y_range = zoom_range_by_factor(init.initial_y_range, factor, final_y_axis.scale_type)
+    zoom_y2_range = get_synced_y2(
+      zoom_y_range,
+      zoom_range_by_factor(init.initial_y2_range, factor, final_y2_axis.scale_type),
+    )
+  }
+
+  // Pan drag handler (drag direction inverted on x for natural pan feel)
+  const on_pan_move = (evt: MouseEvent) => {
+    if (!pan_drag_state) return
+    const sensitivity = pan?.drag_sensitivity ?? 1
+    pan_all_axes(
+      pan_drag_state,
+      -(evt.clientX - pan_drag_state.start.x) * sensitivity,
+      (evt.clientY - pan_drag_state.start.y) * sensitivity,
     )
   }
 
@@ -1494,6 +1253,22 @@
     window.removeEventListener(`mousemove`, on_pan_move)
     window.removeEventListener(`mouseup`, on_pan_end)
   }
+
+  // Tear down any window listeners + cursor override if the component unmounts mid-drag
+  // (mouseup/panend would otherwise never fire, leaking listeners and a stuck cursor).
+  // onDestroy also runs during SSR teardown, where window/document don't exist.
+  onDestroy(() => {
+    if (typeof window === `undefined`) return
+    window.removeEventListener(`mousemove`, on_window_mouse_move)
+    window.removeEventListener(`mouseup`, on_window_mouse_up)
+    window.removeEventListener(`mousemove`, on_pan_move)
+    window.removeEventListener(`mouseup`, on_pan_end)
+    drag_start_coords = null
+    drag_current_coords = null
+    svg_bounding_box = null
+    pan_drag_state = null
+    document.body.style.cursor = ``
+  })
 
   function handle_mouse_down(evt: MouseEvent) {
     if (!svg_element) return
@@ -1546,35 +1321,19 @@
     const plot_height = Math.max(1, height - pad.t - pad.b)
     const sensitivity = pan?.wheel_sensitivity ?? 1
 
-    // Determine pan direction based on wheel delta
-    // deltaX for horizontal scroll (trackpad), deltaY for vertical
-    const x_delta = pixels_to_data_delta(
-      evt.deltaX * sensitivity,
-      zoom_x_range,
-      plot_width,
-    )
-    const x2_delta = pixels_to_data_delta(
-      evt.deltaX * sensitivity,
-      zoom_x2_range,
-      plot_width,
-    )
-    const y_delta = pixels_to_data_delta(
-      evt.deltaY * sensitivity,
-      zoom_y_range,
-      plot_height,
-    )
-    const y2_delta = pixels_to_data_delta(
-      evt.deltaY * sensitivity,
-      zoom_y2_range,
-      plot_height,
-    )
-
+    // Pan along the dominant wheel direction
+    // (deltaX for horizontal scroll on trackpads, deltaY for vertical)
     if (Math.abs(evt.deltaX) > Math.abs(evt.deltaY)) {
-      zoom_x_range = pan_range(zoom_x_range, x_delta)
-      zoom_x2_range = pan_range(zoom_x2_range, x2_delta)
+      const dx = evt.deltaX * sensitivity
+      zoom_x_range = pan_range_by_pixels(zoom_x_range, dx, plot_width, final_x_axis.scale_type)
+      zoom_x2_range = pan_range_by_pixels(zoom_x2_range, dx, plot_width, final_x2_axis.scale_type)
     } else {
-      zoom_y_range = pan_range(zoom_y_range, y_delta)
-      zoom_y2_range = get_synced_y2(zoom_y_range, pan_range(zoom_y2_range, y2_delta))
+      const dy = evt.deltaY * sensitivity
+      zoom_y_range = pan_range_by_pixels(zoom_y_range, dy, plot_height, final_y_axis.scale_type)
+      zoom_y2_range = get_synced_y2(
+        zoom_y_range,
+        pan_range_by_pixels(zoom_y2_range, dy, plot_height, final_y2_axis.scale_type),
+      )
     }
   }
 
@@ -1612,75 +1371,15 @@
 
     // Calculate pinch scale (curr/start so spread = zoom out, pinch = zoom in)
     const start_dist = Math.hypot(s2.x - s1.x, s2.y - s1.y)
-    // Guard against zero-distance pinch to avoid Infinity scale
-    if (start_dist < Number.EPSILON) return
+    // ignore near-coincident touches so curr_dist / start_dist can't blow up the scale
+    if (start_dist < MIN_TOUCH_DISTANCE_PIXELS) return
     const curr_dist = Math.hypot(t2.clientX - t1.clientX, t2.clientY - t1.clientY)
     const scale = curr_dist / start_dist
 
-    // Clamp to at least 1 to avoid Infinity deltas when padding equals container size
-    const plot_width = Math.max(1, width - pad.l - pad.r)
-    const plot_height = Math.max(1, height - pad.t - pad.b)
-
-    // If scale changed significantly, treat as pinch-zoom
-    // Also guard against scale being too small to avoid division by zero
+    // Pinch zoom about the view center (spread = zoom in, pinch = zoom out)
     if (Math.abs(scale - 1) > PINCH_ZOOM_THRESHOLD && scale > Number.EPSILON) {
-      // Pinch zoom centered on gesture center
-      // Divide by scale so spread (scale > 1) = smaller span (zoom in)
-      const x_span = touch_state.initial_x_range[1] - touch_state.initial_x_range[0]
-      const x2_span = touch_state.initial_x2_range[1] -
-        touch_state.initial_x2_range[0]
-      const y_span = touch_state.initial_y_range[1] - touch_state.initial_y_range[0]
-      const y2_span = touch_state.initial_y2_range[1] -
-        touch_state.initial_y2_range[0]
-      const x_center =
-        (touch_state.initial_x_range[0] + touch_state.initial_x_range[1]) / 2
-      const x2_center =
-        (touch_state.initial_x2_range[0] + touch_state.initial_x2_range[1]) / 2
-      const y_center =
-        (touch_state.initial_y_range[0] + touch_state.initial_y_range[1]) / 2
-      const y2_center =
-        (touch_state.initial_y2_range[0] + touch_state.initial_y2_range[1]) / 2
-
-      zoom_x_range = [x_center - x_span / scale / 2, x_center + x_span / scale / 2]
-      zoom_x2_range = [
-        x2_center - x2_span / scale / 2,
-        x2_center + x2_span / scale / 2,
-      ]
-      zoom_y_range = [y_center - y_span / scale / 2, y_center + y_span / scale / 2]
-      zoom_y2_range = get_synced_y2(zoom_y_range, [
-        y2_center - y2_span / scale / 2,
-        y2_center + y2_span / scale / 2,
-      ])
-    } else {
-      // Pan
-      const x_delta = pixels_to_data_delta(
-        -dx,
-        touch_state.initial_x_range,
-        plot_width,
-      )
-      const x2_delta = pixels_to_data_delta(
-        -dx,
-        touch_state.initial_x2_range,
-        plot_width,
-      )
-      const y_delta = pixels_to_data_delta(
-        dy,
-        touch_state.initial_y_range,
-        plot_height,
-      )
-      const y2_delta = pixels_to_data_delta(
-        dy,
-        touch_state.initial_y2_range,
-        plot_height,
-      )
-      zoom_x_range = pan_range(touch_state.initial_x_range, x_delta)
-      zoom_x2_range = pan_range(touch_state.initial_x2_range, x2_delta)
-      zoom_y_range = pan_range(touch_state.initial_y_range, y_delta)
-      zoom_y2_range = get_synced_y2(
-        zoom_y_range,
-        pan_range(touch_state.initial_y2_range, y2_delta),
-      )
-    }
+      zoom_all_axes(touch_state, scale)
+    } else pan_all_axes(touch_state, -dx, dy)
   }
 
   function handle_touch_end() {
@@ -2084,6 +1783,7 @@
       ontouchstart={handle_touch_start}
       ontouchmove={handle_touch_move}
       ontouchend={handle_touch_end}
+      ontouchcancel={handle_touch_end}
       style:cursor={pan_drag_state
       ? `grabbing`
       : shift_held && pan?.enabled !== false
@@ -2431,45 +2131,12 @@
 
     <!-- Tooltip overlay above all plot overlays (legend, colorbar) -->
     {#if handler_props && hovered && tooltip_point}
-      {@const { color_value, point_label, point_style, series_idx } = tooltip_point}
-      {@const hovered_series = series_with_ids[series_idx]}
-      {@const series_markers = hovered_series?.markers ?? DEFAULT_MARKERS}
-      {@const is_transparent_or_none = (color: string | undefined | null): boolean =>
-      !color ||
-      color === `none` ||
-      color === `transparent` ||
-      /rgba\([^)]+[,/]\s*0(\.0*)?\s*\)$/.test(color)}
-      {@const tooltip_bg_color = (() => {
-      const scale_color = color_value != null
-        ? color_scale_fn(color_value)
-        : undefined
-      if (!is_transparent_or_none(scale_color)) return scale_color
-      const fill_color = point_style?.fill
-      if (!is_transparent_or_none(fill_color)) return fill_color
-      if (series_markers?.includes(`points`)) {
-        const stroke_color = point_style?.stroke
-        if (!is_transparent_or_none(stroke_color)) return stroke_color
-      }
-      if (series_markers?.includes(`line`)) {
-        const line_style = hovered_series?.line_style ?? {}
-        const first_point_style = Array.isArray(hovered_series?.point_style)
-          ? hovered_series?.point_style[0]
-          : hovered_series?.point_style
-        const first_color_value = hovered_series?.color_values?.[0]
-        let line_color_candidate = line_style.stroke
-        if (is_transparent_or_none(line_color_candidate)) {line_color_candidate =
-            first_point_style?.fill}
-        if (
-          is_transparent_or_none(line_color_candidate) && first_color_value != null
-        ) line_color_candidate = color_scale_fn(first_color_value)
-        if (
-          is_transparent_or_none(line_color_candidate) &&
-          series_markers?.includes(`points`)
-        ) line_color_candidate = first_point_style?.stroke
-        if (!is_transparent_or_none(line_color_candidate)) return line_color_candidate
-      }
-      return `rgba(0, 0, 0, 0.7)`
-    })()}
+      {@const { point_label, series_idx } = tooltip_point}
+      {@const tooltip_bg_color = pick_tooltip_bg(
+      tooltip_point,
+      series_with_ids[series_idx],
+      color_scale_fn,
+    )}
       {@const tooltip_pos = constrain_tooltip_position(
       handler_props.cx,
       handler_props.cy,
@@ -2613,24 +2280,9 @@
           null}
         draggable={legend?.draggable ?? true}
         {...legend}
-        on_toggle={legend?.on_toggle ??
-        ((series_idx: number) => {
-          series = toggle_series_visibility(series, series_idx)
-        })}
-        on_double_click={legend?.on_double_click ??
-        ((double_clicked_idx: number) => {
-          const result = handle_legend_double_click(
-            series,
-            double_clicked_idx,
-            prev_series_visibility,
-          )
-          series = result.series
-          prev_series_visibility = result.prev_visibility
-        })}
-        on_group_toggle={legend?.on_group_toggle ??
-        ((_group_name: string, series_indices: number[]) => {
-          series = toggle_group_visibility(series, series_indices)
-        })}
+        on_toggle={legend?.on_toggle ?? legend_vis.on_toggle}
+        on_double_click={legend?.on_double_click ?? legend_vis.on_double_click}
+        on_group_toggle={legend?.on_group_toggle ?? legend_vis.on_group_toggle}
         on_fill_toggle={(source_type: `fill_region` | `error_band`, source_idx: number) => {
           // Only fill_regions can be toggled (error_bands are not bindable)
           if (source_type === `fill_region`) {
@@ -2704,8 +2356,10 @@
     background: var(--scatter-fullscreen-bg, var(--scatter-bg, var(--plot-bg)));
     max-height: none !important;
     overflow: hidden;
-    /* Add padding to prevent titles from being cropped at top */
-    padding-top: var(--plot-fullscreen-padding-top, 2em);
+    /* border-top (not padding-top): bind:clientHeight includes padding but excludes
+    borders - padding made the chart overflow + clip its bottom 2em (x-axis title) */
+    border-top: var(--plot-fullscreen-padding-top, 2em) solid
+      var(--scatter-fullscreen-bg, var(--scatter-bg, var(--plot-bg, transparent)));
     box-sizing: border-box;
   }
   /* Center the colorbar within its wrapper when shorter than it (e.g. capped by --cbar-max-height

--- a/src/lib/plot/scatter/ScatterPlot.svelte
+++ b/src/lib/plot/scatter/ScatterPlot.svelte
@@ -88,7 +88,9 @@
     normalize_y2_sync,
     pan_range_by_pixels,
     PINCH_ZOOM_THRESHOLD,
+    sorted_range,
     sync_y2_range,
+    to_epoch_num,
     zoom_range_by_factor,
   } from '$lib/plot/core/interactions'
   import type { Rect, Sides } from '$lib/plot/core/layout'
@@ -97,6 +99,7 @@
     constrain_tooltip_position,
     filter_padding,
     LABEL_GAP_DEFAULT,
+    y2_axis_label_x,
     measure_full_footprint,
     measure_max_tick_width,
     sample_series_obstacle_points,
@@ -1131,33 +1134,11 @@
       const start_data_y_val = y_scale_fn.invert(drag_start_coords.y)
       const end_data_y_val = y_scale_fn.invert(drag_current_coords.y)
 
-      // Ensure range is not zero and order is correct
-      let x1: number, x2: number
-      if (start_data_x_val instanceof Date && end_data_x_val instanceof Date) {
-        x1 = start_data_x_val.getTime()
-        x2 = end_data_x_val.getTime()
-      } else if (
-        typeof start_data_x_val === `number` &&
-        typeof end_data_x_val === `number`
-      ) {
-        x1 = start_data_x_val
-        x2 = end_data_x_val
-      } else {
-        console.error(`Mismatched types for x-axis zoom calculation`)
-        // Reset states without zooming if types are wrong
-        drag_start_coords = null
-        drag_current_coords = null
-        window.removeEventListener(`mousemove`, on_window_mouse_move)
-        window.removeEventListener(`mouseup`, on_window_mouse_up)
-        return
-      }
-
-      const next_x_range: [number, number] = [Math.min(x1, x2), Math.max(x1, x2)]
+      // Same scale inverts both coords, so both are numbers or both are Dates
+      const [x1, x2] = [to_epoch_num(start_data_x_val), to_epoch_num(end_data_x_val)]
+      const next_x_range = sorted_range(x1, x2)
       // Y axis is always number
-      const next_y_range: [number, number] = [
-        Math.min(start_data_y_val, end_data_y_val),
-        Math.max(start_data_y_val, end_data_y_val),
-      ]
+      const next_y_range = sorted_range(start_data_y_val, end_data_y_val)
 
       // Check for minuscule zoom box (e.g. accidental click)
       const min_zoom_size = 5 // Minimum pixels to trigger zoom
@@ -1176,18 +1157,9 @@
 
         // X2 axis: invert screen coords using x2 scale
         if (x2_points.length > 0) {
-          const start_x2_val = x2_scale_fn.invert(drag_start_coords.x)
-          const end_x2_val = x2_scale_fn.invert(drag_current_coords.x)
-          const x2_a = start_x2_val instanceof Date
-            ? start_x2_val.getTime()
-            : start_x2_val as number
-          const x2_b = end_x2_val instanceof Date
-            ? end_x2_val.getTime()
-            : end_x2_val as number
-          x2_axis = {
-            ...x2_axis,
-            range: [Math.min(x2_a, x2_b), Math.max(x2_a, x2_b)],
-          }
+          const x2_a = to_epoch_num(x2_scale_fn.invert(drag_start_coords.x))
+          const x2_b = to_epoch_num(x2_scale_fn.invert(drag_current_coords.x))
+          x2_axis = { ...x2_axis, range: sorted_range(x2_a, x2_b) }
         }
 
         // Y2 axis: when sync is enabled the y_axis effect derives y2; with sync 'none'
@@ -1195,10 +1167,7 @@
         if (y2_points.length > 0 && y2_sync_config.mode === `none`) {
           const y2_a = y2_scale_fn.invert(drag_start_coords.y)
           const y2_b = y2_scale_fn.invert(drag_current_coords.y)
-          y2_axis = {
-            ...y2_axis,
-            range: [Math.min(y2_a, y2_b), Math.max(y2_a, y2_b)],
-          }
+          y2_axis = { ...y2_axis, range: sorted_range(y2_a, y2_b) }
         }
       }
     }
@@ -1590,7 +1559,6 @@
     return construct_handler_props(tooltip_point)
   })
 
-  let using_controls = $derived(controls.show)
   let has_multiple_series = $derived(series_with_ids.filter(Boolean).length > 1)
 
   // Precompute non-click event names from point_events so we don't rebuild
@@ -1876,9 +1844,6 @@
 
       <!-- Y2-axis (Right) -->
       {#if y2_points.length > 0}
-        {@const y2_inside = final_y2_axis.tick?.label?.inside ?? false}
-        {@const y2_tick_shift = y2_inside ? 0 : (final_y2_axis.tick?.label?.shift?.x ?? 0) + 8}
-        {@const y2_tick_width = y2_inside ? 0 : tick_label_widths.y2_max}
         <PlotAxis
           side="y2"
           ticks={y2_tick_values}
@@ -1892,8 +1857,7 @@
           domain={[y2_min, y2_max]}
           unit_on_first_tick
           tick_label={(tick) => get_tick_label(tick, final_y2_axis.ticks)}
-          label_x={width - pad.r + y2_tick_shift + y2_tick_width + LABEL_GAP_DEFAULT +
-          (final_y2_axis.label_shift?.x ?? 0)}
+          label_x={y2_axis_label_x(final_y2_axis, width, pad.r, tick_label_widths.y2_max)}
           label_y={pad.t + (height - pad.t - pad.b) / 2 + (final_y2_axis.label_shift?.y ?? 0)}
           axis_loading={axis_loading === `y2`}
           on_axis_change={(key) => handle_axis_change(`y2`, key)}
@@ -1985,7 +1949,7 @@
               {@const finite_screen_points = all_line_points
           .map((point) => get_screen_coords(point, series_data))
           .filter(([sx, sy]) => isFinite(sx) && isFinite(sy))}
-              {@const apply_line_controls = using_controls &&
+              {@const apply_line_controls = controls.show &&
           (!has_multiple_series ||
             series_data._id === series_with_ids[selected_series_idx]?._id)}
               {@const ls = series_data.line_style}
@@ -2056,7 +2020,7 @@
                 {@const screen_y = isFinite(raw_screen_y)
           ? raw_screen_y
           : (series_data.y_axis === `y2` ? y2_scale_fn : y_scale_fn).range()[0]}
-                {@const apply_controls = using_controls &&
+                {@const apply_controls = controls.show &&
           (!has_multiple_series ||
             series_data._id === series_with_ids[selected_series_idx]?._id)}
                 {@const pt = point.point_style}

--- a/src/lib/plot/scatter/scatter-data.ts
+++ b/src/lib/plot/scatter/scatter-data.ts
@@ -1,0 +1,287 @@
+// Pure data-transform helpers extracted from ScatterPlot.svelte. Everything here is
+// stateless: component $state/$derived values are passed in as parameters.
+import type { D3SymbolName } from '$lib/labels'
+import { symbol_names } from '$lib/labels'
+import type { Vec2 } from '$lib/math'
+import type { DataSeries, FillRegion, InternalPoint, LegendItem, PointStyle } from '$lib/plot'
+import {
+  get_series_color,
+  get_series_symbol,
+  process_prop,
+} from '$lib/plot/core/data-transform'
+import { is_fill_gradient } from '$lib/plot/core/fill-utils'
+import { DEFAULT_MARKERS } from '$lib/plot/core/types'
+
+const in_range = (val: number | null | undefined, lo: number, hi: number) =>
+  val != null && !isNaN(val) && val >= Math.min(lo, hi) && val <= Math.max(lo, hi)
+
+export interface AxisRanges {
+  x: Vec2
+  x2: Vec2
+  y: Vec2
+  y2: Vec2
+}
+
+// Filter series data to only include points within bounds and augment with internal data.
+// Full x/y arrays are kept on each returned series (via spread) so connecting lines can
+// continue through off-range points; only filtered_data (rendered markers) is range-limited.
+export function filter_series_to_ranges<Metadata = Record<string, unknown>>(
+  series: readonly DataSeries<Metadata>[],
+  ranges: AxisRanges,
+): (DataSeries<Metadata> & { filtered_data: InternalPoint<Metadata>[] })[] {
+  const [x_min, x_max] = ranges.x
+  const [x2_min, x2_max] = ranges.x2
+  const [y_min, y_max] = ranges.y
+  const [y2_min, y2_max] = ranges.y2
+
+  return (
+    series
+      .map((data_series: DataSeries<Metadata>, series_idx): DataSeries<Metadata> => {
+        if (!data_series) {
+          return {
+            x: [],
+            y: [],
+            visible: true,
+            filtered_data: [],
+            _id: series_idx,
+            orig_series_idx: series_idx,
+          }
+        }
+        if (!(data_series.visible ?? true)) {
+          return {
+            ...data_series,
+            visible: false,
+            filtered_data: [],
+            orig_series_idx: series_idx,
+          }
+        }
+
+        const { x: xs, y: ys, color_values, size_values, ...series_rest } = data_series
+        const processed_points: InternalPoint<Metadata>[] = xs.map(
+          (x_val: number, point_idx: number) => ({
+            x: x_val,
+            y: ys[point_idx],
+            color_value: color_values?.[point_idx],
+            metadata: process_prop(series_rest.metadata, point_idx),
+            point_style: process_prop(series_rest.point_style, point_idx),
+            point_hover: process_prop(series_rest.point_hover, point_idx),
+            point_label: process_prop(series_rest.point_label, point_idx),
+            point_offset: process_prop(series_rest.point_offset, point_idx),
+            series_idx,
+            point_idx,
+            size_value: size_values?.[point_idx],
+          }),
+        )
+
+        // Filter to plot bounds using the series' assigned axes (in_range handles
+        // inverted ranges like [3.5, 1.4])
+        const [series_x_min, series_x_max] =
+          (data_series.x_axis ?? `x1`) === `x2` ? [x2_min, x2_max] : [x_min, x_max]
+        const [series_y_min, series_y_max] =
+          (data_series.y_axis ?? `y1`) === `y2` ? [y2_min, y2_max] : [y_min, y_max]
+        const filtered_data = processed_points.filter(
+          ({ x, y }) =>
+            in_range(x, series_x_min, series_x_max) && in_range(y, series_y_min, series_y_max),
+        )
+
+        // orig_series_idx keeps auto-cycled colors/symbols stable across filtering
+        return { ...data_series, visible: true, filtered_data, orig_series_idx: series_idx }
+      })
+      // Drop series left completely empty after point filtering
+      .filter(
+        (srs): srs is DataSeries<Metadata> & { filtered_data: InternalPoint<Metadata>[] } =>
+          (srs.filtered_data?.length ?? 0) > 0,
+      )
+  )
+}
+
+// Display style attached to each legend item (matches PlotLegend expectations)
+type LegendDisplayStyle = {
+  symbol_type?: D3SymbolName
+  symbol_color?: string
+  line_color?: string
+  line_dash?: string
+}
+
+// Minimal shape of a computed fill region needed for legend entries
+export type LegendFill = FillRegion & {
+  idx: number
+  source_type: `fill_region` | `error_band`
+  source_idx: number
+}
+
+export type ScatterLegendItem = LegendItem & { has_explicit_label?: boolean }
+
+// Prepare legend items from series + computed fill regions, deduplicated by
+// legend_group::label (first occurrence wins across both series and fills)
+export function build_legend_data<Metadata = Record<string, unknown>>(
+  series: readonly DataSeries<Metadata>[],
+  computed_fills: readonly LegendFill[],
+  color_scale_fn: (value: number) => string,
+): ScatterLegendItem[] {
+  const items = series.map((data_series: DataSeries<Metadata>, series_idx: number) => {
+    // Prefer top-level label, fall back to metadata label, then a generated default
+    const explicit_label =
+      data_series?.label ??
+      (typeof data_series?.metadata === `object` &&
+      data_series.metadata !== null &&
+      `label` in data_series.metadata &&
+      typeof data_series.metadata.label === `string`
+        ? data_series.metadata.label
+        : null)
+
+    // Series-index defaults give auto-cycled colors/symbols
+    const series_default_color = get_series_color(series_idx)
+    const display_style: LegendDisplayStyle = {
+      symbol_type: get_series_symbol(series_idx),
+      symbol_color: series_default_color,
+      line_color: series_default_color,
+    }
+    const series_markers = data_series?.markers ?? DEFAULT_MARKERS
+    const first_point_style = Array.isArray(data_series?.point_style)
+      ? data_series.point_style[0]
+      : data_series?.point_style
+
+    if (series_markers?.includes(`points`)) {
+      if (first_point_style) {
+        if (
+          typeof first_point_style.symbol_type === `string` &&
+          symbol_names.includes(first_point_style.symbol_type)
+        ) {
+          display_style.symbol_type = first_point_style.symbol_type
+        }
+        if (first_point_style.fill) display_style.symbol_color = first_point_style.fill
+        // Fall back to stroke when the fill is missing/none/transparent
+        if (
+          first_point_style.stroke &&
+          (!display_style.symbol_color ||
+            display_style.symbol_color === `none` ||
+            display_style.symbol_color.startsWith(`rgba(`, 0))
+        ) {
+          display_style.symbol_color = first_point_style.stroke
+        }
+      }
+    } else {
+      // No points marker: no symbol swatch in the legend
+      display_style.symbol_type = undefined
+      display_style.symbol_color = undefined
+    }
+
+    if (series_markers?.includes(`line`)) {
+      // Explicit line stroke, then color scale, then point colors, then series default
+      let line_color = data_series?.line_style?.stroke
+      if (!line_color) {
+        const first_cv = Array.isArray(data_series?.color_values)
+          ? data_series?.color_values?.find((color_val: number | null) => color_val != null)
+          : undefined
+        /* oxlint-disable @typescript-eslint/prefer-nullish-coalescing -- empty-string colors should fall through */
+        line_color =
+          (first_cv != null ? color_scale_fn(first_cv) : undefined) ||
+          first_point_style?.fill ||
+          first_point_style?.stroke ||
+          series_default_color
+        /* oxlint-enable @typescript-eslint/prefer-nullish-coalescing */
+      }
+      display_style.line_color = line_color
+      display_style.line_dash = data_series?.line_style?.line_dash
+    } else {
+      // No line marker: no line swatch in the legend
+      display_style.line_dash = undefined
+      display_style.line_color = undefined
+    }
+
+    return {
+      series_idx,
+      label: explicit_label ?? `Series ${series_idx + 1}`,
+      visible: data_series?.visible ?? true,
+      display_style,
+      has_explicit_label: explicit_label != null,
+      legend_group: data_series?.legend_group,
+    }
+  })
+
+  // Deduplicate by legend_group::label (first occurrence wins, across series + fills)
+  const seen_labels = new Set<string>()
+  const first_seen = (group: string | undefined, label: string | undefined) => {
+    const key = `${group ?? ``}::${label ?? ``}`
+    if (seen_labels.has(key)) return false
+    seen_labels.add(key)
+    return true
+  }
+  const series_items = items.filter((item) => first_seen(item.legend_group, item.label))
+
+  const fill_items = computed_fills
+    .filter((fill) => fill.show_in_legend !== false && fill.label)
+    .filter((fill) => first_seen(fill.legend_group, fill.label))
+    .map((fill) => {
+      // Pass gradient for swatch rendering, or solid color as fallback
+      const fill_gradient = is_fill_gradient(fill.fill) ? fill.fill : undefined
+      const fill_color = typeof fill.fill === `string` ? fill.fill : undefined
+
+      return {
+        series_idx: -1, // Not a series
+        fill_idx: fill.idx,
+        fill_source_type: fill.source_type,
+        fill_source_idx: fill.source_idx,
+        item_type: `fill` as const,
+        label: fill.label ?? ``,
+        visible: fill.visible !== false,
+        legend_group: fill.legend_group,
+        display_style: {
+          fill_color,
+          fill_opacity: fill.fill_opacity ?? 0.3,
+          edge_color: fill.edge_upper?.color,
+          fill_gradient,
+        },
+      }
+    })
+
+  return [...series_items, ...fill_items]
+}
+
+const is_transparent_or_none = (color: string | undefined | null): boolean =>
+  !color ||
+  color === `none` ||
+  color === `transparent` ||
+  /rgba\([^)]+[,/]\s*0(\.0*)?\s*\)$/.test(color)
+
+// Type-guard negation of is_transparent_or_none so usable colors narrow to string
+const is_opaque_color = (color: string | undefined | null): color is string =>
+  !is_transparent_or_none(color)
+
+// Resolve tooltip background color: point color-scale value, then point fill, then point
+// stroke (points marker), then line color cascade (line marker), then dark fallback
+export function pick_tooltip_bg<Metadata = Record<string, unknown>>(
+  point: { color_value?: number | null; point_style?: PointStyle },
+  series: DataSeries<Metadata> | undefined,
+  color_scale_fn: (value: number) => string,
+): string {
+  const { color_value, point_style } = point
+  const series_markers = series?.markers ?? DEFAULT_MARKERS
+
+  const scale_color = color_value != null ? color_scale_fn(color_value) : undefined
+  if (is_opaque_color(scale_color)) return scale_color
+  const fill_color = point_style?.fill
+  if (is_opaque_color(fill_color)) return fill_color
+  if (series_markers?.includes(`points`)) {
+    const stroke_color = point_style?.stroke
+    if (is_opaque_color(stroke_color)) return stroke_color
+  }
+  if (series_markers?.includes(`line`)) {
+    const line_style = series?.line_style ?? {}
+    const first_point_style = Array.isArray(series?.point_style)
+      ? series?.point_style[0]
+      : series?.point_style
+    const first_color_value = series?.color_values?.[0]
+    let line_color_candidate = line_style.stroke
+    if (is_transparent_or_none(line_color_candidate)) {
+      line_color_candidate = first_point_style?.fill
+    }
+    if (is_transparent_or_none(line_color_candidate) && first_color_value != null)
+      line_color_candidate = color_scale_fn(first_color_value)
+    if (is_transparent_or_none(line_color_candidate) && series_markers?.includes(`points`))
+      line_color_candidate = first_point_style?.stroke
+    if (is_opaque_color(line_color_candidate)) return line_color_candidate
+  }
+  return `rgba(0, 0, 0, 0.7)`
+}

--- a/src/lib/plot/scatter/scatter-data.ts
+++ b/src/lib/plot/scatter/scatter-data.ts
@@ -2,7 +2,6 @@
 // stateless: component $state/$derived values are passed in as parameters.
 import type { D3SymbolName } from '$lib/labels'
 import { symbol_names } from '$lib/labels'
-import type { Vec2 } from '$lib/math'
 import type { DataSeries, FillRegion, InternalPoint, LegendItem, PointStyle } from '$lib/plot'
 import {
   get_series_color,
@@ -10,17 +9,12 @@ import {
   process_prop,
 } from '$lib/plot/core/data-transform'
 import { is_fill_gradient } from '$lib/plot/core/fill-utils'
-import { DEFAULT_MARKERS } from '$lib/plot/core/types'
+import { type AxisRanges, DEFAULT_MARKERS } from '$lib/plot/core/types'
+
+export type { AxisRanges }
 
 const in_range = (val: number | null | undefined, lo: number, hi: number) =>
   val != null && !isNaN(val) && val >= Math.min(lo, hi) && val <= Math.max(lo, hi)
-
-export interface AxisRanges {
-  x: Vec2
-  x2: Vec2
-  y: Vec2
-  y2: Vec2
-}
 
 // Filter series data to only include points within bounds and augment with internal data.
 // Full x/y arrays are kept on each returned series (via spread) so connecting lines can

--- a/src/lib/plot/sunburst/Sunburst.svelte
+++ b/src/lib/plot/sunburst/Sunburst.svelte
@@ -32,6 +32,7 @@
   import { create_color_scale } from '$lib/plot/core/scales'
   import {
     arc_label_transform,
+    arrow_nav_target,
     project_arcs,
     type ScreenArc as ScreenArcOf,
   } from '$lib/plot/sunburst/render'
@@ -480,50 +481,24 @@
   }
 
   // Arrow-key navigation: left/right cycle through visible siblings (wrapping),
-  // down enters the first child, up returns to the parent
-  function arrow_nav_target(event: KeyboardEvent): number | null {
-    if (![`ArrowRight`, `ArrowLeft`, `ArrowUp`, `ArrowDown`].includes(event.key)) {
-      return null
-    }
+  // down enters the first child, up returns to the parent. The pre-order walk
+  // lives in render.ts (arrow_nav_target); this wrapper supplies the event's arc
+  // and the current screen-space visibility.
+  const nav_target_from_event = (event: KeyboardEvent): number | null => {
     const cur = screen_arc_from_event(event)?.arc
     if (!cur) return null
-    if (event.key === `ArrowDown`) {
-      // pre-order: a branch's first child directly follows it
-      const child = layout.arcs[cur.node_idx + 1]
-      return child && child.parent_idx === cur.node_idx &&
-          screen_arcs[child.node_idx]?.visible
-        ? child.node_idx
-        : null
-    }
-    if (event.key === `ArrowUp`) {
-      const parent = parent_of(cur)
-      return parent && parent.depth > 0 && screen_arcs[parent.node_idx]?.visible
-        ? parent.node_idx
-        : null
-    }
-    // Walk siblings via the contiguous pre-order subtree ranges (each sibling starts
-    // right after the previous one's subtree ends) - pre-order also matches angular
-    // order, so no sorting needed and no full-arcs scan per keypress
-    const parent = parent_of(cur)
-    const last = parent?.subtree_end ?? layout.arcs.length - 1
-    const siblings: number[] = []
-    for (
-      let idx = (parent?.node_idx ?? 0) + 1;
-      idx <= last;
-      idx = layout.arcs[idx].subtree_end + 1
-    ) {
-      if (screen_arcs[idx]?.visible) siblings.push(idx)
-    }
-    if (siblings.length < 2) return null
-    const pos = siblings.indexOf(cur.node_idx)
-    const step = event.key === `ArrowRight` ? 1 : -1
-    return siblings[(pos + step + siblings.length) % siblings.length]
+    return arrow_nav_target(
+      layout.arcs,
+      (idx) => screen_arcs[idx]?.visible ?? false,
+      cur.node_idx,
+      event.key,
+    )
   }
 
   const is_activation_key = (evt: KeyboardEvent) => [`Enter`, ` `].includes(evt.key)
 
   function handle_arc_keydown(event: KeyboardEvent) {
-    const nav_target = arrow_nav_target(event)
+    const nav_target = nav_target_from_event(event)
     if (nav_target != null) {
       event.preventDefault()
       focus_arc(nav_target)
@@ -971,7 +946,10 @@
     background: var(--sunburst-fullscreen-bg, var(--sunburst-bg, var(--plot-bg)));
     max-height: none !important;
     overflow: hidden;
-    padding-top: var(--plot-fullscreen-padding-top, 2em);
+    /* border-top (not padding-top): bind:clientHeight includes padding but excludes
+    borders - padding made the chart overflow + clip its bottom 2em (x-axis title) */
+    border-top: var(--plot-fullscreen-padding-top, 2em) solid
+      var(--sunburst-fullscreen-bg, var(--sunburst-bg, var(--plot-bg, transparent)));
     box-sizing: border-box;
   }
   .header-controls {

--- a/src/lib/plot/sunburst/Sunburst.svelte
+++ b/src/lib/plot/sunburst/Sunburst.svelte
@@ -24,7 +24,6 @@
   import { closest_data_idx, get_relative_coords } from '$lib/plot/core/interactions'
   import {
     compute_element_placement,
-    constrain_tooltip_position,
     filter_padding,
     measure_text_width,
   } from '$lib/plot/core/layout'
@@ -156,7 +155,6 @@
   let wrapper: HTMLDivElement | undefined = $state()
   let svg_element: SVGSVGElement | null = $state(null)
   let center_el: SVGCircleElement | null = $state(null)
-  let tooltip_el = $state<HTMLDivElement | undefined>()
 
   let hovered_idx = $state<number | null>(null)
   let hover_info = $state<SunburstNodeHandlerProps<Metadata> | null>(null)
@@ -852,21 +850,13 @@
   {/if}
 
   {#if hover_info}
-    {@const tip = constrain_tooltip_position(
-      hover_pos.x,
-      hover_pos.y,
-      tooltip_el?.offsetWidth ?? 140,
-      tooltip_el?.offsetHeight ?? 44,
-      width,
-      height,
-      { offset_x: 10, offset_y: 5 },
-    )}
     <PlotTooltip
-      x={tip.x}
-      y={tip.y}
-      offset={{ x: 0, y: 0 }}
+      x={hover_pos.x}
+      y={hover_pos.y}
+      offset={{ x: 10, y: 5 }}
+      constrain_to={{ width, height }}
+      fallback_size={{ width: 140, height: 44 }}
       bg_color={hover_info.color}
-      bind:wrapper={tooltip_el}
     >
       {#if tooltip}
         {@render tooltip(hover_info)}

--- a/src/lib/plot/sunburst/Sunburst.svelte
+++ b/src/lib/plot/sunburst/Sunburst.svelte
@@ -202,12 +202,16 @@
 
   // Drop muted ids that no longer exist when data changes (untrack avoids a
   // self-trigger loop from reading/writing muted_ids in the same effect).
+  // Hover/focus state is index-based, so a layout swap would otherwise leave a stale
+  // tooltip and highlight whatever unrelated node now occupies the old index.
   $effect(() => {
     const valid = new Set(
       layout.arcs.filter((arc) => arc.depth === 1).map((arc) => arc.id),
     )
     untrack(() => {
       for (const id of muted_ids) if (!valid.has(id)) muted_ids.delete(id)
+      set_arc_hover(null)
+      focused_idx = null
     })
   })
 
@@ -225,12 +229,14 @@
 
   // Zooming tweens this single object; all arc geometry re-derives from view.current
   // each frame via clamping scales (the classic zoomable-sunburst trick - no per-arc
-  // tweens, no re-layout). Initialized at the target so charts load fully drawn.
-  const view = new Tween(
-    untrack(() => view_target),
+  // tweens, no re-layout). Tween.of seeds it at view_target (charts load fully drawn)
+  // then re-targets on change via a render-effect that reads only view_target, never
+  // view.current - so the tween can't feed back into its own target. untrack reads the
+  // tween options once at init (they're not meant to update reactively).
+  const view = Tween.of(
+    () => view_target,
     untrack(() => ({ duration: 400, easing: cubicInOut, ...tween })),
   )
-  $effect(() => void view.set(view_target))
 
   // Pixel geometry
   let radius = $derived(Math.max(0, Math.min(inner_width, inner_height) / 2))
@@ -333,8 +339,9 @@
   const is_muted = (arc: PositionedArc<Metadata>): boolean =>
     arc.path.length > 0 && muted_ids.has(arc.path[0])
 
+  const MUTED_OPACITY = 0.12
   const arc_opacity = (arc: PositionedArc<Metadata>): number => {
-    if (is_muted(arc)) return 0.12
+    if (is_muted(arc)) return MUTED_OPACITY
     if (active && !active(arc)) return 0.3
     return 1
   }
@@ -382,8 +389,10 @@
     event?: MouseEvent | FocusEvent,
   ) {
     // Same arc as before: only the cursor anchor moves - skip rebuilding the handler
-    // payload and re-firing change/on_node_hover on every mousemove within an arc
-    if (screen && screen.arc.node_idx === hovered_idx) {
+    // payload and re-firing change/on_node_hover on every mousemove within an arc.
+    // Requires hover_info: legend item hover sets hovered_idx alone (for dimming), and
+    // skipping then would leave the arc's own tooltip permanently suppressed.
+    if (screen && screen.arc.node_idx === hovered_idx && hover_info) {
       hover_pos = event_pos(event) ?? hover_pos
       return
     }
@@ -395,6 +404,9 @@
       change(hover_info)
       if (event) on_node_hover?.({ ...hover_info, event })
     } else {
+      // Already clear: don't re-fire change(null)/on_node_hover(null) - both the svg
+      // and chart group have mouseleave handlers, and zoom_to clears unconditionally
+      if (hovered_idx == null && hover_info == null) return
       hovered = false
       hovered_idx = null
       hover_info = null
@@ -450,9 +462,13 @@
   }
 
   // Double-clicking empty chart background resets the zoom to the root (double-
-  // clicking an arc or label is click-to-zoom/text-selection territory, not a reset)
+  // clicking an arc or label is click-to-zoom/text-selection territory, not a reset;
+  // the center zoom-out button already fired its own click action twice - compounding
+  // a third full reset would teleport step-by-step zoom-outs straight to the root)
   function handle_dblclick(event: MouseEvent) {
     if (screen_arc_from_event(event) || selection_in_chart()) return
+    const target = event.target as Element | null
+    if (target?.closest?.(`.center-circle, .center-label`)) return
     if (zoomed) zoom_to(null)
   }
 
@@ -518,12 +534,14 @@
     const prev_root = zoom_root_id
     handle_arc_click(event)
     // Zooming via keyboard unmounts the focused arc - move focus to the center circle
-    // (the zoom-out button; first arc of the new view in icicle mode) so keyboard
-    // users stay inside the chart
+    // (the zoom-out button) so keyboard users stay inside the chart. In icicle mode
+    // focus the new root's first child (pre-order: node_idx + 1): the clicked arc
+    // itself collapses to zero height once the zoom tween settles, so focusing it
+    // (the roving index) would drop focus to <body> mid-animation.
     if (zoom_root_id !== prev_root) {
       tick().then(() => {
         if (shape === `sunburst`) center_el?.focus()
-        else focus_arc(roving_idx)
+        else focus_arc(zoom_root ? zoom_root.node_idx + 1 : roving_idx)
       })
     }
   }
@@ -807,6 +825,7 @@
                   data-sunburst-node-idx={screen.arc.node_idx}
                   transform={lbl.transform}
                   fill={label_color(screen.arc)}
+                  fill-opacity={is_muted(screen.arc) ? MUTED_OPACITY : undefined}
                   style:cursor={arc_clickable(screen.arc) ? `pointer` : `text`}
                 >
                   {lbl.text}
@@ -1025,7 +1044,7 @@
     /* stroke via CSS (not presentation attributes): var() substitution in SVG
     presentation attributes is not reliably supported across browsers */
     stroke: var(--sunburst-arc-stroke, var(--plot-bg, white));
-    stroke-width: var(--sunburst-arc-stroke-width, 0.5);
+    stroke-width: var(--sunburst-arc-stroke-width, 0.25);
     transition: fill-opacity 0.15s ease, transform 0.15s ease;
     /* hover 'pull': scaling about the chart center offsets the arc radially */
     transform-origin: 0 0;

--- a/src/lib/plot/sunburst/render.ts
+++ b/src/lib/plot/sunburst/render.ts
@@ -4,8 +4,11 @@
 // Sunburst.svelte wires them to reactive state and the DOM.
 
 import { to_degrees } from '$lib/math'
-import type { SunburstLabelRotation, SunburstShape } from '$lib/plot/core/types'
-import type { PositionedArc } from '$lib/plot/sunburst/sunburst'
+import type {
+  PositionedArc,
+  SunburstLabelRotation,
+  SunburstShape,
+} from '$lib/plot/sunburst/sunburst'
 
 const TWO_PI = 2 * Math.PI
 
@@ -76,6 +79,45 @@ export function project_arcs<Metadata>(
     if (screen.visible) visible.push(screen)
   }
   return { all, visible }
+}
+
+// Arrow-key navigation over the pre-order arc array: ArrowLeft/ArrowRight cycle
+// through visible siblings (wrapping), ArrowDown enters the first child, ArrowUp
+// returns to the parent (never the hidden root at depth 0). Visibility is delegated
+// to is_visible (the component supplies screen-space collapse state). Returns the
+// target node_idx, or null when the key isn't an arrow key or no target qualifies.
+export function arrow_nav_target<Metadata>(
+  arcs: readonly PositionedArc<Metadata>[],
+  is_visible: (idx: number) => boolean,
+  current_idx: number,
+  key: string,
+): number | null {
+  if (![`ArrowRight`, `ArrowLeft`, `ArrowUp`, `ArrowDown`].includes(key)) return null
+  const cur = arcs[current_idx]
+  if (!cur) return null
+  if (key === `ArrowDown`) {
+    // pre-order: a branch's first child directly follows it
+    const child = arcs[cur.node_idx + 1]
+    return child && child.parent_idx === cur.node_idx && is_visible(child.node_idx)
+      ? child.node_idx
+      : null
+  }
+  const parent = cur.parent_idx != null ? arcs[cur.parent_idx] : null
+  if (key === `ArrowUp`) {
+    return parent && parent.depth > 0 && is_visible(parent.node_idx) ? parent.node_idx : null
+  }
+  // Walk siblings via the contiguous pre-order subtree ranges (each sibling starts
+  // right after the previous one's subtree ends) - pre-order also matches angular
+  // order, so no sorting needed and no full-arcs scan per keypress
+  const last = parent?.subtree_end ?? arcs.length - 1
+  const siblings: number[] = []
+  for (let idx = (parent?.node_idx ?? 0) + 1; idx <= last; idx = arcs[idx].subtree_end + 1) {
+    if (is_visible(idx)) siblings.push(idx)
+  }
+  if (siblings.length < 2) return null
+  const pos = siblings.indexOf(cur.node_idx)
+  const step = key === `ArrowRight` ? 1 : -1
+  return siblings[(pos + step + siblings.length) % siblings.length]
 }
 
 // Arc label placement: fit the text radially or tangentially (whichever has more room

--- a/src/lib/plot/sunburst/sunburst.ts
+++ b/src/lib/plot/sunburst/sunburst.ts
@@ -8,8 +8,42 @@
 import { hsl } from 'd3-color'
 import type { HierarchyRectangularNode } from 'd3-hierarchy'
 import { hierarchy, partition } from 'd3-hierarchy'
-import type { SunburstNode, SunburstSort, SunburstValueMode } from '$lib/plot/core/types'
 import { DEFAULT_SERIES_COLORS } from '$lib/plot/core/types'
+
+// === Sunburst chart types ===
+// How node values are interpreted (plotly `branchvalues` semantics):
+// 'leaf-sum'  - parent values ignored, computed as sum of leaf values (d3 .sum default)
+// 'total'     - every node's value is authoritative; children should sum <= parent
+//               (plotly branchvalues='total'; a shortfall leaves an angular gap)
+// 'remainder' - a node's own value is added on top of its children's sum
+export type SunburstValueMode = `leaf-sum` | `total` | `remainder`
+// Arc label orientation: 'auto' picks radial/tangential per arc based on available space
+export type SunburstLabelRotation = `auto` | `radial` | `tangential` | `horizontal`
+// Sibling ordering: 'none' preserves input order (e.g. spacegroup number order)
+export type SunburstSort = `descending` | `ascending` | `none`
+// What arc labels display (plotly textinfo equivalent); percent is of the root total
+export type SunburstLabelText = `label` | `value` | `percent` | `label+value` | `label+percent`
+// Chart geometry: polar rings (sunburst) or stacked horizontal rows (icicle)
+export type SunburstShape = `sunburst` | `icicle`
+
+export interface SunburstNode<Metadata = Record<string, unknown>> {
+  id?: string | number // stable id (defaults to slash-joined label path, e.g. "cubic/Fm-3m")
+  label?: string
+  value?: number // required on leaves ('leaf-sum') / authoritative on all nodes ('total')
+  color?: string // explicit color, inherited by descendants without their own
+  children?: SunburstNode<Metadata>[]
+  metadata?: Metadata
+}
+
+// Event payload for hover/click/zoom callbacks: a PositionedArc minus its geometry
+// (screen coords are an implementation detail), plus the resolved parent id
+export interface SunburstNodeHandlerProps<Metadata = Record<string, unknown>> extends Omit<
+  PositionedArc<Metadata>,
+  `x0` | `x1` | `y0` | `y1` | `subtree_end` | `parent_idx`
+> {
+  type: `node`
+  parent_id: string | number | null
+}
 
 // An arc after layout, in normalized partition coordinates (pixel mapping at render)
 export interface PositionedArc<Metadata = Record<string, unknown>> {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1087,7 +1087,7 @@ export const SETTINGS_CONFIG: SettingsConfig = {
         maximum: 1,
       },
       stroke_width: {
-        value: 1.5,
+        value: 0.5,
         description: `Box outline width`,
         minimum: 0,
         maximum: 5,
@@ -1105,7 +1105,7 @@ export const SETTINGS_CONFIG: SettingsConfig = {
     },
     whisker: {
       width: {
-        value: 1.5,
+        value: 1,
         description: `Whisker line width`,
         minimum: 0.5,
         maximum: 5,
@@ -1123,7 +1123,7 @@ export const SETTINGS_CONFIG: SettingsConfig = {
     },
     median: {
       width: {
-        value: 2,
+        value: 1.5,
         description: `Median line width`,
         minimum: 0.5,
         maximum: 6,
@@ -1237,7 +1237,7 @@ export const SETTINGS_CONFIG: SettingsConfig = {
       maximum: 0.8,
     },
     pad_angle: {
-      value: 0.2,
+      value: 0.1,
       description: `Angular gap in degrees between sibling arcs`,
       minimum: 0,
       maximum: 4,

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -344,19 +344,28 @@
   // Prevent circular updates when syncing legend toggles back to bindable visible_properties.
   let syncing_visible_properties = false
 
-  // Regenerate plot series when trajectory, config, or visible_properties change
+  // Regenerate plot series when trajectory, config, or visible_properties change.
+  // Read ALL reactive deps before the syncing guard can return: a guarded run that
+  // reads no dependencies leaves the effect dep-less, and Svelte permanently unlinks
+  // dep-less effects - trajectory changes would then never regenerate the plot.
   $effect(() => {
+    const [traj, extractor, config, keys] = [
+      trajectory,
+      data_extractor,
+      extended_config,
+      visible_properties,
+    ]
     if (syncing_visible_properties) return
-    const keys_set = visible_properties ? new Set(visible_properties) : undefined
+    const keys_set = keys ? new Set(keys) : undefined
 
-    if (trajectory?.plot_metadata) {
-      plot_series = generate_streaming_plot_series(trajectory.plot_metadata, {
-        property_config: extended_config,
+    if (traj?.plot_metadata) {
+      plot_series = generate_streaming_plot_series(traj.plot_metadata, {
+        property_config: config,
         default_visible_properties: keys_set,
       })
-    } else if (trajectory) {
-      plot_series = generate_plot_series(trajectory, data_extractor, {
-        property_config: extended_config,
+    } else if (traj) {
+      plot_series = generate_plot_series(traj, extractor, {
+        property_config: config,
         default_visible_properties: keys_set,
       })
     } else {

--- a/tests/vitest/convex-hull/thermodynamics.test.ts
+++ b/tests/vitest/convex-hull/thermodynamics.test.ts
@@ -215,11 +215,7 @@ describe(`3D Convex Hull`, () => {
         { x: 0, y: 0, z: 0 },
         { x: 1, y: 0, z: 0 },
         { x: 0, y: 1, z: 0 },
-        {
-          x: 1,
-          y: 1,
-          z: 0,
-        },
+        { x: 1, y: 1, z: 0 },
       ],
       `coplanar`,
     ],

--- a/tests/vitest/phase-diagram/IsobaricBinaryPhaseDiagram.test.ts
+++ b/tests/vitest/phase-diagram/IsobaricBinaryPhaseDiagram.test.ts
@@ -1,232 +1,287 @@
 import { format_hover_info_text, IsobaricBinaryPhaseDiagram } from '$lib/phase-diagram'
 import type { LeverRuleResult, PhaseDiagramData } from '$lib/phase-diagram/types'
-import { mount } from 'svelte'
-import { describe, expect, test } from 'vitest'
+import { mount, tick } from 'svelte'
+import { describe, expect, test, vi } from 'vitest'
 import { resize_element } from '../setup'
 import { create_hover_info } from './fixtures/test-data'
 
-describe(`IsobaricBinaryPhaseDiagram`, () => {
-  // gradient ids derive from user region ids ('alpha + beta' etc.) - two diagrams on
-  // one page would otherwise cross-reference each other's gradients (first id wins,
-  // with that instance's userSpaceOnUse pixel coords)
-  test(`multi-phase gradient ids are unique per instance`, async () => {
-    const data: PhaseDiagramData = {
-      components: [`Al`, `Cu`],
-      temperature_range: [300, 1000],
-      regions: [
-        {
-          id: `ab`,
-          name: `α + β`, // 2+ phases -> gradient fill
-          vertices: [
-            [0, 300],
-            [1, 300],
-            [1, 1000],
-            [0, 1000],
-          ],
-        },
+// Simple eutectic-style system: Liquid on top, two-phase field below. With a 500x400
+// mount and default margins (l=60 r=25 t=25 b=50) the plot area spans x: [60, 475],
+// y: [25, 350]; to_client converts (composition, temperature) -> client coords.
+const eutectic: PhaseDiagramData = {
+  components: [`Al`, `Cu`],
+  temperature_range: [0, 1000],
+  regions: [
+    {
+      id: `liq`,
+      name: `Liquid`,
+      vertices: [
+        [0, 500],
+        [1, 500],
+        [1, 1000],
+        [0, 1000],
       ],
-      boundaries: [],
-    }
-    for (let idx = 0; idx < 2; idx++) {
-      const target = document.createElement(`div`)
-      document.body.append(target)
-      mount(IsobaricBinaryPhaseDiagram, {
-        target,
-        props: { data, style: `width: 500px; height: 400px;` },
-      })
-      const wrapper = target.querySelector<HTMLElement>(`.binary-phase-diagram`)
-      if (!wrapper) throw new Error(`phase diagram root not found`)
-      await resize_element(wrapper, 500, 400)
-    }
-    const ids = [...document.querySelectorAll(`linearGradient`)].map((el) => el.id)
-    expect(ids).toHaveLength(2)
-    expect(new Set(ids).size).toBe(2)
-    // each region path must reference its own instance's gradient
-    const fills = [...document.querySelectorAll(`.phase-regions path`)].map((el) =>
-      el.getAttribute(`fill`),
+    },
+    {
+      id: `ab`,
+      name: `α + β`, // 2+ phases -> gradient fill + lever rule
+      vertices: [
+        [0, 0],
+        [1, 0],
+        [1, 500],
+        [0, 500],
+      ],
+    },
+  ],
+  boundaries: [
+    {
+      id: `eut-line`,
+      type: `eutectic`,
+      points: [
+        [0, 500],
+        [1, 500],
+      ],
+    },
+  ],
+  special_points: [{ id: `eut`, type: `eutectic`, position: [0.5, 500], label: `E` }],
+}
+
+const [width, height] = [500, 400]
+const [left, right, top, bottom] = [60, 475, 25, 350] // from default margins
+const to_client = (composition: number, temperature: number) => ({
+  clientX: left + composition * (right - left),
+  clientY: bottom - (temperature / 1000) * (bottom - top),
+})
+
+async function mount_diagram(props: Record<string, unknown> = {}): Promise<HTMLElement> {
+  const target = document.createElement(`div`)
+  document.body.append(target)
+  mount(IsobaricBinaryPhaseDiagram, {
+    target,
+    props: { data: eutectic, style: `width: ${width}px; height: ${height}px;`, ...props },
+  })
+  const wrapper = target.querySelector<HTMLElement>(`.binary-phase-diagram`)
+  if (!wrapper) throw new Error(`phase diagram root not found`)
+  await resize_element(wrapper, width, height)
+  return wrapper
+}
+
+const diagram_svg = (wrapper: HTMLElement): SVGElement => {
+  const svg = wrapper.querySelector<SVGElement>(`svg[role="application"]`)
+  if (!svg) throw new Error(`diagram svg not found`)
+  return svg
+}
+
+const hover_at = async (
+  wrapper: HTMLElement,
+  composition: number,
+  temperature: number,
+): Promise<SVGElement> => {
+  const svg = diagram_svg(wrapper)
+  svg.dispatchEvent(
+    new PointerEvent(`pointermove`, { ...to_client(composition, temperature), bubbles: true }),
+  )
+  await tick()
+  return svg
+}
+
+describe(`IsobaricBinaryPhaseDiagram`, () => {
+  test(`renders regions, boundaries, labels, special points and axes`, async () => {
+    const wrapper = await mount_diagram()
+    expect(wrapper.querySelectorAll(`.phase-regions path`)).toHaveLength(2)
+    expect(wrapper.querySelectorAll(`.boundaries path`)).toHaveLength(1)
+    const labels = wrapper.querySelector(`.region-labels`)?.textContent ?? ``
+    expect(labels).toContain(`Liquid`)
+    expect(labels).toContain(`α`)
+    expect(wrapper.querySelectorAll(`.special-point-marker`)).toHaveLength(1)
+    expect(wrapper.querySelector(`.special-points`)?.textContent).toContain(`E`)
+    expect(wrapper.querySelector(`.x-axis`)?.textContent).toContain(`Cu (at%)`)
+    expect(wrapper.querySelector(`.y-axis`)?.textContent).toContain(`Temperature (K)`)
+  })
+
+  test(`hover reports phase info, shows the tooltip, and clears on leave`, async () => {
+    const on_phase_hover = vi.fn()
+    const wrapper = await mount_diagram({ on_phase_hover })
+    await hover_at(wrapper, 0.5, 750) // inside Liquid
+    const info = on_phase_hover.mock.lastCall?.[0]
+    expect(info?.region?.id).toBe(`liq`)
+    expect(info?.composition).toBeCloseTo(0.5, 9)
+    expect(info?.temperature).toBeCloseTo(750, 9)
+    expect(wrapper.querySelector(`.tooltip-container`)?.textContent).toContain(`Liquid`)
+
+    // outside the plot area (left of the y-axis) -> hover cleared
+    diagram_svg(wrapper).dispatchEvent(
+      new PointerEvent(`pointermove`, { clientX: 10, clientY: 100, bubbles: true }),
     )
+    await tick()
+    expect(on_phase_hover).toHaveBeenLastCalledWith(null)
+    expect(wrapper.querySelector(`.tooltip-container`)).toBeNull()
+  })
+
+  test(`two-phase hover computes the lever rule and draws the tie-line`, async () => {
+    const on_phase_hover = vi.fn()
+    const wrapper = await mount_diagram({ on_phase_hover })
+    await hover_at(wrapper, 0.25, 250) // inside the α + β field spanning x: [0, 1]
+    const lever_rule = on_phase_hover.mock.lastCall?.[0]?.lever_rule as LeverRuleResult
+    expect(lever_rule).toMatchObject({ left_phase: `α`, right_phase: `β` })
+    expect(lever_rule.left_composition).toBeCloseTo(0, 9)
+    expect(lever_rule.right_composition).toBeCloseTo(1, 9)
+    expect(lever_rule.fraction_right).toBeCloseTo(0.25, 9)
+    // tie-line spans the full field at the hovered temperature
+    const tie_line = wrapper.querySelector(`g.tie-line line`)
+    expect(tie_line?.getAttribute(`x1`)).toBe(`${left}`)
+    expect(tie_line?.getAttribute(`x2`)).toBe(`${right}`)
+    expect(wrapper.querySelector(`.tooltip-container`)?.textContent).toContain(`α + β`)
+  })
+
+  test(`click locks the tooltip; click again or Escape unlocks`, async () => {
+    const wrapper = await mount_diagram()
+    const svg = await hover_at(wrapper, 0.5, 750)
+    const leave = () => {
+      svg.dispatchEvent(new PointerEvent(`pointerleave`))
+      return tick()
+    }
+    svg.dispatchEvent(new MouseEvent(`click`, { bubbles: true }))
+    await tick()
+    expect(wrapper.querySelector(`.tooltip-lock-indicator`)).not.toBeNull()
+    await leave() // locked tooltips survive the pointer leaving
+    expect(wrapper.querySelector(`.tooltip-container.locked`)).not.toBeNull()
+
+    svg.dispatchEvent(new MouseEvent(`click`, { bubbles: true })) // unlock
+    await tick()
+    expect(wrapper.querySelector(`.tooltip-lock-indicator`)).toBeNull()
+    await leave()
+    expect(wrapper.querySelector(`.tooltip-container`)).toBeNull()
+
+    await hover_at(wrapper, 0.5, 750)
+    svg.dispatchEvent(new MouseEvent(`click`, { bubbles: true })) // re-lock
+    await tick()
+    document.dispatchEvent(new KeyboardEvent(`keydown`, { key: `Escape` }))
+    await tick()
+    expect(wrapper.querySelector(`.tooltip-lock-indicator`)).toBeNull()
+  })
+
+  test(`display_temp_unit converts y-axis ticks and label`, async () => {
+    const kelvin = await mount_diagram()
+    expect(kelvin.querySelector(`.y-axis`)?.textContent).toContain(`1000`)
+    document.body.innerHTML = ``
+    const celsius = await mount_diagram({ display_temp_unit: `°C` })
+    const y_axis = celsius.querySelector(`.y-axis`)?.textContent ?? ``
+    expect(y_axis).toContain(`Temperature (°C)`)
+    expect(y_axis).not.toContain(`1000`) // K range [0, 1000] -> °C [-273.15, 726.85]
+    expect(y_axis).toContain(`600`)
+  })
+
+  // gradient ids derive from user region ids - two diagrams on one page would
+  // otherwise cross-reference each other's gradients (first id wins, with that
+  // instance's userSpaceOnUse pixel coords)
+  test(`multi-phase gradient ids are unique per instance`, async () => {
+    await mount_diagram()
+    await mount_diagram()
+    const ids = [...document.querySelectorAll(`linearGradient`)].map((el) => el.id)
+    expect(ids).toHaveLength(2) // one gradient (the α + β region) per instance
+    expect(new Set(ids).size).toBe(2)
+    // each gradient-filled region path must reference its own instance's gradient
+    const fills = [...document.querySelectorAll(`.phase-regions path`)]
+      .map((el) => el.getAttribute(`fill`))
+      .filter((fill) => fill?.startsWith(`url(`))
     expect(fills).toEqual(ids.map((id) => `url(#${id})`))
   })
 })
 
 describe(`format_hover_info_text`, () => {
-  test(`formats basic phase info with phase name`, () => {
-    const hover_info = create_hover_info({
-      region: { id: `alpha`, name: `α (FCC)`, vertices: [] },
-    })
-
-    const text = format_hover_info_text(hover_info)
-
-    expect(text).toContain(`Phase: α (FCC)`)
-  })
-
-  test(`formats temperature with correct unit`, () => {
-    const hover_info = create_hover_info({ temperature: 1200 })
-
-    const text_kelvin = format_hover_info_text(hover_info, `K`)
-    expect(text_kelvin).toContain(`Temperature: 1200 K`)
-
-    const text_celsius = format_hover_info_text(hover_info, `°C`)
-    expect(text_celsius).toContain(`Temperature: 1200 °C`)
-  })
-
-  test(`formats composition with at% unit`, () => {
-    const hover_info = create_hover_info({ composition: 0.35 })
-
-    const text = format_hover_info_text(hover_info, `K`, `at%`, `Al`, `Cu`)
-
-    expect(text).toContain(`35 at% Cu`)
-    expect(text).toContain(`65 at% Al`)
-  })
-
-  test(`formats composition with mol% unit`, () => {
-    const hover_info = create_hover_info({ composition: 0.25 })
-
-    const text = format_hover_info_text(hover_info, `K`, `mol%`, `Fe`, `Ni`)
-
-    expect(text).toContain(`25 mol% Ni`)
-    expect(text).toContain(`75 mol% Fe`)
-  })
-
-  test(`formats composition with fraction unit`, () => {
-    const hover_info = create_hover_info({ composition: 0.456 })
-
-    const text = format_hover_info_text(hover_info, `K`, `fraction`, `A`, `B`)
-
-    expect(text).toContain(`0.456 B`)
-    expect(text).toContain(`0.544 A`)
-  })
-
-  test(`includes lever rule data for two-phase regions`, () => {
-    const lever_rule: LeverRuleResult = {
-      left_phase: `α`,
-      right_phase: `β`,
-      left_composition: 0.2,
-      right_composition: 0.8,
-      fraction_left: 0.6,
-      fraction_right: 0.4,
-    }
-    const hover_info = create_hover_info({
-      region: { id: `two_phase`, name: `α + β`, vertices: [] },
-      lever_rule,
-    })
-
-    const text = format_hover_info_text(hover_info, `K`, `at%`)
-
-    expect(text).toContain(`Lever Rule:`)
-    expect(text).toContain(`α: 60.0%`)
-    expect(text).toContain(`β: 40.0%`)
-    expect(text).toContain(`at 20 at%`)
-    expect(text).toContain(`at 80 at%`)
-  })
-
-  test(`lever rule uses fraction unit correctly`, () => {
-    const lever_rule: LeverRuleResult = {
-      left_phase: `α`,
-      right_phase: `L`,
-      left_composition: 0.15,
-      right_composition: 0.75,
-      fraction_left: 0.75,
-      fraction_right: 0.25,
-    }
-    const hover_info = create_hover_info({
-      region: { id: `two_phase`, name: `α + L`, vertices: [] },
-      lever_rule,
-    })
-
-    const text = format_hover_info_text(hover_info, `K`, `fraction`)
-
-    expect(text).toContain(`Lever Rule:`)
-    expect(text).toContain(`α: 75.0%`)
-    expect(text).toContain(`L: 25.0%`)
-    expect(text).toContain(`at 0.15`)
-    expect(text).toContain(`at 0.75`)
-  })
-
-  test(`does not include lever rule for single-phase regions`, () => {
-    const hover_info = create_hover_info({
-      region: { id: `liquid`, name: `Liquid`, vertices: [] },
-    })
-
-    const text = format_hover_info_text(hover_info)
-
-    expect(text).not.toContain(`Lever Rule`)
-  })
-
-  test(`uses default component names when not provided`, () => {
-    const hover_info = create_hover_info({ composition: 0.5 })
-
-    const text = format_hover_info_text(hover_info)
-
-    expect(text).toContain(` B`)
-    expect(text).toContain(` A`)
-  })
-
-  test(`output has correct line structure`, () => {
-    const hover_info = create_hover_info({
-      region: { id: `alpha`, name: `α`, vertices: [] },
-      composition: 0.5,
-      temperature: 1000,
-    })
-
-    const text = format_hover_info_text(hover_info, `K`, `at%`, `Al`, `Cu`)
-    const lines = text.split(`\n`)
-
-    expect(lines[0]).toBe(`Phase: α`)
-    expect(lines[1]).toBe(`Temperature: 1000 K`)
-    expect(lines[2]).toContain(`Composition:`)
-  })
-
-  test(`output structure with lever rule includes blank line separator`, () => {
-    const lever_rule: LeverRuleResult = {
-      left_phase: `α`,
-      right_phase: `β`,
-      left_composition: 0.2,
-      right_composition: 0.8,
-      fraction_left: 0.5,
-      fraction_right: 0.5,
-    }
-    const hover_info = create_hover_info({
-      region: { id: `two_phase`, name: `α + β`, vertices: [] },
-      lever_rule,
-    })
-
-    const text = format_hover_info_text(hover_info)
-    const lines = text.split(`\n`)
-
-    // Find blank line before "Lever Rule:"
-    const lever_idx = lines.findIndex((line: string) => line === `Lever Rule:`)
-    expect(lever_idx).toBeGreaterThan(0)
-    expect(lines[lever_idx - 1]).toBe(``)
+  test.each([
+    { composition: 0.35, unit: `at%`, expected: `Composition: 35 at% Cu (65 at% Al)` },
+    { composition: 0.25, unit: `mol%`, expected: `Composition: 25 mol% Cu (75 mol% Al)` },
+    { composition: 0.456, unit: `fraction`, expected: `Composition: 0.456 Cu (0.544 Al)` },
+    { composition: 0, unit: `at%`, expected: `Composition: 0 at% Cu (100 at% Al)` },
+    { composition: 1, unit: `at%`, expected: `Composition: 100 at% Cu (0 at% Al)` },
+    { composition: 0.333, unit: `at%`, expected: `Composition: 33.3 at% Cu (66.7 at% Al)` },
+  ] as const)(`composition $composition as $unit`, ({ composition, unit, expected }) => {
+    const text = format_hover_info_text(
+      create_hover_info({ composition }),
+      `K`,
+      unit,
+      `Al`,
+      `Cu`,
+    )
+    expect(text).toContain(expected)
   })
 
   test.each([
-    { composition: 0, expected_b: `0`, expected_a: `100` },
-    { composition: 1, expected_b: `100`, expected_a: `0` },
-    { composition: 0.333, expected_b: `33.3`, expected_a: `66.7` },
-    { composition: 0.667, expected_b: `66.7`, expected_a: `33.3` },
-  ])(
-    `correctly formats edge case composition $composition`,
-    ({ composition, expected_b, expected_a }) => {
-      const hover_info = create_hover_info({ composition })
-
-      const text = format_hover_info_text(hover_info, `K`, `at%`, `A`, `B`)
-
-      expect(text).toContain(`${expected_b} at% B`)
-      expect(text).toContain(`${expected_a} at% A`)
+    { temperature: 273.15, display: `K`, data: `K`, expected: `Temperature: 273 K` },
+    { temperature: 2500.7, display: `K`, data: `K`, expected: `Temperature: 2501 K` },
+    { temperature: 1200, display: `°C`, data: `°C`, expected: `Temperature: 1200 °C` }, // no conversion
+    // data stored in K, displayed in °C -> converted (1200 K = 926.85 °C)
+    { temperature: 1200, display: `°C`, data: `K`, expected: `Temperature: 927 °C` },
+  ] as const)(
+    `temperature $temperature: $data data shown as $display`,
+    ({ temperature, display, data, expected }) => {
+      const info = create_hover_info({ temperature })
+      const text = format_hover_info_text(info, display, `at%`, `A`, `B`, data)
+      expect(text).toContain(expected)
     },
   )
 
+  const lever_rule: LeverRuleResult = {
+    left_phase: `α`,
+    right_phase: `β`,
+    left_composition: 0.2,
+    right_composition: 0.8,
+    fraction_left: 0.6,
+    fraction_right: 0.4,
+  }
+
   test.each([
-    { temperature: 0, expected: `0 K` },
-    { temperature: 273.15, expected: `273 K` },
-    { temperature: 1000, expected: `1000 K` },
-    { temperature: 2500.7, expected: `2501 K` },
-  ])(`correctly formats temperature $temperature`, ({ temperature, expected }) => {
-    const hover_info = create_hover_info({ temperature })
+    { unit: `at%`, expected: [`  α: 60.0% (at 20 at%)`, `  β: 40.0% (at 80 at%)`] },
+    { unit: `fraction`, expected: [`  α: 60.0% (at 0.2)`, `  β: 40.0% (at 0.8)`] },
+  ] as const)(`horizontal lever rule in $unit`, ({ unit, expected }) => {
+    const info = create_hover_info({
+      region: { id: `two_phase`, name: `α + β`, vertices: [] },
+      lever_rule,
+    })
+    const lines = format_hover_info_text(info, `K`, unit).split(`\n`)
+    expect(lines).toContain(`Lever Rule:`)
+    for (const line of expected) expect(lines).toContain(line)
+  })
 
-    const text = format_hover_info_text(hover_info, `K`)
+  test(`vertical mode prints only the vertical lever rule, with converted temps`, () => {
+    const info = create_hover_info({
+      region: { id: `two_phase`, name: `α + L`, vertices: [] },
+      lever_rule, // present but must be ignored in vertical mode
+      vertical_lever_rule: {
+        bottom_phase: `α`,
+        top_phase: `L`,
+        bottom_temperature: 800,
+        top_temperature: 1000,
+        fraction_bottom: 0.25,
+        fraction_top: 0.75,
+      },
+    })
+    const lines = format_hover_info_text(info, `°C`, `at%`, `A`, `B`, `K`, `vertical`).split(
+      `\n`,
+    )
+    expect(lines).toContain(`Vertical Lever Rule:`)
+    expect(lines).toContain(`  α: 25.0% (at 527 °C)`) // 800 K -> 526.85 °C
+    expect(lines).toContain(`  L: 75.0% (at 727 °C)`)
+    expect(lines).not.toContain(`Lever Rule:`)
+  })
 
-    expect(text).toContain(`Temperature: ${expected}`)
+  test(`line structure: header order, blank line before lever rule, none for single phase`, () => {
+    const info = create_hover_info({
+      region: { id: `two_phase`, name: `α + β`, vertices: [] },
+      composition: 0.5,
+      temperature: 1000,
+      lever_rule,
+    })
+    const lines = format_hover_info_text(info).split(`\n`)
+    expect(lines[0]).toBe(`Phase: α + β`)
+    expect(lines[1]).toBe(`Temperature: 1000 K`)
+    expect(lines[2]).toBe(`Composition: 50 at% B (50 at% A)`) // default component names
+    const lever_idx = lines.indexOf(`Lever Rule:`)
+    expect(lever_idx).toBeGreaterThan(2)
+    expect(lines[lever_idx - 1]).toBe(``)
+    // single-phase hover (no lever_rule data) -> no lever rule section
+    expect(format_hover_info_text(create_hover_info())).not.toContain(`Lever Rule`)
   })
 })

--- a/tests/vitest/phase-diagram/IsobaricBinaryPhaseDiagram.test.ts
+++ b/tests/vitest/phase-diagram/IsobaricBinaryPhaseDiagram.test.ts
@@ -1,6 +1,53 @@
-import { format_hover_info_text, type LeverRuleResult } from '$lib/phase-diagram'
+import { format_hover_info_text, IsobaricBinaryPhaseDiagram } from '$lib/phase-diagram'
+import type { LeverRuleResult, PhaseDiagramData } from '$lib/phase-diagram/types'
+import { mount } from 'svelte'
 import { describe, expect, test } from 'vitest'
+import { resize_element } from '../setup'
 import { create_hover_info } from './fixtures/test-data'
+
+describe(`IsobaricBinaryPhaseDiagram`, () => {
+  // gradient ids derive from user region ids ('alpha + beta' etc.) - two diagrams on
+  // one page would otherwise cross-reference each other's gradients (first id wins,
+  // with that instance's userSpaceOnUse pixel coords)
+  test(`multi-phase gradient ids are unique per instance`, async () => {
+    const data: PhaseDiagramData = {
+      components: [`Al`, `Cu`],
+      temperature_range: [300, 1000],
+      regions: [
+        {
+          id: `ab`,
+          name: `α + β`, // 2+ phases -> gradient fill
+          vertices: [
+            [0, 300],
+            [1, 300],
+            [1, 1000],
+            [0, 1000],
+          ],
+        },
+      ],
+      boundaries: [],
+    }
+    for (let idx = 0; idx < 2; idx++) {
+      const target = document.createElement(`div`)
+      document.body.append(target)
+      mount(IsobaricBinaryPhaseDiagram, {
+        target,
+        props: { data, style: `width: 500px; height: 400px;` },
+      })
+      const wrapper = target.querySelector<HTMLElement>(`.binary-phase-diagram`)
+      if (!wrapper) throw new Error(`phase diagram root not found`)
+      await resize_element(wrapper, 500, 400)
+    }
+    const ids = [...document.querySelectorAll(`linearGradient`)].map((el) => el.id)
+    expect(ids).toHaveLength(2)
+    expect(new Set(ids).size).toBe(2)
+    // each region path must reference its own instance's gradient
+    const fills = [...document.querySelectorAll(`.phase-regions path`)].map((el) =>
+      el.getAttribute(`fill`),
+    )
+    expect(fills).toEqual(ids.map((id) => `url(#${id})`))
+  })
+})
 
 describe(`format_hover_info_text`, () => {
   test(`formats basic phase info with phase name`, () => {

--- a/tests/vitest/phase-diagram/utils.test.ts
+++ b/tests/vitest/phase-diagram/utils.test.ts
@@ -765,9 +765,7 @@ describe(`tokenize_formula`, () => {
         { sub: `12` },
         { text: `H` },
         { sub: `22` },
-        {
-          text: `O`,
-        },
+        { text: `O` },
         { sub: `11` },
       ],
       desc: `multi-digit subscripts`,

--- a/tests/vitest/plot/BarPlot.test.ts
+++ b/tests/vitest/plot/BarPlot.test.ts
@@ -2,7 +2,7 @@ import { BarPlot } from '$lib'
 import type { BarHandlerProps, BarMode, BarSeries, Orientation } from '$lib/plot'
 import { type ComponentProps, createRawSnippet, mount, tick } from 'svelte'
 import { describe, expect, test, vi } from 'vitest'
-import { resize_element } from '../setup'
+import { inside_clip_path, resize_element } from '../setup'
 
 const basic: BarSeries = {
   x: [1, 2, 3, 4, 5],
@@ -553,5 +553,31 @@ describe(`BarPlot`, () => {
     expect(legend).toBeInstanceOf(HTMLElement)
     // interior default is top-left (~pad.t + 10); auto-outside drops it well into the lower half
     expect(parseFloat(legend?.style.top ?? `0`)).toBeGreaterThan(150)
+  })
+
+  // ref-line annotations must render outside the chart clip group so labels at the
+  // plot edges (e.g. a vertical line's top label) can overflow instead of being cropped,
+  // while z ordering still holds: below-lines refs paint behind bars, above-all in front
+  test(`reference-line annotations are unclipped and z-ordered around the bars`, async () => {
+    const plot = await mount_sized_bar_plot({
+      series: [basic],
+      ref_lines: [
+        { type: `vertical`, x: 3, annotation: { text: `behind` } }, // default z: below-lines
+        { type: `vertical`, x: 4, z_index: `above-all`, annotation: { text: `front` } },
+      ],
+    })
+    await tick()
+    const labels = Object.fromEntries(
+      [...plot.querySelectorAll(`svg text`)].map((el) => [el.textContent?.trim(), el]),
+    )
+    const bars = plot.querySelector(`svg .bar-series`)
+    if (!labels.behind || !labels.front || !bars) throw new Error(`missing elements`)
+    for (const label of [labels.behind, labels.front]) {
+      expect(inside_clip_path(label), `annotation must escape the clip-path`).toBe(false)
+    }
+    // document order encodes paint order: below-lines < bars < above-all
+    const order = (el: Element) => bars.compareDocumentPosition(el)
+    expect(Boolean(order(labels.behind) & Node.DOCUMENT_POSITION_PRECEDING)).toBe(true)
+    expect(Boolean(order(labels.front) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true)
   })
 })

--- a/tests/vitest/plot/BarPlot.test.ts
+++ b/tests/vitest/plot/BarPlot.test.ts
@@ -116,6 +116,24 @@ describe(`BarPlot`, () => {
     expect(plot.querySelector(`.x2-label`)?.textContent).toBe(`Temperature (K)`)
   })
 
+  test(`y2 axis title shares the y axis title's vertical center`, async () => {
+    const plot = await mount_sized_bar_plot({
+      series: [basic, { x: [1, 2, 3], y: [100, 200, 300], label: `Sec`, y_axis: `y2` }],
+      y_axis: { label: `Primary` },
+      y2_axis: { label: `Secondary` },
+    })
+    // both y titles rotate about the plot's vertical center; a stale label_shift default
+    // used to push the y2 title 60px below center
+    const pivot_y = (selector: string) => {
+      const transform =
+        plot.querySelector(selector)?.closest(`foreignObject`)?.getAttribute(`transform`) ?? ``
+      const match = /rotate\(-90,\s*[\d.-]+,\s*([\d.-]+)\)/.exec(transform)
+      if (!match) throw new Error(`no rotate transform on ${selector}: "${transform}"`)
+      return Number(match[1])
+    }
+    expect(pivot_y(`.axis-label.y2-label`)).toBeCloseTo(pivot_y(`.axis-label.y-label`), 5)
+  })
+
   test.each<[Orientation, BarMode]>([
     [`vertical`, `overlay`],
     [`horizontal`, `overlay`],
@@ -135,20 +153,14 @@ describe(`BarPlot`, () => {
       `overlay`,
       [
         { x: [1, 2, 3, 4], y: [-10, -5, 15, 20] },
-        {
-          x: [1, 2, 3, 4],
-          y: [5, -8, 12, -3],
-        },
+        { x: [1, 2, 3, 4], y: [5, -8, 12, -3] },
       ],
     ],
     [
       `stacked`,
       [
         { x: [1, 2, 3, 4], y: [10, -5, 15, 20] },
-        {
-          x: [1, 2, 3, 4],
-          y: [-5, 10, -8, 5],
-        },
+        { x: [1, 2, 3, 4], y: [-5, 10, -8, 5] },
       ],
     ],
     [

--- a/tests/vitest/plot/BarPlot.test.ts
+++ b/tests/vitest/plot/BarPlot.test.ts
@@ -373,17 +373,24 @@ describe(`BarPlot`, () => {
       },
     )
 
-    test(`single series with 3 categories renders 3 bars`, async () => {
-      mount(BarPlot, {
-        target: document.body,
-        props: {
-          series: [{ x: [`Foo`, `Bar`, `Baz`], y: [1, 2, 3], color: `blue` }],
-          style: `width: 400px; height: 300px`,
-        },
-      })
-      await tick()
-      expect(document.querySelectorAll(`path[role="button"]`)).toHaveLength(3)
-    })
+    // every category renders a bar; x-axis ticks thin only when labels can't fit the
+    // 400px axis at ~28px each (3 fit untouched, 30 thin to every ~3rd category)
+    test.each([
+      { desc: `few categories keep every tick`, n_cats: 3, min_ticks: 3, max_ticks: 3 },
+      { desc: `many categories thin the ticks`, n_cats: 30, min_ticks: 3, max_ticks: 14 },
+    ])(
+      `single categorical series renders every bar ($desc)`,
+      async ({ n_cats, min_ticks, max_ticks }) => {
+        const cats = Array.from({ length: n_cats }, (_cat, idx) => `cat${idx}`)
+        const plot = await mount_sized_bar_plot({
+          series: [{ x: cats, y: cats.map((_cat, idx) => idx + 1), color: `blue` }],
+        })
+        expect(plot.querySelectorAll(`path[role="button"]`)).toHaveLength(n_cats)
+        const tick_count = plot.querySelectorAll(`g.x-axis g.tick`).length
+        expect(tick_count).toBeGreaterThanOrEqual(min_ticks)
+        expect(tick_count).toBeLessThanOrEqual(max_ticks)
+      },
+    )
 
     test(`hover provides category_label and preserves metadata`, async () => {
       const hover_fn = vi.fn()

--- a/tests/vitest/plot/BarPlot.test.ts
+++ b/tests/vitest/plot/BarPlot.test.ts
@@ -392,6 +392,19 @@ describe(`BarPlot`, () => {
       },
     )
 
+    // categorical ticks are generated for every category regardless of the view, so
+    // a panned/zoomed range must cull the ones that fall outside the plot area
+    test(`ticks panned outside the plot area are culled`, async () => {
+      const plot = await mount_sized_bar_plot({
+        series: [{ x: [`A`, `B`, `C`, `D`, `E`], y: [1, 2, 3, 4, 5], color: `blue` }],
+        x_axis: { range: [1.5, 3.5] }, // panned view: only C and D remain in range
+      })
+      const labels = [...plot.querySelectorAll(`g.x-axis g.tick text`)].map((el) =>
+        el.textContent?.trim(),
+      )
+      expect(labels).toEqual([`C`, `D`])
+    })
+
     test(`hover provides category_label and preserves metadata`, async () => {
       const hover_fn = vi.fn()
       mount(BarPlot, {
@@ -560,6 +573,26 @@ describe(`BarPlot`, () => {
     expect(legend).toBeInstanceOf(HTMLElement)
     // interior default is top-left (~pad.t + 10); auto-outside drops it well into the lower half
     expect(parseFloat(legend?.style.top ?? `0`)).toBeGreaterThan(150)
+  })
+
+  // double-clicking a legend item isolates that series (shared helper, same as
+  // ScatterPlot); a second double-click restores the previous visibility
+  test(`legend double-click isolates a series and restores on repeat`, async () => {
+    const series = [basic, { ...basic, label: `Other`, color: `tomato` }]
+    const plot = await mount_sized_bar_plot({ series, show_legend: true })
+    const visible_states = () =>
+      [...plot.querySelectorAll(`.legend-item`)].map((el) => !el.classList.contains(`hidden`))
+    expect(visible_states()).toEqual([true, true])
+    const dblclick = () =>
+      plot
+        .querySelector(`.legend-item`)
+        ?.dispatchEvent(new MouseEvent(`dblclick`, { bubbles: true }))
+    dblclick()
+    await tick()
+    expect(visible_states()).toEqual([true, false]) // isolated
+    dblclick()
+    await tick()
+    expect(visible_states()).toEqual([true, true]) // restored
   })
 
   // ref-line annotations must render outside the chart clip group so labels at the

--- a/tests/vitest/plot/BinnedScatterPlot.test.svelte.ts
+++ b/tests/vitest/plot/BinnedScatterPlot.test.svelte.ts
@@ -137,6 +137,30 @@ describe(`BinnedScatterPlot`, () => {
     expect(toggle.getAttribute(`aria-label`)).toBe(`Enter fullscreen`)
   })
 
+  // a NaN bound in a partially-set axis range would otherwise loop the auto-range
+  // effect forever (NaN !== NaN never settles) until effect_update_depth_exceeded
+  test(`NaN axis-range bound mounts without a reactive loop`, async () => {
+    const errors: unknown[][] = []
+    const error_spy = vi
+      .spyOn(console, `error`)
+      .mockImplementation((...args) => void errors.push(args))
+    try {
+      mount(BinnedScatterPlot, {
+        target: document.body,
+        props: {
+          series: [{ x: [0, 1], y: [0, 1] }],
+          density: hidden_density,
+          x_axis: { range: [null, NaN] as [null, number] },
+          style: `width: 800px; height: 600px`,
+        },
+      })
+      await settle()
+    } finally {
+      error_spy.mockRestore()
+    }
+    expect(errors.map(String).join(`\n`)).toBe(``)
+  })
+
   test(`can hide the fullscreen toggle`, async () => {
     mount(BinnedScatterPlot, {
       target: document.body,

--- a/tests/vitest/plot/BoxPlot.test.ts
+++ b/tests/vitest/plot/BoxPlot.test.ts
@@ -2,7 +2,7 @@ import { BoxPlot } from '$lib'
 import type { BoxPlotSeries, Orientation, WhiskerMode } from '$lib/plot'
 import { type ComponentProps, mount, tick } from 'svelte'
 import { describe, expect, test, vi } from 'vitest'
-import { resize_element } from '../setup'
+import { inside_clip_path, resize_element } from '../setup'
 
 const dist = (n: number, center = 0, spread = 1): number[] =>
   Array.from(
@@ -292,5 +292,37 @@ describe(`BoxPlot`, () => {
     ]
     const plot = await mount_sized_box_plot({ series, kind: `violin` })
     expect(plot.querySelectorAll(`g.x-axis g.tick`)).toHaveLength(2)
+  })
+
+  // on a log value axis, stats <= 0 (whisker_low is often exactly 0, outliers can be
+  // negative) must clamp to the log floor instead of rendering NaN coordinates
+  test(`log value axis renders finite coordinates when data includes zero`, async () => {
+    const plot = await mount_sized_box_plot({
+      series: [{ y: [0, 1, 2, 5, 10, 100], label: `Z` }],
+      y_axis: { scale_type: `log` },
+    })
+    const attrs = [...plot.querySelectorAll(`.box-series line, .box-series rect`)].flatMap(
+      (el) => [...el.attributes].map((attr) => attr.value),
+    )
+    expect(attrs.length).toBeGreaterThan(0)
+    expect(
+      attrs.some((val) => val.includes(`NaN`)),
+      `no NaN in box glyphs`,
+    ).toBe(false)
+  })
+
+  // same contract as BarPlot: ref-line annotations render outside the chart clip group
+  // so labels at the plot edges can overflow instead of being cropped
+  test(`reference-line annotation is not clipped by the chart area`, async () => {
+    const plot = await mount_sized_box_plot({
+      series: [basic],
+      ref_lines: [{ type: `horizontal`, y: 0, annotation: { text: `threshold` } }],
+    })
+    await tick()
+    const label = [...plot.querySelectorAll(`svg text`)].find(
+      (el) => el.textContent?.trim() === `threshold`,
+    )
+    if (!label) throw new Error(`annotation text should render`)
+    expect(inside_clip_path(label), `annotation must escape the clip-path`).toBe(false)
   })
 })

--- a/tests/vitest/plot/BoxPlot.test.ts
+++ b/tests/vitest/plot/BoxPlot.test.ts
@@ -2,7 +2,7 @@ import { BoxPlot } from '$lib'
 import type { BoxPlotSeries, Orientation, WhiskerMode } from '$lib/plot'
 import { type ComponentProps, mount, tick } from 'svelte'
 import { describe, expect, test, vi } from 'vitest'
-import { inside_clip_path, resize_element } from '../setup'
+import { bind_props, inside_clip_path, resize_element } from '../setup'
 
 const dist = (n: number, center = 0, spread = 1): number[] =>
   Array.from(
@@ -132,6 +132,45 @@ describe(`BoxPlot`, () => {
     })
     expect(plot.querySelector(`g.y2-axis`)).toBeInstanceOf(SVGGElement)
     expect(plot.querySelector(`.y2-label`)?.textContent).toBe(`Secondary`)
+  })
+
+  test(`vertical rect-zoom zooms y2 but writes no phantom x2 range`, async () => {
+    // vertical orientation: the secondary value axis is y2; x is categorical and x2 is a
+    // sentinel, so rect-zoom must not write back an x2 range. Mount directly (the helper
+    // spreads props, which would sever the bind_props getters and lose the write-back).
+    const state = {
+      x2_axis: {} as Record<string, unknown>,
+      y2_axis: {} as Record<string, unknown>,
+    }
+    const container = document.createElement(`div`)
+    document.body.append(container)
+    mount(BoxPlot, {
+      target: container,
+      props: bind_props(
+        {
+          series: [
+            { y: dist(40, 0, 1), label: `A` },
+            { y: dist(40, 50, 5), label: `B`, y_axis: `y2` as const },
+          ],
+          style: `width: 400px; height: 300px;`,
+        },
+        state,
+      ),
+    })
+    const plot = container.querySelector<HTMLElement>(`.box-plot`)
+    if (!plot) throw new Error(`BoxPlot root element not found`)
+    await resize_element(plot, 400, 300)
+    const svg = plot.querySelector(`svg[role="application"]`)
+    if (!svg) throw new Error(`svg not found`)
+    svg.dispatchEvent(
+      new MouseEvent(`mousedown`, { clientX: 100, clientY: 50, bubbles: true }),
+    )
+    window.dispatchEvent(new MouseEvent(`mousemove`, { clientX: 300, clientY: 200 }))
+    window.dispatchEvent(new MouseEvent(`mouseup`, { clientX: 300, clientY: 200 }))
+    await tick()
+    const y2_range = state.y2_axis.range as [number, number] | undefined
+    expect(y2_range?.every(Number.isFinite)).toBe(true)
+    expect(state.x2_axis.range).toBeUndefined() // no phantom x2 range in vertical mode
   })
 
   test(`category tick labels are colored per box`, async () => {

--- a/tests/vitest/plot/Histogram.test.ts
+++ b/tests/vitest/plot/Histogram.test.ts
@@ -78,15 +78,23 @@ describe(`Histogram`, () => {
       series: [repeated_histogram_series, repeated_histogram_series],
       expected_indices: [`0`, `1`],
     },
-  ])(`rendered series keep original indices $name`, async ({ series, expected_indices }) => {
-    mount_histogram({ series, show_legend: true })
-    await tick()
+  ])(
+    `rendered series keep original indices and clip to chart area $name`,
+    async ({ series, expected_indices }) => {
+      mount_histogram({ series, show_legend: true })
+      await tick()
 
-    const series_indices = Array.from(document.querySelectorAll(`g.histogram-series`)).map(
-      (element) => element.getAttribute(`data-series-idx`),
-    )
-    expect(series_indices).toEqual(expected_indices)
-  })
+      const groups = Array.from(document.querySelectorAll(`g.histogram-series`))
+      const series_indices = groups.map((element) => element.getAttribute(`data-series-idx`))
+      expect(series_indices).toEqual(expected_indices)
+
+      // bars must clip to the chart area, else zooming/panning the y range lets tall
+      // bars paint over the top margin and x2 axis (ref lines stay outside the clip)
+      for (const group of groups) {
+        expect(group.getAttribute(`clip-path`)).toMatch(/^url\(#histogram-clip/)
+      }
+    },
+  )
 
   test(`single mode falls back when selected_property is stale`, async () => {
     mount_histogram({

--- a/tests/vitest/plot/Histogram.test.ts
+++ b/tests/vitest/plot/Histogram.test.ts
@@ -24,6 +24,22 @@ function get_tick_numbers(axis: `x` | `y`): number[] {
 
 const get_y_tick_numbers = (): number[] => get_tick_numbers(`y`)
 
+const get_svg = () => {
+  const svg = document.querySelector(`svg[role="application"]`)
+  if (!svg) throw new Error(`histogram plot area not found`)
+  return svg
+}
+
+// happy-dom lacks Touch/TouchEvent constructors, so dispatch plain events
+// carrying a touches array (the handlers only read touches[*].clientX/Y)
+const touch_event = (type: string, touches: readonly (readonly [number, number])[]) => {
+  const evt = new Event(type, { bubbles: true, cancelable: true })
+  Object.defineProperty(evt, `touches`, {
+    value: touches.map(([clientX, clientY]) => ({ clientX, clientY })),
+  })
+  return evt
+}
+
 describe(`Histogram`, () => {
   test.each([
     {
@@ -46,6 +62,30 @@ describe(`Histogram`, () => {
     const max_tick = Math.max(...ticks)
     expect(max_tick).toBeGreaterThanOrEqual(expected_min_max[0])
     expect(max_tick).toBeLessThanOrEqual(expected_min_max[1])
+  })
+
+  // pan must be screen-uniform: on a log axis that's a constant *factor*, not a
+  // constant amount. A multi-plot-height wheel pan over [1, 100] must land decades
+  // up while still spanning 2 decades - the old linear-space math collapsed the
+  // view to a sub-decade slice (and panning down shifted past zero into NaN)
+  test(`shift+wheel pan on a log y axis shifts by decades, not linearly`, async () => {
+    mount_histogram({
+      series: [{ x: [], y: [1, 2, 3, 4, 5], label: `A` }],
+      y_axis: { scale_type: `log`, range: [1, 100] },
+    })
+    await tick()
+    const plot = get_svg()
+    plot.dispatchEvent(new FocusEvent(`focusin`, { bubbles: true }))
+    window.dispatchEvent(new KeyboardEvent(`keydown`, { key: `Shift` }))
+    await tick()
+    plot.dispatchEvent(new WheelEvent(`wheel`, { deltaY: 2000, bubbles: true }))
+    await tick()
+    const ticks = get_y_tick_numbers()
+    expect(ticks.length).toBeGreaterThan(0)
+    expect(Math.min(...ticks)).toBeGreaterThan(100) // moved decades up from [1, 100]
+    // log pan preserves the visible span (a constant factor): ticks still cover >= 1
+    // decade; the old linear math left a sub-decade slice here
+    expect(Math.max(...ticks) / Math.min(...ticks)).toBeGreaterThanOrEqual(10)
   })
 
   test(`multi-series uses maximum counts across series`, async () => {
@@ -123,15 +163,19 @@ describe(`Histogram`, () => {
     expect(max_few).toBeGreaterThanOrEqual(max_many)
   })
 
-  test(`y_range caps auto count domain`, async () => {
-    mount_histogram({ series: [{ x: [], y: [1, 1, 1, 1, 1] }], bins: 5, y_range: [0, 3] })
+  test(`y_axis.range caps auto count domain`, async () => {
+    mount_histogram({
+      series: [{ x: [], y: [1, 1, 1, 1, 1] }],
+      bins: 5,
+      y_axis: { range: [0, 3] },
+    })
     await tick()
     const ticks = get_y_tick_numbers()
     const max_tick = Math.max(...ticks)
     expect(max_tick).toBeLessThanOrEqual(3)
   })
 
-  test(`x_range applies domain; y max tick >= computed max bin count`, async () => {
+  test(`x_axis.range applies domain; y max tick >= computed max bin count`, async () => {
     const series = [{ x: [], y: [0, 0, 1, 1, 1, 2, 2, 10, 10, 10], label: `A` }]
 
     mount_histogram({ series, bins: 5 })
@@ -142,7 +186,7 @@ describe(`Histogram`, () => {
     const full_expected = d3max(full_hist, (b) => b.length) ?? 0
     expect(full_max).toBeGreaterThanOrEqual(full_expected)
 
-    mount_histogram({ series, bins: 5, x_range: [0, 3] })
+    mount_histogram({ series, bins: 5, x_axis: { range: [0, 3] } })
     await tick()
     const ticks_zoom = get_y_tick_numbers()
     const zoom_max = Math.max(...ticks_zoom)
@@ -155,8 +199,7 @@ describe(`Histogram`, () => {
     mount_histogram({
       series: [{ x: [], y: [1, 1, 1, 1, 1] }],
       bins: 5,
-      y_axis: { scale_type: `log`, format: `.2r` },
-      y_range: [1, null],
+      y_axis: { scale_type: `log`, format: `.2r`, range: [1, null] },
     })
     await tick()
     const ticks = get_y_tick_numbers()
@@ -199,6 +242,36 @@ describe(`Histogram`, () => {
     await tick()
     // Verify component mounted without crashing
     expect(document.querySelector(`.histogram`)).toBeInstanceOf(HTMLElement)
+  })
+
+  // oxfmt-ignore
+  test.each([
+    {
+      // 1px apart: passes a Number.EPSILON guard, so curr_dist / start_dist would
+      // blow up the zoom factor without the MIN_TOUCH_DISTANCE_PIXELS guard
+      name: `near-coincident two-finger start is ignored (no explosive pinch zoom)`,
+      events: [[`touchstart`, [[100, 100], [101, 100]]], [`touchmove`, [[50, 100], [250, 100]]]],
+    },
+    {
+      // OS-cancelled gesture (e.g. notification swipe) fires touchcancel, not touchend;
+      // stale touch state must not let the later touchmove pan
+      name: `touchcancel clears touch state so later touchmove does not pan`,
+      events: [
+        [`touchstart`, [[100, 100], [200, 100]]],
+        [`touchcancel`, []],
+        [`touchmove`, [[150, 150], [250, 150]]],
+      ],
+    },
+  ] as const)(`$name`, async ({ events }) => {
+    mount_histogram({ series: [{ x: [], y: [1, 2, 3, 4, 5], label: `A` }] })
+    await tick()
+    const svg = get_svg()
+    const ticks_before = { x: get_tick_numbers(`x`), y: get_y_tick_numbers() }
+    expect(ticks_before.x.length).toBeGreaterThan(0)
+    for (const [type, touches] of events) svg.dispatchEvent(touch_event(type, touches))
+    await tick()
+    expect(get_tick_numbers(`x`)).toEqual(ticks_before.x)
+    expect(get_y_tick_numbers()).toEqual(ticks_before.y)
   })
 
   test(`legend auto-moves to the bottom margin when bars fill the plot`, async () => {

--- a/tests/vitest/plot/Histogram.test.ts
+++ b/tests/vitest/plot/Histogram.test.ts
@@ -2,6 +2,7 @@ import { Histogram } from '$lib'
 import { bin, max as d3max } from 'd3-array'
 import { mount, tick } from 'svelte'
 import { describe, expect, test } from 'vitest'
+import { resize_element } from '../setup'
 
 function mount_histogram(props: Record<string, unknown>) {
   document.body.innerHTML = ``
@@ -227,6 +228,34 @@ describe(`Histogram`, () => {
     expect(Math.max(...x_ticks)).toBeLessThan(100)
     // y-range must bin the x2 series over the x2 domain (4 of 5 values share one bin)
     expect(Math.max(...get_y_tick_numbers())).toBeGreaterThanOrEqual(4)
+  })
+
+  test(`y2 axis title shares the y axis title's vertical center`, async () => {
+    mount_histogram({
+      series: [
+        { x: [], y: [1, 2, 3], label: `Main` },
+        { x: [], y: [10, 20, 30], label: `Sec`, y_axis: `y2` },
+      ],
+      mode: `overlay`, // single mode (default) would drop the y2 series
+      y_axis: { label: `Primary` },
+      y2_axis: { label: `Secondary` },
+    })
+    const plot = document.querySelector<HTMLElement>(`.histogram`)
+    if (!plot) throw new Error(`Histogram root element not found`)
+    await resize_element(plot, 400, 300) // axis labels only render once the plot has a size
+    // both y titles rotate about the plot's vertical center; a stale label_shift default
+    // used to push the y2 title 60px below center
+    const pivot_y = (selector: string) => {
+      const transform =
+        document
+          .querySelector(selector)
+          ?.closest(`foreignObject`)
+          ?.getAttribute(`transform`) ?? ``
+      const match = /rotate\(-90,\s*[\d.-]+,\s*([\d.-]+)\)/.exec(transform)
+      if (!match) throw new Error(`no rotate transform on ${selector}: "${transform}"`)
+      return Number(match[1])
+    }
+    expect(pivot_y(`.axis-label.y2-label`)).toBeCloseTo(pivot_y(`.axis-label.y-label`), 5)
   })
 
   test(`renders without error when legend prop is null`, async () => {

--- a/tests/vitest/plot/PlotAxis.test.ts
+++ b/tests/vitest/plot/PlotAxis.test.ts
@@ -99,6 +99,7 @@ describe(`PlotAxis`, () => {
     expect(lines).toHaveLength(2) // grid + tick mark
     const grid = lines[0] // grid rendered before the tick mark
     expect(grid.getAttribute(`stroke-dasharray`)).toBe(`4`) // from DEFAULT_GRID_STYLE
+    expect(grid.getAttribute(`stroke-width`)).toBe(`0.5`) // thin grid lines by default
     for (const [attr, value] of Object.entries(expected)) {
       expect(grid.getAttribute(attr)).toBe(value)
     }

--- a/tests/vitest/plot/ScatterPlot.test.svelte.ts
+++ b/tests/vitest/plot/ScatterPlot.test.svelte.ts
@@ -690,4 +690,67 @@ describe(`ScatterPlot`, () => {
     const legend = doc_query<HTMLElement>(`.legend`)
     expect(parseFloat(legend.style.top)).toBeGreaterThan(150)
   })
+
+  // rect-zoom must zoom y2 series too when sync is 'none' (the default) - BarPlot,
+  // Histogram and BoxPlot all do; only the synced/align modes derive y2 from y1
+  test(`rect-zoom updates y2 range when y2 sync is 'none'`, async () => {
+    const state = { y2_axis: {} as Record<string, unknown> }
+    // mount directly: mount_sized_scatter_plot spreads props, which would sever the
+    // bind_props getters and lose the y2_axis write-back
+    const container = document.createElement(`div`)
+    document.body.append(container)
+    mount(ScatterPlot, {
+      target: container,
+      props: bind_props(
+        {
+          series: [
+            { x: [1, 2, 3], y: [1, 2, 3] },
+            { x: [1, 2, 3], y: [10, 20, 30], y_axis: `y2` as const },
+          ],
+          style: `width: 400px; height: 300px;`,
+        },
+        state,
+      ),
+    })
+    const plot = container.querySelector<HTMLElement>(`.scatter`)
+    if (!plot) throw new Error(`ScatterPlot root element not found`)
+    await resize_element(plot, 400, 300)
+    const svg = plot.querySelector(`svg[role="application"]`) // chart svg, not control icons
+    if (!svg) throw new Error(`svg not found`)
+    svg.dispatchEvent(
+      new MouseEvent(`mousedown`, { clientX: 100, clientY: 50, bubbles: true }),
+    )
+    window.dispatchEvent(new MouseEvent(`mousemove`, { clientX: 300, clientY: 200 }))
+    window.dispatchEvent(new MouseEvent(`mouseup`, { clientX: 300, clientY: 200 }))
+    await tick()
+    const y2_range = state.y2_axis.range as [number, number] | undefined
+    if (!y2_range) throw new Error(`y2_axis.range not set by rect-zoom`)
+    expect(y2_range.every(Number.isFinite)).toBe(true)
+    expect(y2_range[0]).toBeLessThan(y2_range[1])
+    expect(y2_range[1] - y2_range[0]).toBeLessThan(20) // narrower than full data span
+  })
+
+  // Regression guard for effect_update_depth_exceeded: with an explicit y range the
+  // range-sync effect assigns zoom_y_range a fresh array every run, and the y2-sync
+  // branch reads it back - a tracked read would re-trigger the effect forever. Svelte's
+  // loop guard logs via console.error and throws, so a clean mount proves the fix.
+  test(`explicit y range + y2 sync mounts without a reactive loop`, async () => {
+    const errors: unknown[][] = []
+    const error_spy = vi
+      .spyOn(console, `error`)
+      .mockImplementation((...args) => void errors.push(args))
+    try {
+      await mount_sized_scatter_plot({
+        series: [
+          { x: [1, 2, 3], y: [1, 2, 3] },
+          { x: [1, 2, 3], y: [10, 20, 30], y_axis: `y2` },
+        ],
+        y_axis: { range: [0, 5] as Vec2 },
+        y2_axis: { sync: `synced` },
+      })
+    } finally {
+      error_spy.mockRestore()
+    }
+    expect(errors.map(String).join(`\n`)).toBe(``)
+  })
 })

--- a/tests/vitest/plot/ScatterPlot.test.svelte.ts
+++ b/tests/vitest/plot/ScatterPlot.test.svelte.ts
@@ -20,7 +20,10 @@ async function mount_sized_scatter_plot(
   document.body.append(container)
   mount(ScatterPlot, {
     target: container,
-    props: { ...props, style: `width: 400px; height: 300px; ${props.style ?? ``}` },
+    // Object.assign (not spread) keeps bind_props accessors intact for bindable-prop tests
+    props: Object.assign(props, {
+      style: `width: 400px; height: 300px; ${props.style ?? ``}`,
+    }),
   })
   const plot = container.querySelector<HTMLElement>(`.scatter`)
   if (!plot) throw new Error(`ScatterPlot root element not found`)
@@ -695,26 +698,17 @@ describe(`ScatterPlot`, () => {
   // Histogram and BoxPlot all do; only the synced/align modes derive y2 from y1
   test(`rect-zoom updates y2 range when y2 sync is 'none'`, async () => {
     const state = { y2_axis: {} as Record<string, unknown> }
-    // mount directly: mount_sized_scatter_plot spreads props, which would sever the
-    // bind_props getters and lose the y2_axis write-back
-    const container = document.createElement(`div`)
-    document.body.append(container)
-    mount(ScatterPlot, {
-      target: container,
-      props: bind_props(
+    const plot = await mount_sized_scatter_plot(
+      bind_props(
         {
           series: [
             { x: [1, 2, 3], y: [1, 2, 3] },
             { x: [1, 2, 3], y: [10, 20, 30], y_axis: `y2` as const },
           ],
-          style: `width: 400px; height: 300px;`,
         },
         state,
       ),
-    })
-    const plot = container.querySelector<HTMLElement>(`.scatter`)
-    if (!plot) throw new Error(`ScatterPlot root element not found`)
-    await resize_element(plot, 400, 300)
+    )
     const svg = plot.querySelector(`svg[role="application"]`) // chart svg, not control icons
     if (!svg) throw new Error(`svg not found`)
     svg.dispatchEvent(

--- a/tests/vitest/plot/ScatterPlot.test.svelte.ts
+++ b/tests/vitest/plot/ScatterPlot.test.svelte.ts
@@ -75,11 +75,7 @@ describe(`ScatterPlot`, () => {
     {
       series: [
         basic,
-        {
-          x: [1, 2, 3],
-          y: [2, 5, 3],
-          point_style: { fill: `orangered`, radius: 4 },
-        },
+        { x: [1, 2, 3], y: [2, 5, 3], point_style: { fill: `orangered`, radius: 4 } },
       ],
       markers: `line+points`,
       expected_markers: 8,

--- a/tests/vitest/plot/ScatterPoint.test.ts
+++ b/tests/vitest/plot/ScatterPoint.test.ts
@@ -376,12 +376,7 @@ describe(`ScatterPoint`, () => {
       },
       {
         name: `starts at explicit negative origin`,
-        props: {
-          x: -100,
-          y: -150,
-          origin: { x: -50, y: -75 },
-          offset: { x: -10, y: 10 },
-        },
+        props: { x: -100, y: -150, origin: { x: -50, y: -75 }, offset: { x: -10, y: 10 } },
         expected_origin: { x: -50, y: -75 },
       },
     ] as const)(`$name`, ({ props, expected_origin }) => {
@@ -396,12 +391,7 @@ describe(`ScatterPoint`, () => {
       const target = doc_query(`div`)
       mount(ScatterPoint, {
         target,
-        props: {
-          x: 100,
-          y: 150,
-          origin: { x: 12, y: 34 },
-          point_tween: { duration: 800 },
-        },
+        props: { x: 100, y: 150, origin: { x: 12, y: 34 }, point_tween: { duration: 800 } },
       })
       expect(doc_query(`g`).getAttribute(`transform`)).toBe(`translate(12 34)`)
     })

--- a/tests/vitest/plot/Sunburst.test.svelte.ts
+++ b/tests/vitest/plot/Sunburst.test.svelte.ts
@@ -1,7 +1,7 @@
 import { Sunburst } from '$lib'
 import type { PositionedArc, SunburstNode, SunburstNodeHandlerProps } from '$lib/plot'
 import { DEFAULT_SERIES_COLORS } from '$lib/plot'
-import { type ComponentProps, mount, tick } from 'svelte'
+import { type ComponentProps, flushSync, mount, tick } from 'svelte'
 import { describe, expect, test, vi } from 'vitest'
 import { resize_element } from '../setup'
 
@@ -182,16 +182,28 @@ describe(`Sunburst`, () => {
     ])
   })
 
-  test(`legend toggle mutes a category's subtree; re-click restores it`, async () => {
-    const plot = await mount_sized_sunburst({ data: tree, show_legend: true })
+  test(`legend toggle mutes a category's subtree (labels too); re-click restores it`, async () => {
+    const plot = await mount_sized_sunburst({
+      data: tree,
+      show_legend: true,
+      show_labels: true,
+    })
     const opacities = () =>
       ([`A`, `A1`, `A2`, `B`] as const).map((lbl) =>
         arc_path(plot, lbl).getAttribute(`fill-opacity`),
       )
+    const label_opacity = (text: string) =>
+      [...plot.querySelectorAll(`.arc-label`)]
+        .find((el) => el.textContent?.trim().startsWith(text))
+        ?.getAttribute(`fill-opacity`)
     await fire(plot.querySelector(`.legend-item`)) // mute A
     expect(opacities()).toEqual([`0.12`, `0.12`, `0.12`, `1`])
+    // muted arcs must not keep fully opaque labels floating over invisible arcs
+    expect(label_opacity(`A`)).toBe(`0.12`)
+    expect(label_opacity(`B`)).toBeNull()
     await fire(plot.querySelector(`.legend-item`)) // unmute A
     expect(opacities()).toEqual([`1`, `1`, `1`, `1`])
+    expect(label_opacity(`A`)).toBeNull()
   })
 
   test(`hovering an arc dims unrelated arcs but keeps its ancestors opaque`, async () => {
@@ -213,6 +225,53 @@ describe(`Sunburst`, () => {
     ]
     const plot = await mount_sized_sunburst({ data, value_mode: `total` })
     expect(plot.querySelector(`.center-label`)?.textContent).toContain(`10`)
+  })
+
+  // Regression guard for the effect_update_depth_exceeded class: a multi-root
+  // value_mode='total' hierarchy rendered as two instances with the default
+  // (non-zero) tween - the exact shape that surfaced the bug. A reactive read/write
+  // cycle in an effect (e.g. the view tween feeding back into its own target) trips
+  // Svelte's infinite-loop guard, which logs via console.error and throws; happy-dom
+  // flushes effects eagerly at mount, so it fires here. Mounts directly (not via the
+  // duration:0 helper) so the real Tween.of render-effect path is exercised.
+  test(`multi-root value_mode=total renders two instances without a reactive loop`, async () => {
+    const errors: unknown[][] = []
+    const error_spy = vi
+      .spyOn(console, `error`)
+      .mockImplementation((...args) => void errors.push(args))
+    // 7 roots x 34 numeric-labeled children, parent value == children sum (no warning)
+    const multi_root: SunburstNode[] = Array.from({ length: 7 }, (_root, sys) => ({
+      id: `sys${sys}`,
+      label: `sys${sys}`,
+      value: 34,
+      children: Array.from({ length: 34 }, (_child, num) => ({
+        id: `sys${sys}/${num}`,
+        label: `${num}`,
+        value: 1,
+      })),
+    }))
+    try {
+      for (let idx = 0; idx < 2; idx++) {
+        const target = document.createElement(`div`)
+        document.body.append(target)
+        mount(Sunburst, {
+          target,
+          props: {
+            data: multi_root,
+            value_mode: `total`,
+            style: `width: 500px; height: 360px`,
+          },
+        })
+        const plot = target.querySelector<HTMLElement>(`.sunburst`)
+        if (!plot) throw new Error(`Sunburst root element not found`)
+        await resize_element(plot, 500, 360)
+        expect(n_arcs(plot)).toBe(7 * 35) // 7 roots x (34 children + 1 root arc)
+      }
+    } finally {
+      error_spy.mockRestore()
+    }
+    // a clean render logs nothing; the loop guard logs (and throws) on a feedback cycle
+    expect(errors, errors.map(String).join(`\n`)).toHaveLength(0)
   })
 
   test.each([`Enter`, ` `])(
@@ -243,6 +302,108 @@ describe(`Sunburst`, () => {
     await fire(arc_path(plot, `A`))
     // the clicked arc collapsed into the hole - its tooltip must not linger
     expect(plot.querySelector(`.plot-tooltip`)).toBeNull()
+  })
+
+  // hover/focus state is index-based - swapping data must clear it, else the old
+  // tooltip lingers and whatever node now occupies the index renders as hovered
+  test(`swapping data clears stale hover/tooltip state`, async () => {
+    const props = $state({
+      data: tree,
+      tween: { duration: 0 },
+      style: `width: 500px; height: 360px;`,
+    })
+    const target = document.createElement(`div`)
+    document.body.append(target)
+    mount(Sunburst, { target, props })
+    const plot = target.querySelector<HTMLElement>(`.sunburst`)
+    if (!plot) throw new Error(`Sunburst root element not found`)
+    await resize_element(plot, 500, 360)
+    await fire(arc_path(plot, `B`), mouse(`mousemove`))
+    expect(plot.querySelector(`.plot-tooltip`)).not.toBeNull()
+    props.data = Array.from({ length: 5 }, (_node, idx) => ({
+      label: `N${idx}`,
+      value: idx + 1,
+    }))
+    flushSync()
+    await tick()
+    expect(plot.querySelector(`.plot-tooltip`)).toBeNull()
+    // no arc of the new data may inherit the stale hover highlight/dimming
+    const opacities = [...plot.querySelectorAll(`.arcs path`)].map((path) =>
+      path.getAttribute(`fill-opacity`),
+    )
+    expect(opacities).toEqual([`1`, `1`, `1`, `1`, `1`])
+  })
+
+  // legend hover sets hovered_idx without hover_info (dim-only); the same-arc early
+  // return in set_arc_hover must not then suppress the arc's own tooltip forever
+  test(`tooltip still appears on an arc after its legend item was hovered`, async () => {
+    const plot = await mount_sized_sunburst({ data: tree, show_legend: true })
+    const legend_item = plot.querySelector(`.legend-item`) // item for category A
+    await fire(legend_item, mouse(`mouseenter`))
+    await fire(arc_path(plot, `A`), mouse(`mousemove`))
+    expect(plot.querySelector(`.plot-tooltip`)).not.toBeNull()
+  })
+
+  // leaving the chart fires mouseleave on both the chart <g> and the <svg>; a hover
+  // clear must only report null once (and not at all when nothing was hovered)
+  test(`clearing an empty hover does not re-fire null callbacks`, async () => {
+    const on_node_hover = vi.fn()
+    const plot = await mount_sized_sunburst({ data: tree, on_node_hover })
+    const svg = plot.querySelector(`svg[role="application"]`)
+    await fire(arc_path(plot, `A`), mouse(`mousemove`)) // 1 call (hover info)
+    await fire(svg, new MouseEvent(`mouseleave`)) // 2nd call (null)
+    await fire(svg, new MouseEvent(`mouseleave`)) // already clear - no 3rd call
+    expect(on_node_hover.mock.calls.map((args) => args[0] && `info`)).toEqual([`info`, null])
+  })
+
+  // a fast double-click on the center zoom-out button fires click+click+dblclick;
+  // the dblclick background-reset must not compound onto the two zoom-out steps
+  test(`double-clicking the center circle steps out without resetting to root`, async () => {
+    const chain: SunburstNode[] = [
+      {
+        label: `L1`,
+        children: [
+          {
+            label: `L2`,
+            children: [
+              {
+                label: `L3`,
+                children: [
+                  { label: `L4a`, value: 1 },
+                  { label: `L4b`, value: 2 },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ]
+    const on_zoom = vi.fn()
+    const plot = await mount_sized_sunburst({ data: chain, on_zoom })
+    await fire(plot.querySelector(`[data-sunburst-node-idx="3"]`)) // zoom to L3 (depth 3)
+    const center = plot.querySelector(`.center-circle`)
+    await fire(center) // zoom out -> L2
+    await fire(center) // zoom out -> L1
+    await fire(center, mouse(`dblclick`)) // must NOT additionally reset to root
+    const last_root = on_zoom.mock.lastCall?.[0]?.root
+    expect(last_root?.label).toBe(`L1`)
+  })
+
+  // keyboard-zooming an icicle must move focus to the new root's first child: the
+  // clicked row itself collapses once the zoom tween settles, so focusing it (the
+  // roving index) would drop keyboard users out of the chart onto <body>
+  test(`icicle keyboard zoom focuses the new root's first child`, async () => {
+    const plot = await mount_sized_sunburst({
+      data: deep,
+      shape: `icicle`,
+      tween: { duration: 50 }, // real tween: the collapsing row is still mounted at t=0
+    })
+    const l1 = plot.querySelector<SVGPathElement>(`[data-sunburst-node-idx="1"]`)
+    l1?.focus()
+    await fire(l1, key(`Enter`)) // zoom to L1
+    await tick() // focus handoff runs in tick().then()
+    await tick()
+    expect(document.activeElement?.getAttribute(`data-sunburst-node-idx`)).toBe(`2`)
   })
 
   test.each([

--- a/tests/vitest/plot/Sunburst.test.svelte.ts
+++ b/tests/vitest/plot/Sunburst.test.svelte.ts
@@ -442,11 +442,14 @@ describe(`Sunburst label selection`, () => {
     const get_selection = vi
       .spyOn(globalThis, `getSelection`)
       .mockReturnValue({ isCollapsed: false, anchorNode: label } as unknown as Selection)
-    await fire(arc_path(plot, `A`))
-    // the mouseup ending a selection drag must not zoom or fire click handlers
-    expect(on_zoom).not.toHaveBeenCalled()
-    expect(on_node_click).not.toHaveBeenCalled()
-    get_selection.mockRestore()
+    try {
+      await fire(arc_path(plot, `A`))
+      // the mouseup ending a selection drag must not zoom or fire click handlers
+      expect(on_zoom).not.toHaveBeenCalled()
+      expect(on_node_click).not.toHaveBeenCalled()
+    } finally {
+      get_selection.mockRestore() // always restore so the spy can't leak into other tests
+    }
   })
 })
 

--- a/tests/vitest/plot/bar-data.test.ts
+++ b/tests/vitest/plot/bar-data.test.ts
@@ -94,8 +94,19 @@ describe(`normalize_categorical`, () => {
         color_values: [7, 8],
         size_values: [5, 6],
         metadata: { tag: `scalar` },
+        // per-point style arrays must follow the category reorder too
+        point_style: [{ fill: `red` }, { fill: `blue` }],
+        point_offset: [
+          { x: 1, y: 1 },
+          { x: 2, y: 2 },
+        ],
       },
-      { x: [`a`, `b`, `c`], y: [1, 2, 3], metadata: [{ id: 1 }, { id: 2 }, { id: 3 }] },
+      {
+        x: [`a`, `b`, `c`],
+        y: [1, 2, 3],
+        metadata: [{ id: 1 }, { id: 2 }, { id: 3 }],
+        point_style: { fill: `green` }, // scalar: broadcast, must pass through unchanged
+      },
     ]
     const { internal_series } = normalize_categorical(series)
     // categories: ['b', 'c', 'a'] (first-seen order across series)
@@ -104,9 +115,14 @@ describe(`normalize_categorical`, () => {
     expect(s1.bar_width).toEqual([0.2, 0.4, 0.5])
     expect(s1.color_values).toEqual([7, 8, null])
     expect(s1.size_values).toEqual([5, 6, null])
-    // scalar metadata is replicated for present categories, undefined for missing
+    // per-point style arrays reorder with categories; missing slot -> undefined
+    expect(s1.point_style).toEqual([{ fill: `red` }, { fill: `blue` }, undefined])
+    expect(s1.point_offset).toEqual([{ x: 1, y: 1 }, { x: 2, y: 2 }, undefined])
+    // scalar metadata is replicated per category; a scalar point prop is left as a single
+    // object (process_prop broadcasts it at render) - not replicated, not reordered
     expect(s1.metadata).toEqual([{ tag: `scalar` }, { tag: `scalar` }, undefined])
     expect(s2.metadata).toEqual([{ id: 2 }, { id: 3 }, { id: 1 }])
+    expect(s2.point_style).toEqual({ fill: `green` })
   })
 })
 

--- a/tests/vitest/plot/bar-data.test.ts
+++ b/tests/vitest/plot/bar-data.test.ts
@@ -1,0 +1,226 @@
+import type { BarAutoRangeOpts, NumericBarSeries } from '$lib/plot/bar/data'
+import {
+  compute_bar_auto_ranges,
+  compute_group_info,
+  compute_stacked_offsets,
+  normalize_categorical,
+} from '$lib/plot/bar/data'
+import type { BarSeries } from '$lib/plot'
+import { describe, expect, test, vi } from 'vitest'
+
+const bar = (overrides: Partial<NumericBarSeries> = {}): NumericBarSeries => ({
+  x: [0, 1],
+  y: [1, 2],
+  ...overrides,
+})
+
+const make_opts = (overrides: Partial<BarAutoRangeOpts> = {}): BarAutoRangeOpts => ({
+  visible_series: [],
+  y1_series: [],
+  y2_series: [],
+  x2_series: [],
+  mode: `overlay`,
+  orientation: `vertical`,
+  range_padding: 0,
+  category_count: 0,
+  x_range: [null, null],
+  x_scale_type: `linear`,
+  x_is_time: false,
+  x2_range: [null, null],
+  x2_scale_type: `linear`,
+  x2_is_time: false,
+  y_range: [null, null],
+  y_scale_type: `linear`,
+  y2_range: [null, null],
+  y2_scale_type: `linear`,
+  ...overrides,
+})
+
+const auto_ranges = (series: NumericBarSeries[], overrides: Partial<BarAutoRangeOpts> = {}) =>
+  compute_bar_auto_ranges(
+    make_opts({ visible_series: series, y1_series: series, ...overrides }),
+  )
+
+describe(`normalize_categorical`, () => {
+  test(`passes numeric-only series through with same identity`, () => {
+    const series: BarSeries[] = [{ x: [1, 2], y: [3, 4] }]
+    const { category_list, internal_series } = normalize_categorical(series)
+    expect(category_list).toEqual([])
+    expect(internal_series).toBe(series) // no copy when nothing to normalize
+  })
+
+  test(`aligns mixed series onto the union of categories with fallbacks`, () => {
+    const series: BarSeries[] = [
+      { x: [`a`, `b`], y: [1, 2] },
+      { x: [`b`, `c`], y: [3, 4] },
+      { x: [`c`], y: [9], render_mode: `line` },
+    ]
+    const { category_list, internal_series } = normalize_categorical(series)
+    expect(category_list).toEqual([`a`, `b`, `c`])
+    expect(internal_series[0].x).toEqual([0, 1, 2]) // categories map to integer indices
+    // bar series get 0 for missing categories
+    expect(internal_series[0].y).toEqual([1, 2, 0])
+    expect(internal_series[1].y).toEqual([0, 3, 4])
+    // line series get NaN for missing categories (gap, not a zero point)
+    expect(internal_series[2].y).toEqual([NaN, NaN, 9])
+  })
+
+  test(`respects explicit category order and drops absent categories`, () => {
+    const series: BarSeries[] = [{ x: [`a`, `b`, `c`], y: [1, 2, 3] }]
+    const { category_list, internal_series } = normalize_categorical(series, [`c`, `a`])
+    expect(category_list).toEqual([`c`, `a`])
+    expect(internal_series[0].x).toEqual([0, 1])
+    expect(internal_series[0].y).toEqual([3, 1])
+  })
+
+  test(`warns on duplicate x values and keeps last occurrence`, () => {
+    const warn_spy = vi.spyOn(console, `warn`).mockImplementation(() => {})
+    const series: BarSeries[] = [{ x: [`a`, `a`], y: [1, 2], label: `dupes` }]
+    const { internal_series } = normalize_categorical(series)
+    expect(internal_series[0].y).toEqual([2])
+    expect(warn_spy).toHaveBeenCalledWith(
+      `BarPlot: series "dupes" has duplicate x values — last occurrence wins`,
+    )
+    warn_spy.mockRestore()
+  })
+
+  test(`remaps per-point arrays and replicates scalar metadata`, () => {
+    const series: BarSeries[] = [
+      {
+        x: [`b`, `c`],
+        y: [2, 3],
+        labels: [`B`, `C`],
+        bar_width: [0.2, 0.4],
+        color_values: [7, 8],
+        size_values: [5, 6],
+        metadata: { tag: `scalar` },
+      },
+      { x: [`a`, `b`, `c`], y: [1, 2, 3], metadata: [{ id: 1 }, { id: 2 }, { id: 3 }] },
+    ]
+    const { internal_series } = normalize_categorical(series)
+    // categories: ['b', 'c', 'a'] (first-seen order across series)
+    const [s1, s2] = internal_series
+    expect(s1.labels).toEqual([`B`, `C`, null])
+    expect(s1.bar_width).toEqual([0.2, 0.4, 0.5])
+    expect(s1.color_values).toEqual([7, 8, null])
+    expect(s1.size_values).toEqual([5, 6, null])
+    // scalar metadata is replicated for present categories, undefined for missing
+    expect(s1.metadata).toEqual([{ tag: `scalar` }, { tag: `scalar` }, undefined])
+    expect(s2.metadata).toEqual([{ id: 2 }, { id: 3 }, { id: 1 }])
+  })
+})
+
+describe(`compute_bar_auto_ranges`, () => {
+  // stacked totals track pos/neg per x separately; linear scales clamp the value
+  // range to include 0 only when all totals share one sign
+  test.each([
+    { y1: [3, 4], y2: [2, -5], expected: [-5, 5], desc: `mixed signs span totals, no clamp` },
+    { y1: [3, 4], y2: [2, 0], expected: [0, 5], desc: `all-positive clamps min to 0` },
+    { y1: [-3, -4], y2: [-2, 0], expected: [-5, 0], desc: `all-negative clamps max to 0` },
+  ])(`stacked totals: $desc`, ({ y1, y2, expected }) => {
+    const series = [bar({ y: y1 }), bar({ y: y2 })]
+    expect(auto_ranges(series, { mode: `stacked` }).y).toEqual(expected)
+  })
+
+  test(`stacked mode lets line series contribute absolute (unstacked) values`, () => {
+    const series = [bar({ y: [3, 4] }), bar({ y: [10, 10], render_mode: `line` })]
+    expect(auto_ranges(series, { mode: `stacked` }).y).toEqual([0, 10]) // line max not stacked
+  })
+
+  test(`log scale skips zero-clamping`, () => {
+    const series = [bar({ y: [4, 5] })]
+    expect(auto_ranges(series).y[0]).toBe(0)
+    expect(auto_ranges(series, { y_scale_type: `log` }).y[0]).toBeGreaterThan(0)
+  })
+
+  test(`explicit y_range disables zero-clamping`, () => {
+    expect(auto_ranges([bar({ y: [4, 5] })], { y_range: [2, 6] }).y).toEqual([2, 6])
+  })
+
+  test(`categorical data fixes x range to [-0.5, count - 0.5]`, () => {
+    const series = [bar({ x: [0, 1, 2], y: [1, 2, 3] })]
+    expect(auto_ranges(series, { category_count: 3 }).x).toEqual([-0.5, 2.5])
+  })
+
+  test(`horizontal orientation swaps category and value axes`, () => {
+    const series = [bar({ x: [0, 10], y: [1, 5] })]
+    expect(auto_ranges(series)).toMatchObject({ x: [0, 10], y: [0, 5] })
+    expect(auto_ranges(series, { orientation: `horizontal` })).toMatchObject({
+      x: [0, 5],
+      y: [0, 10],
+    })
+  })
+
+  test(`empty series fall back to [0, 1] sentinels`, () => {
+    expect(auto_ranges([])).toEqual({ x: [0, 1], x2: [0, 1], y: [0, 1], y2: [0, 1] })
+  })
+
+  test(`x2 series get their own range; x stays sentinel without x1 series`, () => {
+    const x2_srs = bar({ x: [100, 200], y: [1, 2], x_axis: `x2` })
+    const result = auto_ranges([x2_srs], { x2_series: [x2_srs] })
+    expect(result.x2).toEqual([100, 200])
+    expect(result.x).toEqual([0, 1])
+  })
+})
+
+describe(`compute_stacked_offsets`, () => {
+  test.each([`overlay`, `grouped`] as const)(`returns [] for %s mode`, (mode) => {
+    expect(compute_stacked_offsets([bar(), bar()], mode)).toEqual([])
+  })
+
+  // expected is the offsets matrix, one row per original series index
+  // oxfmt-ignore
+  test.each([
+    {
+      desc: `accumulate per x value across visible bar series`,
+      series: [bar({ y: [1, 2] }), bar({ y: [3, 4] }), bar({ y: [5, 6] })],
+      expected: [[0, 0], [1, 2], [4, 6]],
+    },
+    {
+      // hidden rows are all zeros at their original index so visible rows don't shift
+      desc: `skip hidden series but keep original-index rows`,
+      series: [bar({ y: [1, 2] }), bar({ y: [10, 10], visible: false }), bar({ y: [3, 4] })],
+      expected: [[0, 0], [0, 0], [1, 2]],
+    },
+    {
+      desc: `exclude line series from stacking`,
+      series: [bar({ y: [1, 2] }), bar({ y: [10, 10], render_mode: `line` }), bar({ y: [3, 4] })],
+      expected: [[0, 0], [0, 0], [1, 2]],
+    },
+    {
+      desc: `stack positive and negative values on separate baselines`,
+      series: [bar({ y: [5, -5] }), bar({ y: [3, -2] }), bar({ y: [-1, -3] })],
+      expected: [[0, 0], [5, -5], [0, -7]],
+    },
+    {
+      desc: `accumulate y1 and y2 series independently`,
+      series: [bar({ y: [1, 1] }), bar({ y: [2, 2], y_axis: `y2` }), bar({ y: [3, 3] })],
+      expected: [[0, 0], [0, 0], [1, 1]],
+    },
+    {
+      // second series: x=1 stacks on first series' 2, x=2 starts fresh
+      desc: `stack misaligned x grids per x value`,
+      series: [bar({ x: [0, 1], y: [1, 2] }), bar({ x: [1, 2], y: [3, 4] })],
+      expected: [[0, 0], [2, 0]],
+    },
+  ])(`offsets $desc`, ({ series, expected }) => {
+    expect(compute_stacked_offsets(series, `stacked`)).toEqual(expected)
+  })
+})
+
+describe(`compute_group_info`, () => {
+  test.each([`overlay`, `stacked`] as const)(`returns empty info for %s mode`, (mode) => {
+    expect(compute_group_info([bar(), bar()], mode)).toEqual({
+      bar_series_count: 0,
+      bar_series_indices: [],
+    })
+  })
+
+  test(`indices are original series indices, skipping hidden and line series`, () => {
+    const series = [bar(), bar({ visible: false }), bar({ render_mode: `line` }), bar()]
+    expect(compute_group_info(series, `grouped`)).toEqual({
+      bar_series_count: 2,
+      bar_series_indices: [0, 3],
+    })
+  })
+})

--- a/tests/vitest/plot/interactions.test.ts
+++ b/tests/vitest/plot/interactions.test.ts
@@ -83,6 +83,11 @@ describe(`zoom_range_by_factor`, () => {
     expect(Number.isFinite(lo) && Number.isFinite(hi)).toBe(true)
     expect(lo).toBeCloseTo(-hi, 9) // asinh is odd, so symmetry is preserved
   })
+
+  // invalid factors would emit Infinity/NaN into axis state - return the range unchanged
+  it.each([0, -2, NaN, Infinity])(`factor %s returns the range unchanged`, (factor) => {
+    expect(zoom_range_by_factor([10, 20], factor)).toEqual([10, 20])
+  })
 })
 
 describe(`normalize_y2_sync`, () => {

--- a/tests/vitest/plot/interactions.test.ts
+++ b/tests/vitest/plot/interactions.test.ts
@@ -2,13 +2,17 @@
 import type { Vec2 } from '$lib/math'
 import { LOG_EPS } from '$lib/math'
 import {
+  axis_ranges_equal,
   expand_range_if_needed,
   normalize_y2_sync,
   pan_range_by_pixels,
+  resolve_axis_ranges,
+  sorted_range,
   sync_y2_range,
+  vec2_equal,
   zoom_range_by_factor,
 } from '$lib/plot/core/interactions'
-import type { ScaleType, Y2SyncConfig, Y2SyncMode } from '$lib/plot/core/types'
+import type { AxisRanges, ScaleType, Y2SyncConfig, Y2SyncMode } from '$lib/plot/core/types'
 import { describe, expect, it } from 'vitest'
 
 describe(`pan_range_by_pixels`, () => {
@@ -240,5 +244,54 @@ describe(`expand_range_if_needed`, () => {
     expect(result.range[0]).toBeCloseTo(0.3)
     expect(result.range[1]).toBeCloseTo(1.8)
     expect(result.changed).toBe(true)
+  })
+})
+
+describe(`sorted_range`, () => {
+  it(`sorts bounds ascending regardless of input order`, () => {
+    expect(sorted_range(5, 1)).toEqual([1, 5]) // reversed
+    expect(sorted_range(4, 4)).toEqual([4, 4]) // degenerate
+  })
+})
+
+describe(`vec2_equal`, () => {
+  it(`compares bounds; NaN never equal (so the sync effect can't loop)`, () => {
+    expect(vec2_equal([1, 2], [1, 2])).toBe(true)
+    expect(vec2_equal([1, 2], [1, 3])).toBe(false)
+    expect(vec2_equal([NaN, 5], [NaN, 5])).toBe(false)
+  })
+})
+
+describe(`axis_ranges_equal`, () => {
+  // a diff in any single axis must register (guards the && chain from dropping an axis)
+  const base: AxisRanges = { x: [0, 1], x2: [2, 3], y: [4, 5], y2: [6, 7] }
+  it.each<[string, AxisRanges, boolean]>([
+    [`all match`, { x: [0, 1], x2: [2, 3], y: [4, 5], y2: [6, 7] }, true],
+    [`x differs`, { x: [9, 9], x2: [2, 3], y: [4, 5], y2: [6, 7] }, false],
+    [`x2 differs`, { x: [0, 1], x2: [9, 9], y: [4, 5], y2: [6, 7] }, false],
+    [`y differs`, { x: [0, 1], x2: [2, 3], y: [9, 9], y2: [6, 7] }, false],
+    [`y2 differs`, { x: [0, 1], x2: [2, 3], y: [4, 5], y2: [9, 9] }, false],
+  ])(`%s`, (_desc, other, expected) => {
+    expect(axis_ranges_equal(base, other)).toBe(expected)
+  })
+})
+
+describe(`resolve_axis_ranges`, () => {
+  const auto = { x: [0, 10], x2: [0, 20], y: [0, 30], y2: [0, 40] }
+  const no_overrides = { x: {}, x2: {}, y: {}, y2: {} }
+
+  it(`merges explicit over auto per-bound; null/missing bounds fall back to auto`, () => {
+    const resolved = resolve_axis_ranges(
+      { x: { range: [1, 9] }, x2: { range: [null, 5] }, y: { range: [3, null] }, y2: {} },
+      auto,
+    )
+    // x: full override, x2/y: one-sided pins, y2: full fallback
+    expect(resolved).toEqual({ x: [1, 9], x2: [0, 5], y: [3, 30], y2: [0, 40] })
+  })
+
+  it(`returns null when any resolved bound is non-finite`, () => {
+    expect(resolve_axis_ranges(no_overrides, { ...auto, y: [0, NaN] })).toBeNull()
+    const inf = { ...no_overrides, x: { range: [0, Infinity] as [number, number] } }
+    expect(resolve_axis_ranges(inf, auto)).toBeNull()
   })
 })

--- a/tests/vitest/plot/interactions.test.ts
+++ b/tests/vitest/plot/interactions.test.ts
@@ -1,77 +1,83 @@
 // Unit tests for plot interaction utilities
 import type { Vec2 } from '$lib/math'
+import { LOG_EPS } from '$lib/math'
 import {
   expand_range_if_needed,
   normalize_y2_sync,
-  pan_range,
-  pixels_to_data_delta,
+  pan_range_by_pixels,
   sync_y2_range,
+  zoom_range_by_factor,
 } from '$lib/plot/core/interactions'
-import type { Y2SyncConfig, Y2SyncMode } from '$lib/plot/core/types'
+import type { ScaleType, Y2SyncConfig, Y2SyncMode } from '$lib/plot/core/types'
 import { describe, expect, it } from 'vitest'
 
-describe(`pan_range`, () => {
-  // [range, delta, expected]
-  it.each<[Vec2, number, Vec2]>([
-    [[0, 10], 5, [5, 15]],
-    [[0, 10], -5, [-5, 5]],
-    [[-10, -5], 3, [-7, -2]],
-    [[0, 100], 0.5, [0.5, 100.5]],
-  ])(`pan_range(%j, %s) = %j`, (range, delta, expected) => {
-    expect(pan_range(range, delta)).toEqual(expected)
+describe(`pan_range_by_pixels`, () => {
+  // pan must be uniform in *screen* space: constant shift on linear axes,
+  // constant factor on log axes (never crossing zero), asinh-shift on arcsinh
+  // [desc, range, px, span, scale_type, expected]
+  it.each<[string, Vec2, number, number, ScaleType | undefined, Vec2]>([
+    [`linear matches pan_range`, [0, 100], 50, 200, undefined, [25, 125]],
+    [`linear default scale_type`, [0, 10], -100, 200, `linear`, [-5, 5]],
+    [`time is linear in ms`, [0, 1000], 100, 200, `time`, [500, 1500]],
+    [`log shifts by one decade`, [1, 100], 100, 200, `log`, [10, 1000]],
+    [`log shifts back a decade`, [10, 1000], -100, 200, `log`, [1, 100]],
+    [`inverted linear stays inverted`, [100, 0], 50, 200, undefined, [75, -25]],
+    [`degenerate range is a no-op`, [50, 50], 100, 200, undefined, [50, 50]],
+  ])(`%s`, (_desc, range, px, span, type, expected) => {
+    const result = pan_range_by_pixels(range, px, span, type)
+    expect(result[0]).toBeCloseTo(expected[0], 9)
+    expect(result[1]).toBeCloseTo(expected[1], 9)
   })
 
-  it(`returns a new array (immutable)`, () => {
-    const original: Vec2 = [0, 10]
-    const result = pan_range(original, 5)
-    expect(result).not.toBe(original)
-    expect(original).toEqual([0, 10])
+  it(`log pan cannot cross zero, no matter how far`, () => {
+    const result = pan_range_by_pixels([1, 100], -10_000, 200, `log`)
+    expect(result.every((val) => Number.isFinite(val) && val > 0)).toBe(true)
+  })
+
+  it(`log pan preserves the ratio between bounds (screen-uniform)`, () => {
+    const [lo, hi] = pan_range_by_pixels([2, 50], 37, 200, `log`)
+    expect(hi / lo).toBeCloseTo(25, 9)
+  })
+
+  it(`log recovers a stale non-positive bound instead of NaN`, () => {
+    const result = pan_range_by_pixels([-5, 100], 10, 200, `log`)
+    expect(result.every((val) => Number.isFinite(val) && val >= LOG_EPS)).toBe(true)
+  })
+
+  it(`arcsinh pan stays finite across zero`, () => {
+    const result = pan_range_by_pixels([-100, 100], 80, 200, `arcsinh`)
+    expect(result.every(Number.isFinite)).toBe(true)
+    expect(result[0]).toBeLessThan(result[1])
+  })
+
+  it.each<ScaleType>([`linear`, `log`])(`%s: zero pixel span is a no-op`, (type) => {
+    expect(pan_range_by_pixels([1, 100], 50, 0, type)).toEqual([1, 100])
   })
 })
 
-describe(`pixels_to_data_delta`, () => {
-  // [px, data_range, pixel_range, expected]
-  it.each<[number, Vec2, number, number]>([
-    [100, [0, 100], 200, 50],
-    [-100, [0, 100], 200, -50],
-    [0, [0, 100], 200, 0],
-    [100, [-50, 50], 200, 50],
-    [100, [100, 200], 200, 50],
-    [10, [0, 50], 100, 5],
-    [0.5, [0, 100], 1, 50],
-    [100, [0, 1e12], 200, 5e11],
-    [100, [50, 50], 200, 0],
-    [60, [0, 1000], 600, 100],
-    [100, [0, 100], 0, 0],
-    [50, [0, 100], 100, 50],
-    [50, [0, 100], 200, 25],
-  ])(`pixels_to_data_delta(%s, %j, %s) = %s`, (px, data, size, expected) => {
-    expect(pixels_to_data_delta(px, data, size)).toBe(expected)
+describe(`zoom_range_by_factor`, () => {
+  // [desc, range, factor, scale_type, expected]
+  it.each<[string, Vec2, number, ScaleType | undefined, Vec2]>([
+    [`linear zoom in about center`, [0, 10], 2, undefined, [2.5, 7.5]],
+    [`linear zoom out about center`, [2.5, 7.5], 0.5, undefined, [0, 10]],
+    [`log zoom in keeps geometric center`, [1, 10_000], 2, `log`, [10, 1000]],
+    [`log zoom out`, [10, 1000], 0.5, `log`, [1, 10_000]],
+    [`inverted linear stays inverted`, [10, 0], 2, undefined, [7.5, 2.5]],
+  ])(`%s`, (_desc, range, factor, type, expected) => {
+    const result = zoom_range_by_factor(range, factor, type)
+    expect(result[0]).toBeCloseTo(expected[0], 9)
+    expect(result[1]).toBeCloseTo(expected[1], 9)
   })
 
-  it(`handles high-precision data ranges`, () => {
-    expect(pixels_to_data_delta(100, [0.001, 0.002], 200)).toBeCloseTo(0.0005)
-  })
-})
-
-describe(`pan_range + pixels_to_data_delta integration`, () => {
-  it(`50px drag on 200px plot with [0,100] range → 25 data units`, () => {
-    const delta = pixels_to_data_delta(50, [0, 100], 200)
-    expect(delta).toBe(25)
-    expect(pan_range([0, 100], delta)).toEqual([25, 125])
+  it(`log zoom never produces non-positive bounds`, () => {
+    const result = zoom_range_by_factor([0.001, 10], 0.01, `log`)
+    expect(result.every((val) => Number.isFinite(val) && val > 0)).toBe(true)
   })
 
-  it(`multiple pans preserve range span`, () => {
-    let range: Vec2 = [0, 100]
-    range = pan_range(range, pixels_to_data_delta(50, range, 200))
-    range = pan_range(range, pixels_to_data_delta(-30, range, 200))
-    range = pan_range(range, pixels_to_data_delta(20, range, 200))
-    expect(range[1] - range[0]).toBe(100)
-  })
-
-  it(`zoomed state: smaller range = larger per-pixel movement`, () => {
-    expect(pixels_to_data_delta(100, [40, 60], 200)).toBe(10)
-    expect(pan_range([40, 60], 10)).toEqual([50, 70])
+  it(`arcsinh zoom out across zero stays finite and symmetric-ish`, () => {
+    const [lo, hi] = zoom_range_by_factor([-100, 100], 0.5, `arcsinh`)
+    expect(Number.isFinite(lo) && Number.isFinite(hi)).toBe(true)
+    expect(lo).toBeCloseTo(-hi, 9) // asinh is odd, so symmetry is preserved
   })
 })
 

--- a/tests/vitest/plot/scales.test.ts
+++ b/tests/vitest/plot/scales.test.ts
@@ -49,12 +49,15 @@ describe(`scales`, () => {
         domain: [-1000, -5] as Vec2,
         expected: [math.LOG_EPS, math.LOG_EPS],
       },
-    ])(`log scale clamps non-positive domain ($name) stays finite`, ({ domain, expected }) => {
-      const scale = create_scale(`log`, domain, [0, 500])
-      expect(scale.domain()).toEqual(expected)
-      expect(Number.isFinite(scale(10))).toBe(true)
-      expect(Number.isFinite(scale.invert(250))).toBe(true)
-    })
+    ])(
+      `log scale clamps non-positive domain ($name) and stays finite`,
+      ({ domain, expected }) => {
+        const scale = create_scale(`log`, domain, [0, 500])
+        expect(scale.domain()).toEqual(expected)
+        expect(Number.isFinite(scale(10))).toBe(true)
+        expect(Number.isFinite(scale.invert(250))).toBe(true)
+      },
+    )
 
     test(`arcsinh scale with config object`, () => {
       const config: ArcsinhScaleConfig = { type: `arcsinh`, threshold: 10 }

--- a/tests/vitest/plot/scales.test.ts
+++ b/tests/vitest/plot/scales.test.ts
@@ -40,9 +40,20 @@ describe(`scales`, () => {
       expect(scale.range()).toEqual(range)
     })
 
-    test(`log scale with negative domain`, () => {
-      const scale = create_scale(`log`, [-5, 100], [0, 500])
-      expect(scale.domain()).toEqual([math.LOG_EPS, 100])
+    test.each([
+      { name: `negative min`, domain: [-5, 100] as Vec2, expected: [math.LOG_EPS, 100] },
+      // panning a log axis past zero arrives with max <= 0: an unclamped max would make
+      // every output/invert NaN (blank chart); clamping keeps the scale finite/recoverable
+      {
+        name: `non-positive min and max`,
+        domain: [-1000, -5] as Vec2,
+        expected: [math.LOG_EPS, math.LOG_EPS],
+      },
+    ])(`log scale clamps non-positive domain ($name) stays finite`, ({ domain, expected }) => {
+      const scale = create_scale(`log`, domain, [0, 500])
+      expect(scale.domain()).toEqual(expected)
+      expect(Number.isFinite(scale(10))).toBe(true)
+      expect(Number.isFinite(scale.invert(250))).toBe(true)
     })
 
     test(`arcsinh scale with config object`, () => {

--- a/tests/vitest/plot/scatter-data.test.ts
+++ b/tests/vitest/plot/scatter-data.test.ts
@@ -1,0 +1,177 @@
+import type { DataSeries } from '$lib/plot'
+import { get_series_color, get_series_symbol } from '$lib/plot/core/data-transform'
+import type { AxisRanges, LegendFill } from '$lib/plot/scatter/scatter-data'
+import {
+  build_legend_data,
+  filter_series_to_ranges,
+  pick_tooltip_bg,
+} from '$lib/plot/scatter/scatter-data'
+import { describe, expect, test } from 'vitest'
+
+const color_scale = (val: number) => `scale(${val})`
+const ranges: AxisRanges = { x: [0, 10], x2: [100, 200], y: [0, 10], y2: [-50, 50] }
+
+describe(`filter_series_to_ranges`, () => {
+  test(`includes points exactly on range edges, excludes outside`, () => {
+    const series: DataSeries[] = [{ x: [0, 5, 10, 10.001, -0.001], y: [0, 5, 10, 5, 5] }]
+    const [result] = filter_series_to_ranges(series, ranges)
+    expect(result.filtered_data.map((pt) => pt.x)).toEqual([0, 5, 10])
+    expect(result.filtered_data[2]).toMatchObject({ x: 10, y: 10, point_idx: 2 })
+    // full x array preserved so connecting lines can continue off-range
+    expect(result).toMatchObject({ visible: true, x: [0, 5, 10, 10.001, -0.001] })
+  })
+
+  test(`drops series whose points are all filtered out (and hidden series)`, () => {
+    const series: DataSeries[] = [
+      { x: [20, 30], y: [5, 5], label: `off-range` },
+      { x: [1, 2], y: [1, 2], label: `in-range` },
+      { x: [3], y: [3], label: `hidden`, visible: false },
+    ]
+    const result = filter_series_to_ranges(series, ranges)
+    // orig_series_idx 1 (not 0) keeps color cycling stable after dropping series
+    expect(result).toMatchObject([{ label: `in-range`, orig_series_idx: 1 }])
+  })
+
+  test(`y2-axis series filters against y2 range, x2 series against x2 range`, () => {
+    // y=40 outside y range [0,10] but inside y2 [-50,50]; x=150 outside x but inside x2
+    const series: DataSeries[] = [
+      { x: [1, 2, 3], y: [40, -40, 60], y_axis: `y2` },
+      { x: [150, 250], y: [5, 5], x_axis: `x2` },
+    ]
+    const [y2_series, x2_series] = filter_series_to_ranges(series, ranges)
+    expect(y2_series.filtered_data.map((pt) => pt.y)).toEqual([40, -40]) // 60 > 50 excluded
+    expect(x2_series.filtered_data.map((pt) => pt.x)).toEqual([150]) // 250 > 200 excluded
+  })
+
+  test(`handles inverted ranges and skips NaN/null coords`, () => {
+    const series: DataSeries[] = [{ x: [1, 5, NaN], y: [2, 8, 3] }]
+    const [result] = filter_series_to_ranges(series, { ...ranges, x: [10, 0], y: [10, 0] })
+    expect(result.filtered_data.map((pt) => pt.x)).toEqual([1, 5])
+  })
+
+  test(`augments points with per-point styles, color and size values`, () => {
+    const series: DataSeries[] = [
+      {
+        x: [1, 2],
+        y: [3, 4],
+        color_values: [0.1, 0.9],
+        size_values: [7, 9],
+        point_style: [{ fill: `red` }, { fill: `blue` }],
+        metadata: [{ tag: `a` }, { tag: `b` }],
+      },
+    ]
+    const pt = filter_series_to_ranges(series, ranges)[0].filtered_data[1]
+    expect(pt).toMatchObject({ x: 2, y: 4, color_value: 0.9, size_value: 9, point_idx: 1 })
+    expect(pt).toMatchObject({ point_style: { fill: `blue` }, metadata: { tag: `b` } })
+  })
+})
+
+describe(`build_legend_data`, () => {
+  test(`multi-series with fills: labels, default styles, fill entries`, () => {
+    const series: DataSeries[] = [
+      { x: [1], y: [1], label: `alpha` },
+      { x: [2], y: [2] }, // unlabeled -> default label
+    ]
+    const fills = [
+      { idx: 0, source_type: `fill_region`, source_idx: 0, label: `band`, fill: `orange` },
+    ] as unknown as LegendFill[]
+    expect(build_legend_data(series, fills, color_scale)).toMatchObject([
+      {
+        series_idx: 0,
+        label: `alpha`,
+        visible: true,
+        has_explicit_label: true,
+        display_style: {
+          symbol_type: get_series_symbol(0),
+          symbol_color: get_series_color(0),
+          line_color: get_series_color(0),
+        },
+      },
+      {
+        series_idx: 1,
+        label: `Series 2`,
+        has_explicit_label: false,
+        display_style: { symbol_color: get_series_color(1) },
+      },
+      {
+        series_idx: -1,
+        item_type: `fill`,
+        fill_idx: 0,
+        fill_source_type: `fill_region`,
+        fill_source_idx: 0,
+        label: `band`,
+        visible: true,
+        display_style: { fill_color: `orange`, fill_opacity: 0.3 },
+      },
+    ])
+  })
+
+  test(`dedupes by legend_group::label across series and fills, keeping first occurrence`, () => {
+    const series: DataSeries[] = [
+      { x: [1], y: [1], label: `dup`, point_style: { fill: `red` } },
+      { x: [2], y: [2], label: `dup`, point_style: { fill: `blue` } }, // same key -> dropped
+      { x: [3], y: [3], label: `dup`, legend_group: `g1` }, // different group -> kept
+    ]
+    const fills = [
+      { idx: 0, source_type: `fill_region`, source_idx: 0, label: `dup` }, // dup of series label
+      { idx: 1, label: `hidden`, show_in_legend: false },
+      { idx: 2, source_type: `error_band`, source_idx: 0 }, // no label -> dropped
+      { idx: 3, source_type: `error_band`, source_idx: 1, label: `kept`, visible: false },
+    ] as unknown as LegendFill[]
+    const items = build_legend_data(series, fills, color_scale)
+    expect(items.map((item) => item.label)).toEqual([`dup`, `dup`, `kept`])
+    expect(items[0]).toMatchObject({ series_idx: 0, display_style: { symbol_color: `red` } })
+    expect(items[1]).toMatchObject({ series_idx: 2, legend_group: `g1` })
+    expect(items[2]).toMatchObject({ item_type: `fill`, visible: false })
+  })
+
+  test(`markers control which styles appear; line color cascades`, () => {
+    const series: DataSeries[] = [
+      { x: [1], y: [1], markers: `points`, point_style: { fill: `red` } },
+      { x: [2], y: [2], markers: `line`, line_style: { stroke: `green`, line_dash: `4 2` } },
+      // no line stroke -> first non-null color_value through the scale
+      { x: [3], y: [3], markers: `line`, color_values: [null, 0.5] },
+    ]
+    const styles = build_legend_data(series, [], color_scale).map((item) => item.display_style)
+    // toEqual ignores undefined-valued keys, so it pins the other marker's styles as unset
+    expect(styles[0]).toEqual({ symbol_type: get_series_symbol(0), symbol_color: `red` })
+    expect(styles[1]).toEqual({ line_color: `green`, line_dash: `4 2` })
+    expect(styles[2].line_color).toBe(`scale(0.5)`)
+  })
+
+  test(`point stroke replaces transparent/none fill for symbol color`, () => {
+    const series: DataSeries[] = [
+      { x: [1], y: [1], point_style: { fill: `none`, stroke: `purple` } },
+      { x: [2], y: [2], point_style: [{ fill: `rgba(0, 0, 0, 0.5)`, stroke: `teal` }] },
+    ]
+    const items = build_legend_data(series, [], color_scale)
+    expect(items[0].display_style.symbol_color).toBe(`purple`)
+    expect(items[1].display_style.symbol_color).toBe(`teal`) // rgba( prefix counts as transparent
+  })
+})
+
+describe(`pick_tooltip_bg`, () => {
+  const base: DataSeries = { x: [1], y: [1] }
+  // fill is transparent so the cascade must move past it to the point stroke
+  const see_thru = { point_style: { fill: `rgba(0, 0, 0, 0)`, stroke: `blue` } }
+  const dark = `rgba(0, 0, 0, 0.7)` // ultimate fallback
+
+  // cascade: color_value -> point fill -> point stroke (points marker only) -> series
+  // line cascade (stroke -> first point fill -> first color value -> first point stroke)
+  // oxfmt-ignore
+  test.each<[string, Parameters<typeof pick_tooltip_bg>[0], DataSeries | undefined, string]>([
+    [`color_value through scale wins over point fill`, { color_value: 0.7, point_style: { fill: `red` } }, base, `scale(0.7)`],
+    [`point_style fill wins when no color_value`, { point_style: { fill: `red` } }, base, `red`],
+    [`transparent fill falls through to point stroke`, see_thru, base, `blue`],
+    [`line-only markers skip point stroke`, see_thru, { ...base, markers: `line` }, dark],
+    [`line cascade: series stroke`, {}, { ...base, line_style: { stroke: `green` } }, `green`],
+    [`line cascade: first point fill`, {}, { ...base, point_style: [{ fill: `gold` }] }, `gold`],
+    [`line cascade: first color value`, {}, { ...base, color_values: [0.2] }, `scale(0.2)`],
+    [`line cascade: first point stroke`, {}, { ...base, point_style: { stroke: `navy` } }, `navy`],
+    [`dark default when nothing usable`, {}, base, dark],
+    [`dark default for undefined series`, {}, undefined, dark],
+    [`dark default for transparent point fill`, { point_style: { fill: `transparent` } }, base, dark],
+  ])(`%s`, (_desc, point, series, expected) => {
+    expect(pick_tooltip_bg(point, series, color_scale)).toBe(expected)
+  })
+})

--- a/tests/vitest/plot/series-visibility.test.ts
+++ b/tests/vitest/plot/series-visibility.test.ts
@@ -169,6 +169,25 @@ describe(`handle_legend_double_click`, () => {
     expect(result.prev_visibility).toBeNull()
   })
 
+  // inside components, x/y are $state proxies whose identity changes when the series
+  // prop is reassigned by the isolate itself - the snapshot must match by value, not
+  // by array identity, else restore-from-isolation permanently breaks
+  test(`restores when data is value-identical but referentially new`, () => {
+    const original: DataSeries[] = [
+      { x: [1], y: [2], label: `A`, visible: true },
+      { x: [3], y: [4], label: `B`, visible: true },
+    ]
+    const isolated = handle_legend_double_click(original, 0, null)
+    const reproxied = isolated.series.map((srs) => ({
+      ...srs,
+      x: [...srs.x],
+      y: [...srs.y],
+    }))
+    const result = handle_legend_double_click(reproxied, 0, isolated.prev_visibility)
+    expect(result.series.map((srs) => srs.visible)).toEqual([true, true])
+    expect(result.prev_visibility).toBeNull()
+  })
+
   test.each([
     { new_vis: true, desc: `keeps true visibility` },
     { new_vis: false, desc: `keeps false visibility` },

--- a/tests/vitest/plot/sunburst-render.test.ts
+++ b/tests/vitest/plot/sunburst-render.test.ts
@@ -1,5 +1,10 @@
 import type { SunburstNode } from '$lib/plot'
-import { arc_label_transform, compute_sunburst_layout, project_arcs } from '$lib/plot'
+import {
+  arc_label_transform,
+  arrow_nav_target,
+  compute_sunburst_layout,
+  project_arcs,
+} from '$lib/plot'
 import type { ScreenGeometry, ViewWindow } from '$lib/plot/sunburst/render'
 import { describe, expect, test } from 'vitest'
 
@@ -102,5 +107,54 @@ describe(`arc_label_transform`, () => {
     const transform = arc_label_transform(d, text_w, shape, rotation)
     if (expected === null) expect(transform).toBeNull()
     else expect(transform).toMatch(expected)
+  })
+})
+
+describe(`arrow_nav_target`, () => {
+  // pre-order indices: root=0, a=1, a1=2, a2=3, b=4, b1=5, c=6
+  const nav_tree: SunburstNode[] = [
+    {
+      label: `a`,
+      children: [
+        { label: `a1`, value: 1 },
+        { label: `a2`, value: 2 },
+      ],
+    },
+    { label: `b`, children: [{ label: `b1`, value: 4 }] },
+    { label: `c`, value: 8 },
+  ]
+  const { arcs: nav_arcs } = compute_sunburst_layout(nav_tree)
+  const all_visible = () => true
+
+  test.each([
+    [`ArrowRight steps to the next sibling`, 1, `ArrowRight`, 4], // a -> b
+    [`ArrowRight wraps from the last sibling to the first`, 6, `ArrowRight`, 1], // c -> a
+    [`ArrowLeft wraps from the first sibling to the last`, 1, `ArrowLeft`, 6], // a -> c
+    [`ArrowDown enters the first visible child`, 1, `ArrowDown`, 2], // a -> a1
+    [`ArrowDown on a leaf is a no-op`, 6, `ArrowDown`, null], // c has no children
+    [`ArrowUp returns to the parent`, 2, `ArrowUp`, 1], // a1 -> a
+    [`ArrowUp never targets the hidden root at depth 0`, 1, `ArrowUp`, null], // a -> root
+    [`single visible sibling: left/right are no-ops`, 5, `ArrowRight`, null], // b1 alone
+    [`non-arrow keys are ignored`, 1, `Enter`, null],
+    [`unknown current index returns null`, 99, `ArrowRight`, null],
+  ] as const)(`%s`, (_name, current_idx, key, expected) => {
+    expect(arrow_nav_target(nav_arcs, all_visible, current_idx, key)).toBe(expected)
+  })
+
+  test(`hidden arcs are skipped when cycling siblings (wrap respects visibility)`, () => {
+    const b_hidden = (idx: number) => idx !== 4
+    // a -> c directly (b hidden), and c wraps back to a
+    expect(arrow_nav_target(nav_arcs, b_hidden, 1, `ArrowRight`)).toBe(6)
+    expect(arrow_nav_target(nav_arcs, b_hidden, 6, `ArrowRight`)).toBe(1)
+    // only one sibling left visible -> no-op
+    const only_a_visible = (idx: number) => idx === 1
+    expect(arrow_nav_target(nav_arcs, only_a_visible, 1, `ArrowLeft`)).toBeNull()
+  })
+
+  test(`ArrowDown and ArrowUp respect visibility of the target`, () => {
+    // a's first child a1 hidden -> ArrowDown is a no-op (no fall-through to a2)
+    expect(arrow_nav_target(nav_arcs, (idx) => idx !== 2, 1, `ArrowDown`)).toBeNull()
+    // parent a hidden -> ArrowUp from a1 is a no-op
+    expect(arrow_nav_target(nav_arcs, (idx) => idx !== 1, 2, `ArrowUp`)).toBeNull()
   })
 })

--- a/tests/vitest/setup.ts
+++ b/tests/vitest/setup.ts
@@ -81,6 +81,18 @@ export const doc_query = <T extends HTMLElement>(
 
 export const svg_query = (selector: string): SVGElement => query_required(selector)
 
+// Walk up from `el` to the owning <svg>: true if any ancestor applies a clip-path.
+// Used to assert reference-line annotations render unclipped at the plot edges.
+export const inside_clip_path = (el: Element | null | undefined): boolean => {
+  for (
+    let node = el?.parentElement;
+    node && node.tagName.toLowerCase() !== `svg`;
+    node = node.parentElement
+  )
+    if (node.getAttribute(`clip-path`)) return true
+  return false
+}
+
 export function set_element_size(element: HTMLElement, width: number, height: number): void {
   Object.defineProperty(element, `clientWidth`, { value: width, configurable: true })
   Object.defineProperty(element, `clientHeight`, { value: height, configurable: true })

--- a/tests/vitest/structure/index.test.ts
+++ b/tests/vitest/structure/index.test.ts
@@ -400,13 +400,7 @@ describe(`get_structure_vector_keys`, () => {
     },
     {
       desc: `prefixed keys across sites`,
-      sites: [
-        { force_DFT: [1, 0, 0] },
-        {
-          force_MLFF: [0.9, 0, 0],
-          force_DFT: [1, 0, 0],
-        },
-      ],
+      sites: [{ force_DFT: [1, 0, 0] }, { force_MLFF: [0.9, 0, 0], force_DFT: [1, 0, 0] }],
       expected: [`force_DFT`, `force_MLFF`],
     },
     {
@@ -433,10 +427,7 @@ describe(`get_structure_vector_keys`, () => {
       sites: [
         { force: [1, 0, 0] },
         { magmom: [0, 0, 1] },
-        {
-          spin_DFT: 0.5,
-          force_MLFF: [0, 1, 0],
-        },
+        { spin_DFT: 0.5, force_MLFF: [0, 1, 0] },
       ],
       expected: [`force`, `force_MLFF`, `magmom`, `spin_DFT`],
     },

--- a/tests/vitest/trajectory/Trajectory.test.svelte.ts
+++ b/tests/vitest/trajectory/Trajectory.test.svelte.ts
@@ -1,0 +1,51 @@
+import type { ElementSymbol, Vec3 } from '$lib'
+import { Trajectory } from '$lib/trajectory'
+import { flushSync, mount, tick } from 'svelte'
+import { describe, expect, test } from 'vitest'
+import { resize_element } from '../setup'
+
+const site = {
+  species: [{ element: `H` as ElementSymbol, occu: 1, oxidation_state: 0 }],
+  abc: [0, 0, 0] as Vec3,
+  xyz: [0, 0, 0] as Vec3,
+  label: `H1`,
+  properties: {},
+}
+const make_traj = (metadatas: Record<string, number>[]) => ({
+  frames: metadatas.map((metadata, idx) => ({
+    structure: { sites: [site], charge: 0 },
+    step: idx,
+    metadata,
+  })),
+  metadata: {},
+})
+
+describe(`Trajectory`, () => {
+  // Regression: the series-regeneration effect must survive the visible_properties
+  // write-back from the legend-sync effect. That write re-runs the regeneration
+  // effect while the syncing flag is set; returning before reading any reactive dep
+  // leaves the effect dep-less, and Svelte permanently unlinks dep-less effects -
+  // after which loading a new trajectory kept showing the previous one's series.
+  test(`swapping the trajectory prop regenerates plot series`, async () => {
+    const props = $state({
+      trajectory: make_traj([{ energy: -1.5 }, { energy: -2.5 }]),
+      display_mode: `scatter` as const,
+      show_controls: false,
+    })
+    const target = document.createElement(`div`)
+    document.body.append(target)
+    mount(Trajectory, { target, props })
+    flushSync()
+    await tick()
+    const plot = target.querySelector<HTMLElement>(`.scatter`)
+    if (!plot) throw new Error(`trajectory scatter plot not found`)
+    await resize_element(plot, 600, 400)
+    expect(plot.textContent).toContain(`Energy`)
+
+    props.trajectory = make_traj([{ volume: 10 }, { volume: 12 }])
+    flushSync()
+    await tick()
+    expect(plot.textContent).toContain(`Volume`)
+    expect(plot.textContent).not.toContain(`Energy`)
+  })
+})

--- a/tests/vitest/trajectory/index.test.ts
+++ b/tests/vitest/trajectory/index.test.ts
@@ -54,10 +54,7 @@ describe(`Trajectory Validation`, () => {
       trajectory: {
         frames: [
           {
-            structure: {
-              sites: [create_site(`H`, [0, 0, 0], [0, 0, 0], `H1`)],
-              charge: 0,
-            },
+            structure: { sites: [create_site(`H`, [0, 0, 0], [0, 0, 0], `H1`)], charge: 0 },
             step: `invalid`,
             metadata: {},
           },

--- a/tests/vitest/trajectory/streaming.test.ts
+++ b/tests/vitest/trajectory/streaming.test.ts
@@ -331,9 +331,7 @@ describe(`Trajectory Streaming`, () => {
         data,
         `compressed-trajectory.xyz.gz`,
         undefined,
-        {
-          use_indexing: true,
-        },
+        { use_indexing: true },
       )
 
       expect(result.is_indexed).toBe(true)

--- a/tests/vitest/xrd/XrdPlot.test.ts
+++ b/tests/vitest/xrd/XrdPlot.test.ts
@@ -415,10 +415,7 @@ describe(`XrdPlot`, () => {
     const target = create_sized_container()
     mount(XrdPlot, {
       target,
-      props: {
-        patterns: pattern,
-        allow_file_drop: true,
-      },
+      props: { patterns: pattern, allow_file_drop: true },
     })
 
     await wait_for_plot_render(target)
@@ -429,20 +426,14 @@ describe(`XrdPlot`, () => {
     expect(bar_plot?.classList.contains(`dragover`)).toBe(false)
 
     // Simulate dragover
-    const drag_event = new DragEvent(`dragover`, {
-      bubbles: true,
-      cancelable: true,
-    })
+    const drag_event = new DragEvent(`dragover`, { bubbles: true, cancelable: true })
     bar_plot?.dispatchEvent(drag_event)
 
     await tick()
     expect(bar_plot?.classList.contains(`dragover`)).toBe(true)
 
     // Simulate dragleave
-    const leave_event = new DragEvent(`dragleave`, {
-      bubbles: true,
-      cancelable: true,
-    })
+    const leave_event = new DragEvent(`dragleave`, { bubbles: true, cancelable: true })
     bar_plot?.dispatchEvent(leave_event)
 
     await tick()

--- a/tests/vitest/xrd/broadening.test.ts
+++ b/tests/vitest/xrd/broadening.test.ts
@@ -3,10 +3,7 @@ import { compute_broadened_pattern, DEFAULT_BROADENING } from '$lib/xrd/broadeni
 import { describe, expect, test } from 'vitest'
 
 describe(`compute_broadened_pattern`, () => {
-  const dummy_pattern = {
-    x: [20, 40],
-    y: [100, 50],
-  }
+  const dummy_pattern = { x: [20, 40], y: [100, 50] }
 
   describe(`input validation`, () => {
     test.each([

--- a/tests/vitest/xrd/calc-xrd.test.ts
+++ b/tests/vitest/xrd/calc-xrd.test.ts
@@ -140,10 +140,7 @@ describe(`compute_xrd_pattern edge cases`, () => {
 
   test(`scaled_intensity_tol filters peaks as configured`, () => {
     const structure = make_simple_cubic_structure(3)
-    const base_opts = {
-      wavelength: `CuKa` as const,
-      two_theta_range: [0, 90] as Vec2,
-    }
+    const base_opts = { wavelength: `CuKa` as const, two_theta_range: [0, 90] as Vec2 }
 
     const none_pass = compute_xrd_pattern(structure, {
       ...base_opts,


### PR DESCRIPTION
A set of correctness and rendering fixes across the plotting components, with regression tests for each.

### Reactive update loops
- Guard the range-sync effects in `BarPlot`, `BoxPlot`, `Histogram` and `BinnedScatterPlot` against transient non-finite ranges, and `untrack` the read-back of `ranges` so the effect can't re-trigger itself (`effect_update_depth_exceeded`).
- `ScatterPlot` untracks `zoom_y_range` inside the y2-sync effect.
- `Trajectory` reads all reactive deps before the syncing guard returns, so Svelte can't permanently unlink the otherwise dep-less effect.
- `Sunburst` re-seeds its zoom tween via `Tween.of` instead of an effect that reads and writes the same state.

### Axis / scale handling
- `create_scale` clamps **both** ends of a log domain to the positive floor, so panning a log axis past zero renders flat and recoverable instead of blanking the chart with NaN outputs.
- `BoxPlot` uses a log-safe value scale that clamps non-positive stats (e.g. `whisker_low = 0`, negative outliers) to `LOG_EPS`.
- Secondary-axis (y2) range write-back is gated on actual y2-series presence to avoid storing a phantom range from the `[0, 1]` sentinel scale; `ScatterPlot` now zooms y2 directly from the rect when `sync: 'none'`, matching the other plots.

### Rendering
- Chart content is split into two clip groups so reference lines interleave at their z positions while staying outside the chart clip (annotations can overflow); histogram series are clipped too.
- Legend corner-distance uses the measured footprint; legends cap their height and scroll when many series would overflow the plot.
- `IsobaricBinaryPhaseDiagram` prefixes gradient ids with an instance-unique id so two diagrams on one page don't cross-reference each other's gradients.
- `PieChart` sets `overflow: visible` so thin-slice labels drawn outside the pie aren't clipped.
- Thinner default grid/box/whisker/median/arc stroke widths and smaller pie `pad_angle`.
### Interactions
- Fix stale hover/tooltip state, double-click resets, touch gestures, and categorical tick thinning.

All 418 affected vitest cases pass.