### PR TITLE
Generic categorical entry classification for convex hull diagrams

### DIFF
--- a/extensions/dash/component_manifest.toml
+++ b/extensions/dash/component_manifest.toml
@@ -47,6 +47,7 @@ key = "convex-hull/ConvexHull2D"
 doc = "2D convex hull phase diagram plot."
 # BaseConvexHullProps are imported from index.d.ts; include core props here
 include_from = ["convex-hull/index.d.ts:BaseConvexHullProps"]
+forward_none_props = ["entry_category"]
 
 [components.ConvexHull3D]
 key = "convex-hull/ConvexHull3D"
@@ -55,6 +56,7 @@ include_from = [
   "convex-hull/index.d.ts:BaseConvexHullProps",
   "convex-hull/index.d.ts:Hull3DProps",
 ]
+forward_none_props = ["entry_category"]
 [components.ConvexHull3D.type_hints]
 gizmo = "dict | bool | None"
 
@@ -65,6 +67,7 @@ include_from = [
   "convex-hull/index.d.ts:BaseConvexHullProps",
   "convex-hull/index.d.ts:Hull3DProps",
 ]
+forward_none_props = ["entry_category"]
 [components.ConvexHull4D.type_hints]
 gizmo = "dict | bool | None"
 

--- a/extensions/dash/matterviz_dash_components/MatterViz.py
+++ b/extensions/dash/matterviz_dash_components/MatterViz.py
@@ -71,21 +71,20 @@ class MatterViz(Component):
     @_explicitize_args
     def __init__(
         self,
-        id=None,
-        component=None,
-        mv_props=None,
-        set_props=None,
-        float32_props=None,
-        event_props=None,
-        last_event=None,
-        className=None,
-        style=None,
-        _explicit_args=None,
-        **kwargs,
-    ):
+        id: str | dict[str, str | int | float | bool] | None = None,
+        component: str | None = None,
+        mv_props: dict[str, object] | None = None,
+        set_props: list[str] | None = None,
+        float32_props: list[str] | None = None,
+        event_props: list[str] | None = None,
+        last_event: dict[str, object] | None = None,
+        className: str | None = None,
+        style: dict[str, object] | None = None,
+        _explicit_args: list[str] | None = None,
+        **kwargs: object,
+    ) -> None:
         # _explicit_args is injected by @_explicitize_args decorator and captured above.
-        super().__init__(
-            id=id,
+        props = dict(
             component=component,
             mv_props=mv_props,
             set_props=set_props,
@@ -96,3 +95,6 @@ class MatterViz(Component):
             style=style,
             **kwargs,
         )
+        if id is not None:
+            props["id"] = id
+        super().__init__(**props)

--- a/extensions/dash/matterviz_dash_components/typed.py
+++ b/extensions/dash/matterviz_dash_components/typed.py
@@ -9,6 +9,8 @@ from typing import Any
 
 from .MatterViz import MatterViz
 
+_UNSET = object()
+
 class Structure(MatterViz):
     """3D crystal structure / molecule viewer.
 
@@ -601,7 +603,7 @@ class ConvexHull2D(MatterViz):
         label_threshold: float | None = None,
         show_stable: bool | None = None,
         show_unstable: bool | None = None,
-        entry_category: Any | None = None,
+        entry_category: Any | None = _UNSET,
         hidden_categories: list[str] | None = None,
         color_mode: Any | None = None,
         color_scale: Any | None = None,
@@ -662,7 +664,7 @@ class ConvexHull2D(MatterViz):
             mv_props["show_stable"] = show_stable
         if show_unstable is not None:
             mv_props["show_unstable"] = show_unstable
-        if entry_category is not None:
+        if entry_category is not _UNSET:
             mv_props["entry_category"] = entry_category
         if hidden_categories is not None:
             mv_props["hidden_categories"] = hidden_categories
@@ -748,7 +750,7 @@ class ConvexHull3D(MatterViz):
         label_threshold: float | None = None,
         show_stable: bool | None = None,
         show_unstable: bool | None = None,
-        entry_category: Any | None = None,
+        entry_category: Any | None = _UNSET,
         hidden_categories: list[str] | None = None,
         color_mode: Any | None = None,
         color_scale: Any | None = None,
@@ -810,7 +812,7 @@ class ConvexHull3D(MatterViz):
             mv_props["show_stable"] = show_stable
         if show_unstable is not None:
             mv_props["show_unstable"] = show_unstable
-        if entry_category is not None:
+        if entry_category is not _UNSET:
             mv_props["entry_category"] = entry_category
         if hidden_categories is not None:
             mv_props["hidden_categories"] = hidden_categories
@@ -906,7 +908,7 @@ class ConvexHull4D(MatterViz):
         label_threshold: float | None = None,
         show_stable: bool | None = None,
         show_unstable: bool | None = None,
-        entry_category: Any | None = None,
+        entry_category: Any | None = _UNSET,
         hidden_categories: list[str] | None = None,
         color_mode: Any | None = None,
         color_scale: Any | None = None,
@@ -968,7 +970,7 @@ class ConvexHull4D(MatterViz):
             mv_props["show_stable"] = show_stable
         if show_unstable is not None:
             mv_props["show_unstable"] = show_unstable
-        if entry_category is not None:
+        if entry_category is not _UNSET:
             mv_props["entry_category"] = entry_category
         if hidden_categories is not None:
             mv_props["hidden_categories"] = hidden_categories

--- a/extensions/dash/matterviz_dash_components/typed.py
+++ b/extensions/dash/matterviz_dash_components/typed.py
@@ -585,6 +585,8 @@ class ConvexHull2D(MatterViz):
     Events: on_point_click, on_point_hover, on_file_drop
 
     Unsupported snippets: children
+
+    Explicit None for entry_category is forwarded as JS null (omit the kwarg to keep the JS-side default)
     """
 
     def __init__(
@@ -734,6 +736,8 @@ class ConvexHull3D(MatterViz):
     Events: on_point_click, on_point_hover, on_file_drop
 
     Unsupported snippets: children
+
+    Explicit None for entry_category is forwarded as JS null (omit the kwarg to keep the JS-side default)
     """
 
     def __init__(
@@ -892,6 +896,8 @@ class ConvexHull4D(MatterViz):
     Events: on_point_click, on_point_hover, on_file_drop
 
     Unsupported snippets: children
+
+    Explicit None for entry_category is forwarded as JS null (omit the kwarg to keep the JS-side default)
     """
 
     def __init__(

--- a/extensions/dash/matterviz_dash_components/typed.py
+++ b/extensions/dash/matterviz_dash_components/typed.py
@@ -601,6 +601,8 @@ class ConvexHull2D(MatterViz):
         label_threshold: float | None = None,
         show_stable: bool | None = None,
         show_unstable: bool | None = None,
+        entry_category: Any | None = None,
+        hidden_categories: list[str] | None = None,
         color_mode: Any | None = None,
         color_scale: Any | None = None,
         info_pane_open: bool | None = None,
@@ -660,6 +662,10 @@ class ConvexHull2D(MatterViz):
             mv_props["show_stable"] = show_stable
         if show_unstable is not None:
             mv_props["show_unstable"] = show_unstable
+        if entry_category is not None:
+            mv_props["entry_category"] = entry_category
+        if hidden_categories is not None:
+            mv_props["hidden_categories"] = hidden_categories
         if color_mode is not None:
             mv_props["color_mode"] = color_mode
         if color_scale is not None:
@@ -742,6 +748,8 @@ class ConvexHull3D(MatterViz):
         label_threshold: float | None = None,
         show_stable: bool | None = None,
         show_unstable: bool | None = None,
+        entry_category: Any | None = None,
+        hidden_categories: list[str] | None = None,
         color_mode: Any | None = None,
         color_scale: Any | None = None,
         info_pane_open: bool | None = None,
@@ -802,6 +810,10 @@ class ConvexHull3D(MatterViz):
             mv_props["show_stable"] = show_stable
         if show_unstable is not None:
             mv_props["show_unstable"] = show_unstable
+        if entry_category is not None:
+            mv_props["entry_category"] = entry_category
+        if hidden_categories is not None:
+            mv_props["hidden_categories"] = hidden_categories
         if color_mode is not None:
             mv_props["color_mode"] = color_mode
         if color_scale is not None:
@@ -894,6 +906,8 @@ class ConvexHull4D(MatterViz):
         label_threshold: float | None = None,
         show_stable: bool | None = None,
         show_unstable: bool | None = None,
+        entry_category: Any | None = None,
+        hidden_categories: list[str] | None = None,
         color_mode: Any | None = None,
         color_scale: Any | None = None,
         info_pane_open: bool | None = None,
@@ -954,6 +968,10 @@ class ConvexHull4D(MatterViz):
             mv_props["show_stable"] = show_stable
         if show_unstable is not None:
             mv_props["show_unstable"] = show_unstable
+        if entry_category is not None:
+            mv_props["entry_category"] = entry_category
+        if hidden_categories is not None:
+            mv_props["hidden_categories"] = hidden_categories
         if color_mode is not None:
             mv_props["color_mode"] = color_mode
         if color_scale is not None:

--- a/extensions/dash/scripts/sync_typed_wrappers.py
+++ b/extensions/dash/scripts/sync_typed_wrappers.py
@@ -8,10 +8,9 @@ This script adds *typed* Python wrappers (subclasses of MatterViz) for IDE disco
 
 How props are discovered
 ------------------------
-The MatterViz npm package ships TypeScript declaration files next to its compiled Svelte
-components:
+MatterViz ships TypeScript declaration files next to its compiled Svelte components:
 
-  node_modules/matterviz/dist/**/<Component>.svelte.d.ts
+  <matterviz-dist>/**/<Component>.svelte.d.ts
 
 These contain a `type $$ComponentProps = ...` (often) or a `type Props = ...` plus a Svelte
 component declaration like:
@@ -29,7 +28,7 @@ Usage
 -----
   python scripts/sync_typed_wrappers.py \
       --manifest component_manifest.toml \
-      --matterviz-dist node_modules/matterviz/dist \
+      --matterviz-dist ../../dist \
       --out matterviz_dash_components/typed.py
 """
 
@@ -767,9 +766,11 @@ def main() -> None:
 
     ap = argparse.ArgumentParser()
     ap.add_argument("--manifest", default=f"{dash_root}/component_manifest.toml")
-    ap.add_argument(
-        "--matterviz-dist", default=f"{dash_root}/node_modules/matterviz/dist"
-    )
+    # Default to the repo's own build output (what CI uses), NOT the copy under
+    # extensions/dash/node_modules: pnpm snapshots the `file:../..` dependency at
+    # install time, so that copy silently goes stale as repo components evolve.
+    repo_root = os.path.dirname(os.path.dirname(dash_root))
+    ap.add_argument("--matterviz-dist", default=f"{repo_root}/dist")
     ap.add_argument("--out", default=f"{dash_root}/matterviz_dash_components/typed.py")
     ap.add_argument(
         "--check",
@@ -786,7 +787,9 @@ def main() -> None:
         raise SystemExit(f"Manifest not found: {manifest_path}")
     if not os.path.isdir(dist_dir):
         raise SystemExit(
-            f"MatterViz dist not found: {dist_dir}\nRun `pnpm install` first."
+            f"MatterViz dist not found: {dist_dir}\n"
+            "Build it with `pnpm package:dist` at the repo root (or pass "
+            "--matterviz-dist pointing at a built matterviz dist directory)."
         )
 
     with open(manifest_path, encoding="utf-8") as fh:

--- a/extensions/dash/scripts/sync_typed_wrappers.py
+++ b/extensions/dash/scripts/sync_typed_wrappers.py
@@ -761,8 +761,9 @@ def generate_wrappers(manifest: dict[str, Any], dist_dir: str) -> str:
 
 def main() -> None:
     """CLI entry point for generating typed wrappers."""
-    # Path to extensions/dash/ directory (parent of scripts/)
-    dash_root = os.path.dirname(os.path.dirname(__file__))
+    # Path to extensions/dash/ directory (parent of scripts/). abspath keeps the derived
+    # defaults cwd-independent even where __file__ is relative (e.g. some import modes).
+    dash_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
     ap = argparse.ArgumentParser()
     ap.add_argument("--manifest", default=f"{dash_root}/component_manifest.toml")

--- a/extensions/dash/scripts/sync_typed_wrappers.py
+++ b/extensions/dash/scripts/sync_typed_wrappers.py
@@ -689,6 +689,11 @@ def generate_wrappers(manifest: dict[str, Any], dist_dir: str) -> str:
             lines.append(f"\n    Events: {', '.join(callback_props)}")
         if snippet_props:
             lines.append(f"\n    Unsupported snippets: {', '.join(snippet_props)}")
+        if forward_none_props:
+            lines.append(
+                f"\n    Explicit None for {', '.join(sorted(forward_none_props))} is "
+                "forwarded as JS null (omit the kwarg to keep the JS-side default)"
+            )
         lines.append('    """')
         lines.append("")
 

--- a/extensions/dash/scripts/sync_typed_wrappers.py
+++ b/extensions/dash/scripts/sync_typed_wrappers.py
@@ -617,6 +617,8 @@ def generate_wrappers(manifest: dict[str, Any], dist_dir: str) -> str:
         "",
         "from .MatterViz import MatterViz",
         "",
+        "_UNSET = object()",
+        "",
     ]
 
     for class_name, spec in components.items():
@@ -662,6 +664,7 @@ def generate_wrappers(manifest: dict[str, Any], dist_dir: str) -> str:
         default_float32_props = spec.get("float32_props", auto_float32)
         alias_overrides = spec.get("aliases", {}) or {}
         type_hints = spec.get("type_hints", {}) or {}
+        forward_none_props = set(spec.get("forward_none_props", []))
 
         # Build python->js mapping with unique identifiers
         py_to_js: dict[str, str] = {}
@@ -703,7 +706,8 @@ def generate_wrappers(manifest: dict[str, Any], dist_dir: str) -> str:
             # Avoid duplicate None when type hint already includes it
             if "None" not in py_type:
                 py_type += " | None"
-            sig.append(f"{py}: {py_type} = None")
+            default = "_UNSET" if js in forward_none_props else "None"
+            sig.append(f"{py}: {py_type} = {default}")
         sig += [
             "mv_props: dict | None = None",
             "set_props: list[str] | None = None",
@@ -720,7 +724,8 @@ def generate_wrappers(manifest: dict[str, Any], dist_dir: str) -> str:
         lines.append("        if mv_props is None:")
         lines.append("            mv_props = {}")
         for py, js in py_to_js.items():
-            lines.append(f"        if {py} is not None:")
+            sentinel = "_UNSET" if js in forward_none_props else "None"
+            lines.append(f"        if {py} is not {sentinel}:")
             lines.append(f'            mv_props["{js}"] = {py}')
         if default_set_props:
             lines.append("        if set_props is None:")

--- a/extensions/dash/tests/test_wrappers.py
+++ b/extensions/dash/tests/test_wrappers.py
@@ -26,6 +26,11 @@ class TestMatterVizBase:
         assert comp.id == "test"
         assert comp.component == "Structure"
 
+    def test_instantiation_without_id(self) -> None:
+        """MatterViz omits absent id instead of forwarding id=None."""
+        comp = MatterViz(component="Structure")
+        assert comp.component == "Structure"
+
     def test_mv_props_forwarded(self) -> None:
         """mv_props dict is forwarded correctly."""
         comp = MatterViz(

--- a/extensions/dash/tests/test_wrappers.py
+++ b/extensions/dash/tests/test_wrappers.py
@@ -115,6 +115,20 @@ class TestComponentInstantiation:
         assert comp.component == component
         assert comp.mv_props == mv_props
 
+    @pytest.mark.parametrize(
+        "wrapper",
+        [mvc.ConvexHull2D, mvc.ConvexHull3D, mvc.ConvexHull4D],
+    )
+    def test_convex_hull_entry_category_none_disables_default(
+        self, wrapper: type
+    ) -> None:
+        """Typed convex hull wrappers forward explicit entry_category=None."""
+        omitted = wrapper(entries=[])
+        assert "entry_category" not in omitted.mv_props
+
+        disabled = wrapper(entries=[], entry_category=None)
+        assert disabled.mv_props["entry_category"] is None
+
 
 class TestModuleExports:
     """Tests for module-level exports."""

--- a/src/lib/convex-hull/ConvexHull.svelte
+++ b/src/lib/convex-hull/ConvexHull.svelte
@@ -24,6 +24,7 @@
     wrapper = $bindable(),
     show_stable = $bindable(true),
     show_unstable = $bindable(true),
+    hidden_categories = $bindable([]),
     show_hull_faces = $bindable(true),
     hull_face_opacity: hull_face_opacity_prop = $bindable(
       undefined as number | undefined,
@@ -100,6 +101,7 @@
     bind:wrapper
     bind:show_stable
     bind:show_unstable
+    bind:hidden_categories
     bind:show_hull_faces
     bind:hull_face_opacity
     bind:color_mode

--- a/src/lib/convex-hull/ConvexHull2D.svelte
+++ b/src/lib/convex-hull/ConvexHull2D.svelte
@@ -38,6 +38,7 @@
     HoverData3D,
     PhaseData,
   } from './types'
+  import { MAGNETIC_ORDERING_CATEGORY } from './types'
 
   // Binary convex hull rendered as energy vs composition (x in [0, 1])
   let {
@@ -54,6 +55,8 @@
     label_threshold = 50,
     show_stable = $bindable(DEFAULTS.convex_hull.binary.show_stable),
     show_unstable = $bindable(DEFAULTS.convex_hull.binary.show_unstable),
+    entry_category = MAGNETIC_ORDERING_CATEGORY,
+    hidden_categories = $bindable([]),
     color_mode = $bindable(DEFAULTS.convex_hull.binary.color_mode),
     color_scale = $bindable(
       DEFAULTS.convex_hull.binary.color_scale as D3InterpolateName,
@@ -137,6 +140,8 @@
     max_hull_dist_show_phases: () => max_hull_dist_show_phases,
     show_stable: () => show_stable,
     show_unstable: () => show_unstable,
+    entry_category: () => entry_category,
+    hidden_categories: () => hidden_categories,
     keep_plot_entry: (entry, max_dist) =>
       helpers.entry_is_stable(entry) || (entry.e_above_hull ?? 0) <= max_dist,
     set_temperature: (next_temp) => temperature = next_temp,
@@ -370,6 +375,7 @@
     color_scale = DEFAULTS.convex_hull.binary.color_scale as D3InterpolateName
     show_stable = DEFAULTS.convex_hull.binary.show_stable
     show_unstable = DEFAULTS.convex_hull.binary.show_unstable
+    hidden_categories = []
     show_stable_labels = DEFAULTS.convex_hull.binary.show_stable_labels
     show_unstable_labels = DEFAULTS.convex_hull.binary.show_unstable_labels
     // Use auto-computed threshold based on entry count instead of static default
@@ -389,6 +395,7 @@
       color_scale !== DEFAULTS.convex_hull.binary.color_scale ||
       show_stable !== DEFAULTS.convex_hull.binary.show_stable ||
       show_unstable !== DEFAULTS.convex_hull.binary.show_unstable ||
+      hidden_categories.length > 0 ||
       show_stable_labels !== DEFAULTS.convex_hull.binary.show_stable_labels ||
       show_unstable_labels !== DEFAULTS.convex_hull.binary.show_unstable_labels ||
       // Compare with auto-computed threshold, with small tolerance for floating point
@@ -448,7 +455,7 @@
     await helpers.copy_entry_to_clipboard(entry, position, (visible, pos) => {
       copy_feedback.visible = visible
       copy_feedback.position = pos
-    })
+    }, entry_category)
   }
 
   function close_structure_popup() {
@@ -525,6 +532,7 @@
       {entry}
       polymorph_stats_map={hull_data.polymorph_stats_map}
       highlight_style={entry_highlight}
+      {entry_category}
       tooltip={custom_tooltip}
     />
   {/if}
@@ -551,6 +559,8 @@
         {unstable_entries}
         {show_stable}
         {show_unstable}
+        {entry_category}
+        {hidden_categories}
         {max_hull_dist_show_phases}
         {max_hull_dist_show_labels}
         {label_threshold}
@@ -569,6 +579,8 @@
         bind:color_scale
         bind:show_stable
         bind:show_unstable
+        {entry_category}
+        bind:hidden_categories
         bind:show_stable_labels
         bind:show_unstable_labels
         bind:max_hull_dist_show_phases

--- a/src/lib/convex-hull/ConvexHull3D.svelte
+++ b/src/lib/convex-hull/ConvexHull3D.svelte
@@ -51,6 +51,7 @@
     LabelPlacement,
   } from './types'
   import { compute_hull_stability } from './helpers'
+  import { MAGNETIC_ORDERING_CATEGORY } from './types'
 
   let {
     entries = [],
@@ -66,6 +67,8 @@
     label_threshold = 50,
     show_stable = $bindable(DEFAULTS.convex_hull.ternary.show_stable),
     show_unstable = $bindable(DEFAULTS.convex_hull.ternary.show_unstable),
+    entry_category = MAGNETIC_ORDERING_CATEGORY,
+    hidden_categories = $bindable([]),
     show_hull_faces = $bindable(DEFAULTS.convex_hull.ternary.show_hull_faces),
     hull_face_opacity = $bindable(DEFAULTS.convex_hull.ternary.hull_face_opacity),
     hull_face_color_mode = $bindable(
@@ -135,6 +138,8 @@
     max_hull_dist_show_phases: () => max_hull_dist_show_phases,
     show_stable: () => show_stable,
     show_unstable: () => show_unstable,
+    entry_category: () => entry_category,
+    hidden_categories: () => hidden_categories,
     keep_plot_entry: (entry, max_dist) => (entry.e_above_hull ?? 0) <= max_dist,
     set_temperature: (next_temp) => temperature = next_temp,
     set_max_hull_dist_show_phases: (value) => max_hull_dist_show_phases = value,
@@ -335,6 +340,7 @@
     on_point_click: () => on_point_click,
     on_point_hover: () => on_point_hover,
     on_file_drop: () => on_file_drop,
+    entry_category: () => entry_category,
     zoom: () => camera.zoom,
     set_zoom: (zoom) => camera.zoom = zoom,
     project_point: project_3d_point,
@@ -395,7 +401,7 @@
   // Re-render when important state changes
   $effect(() => {
     // oxfmt-ignore
-    void [show_hull_faces, color_mode, color_scale, show_stable_labels, show_unstable_labels, max_hull_dist_show_labels, camera.elevation, camera.azimuth, camera.zoom, camera.center_x, camera.center_y, plot_entries, hull_face_color, hull_face_opacity, hull_face_color_mode, element_colors, highlighted_entries, text_color] // track reactively
+    void [show_hull_faces, color_mode, color_scale, show_stable_labels, show_unstable_labels, max_hull_dist_show_labels, camera.elevation, camera.azimuth, camera.zoom, camera.center_x, camera.center_y, plot_entries, visible_entries, hull_face_color, hull_face_opacity, hull_face_color_mode, element_colors, highlighted_entries, text_color] // track reactively
 
     render_once()
   })
@@ -415,6 +421,7 @@
     color_scale = DEFAULTS.convex_hull.ternary.color_scale as D3InterpolateName
     show_stable = DEFAULTS.convex_hull.ternary.show_stable
     show_unstable = DEFAULTS.convex_hull.ternary.show_unstable
+    hidden_categories = []
     show_stable_labels = DEFAULTS.convex_hull.ternary.show_stable_labels
     show_unstable_labels = DEFAULTS.convex_hull.ternary.show_unstable_labels
     max_hull_dist_show_labels = DEFAULTS.convex_hull.ternary.max_hull_dist_show_labels
@@ -1148,6 +1155,8 @@
     bind:color_scale
     bind:show_stable
     bind:show_unstable
+    {entry_category}
+    bind:hidden_categories
     bind:show_stable_labels
     bind:show_unstable_labels
     bind:max_hull_dist_show_phases

--- a/src/lib/convex-hull/ConvexHull4D.svelte
+++ b/src/lib/convex-hull/ConvexHull4D.svelte
@@ -35,6 +35,7 @@
     HullFaceColorMode,
     PhaseData,
   } from './types'
+  import { MAGNETIC_ORDERING_CATEGORY } from './types'
   import { compute_hull_stability } from './helpers'
 
   let {
@@ -51,6 +52,8 @@
     label_threshold = 50,
     show_stable = $bindable(DEFAULTS.convex_hull.quaternary.show_stable),
     show_unstable = $bindable(DEFAULTS.convex_hull.quaternary.show_unstable),
+    entry_category = MAGNETIC_ORDERING_CATEGORY,
+    hidden_categories = $bindable([]),
     show_hull_faces = $bindable(DEFAULTS.convex_hull.quaternary.show_hull_faces),
     hull_face_opacity = $bindable(DEFAULTS.convex_hull.quaternary.hull_face_opacity),
     hull_face_color_mode = $bindable(
@@ -126,6 +129,8 @@
     max_hull_dist_show_phases: () => max_hull_dist_show_phases,
     show_stable: () => show_stable,
     show_unstable: () => show_unstable,
+    entry_category: () => entry_category,
+    hidden_categories: () => hidden_categories,
     // Always include stable entries and elemental reference points
     keep_plot_entry: (entry, max_dist) =>
       helpers.entry_is_stable(entry) ||
@@ -241,6 +246,7 @@
     on_point_click: () => on_point_click,
     on_point_hover: () => on_point_hover,
     on_file_drop: () => on_file_drop,
+    entry_category: () => entry_category,
     zoom: () => camera.zoom,
     set_zoom: (zoom) => camera.zoom = zoom,
     project_point: project_3d_point,
@@ -297,7 +303,7 @@
   // Re-render when important state changes
   $effect(() => {
     // oxfmt-ignore
-    void [show_hull_faces, color_mode, color_scale, camera.rotation_x, camera.rotation_y, camera.zoom, camera.center_x, camera.center_y, plot_entries, hull_face_color, hull_face_opacity, hull_face_color_mode, element_colors, text_color, elements] // track reactively
+    void [show_hull_faces, color_mode, color_scale, camera.rotation_x, camera.rotation_y, camera.zoom, camera.center_x, camera.center_y, plot_entries, hull_data.visible_entries, hull_face_color, hull_face_opacity, hull_face_color_mode, element_colors, text_color, elements] // track reactively
 
     render_once()
   })
@@ -336,6 +342,7 @@
     color_scale = DEFAULTS.convex_hull.quaternary.color_scale as D3InterpolateName
     show_stable = DEFAULTS.convex_hull.quaternary.show_stable
     show_unstable = DEFAULTS.convex_hull.quaternary.show_unstable
+    hidden_categories = []
     show_stable_labels = DEFAULTS.convex_hull.quaternary.show_stable_labels
     show_unstable_labels = DEFAULTS.convex_hull.quaternary.show_unstable_labels
     // Use auto-computed threshold based on entry count instead of static default
@@ -836,6 +843,8 @@
     bind:color_scale
     bind:show_stable
     bind:show_unstable
+    {entry_category}
+    bind:hidden_categories
     bind:show_stable_labels
     bind:show_unstable_labels
     bind:max_hull_dist_show_phases

--- a/src/lib/convex-hull/ConvexHullChrome.svelte
+++ b/src/lib/convex-hull/ConvexHullChrome.svelte
@@ -17,6 +17,7 @@
   import { CONVEX_HULL_STYLE } from './index'
   import StructurePopup from './StructurePopup.svelte'
   import type { ConvexHullEntry, HighlightStyle, HullFaceColorMode } from './types'
+  import { MAGNETIC_ORDERING_CATEGORY } from './types'
 
   type ControlsProps = ComponentProps<typeof ConvexHullControls>
 
@@ -51,6 +52,8 @@
     color_scale = $bindable(`interpolateViridis`),
     show_stable = $bindable(true),
     show_unstable = $bindable(true),
+    entry_category = MAGNETIC_ORDERING_CATEGORY,
+    hidden_categories = $bindable([]),
     show_stable_labels = $bindable(true),
     show_unstable_labels = $bindable(false),
     max_hull_dist_show_phases = $bindable(0),
@@ -67,6 +70,8 @@
       | `color_scale`
       | `show_stable`
       | `show_unstable`
+      | `entry_category`
+      | `hidden_categories`
       | `show_stable_labels`
       | `show_unstable_labels`
       | `max_hull_dist_show_phases`
@@ -120,6 +125,8 @@
         {unstable_entries}
         {show_stable}
         {show_unstable}
+        {entry_category}
+        {hidden_categories}
         {max_hull_dist_show_phases}
         {max_hull_dist_show_labels}
         {label_threshold}
@@ -139,6 +146,8 @@
         bind:color_scale
         bind:show_stable
         bind:show_unstable
+        {entry_category}
+        bind:hidden_categories
         bind:show_stable_labels
         bind:show_unstable_labels
         bind:max_hull_dist_show_phases
@@ -187,6 +196,7 @@
       {entry}
       polymorph_stats_map={hull_data.polymorph_stats_map}
       highlight_style={entry_highlight}
+      {entry_category}
       {tooltip}
     />
   </PlotTooltip>

--- a/src/lib/convex-hull/ConvexHullControls.svelte
+++ b/src/lib/convex-hull/ConvexHullControls.svelte
@@ -8,12 +8,14 @@
   import type { ComponentProps } from 'svelte'
   import { tooltip } from 'svelte-multiselect/attachments'
   import type { HTMLAttributes } from 'svelte/elements'
+  import { count_entry_categories, marker_path_data } from './helpers'
   import type {
     ConvexHullControlsType,
     ConvexHullEntry,
+    EntryCategoryConfig,
     HullFaceColorMode,
   } from './types'
-  import { HULL_FACE_COLOR_MODES } from './types'
+  import { HULL_FACE_COLOR_MODES, MAGNETIC_ORDERING_CATEGORY } from './types'
 
   interface CameraState {
     elevation?: number // Elevation angle in degrees (for ternary)
@@ -45,6 +47,8 @@
     color_scale = $bindable(`interpolateViridis`),
     show_stable = $bindable(true),
     show_unstable = $bindable(true),
+    entry_category = MAGNETIC_ORDERING_CATEGORY,
+    hidden_categories = $bindable([]),
     show_stable_labels = $bindable(true),
     show_unstable_labels = $bindable(false),
     show_hull_faces = undefined,
@@ -77,6 +81,9 @@
     color_scale?: D3InterpolateName
     show_stable?: boolean
     show_unstable?: boolean
+    // Categorical classification rendered as filter toggles (null disables the row)
+    entry_category?: EntryCategoryConfig | null
+    hidden_categories?: string[]
     show_stable_labels?: boolean
     show_unstable_labels?: boolean
     // 3D specific controls
@@ -115,6 +122,29 @@
     evt: Event & { currentTarget: HTMLElement },
   ): void {
     evt.currentTarget.nextElementSibling?.querySelector<HTMLInputElement>(`input`)?.focus()
+  }
+
+  // Category filters: only show category values present in the (threshold-filtered) data
+  const category_counts = $derived(
+    count_entry_categories([...stable_entries, ...unstable_entries], entry_category),
+  )
+  const category_values_in_data = $derived(
+    Object.keys(entry_category?.markers ?? {}).filter(
+      (value) => (category_counts[value] ?? 0) > 0,
+    ),
+  )
+  const toggle_category = (value: string) => {
+    hidden_categories = hidden_categories.includes(value)
+      ? hidden_categories.filter((hidden) => hidden !== value)
+      : [...hidden_categories, value]
+  }
+  // Radius of the marker shape swatch SVGs (sized to fit their 12x12 viewBox)
+  const SWATCH_RADIUS = 4.4
+  // Keyboard activation for legend toggles (preventDefault stops Space scrolling the page)
+  const legend_keydown = (action: () => void) => (evt: KeyboardEvent) => {
+    if (![`Enter`, ` `].includes(evt.key)) return
+    evt.preventDefault()
+    action()
   }
 </script>
 
@@ -220,10 +250,10 @@
         <div
           class="legend-item clickable {show_stable ? `active` : `inactive`}"
           onclick={() => show_stable = !show_stable}
-          onkeydown={(evt) =>
-          [`Enter`, ` `].includes(evt.key) && (show_stable = !show_stable)}
+          onkeydown={legend_keydown(() => show_stable = !show_stable)}
           role="button"
           tabindex="0"
+          aria-pressed={show_stable}
           {@attach tooltip({ content: `Toggle visibility of stable points` })}
         >
           <div class="marker stable"></div>
@@ -234,10 +264,10 @@
         <div
           class="legend-item clickable {show_unstable ? `active` : `inactive`}"
           onclick={() => show_unstable = !show_unstable}
-          onkeydown={(evt) =>
-          [`Enter`, ` `].includes(evt.key) && (show_unstable = !show_unstable)}
+          onkeydown={legend_keydown(() => show_unstable = !show_unstable)}
           role="button"
           tabindex="0"
+          aria-pressed={show_unstable}
           {@attach tooltip({ content: `Toggle visibility of above-hull points` })}
         >
           <div class="marker unstable"></div>
@@ -268,6 +298,43 @@
         placeholder="Select color scale"
         {@attach tooltip({ content: `Set interpolator for energy colors` })}
       />
+    </div>
+  {/if}
+
+  <!-- Category filters (only when entries carry recognized category data,
+    e.g. magnetic orderings with the default MAGNETIC_ORDERING_CATEGORY) -->
+  {#if entry_category && category_values_in_data.length > 0}
+    <div class="control-row">
+      <span class="control-label">{entry_category.label}</span>
+      <div class="legend-items-container category-filters">
+        {#each category_values_in_data as value (value)}
+          {@const hidden = hidden_categories.includes(value)}
+          {@const count = category_counts[value] ?? 0}
+          {@const long_name = entry_category.labels?.[value]}
+          <div
+            class="legend-item clickable {hidden ? `inactive` : `active`}"
+            onclick={() => toggle_category(value)}
+            onkeydown={legend_keydown(() => toggle_category(value))}
+            role="button"
+            tabindex="0"
+            aria-pressed={!hidden}
+            {@attach tooltip({
+              content: `Toggle visibility of ${
+                long_name ? `${long_name.toLowerCase()} (${value})` : value
+              } entries`,
+            })}
+          >
+            <svg viewBox="-6 -6 12 12" width="12" height="12" aria-hidden="true">
+              <path d={marker_path_data(SWATCH_RADIUS, entry_category.markers[value]) ?? ``} />
+            </svg>
+            <span>{value}{
+                merged_controls.show_counts
+                ? ` (${hidden ? `0/${count}` : count})`
+                : ``
+              }</span>
+          </div>
+        {/each}
+      </div>
     </div>
   {/if}
 
@@ -490,6 +557,15 @@
   }
   .legend-item.inactive {
     opacity: 0.5;
+  }
+  .category-filters {
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .legend-item svg {
+    margin-right: 4px;
+    flex-shrink: 0;
+    fill: currentColor;
   }
   .marker {
     width: 12px;

--- a/src/lib/convex-hull/ConvexHullControls.svelte
+++ b/src/lib/convex-hull/ConvexHullControls.svelte
@@ -8,7 +8,7 @@
   import type { ComponentProps } from 'svelte'
   import { tooltip } from 'svelte-multiselect/attachments'
   import type { HTMLAttributes } from 'svelte/elements'
-  import { count_entry_categories, marker_path_data } from './helpers'
+  import { get_entry_category, marker_path_data } from './helpers'
   import type {
     ConvexHullControlsType,
     ConvexHullEntry,
@@ -125,9 +125,14 @@
   }
 
   // Category filters: only show category values present in the (threshold-filtered) data
-  const category_counts = $derived(
-    count_entry_categories([...stable_entries, ...unstable_entries], entry_category),
-  )
+  const category_counts = $derived.by(() => {
+    const counts: Record<string, number> = {}
+    for (const entry of [...stable_entries, ...unstable_entries]) {
+      const value = get_entry_category(entry, entry_category)
+      if (value) counts[value] = (counts[value] ?? 0) + 1
+    }
+    return counts
+  })
   const category_values_in_data = $derived(
     Object.keys(entry_category?.markers ?? {}).filter(
       (value) => (category_counts[value] ?? 0) > 0,
@@ -138,8 +143,7 @@
       ? hidden_categories.filter((hidden) => hidden !== value)
       : [...hidden_categories, value]
   }
-  // Radius of the marker shape swatch SVGs (sized to fit their 12x12 viewBox)
-  const SWATCH_RADIUS = 4.4
+  const SWATCH_RADIUS = 4.4 // marker swatch radius, sized to fit the 12x12 viewBox
   // Keyboard activation for legend toggles (preventDefault stops Space scrolling the page)
   const legend_keydown = (action: () => void) => (evt: KeyboardEvent) => {
     if (![`Enter`, ` `].includes(evt.key)) return

--- a/src/lib/convex-hull/ConvexHullInfoPane.svelte
+++ b/src/lib/convex-hull/ConvexHullInfoPane.svelte
@@ -6,7 +6,9 @@
   import type { ComponentProps } from 'svelte'
   import type { HTMLAttributes } from 'svelte/elements'
   import ConvexHullStats from './ConvexHullStats.svelte'
-  import type { ConvexHullEntry, PhaseStats } from './types'
+  import { visible_entries as filter_visible } from './helpers'
+  import type { ConvexHullEntry, EntryCategoryConfig, PhaseStats } from './types'
+  import { MAGNETIC_ORDERING_CATEGORY } from './types'
 
   const usage_tips = [
     { label: `Single click`, value: `Select point`, key: `tip-click` },
@@ -26,6 +28,8 @@
     unstable_entries,
     show_stable = true,
     show_unstable = true,
+    entry_category = MAGNETIC_ORDERING_CATEGORY,
+    hidden_categories = [],
     max_hull_dist_show_phases,
     max_hull_dist_show_labels,
     label_threshold,
@@ -39,6 +43,8 @@
     unstable_entries: ConvexHullEntry[]
     show_stable?: boolean
     show_unstable?: boolean
+    entry_category?: EntryCategoryConfig | null
+    hidden_categories?: string[]
     max_hull_dist_show_phases: number
     max_hull_dist_show_labels: number
     label_threshold: number
@@ -47,15 +53,19 @@
     pane_props?: PaneProps
   } = $props()
 
+  // Show flags true: filter_visible only applies the category filter here
+  const count_visible = (entries: ConvexHullEntry[], shown: boolean): number =>
+    shown ? filter_visible(entries, true, true, entry_category, hidden_categories).length : 0
+
   let settings_rows = $derived([
     {
       label: `Visible stable`,
-      value: `${show_stable ? stable_entries.length : 0} / ${stable_entries.length}`,
+      value: `${count_visible(stable_entries, show_stable)} / ${stable_entries.length}`,
       key: `hull-visible-stable`,
     },
     {
       label: `Visible unstable`,
-      value: `${show_unstable ? unstable_entries.length : 0} / ${unstable_entries.length}`,
+      value: `${count_visible(unstable_entries, show_unstable)} / ${unstable_entries.length}`,
       key: `hull-visible-unstable`,
     },
     {
@@ -112,6 +122,8 @@
     {unstable_entries}
     {show_stable}
     {show_unstable}
+    {entry_category}
+    {hidden_categories}
     style="padding: 3pt; background: var(--pane-bg); --hull-stats-table-height: 30rem"
   />
 

--- a/src/lib/convex-hull/ConvexHullStats.svelte
+++ b/src/lib/convex-hull/ConvexHullStats.svelte
@@ -13,8 +13,14 @@
   import HeatmapTable from '$lib/table/HeatmapTable.svelte'
   import type { HTMLAttributes } from 'svelte/elements'
   import { SvelteMap, SvelteSet } from 'svelte/reactivity'
-  import type { ConvexHullEntry, PhaseArityField, PhaseStats } from './types'
-  import { get_arity, is_on_hull } from './helpers'
+  import type {
+    ConvexHullEntry,
+    EntryCategoryConfig,
+    PhaseArityField,
+    PhaseStats,
+  } from './types'
+  import { MAGNETIC_ORDERING_CATEGORY } from './types'
+  import { get_arity, is_on_hull, visible_entries as filter_visible } from './helpers'
 
   let {
     phase_stats,
@@ -22,6 +28,8 @@
     unstable_entries,
     show_stable = true,
     show_unstable = true,
+    entry_category = MAGNETIC_ORDERING_CATEGORY,
+    hidden_categories = [],
     layout = `toggle`,
     on_entry_click,
     highlighted_entry_id,
@@ -36,6 +44,9 @@
       unstable_entries: ConvexHullEntry[]
       show_stable?: boolean
       show_unstable?: boolean
+      // Categorical classification + hidden values (excluded from shown counts/table)
+      entry_category?: EntryCategoryConfig | null
+      hidden_categories?: string[]
       // 'toggle' shows stats/table with toggle buttons (default)
       // 'side-by-side' shows both stats and table next to each other without toggle
       layout?: `toggle` | `side-by-side`
@@ -86,10 +97,15 @@
 
   // Shared concatenation of stable + unstable for histograms
   let all_entries = $derived([...stable_entries, ...unstable_entries])
-  let shown_entries = $derived([
-    ...(show_stable ? stable_entries : []),
-    ...(show_unstable ? unstable_entries : []),
-  ])
+  // show_stable/show_unstable respect the caller's partition; pass show flags as true
+  // so filter_visible only applies the category filter on top
+  let shown_entries = $derived(filter_visible(
+    [...(show_stable ? stable_entries : []), ...(show_unstable ? unstable_entries : [])],
+    true,
+    true,
+    entry_category,
+    hidden_categories,
+  ))
 
   // Static arity labels for phase breakdown display
   const arity_types: [string, PhaseArityField, number][] = [

--- a/src/lib/convex-hull/ConvexHullTooltip.svelte
+++ b/src/lib/convex-hull/ConvexHullTooltip.svelte
@@ -7,19 +7,22 @@
   import { TooltipContent } from '$lib/tooltip'
   import type { PolymorphStats } from './helpers'
   import type { ConvexHullTooltipProp, TooltipSnippetProps } from './index'
-  import type { HighlightStyle, PhaseData } from './types'
-  import { is_unary_entry } from './helpers'
+  import type { EntryCategoryConfig, HighlightStyle, PhaseData } from './types'
+  import { MAGNETIC_ORDERING_CATEGORY } from './types'
+  import { get_entry_category, is_unary_entry } from './helpers'
 
   let {
     entry,
     polymorph_stats_map,
     highlight_style,
+    entry_category = MAGNETIC_ORDERING_CATEGORY,
     tooltip,
     show_fractional = true,
   }: {
     entry: EntryT
     polymorph_stats_map?: Map<string, PolymorphStats>
     highlight_style?: HighlightStyle
+    entry_category?: EntryCategoryConfig | null
     tooltip?: ConvexHullTooltipProp<EntryT>
     show_fractional?: boolean
   } = $props()
@@ -36,6 +39,7 @@
       ? polymorph_stats_map.get(entry.entry_id)
       : null,
   )
+  const category_value = $derived(get_entry_category(entry, entry_category))
 </script>
 
 <TooltipContent
@@ -68,6 +72,11 @@
     {/if}
     {#if entry.e_form_per_atom != null}
       <div>E<sub>form</sub>: {format_num(entry.e_form_per_atom, `.3~`)} eV/atom</div>
+    {/if}
+    {#if entry_category && category_value}
+      <div title={entry_category.labels?.[category_value]}>
+        {entry_category.label}: {category_value}
+      </div>
     {/if}
 
     {#if show_fractional && !is_element}

--- a/src/lib/convex-hull/canvas-interactions.svelte.ts
+++ b/src/lib/convex-hull/canvas-interactions.svelte.ts
@@ -2,7 +2,7 @@
 import { set_fullscreen_bg, setup_fullscreen_effect } from '$lib/layout'
 import type { AnyStructure } from '$lib/structure'
 import * as helpers from './helpers'
-import type { ConvexHullEntry, HoverData3D, PhaseData } from './types'
+import type { ConvexHullEntry, EntryCategoryConfig, HoverData3D, PhaseData } from './types'
 
 export interface CanvasInteractionInputs {
   // Static config
@@ -25,6 +25,8 @@ export interface CanvasInteractionInputs {
   on_point_click: () => ((entry: ConvexHullEntry) => void) | undefined
   on_point_hover: () => ((data: HoverData3D | null) => void) | undefined
   on_file_drop: () => ((entries: PhaseData[]) => void) | undefined
+  // Categorical classification config (for category line in copied entry text)
+  entry_category: () => EntryCategoryConfig | null
   zoom: () => number
   set_zoom: (zoom: number) => void
   // Component-specific behavior
@@ -139,10 +141,15 @@ export function create_canvas_interactions(inputs: CanvasInteractionInputs) {
   const handle_drag_leave = set_drag_over(false)
 
   async function copy_entry_data(entry: ConvexHullEntry, position: { x: number; y: number }) {
-    await helpers.copy_entry_to_clipboard(entry, position, (visible, pos) => {
-      copy_feedback.visible = visible
-      copy_feedback.position = pos
-    })
+    await helpers.copy_entry_to_clipboard(
+      entry,
+      position,
+      (visible, pos) => {
+        copy_feedback.visible = visible
+        copy_feedback.position = pos
+      },
+      inputs.entry_category(),
+    )
   }
 
   function handle_mouse_down(event: MouseEvent) {

--- a/src/lib/convex-hull/helpers.ts
+++ b/src/lib/convex-hull/helpers.ts
@@ -104,9 +104,9 @@ export function get_entry_category(
 ): string | null {
   if (!config) return null
   const props = Array.isArray(config.property) ? config.property : [config.property]
-  for (const source of [entry as Record<string, unknown>, entry.data, entry.attributes]) {
-    if (!source) continue
-    for (const prop of props) {
+  for (const prop of props) {
+    for (const source of [entry as Record<string, unknown>, entry.data, entry.attributes]) {
+      if (!source) continue
       const value = normalize_category_value(source[prop], config)
       if (value) return value
     }

--- a/src/lib/convex-hull/helpers.ts
+++ b/src/lib/convex-hull/helpers.ts
@@ -12,13 +12,14 @@ import {
 } from './gas-thermodynamics'
 import type {
   ConvexHullConfig,
+  EntryCategoryConfig,
   GasAnalysis,
   GasThermodynamicsConfig,
   HighlightStyle,
   MarkerSymbol,
   PhaseData,
 } from './types'
-import { DEFAULT_GAS_TEMP } from './types'
+import { DEFAULT_GAS_TEMP, MAGNETIC_ORDERING_CATEGORY } from './types'
 
 export { DEFAULT_GAS_TEMP }
 
@@ -76,17 +77,98 @@ export const is_unary_entry = (entry: PhaseData) => get_arity(entry) === 1
 
 export const entry_is_unstable = (entry: StabilityEntry): boolean => !entry_is_stable(entry)
 
+// === Entry category helpers (generic categorical classification) ===
+
+// Loose entry shape for category resolution (any PhaseData-like object qualifies)
+type CategorySource = Pick<PhaseData, `data` | `attributes`>
+
+// Normalize a raw value to a canonical category value: case-insensitive match against
+// config.markers keys, then config.aliases. Returns null for unrecognized values.
+function normalize_category_value(raw: unknown, config: EntryCategoryConfig): string | null {
+  if (typeof raw !== `string`) return null
+  const lower = raw.trim().toLowerCase()
+  if (!lower) return null
+  const canonical = Object.keys(config.markers).find((value) => value.toLowerCase() === lower)
+  if (canonical) return canonical
+  const alias = config.aliases?.[lower]
+  return alias && alias in config.markers ? alias : null
+}
+
+// Resolve an entry's category: first *recognized* value wins, checking each config
+// property top-level, then in the pymatgen `data` and Materials Project `attributes`
+// dicts. Unrecognized values (e.g. MP's ordering='Unknown') fall through to later
+// sources; returns null when none resolve.
+export function get_entry_category(
+  entry: CategorySource,
+  config: EntryCategoryConfig | null | undefined,
+): string | null {
+  if (!config) return null
+  const props = Array.isArray(config.property) ? config.property : [config.property]
+  for (const source of [entry as Record<string, unknown>, entry.data, entry.attributes]) {
+    if (!source) continue
+    for (const prop of props) {
+      const value = normalize_category_value(source[prop], config)
+      if (value) return value
+    }
+  }
+  return null
+}
+
+// Assign default marker shapes by category (per config.markers). Explicit entry.marker
+// values win. Returns the input array unchanged when no marker was assigned (e.g. when
+// config is null or entries lack category data).
+export function apply_category_markers(
+  entries: (PhaseData & { marker?: MarkerSymbol })[],
+  config: EntryCategoryConfig | null | undefined,
+): (PhaseData & { marker?: MarkerSymbol })[] {
+  if (!config) return entries
+  let any_assigned = false
+  const result = entries.map((entry) => {
+    const value = entry.marker ? null : get_entry_category(entry, config)
+    if (!value) return entry
+    any_assigned = true
+    return { ...entry, marker: config.markers[value] }
+  })
+  return any_assigned ? result : entries
+}
+
+// Count entries per category value (values absent from data are omitted)
+export function count_entry_categories(
+  entries: readonly CategorySource[],
+  config: EntryCategoryConfig | null | undefined,
+): Record<string, number> {
+  const counts: Record<string, number> = {}
+  if (!config) return counts
+  for (const entry of entries) {
+    const value = get_entry_category(entry, config)
+    if (value) counts[value] = (counts[value] ?? 0) + 1
+  }
+  return counts
+}
+
 export const entry_is_visible = (
-  entry: StabilityEntry,
+  entry: StabilityEntry & CategorySource,
   show_stable: boolean,
   show_unstable: boolean,
-): boolean => (entry_is_stable(entry) ? show_stable : show_unstable)
+  category: EntryCategoryConfig | null = null,
+  hidden_categories: readonly string[] = [],
+): boolean => {
+  if (!(entry_is_stable(entry) ? show_stable : show_unstable)) return false
+  if (!category || hidden_categories.length === 0) return true
+  const value = get_entry_category(entry, category)
+  return value === null || !hidden_categories.includes(value)
+}
 
-export const visible_entries = <Entry extends StabilityEntry>(
+export const visible_entries = <Entry extends StabilityEntry & CategorySource>(
   entries: readonly Entry[],
   show_stable: boolean,
   show_unstable: boolean,
-): Entry[] => entries.filter((entry) => entry_is_visible(entry, show_stable, show_unstable))
+  category: EntryCategoryConfig | null = null,
+  hidden_categories: readonly string[] = [],
+): Entry[] =>
+  entries.filter((entry) =>
+    entry_is_visible(entry, show_stable, show_unstable, category, hidden_categories),
+  )
 
 // Energy color scale factory (shared)
 export function get_energy_color_scale(
@@ -209,7 +291,10 @@ export function same_entry<Entry extends { entry_id?: string }>(
 }
 
 // Build a tooltip text for any phase entry (shared)
-export function build_entry_tooltip_text(entry: PhaseData): string {
+export function build_entry_tooltip_text(
+  entry: PhaseData,
+  category: EntryCategoryConfig | null = MAGNETIC_ORDERING_CATEGORY,
+): string {
   const is_element = is_unary_entry(entry)
   const elem_symbol = is_element ? Object.keys(entry.composition)[0] : ``
 
@@ -241,6 +326,8 @@ export function build_entry_tooltip_text(entry: PhaseData): string {
     const e_form_str = format_num(e_form_display, `.3~`)
     text += `E<sub>form</sub>: ${e_form_str} eV/atom`
   }
+  const category_value = get_entry_category(entry, category)
+  if (category && category_value) text += `\n${category.label}: ${category_value}`
   if (entry.entry_id) text += `\nID: ${entry.entry_id}`
   return text
 }
@@ -365,8 +452,9 @@ export async function copy_entry_to_clipboard(
   entry: PhaseData,
   position: { x: number; y: number },
   on_feedback: (visible: boolean, pos: { x: number; y: number }) => void,
+  category: EntryCategoryConfig | null = MAGNETIC_ORDERING_CATEGORY,
 ): Promise<void> {
-  const text = build_entry_tooltip_text(entry)
+  const text = build_entry_tooltip_text(entry, category)
   await navigator.clipboard.writeText(text)
   on_feedback(true, position)
   setTimeout(() => on_feedback(false, position), 1500)
@@ -738,22 +826,26 @@ export function draw_hull_points<
   }
 }
 
-// Create a Path2D for a marker symbol. Uses d3-shape for consistent rendering with ScatterPlot.
-export function create_marker_path(size: number, marker: MarkerSymbol = `circle`): Path2D {
-  const safe_size = Number.isFinite(size) ? size : 0
-  const rounded_size = Math.max(0, Number(safe_size.toFixed(3)))
-
+// SVG path data for a marker symbol of given radius, or null for unknown marker names.
+// Uses d3-shape for consistent rendering with ScatterPlot.
+export function marker_path_data(radius: number, marker: MarkerSymbol): string | null {
   // Capitalize first letter to get D3 symbol name (e.g. 'circle' -> 'Circle')
   const d3_name = marker.charAt(0).toUpperCase() + marker.slice(1)
   const symbol_type = symbol_map[d3_name as keyof typeof symbol_map]
-  const symbol_area = Math.PI * rounded_size * rounded_size
-  const path_data = symbol_type ? symbol().type(symbol_type).size(symbol_area)() : null
+  return symbol_type
+    ? symbol()
+        .type(symbol_type)
+        .size(Math.PI * radius * radius)()
+    : null
+}
+
+// Create a Path2D for a marker symbol (canvas rendering in ConvexHull3D/4D)
+export function create_marker_path(size: number, marker: MarkerSymbol = `circle`): Path2D {
+  const safe_size = Number.isFinite(size) ? size : 0
+  const rounded_size = Math.max(0, Number(safe_size.toFixed(3)))
+  const path_data = marker_path_data(rounded_size, marker)
   const path = new Path2D(path_data ?? undefined)
-
-  if (!path_data) {
-    path.arc(0, 0, rounded_size, 0, 2 * Math.PI)
-  }
-
+  if (!path_data) path.arc(0, 0, rounded_size, 0, 2 * Math.PI)
   return path
 }
 

--- a/src/lib/convex-hull/helpers.ts
+++ b/src/lib/convex-hull/helpers.ts
@@ -132,20 +132,6 @@ export function apply_category_markers(
   return any_assigned ? result : entries
 }
 
-// Count entries per category value (values absent from data are omitted)
-export function count_entry_categories(
-  entries: readonly CategorySource[],
-  config: EntryCategoryConfig | null | undefined,
-): Record<string, number> {
-  const counts: Record<string, number> = {}
-  if (!config) return counts
-  for (const entry of entries) {
-    const value = get_entry_category(entry, config)
-    if (value) counts[value] = (counts[value] ?? 0) + 1
-  }
-  return counts
-}
-
 export const entry_is_visible = (
   entry: StabilityEntry & CategorySource,
   show_stable: boolean,

--- a/src/lib/convex-hull/helpers.ts
+++ b/src/lib/convex-hull/helpers.ts
@@ -94,10 +94,11 @@ function normalize_category_value(raw: unknown, config: EntryCategoryConfig): st
   return alias && alias in config.markers ? alias : null
 }
 
-// Resolve an entry's category: first *recognized* value wins, checking each config
-// property top-level, then in the pymatgen `data` and Materials Project `attributes`
-// dicts. Unrecognized values (e.g. MP's ordering='Unknown') fall through to later
-// sources; returns null when none resolve.
+// Resolve an entry's category: first *recognized* value wins. Properties are checked in
+// config order (property-major), each looked up top-level, then in the pymatgen `data`
+// and Materials Project `attributes` dicts — so a `magnetic_ordering` in any source
+// beats a generic `ordering`. Unrecognized values (e.g. MP's ordering='Unknown') fall
+// through; returns null when none resolve.
 export function get_entry_category(
   entry: CategorySource,
   config: EntryCategoryConfig | null | undefined,

--- a/src/lib/convex-hull/hull-state.svelte.ts
+++ b/src/lib/convex-hull/hull-state.svelte.ts
@@ -2,7 +2,12 @@
 import { DEFAULTS } from '$lib/settings'
 import * as helpers from './helpers'
 import * as thermo from './thermodynamics'
-import type { GasSpecies, GasThermodynamicsConfig, PhaseData } from './types'
+import type {
+  EntryCategoryConfig,
+  GasSpecies,
+  GasThermodynamicsConfig,
+  PhaseData,
+} from './types'
 
 const DIM_TO_KIND = { 2: `binary`, 3: `ternary`, 4: `quaternary` } as const
 
@@ -21,6 +26,10 @@ export interface HullDataPipelineInputs<Entry extends PhaseData> {
   max_hull_dist_show_phases: () => number
   show_stable: () => boolean
   show_unstable: () => boolean
+  // Categorical classification (marker shapes + filter toggles), null to disable
+  entry_category: () => EntryCategoryConfig | null
+  // Category values whose entries are hidden from the plot (view predicate)
+  hidden_categories: () => readonly string[]
   // Which entries pass the e_above_hull threshold (predicate differs per dimension)
   keep_plot_entry: (entry: Entry, max_hull_dist: number) => boolean
   // Setters for bindable props written by pipeline effects
@@ -82,12 +91,16 @@ export function create_hull_data_pipeline<Entry extends PhaseData>(
     ),
   )
 
+  // Assign category marker shapes (no-op when entries lack category data)
   const effective_entries = $derived(
-    helpers.get_effective_entries(
-      gas_result.entries,
-      energy_info.energy_mode,
-      energy_info.unary_refs,
-      thermo.compute_e_form_per_atom,
+    helpers.apply_category_markers(
+      helpers.get_effective_entries(
+        gas_result.entries,
+        energy_info.energy_mode,
+        energy_info.unary_refs,
+        thermo.compute_e_form_per_atom,
+      ),
+      inputs.entry_category(),
     ),
   )
 
@@ -140,7 +153,13 @@ export function create_hull_data_pipeline<Entry extends PhaseData>(
       .filter((entry) => inputs.keep_plot_entry(entry, inputs.max_hull_dist_show_phases())),
   )
   const visible_entries = $derived(
-    helpers.visible_entries(plot_entries, inputs.show_stable(), inputs.show_unstable()),
+    helpers.visible_entries(
+      plot_entries,
+      inputs.show_stable(),
+      inputs.show_unstable(),
+      inputs.entry_category(),
+      inputs.hidden_categories(),
+    ),
   )
 
   // Update bindable stable/unstable entry arrays when plot_entries change

--- a/src/lib/convex-hull/index.ts
+++ b/src/lib/convex-hull/index.ts
@@ -84,10 +84,9 @@ export interface BaseConvexHullProps<AnyDimEntry = PhaseData> extends Omit<
   show_stable?: boolean
   show_unstable?: boolean
   // Categorical classification rendered as marker shapes + controls-pane filter toggles.
-  // Defaults to MAGNETIC_ORDERING_CATEGORY, so entries carrying magnetic ordering data
-  // (FM/FiM/AFM/NM) light up automatically. Pass a custom EntryCategoryConfig for other
-  // classifications (metal/semiconductor/insulator, crystalline/amorphous/glass, defect
-  // types, ...) or null to disable.
+  // Defaults to MAGNETIC_ORDERING_CATEGORY (entries with FM/FiM/AFM/NM data light up
+  // automatically); pass a custom EntryCategoryConfig for other classifications
+  // (metal/semiconductor/insulator, crystalline/amorphous/glass, ...) or null to disable
   entry_category?: EntryCategoryConfig | null
   // Category values (e.g. ['FM', 'NM']) whose entries are hidden from the plot (bindable)
   hidden_categories?: string[]

--- a/src/lib/convex-hull/index.ts
+++ b/src/lib/convex-hull/index.ts
@@ -7,6 +7,7 @@ import type { HTMLAttributes } from 'svelte/elements'
 import type {
   ConvexHullConfig,
   ConvexHullControlsType,
+  EntryCategoryConfig,
   GasSpecies,
   GasThermodynamicsConfig,
   HighlightStyle,
@@ -82,6 +83,14 @@ export interface BaseConvexHullProps<AnyDimEntry = PhaseData> extends Omit<
   // Visibility
   show_stable?: boolean
   show_unstable?: boolean
+  // Categorical classification rendered as marker shapes + controls-pane filter toggles.
+  // Defaults to MAGNETIC_ORDERING_CATEGORY, so entries carrying magnetic ordering data
+  // (FM/FiM/AFM/NM) light up automatically. Pass a custom EntryCategoryConfig for other
+  // classifications (metal/semiconductor/insulator, crystalline/amorphous/glass, defect
+  // types, ...) or null to disable.
+  entry_category?: EntryCategoryConfig | null
+  // Category values (e.g. ['FM', 'NM']) whose entries are hidden from the plot (bindable)
+  hidden_categories?: string[]
   color_mode?: `stability` | `energy`
   color_scale?: D3InterpolateName
   info_pane_open?: boolean

--- a/src/lib/convex-hull/types.ts
+++ b/src/lib/convex-hull/types.ts
@@ -58,9 +58,8 @@ export interface PhaseData {
 
 // Categorical classification of hull entries, rendered as distinct marker shapes with
 // show/hide filter toggles in the controls pane. Works for any categorical property:
-// magnetic orderings (see MAGNETIC_ORDERING_CATEGORY, the default), electronic classes
-// (metal/semimetal/semiconductor/insulator), crystallinity (crystalline/amorphous/glass),
-// defect types, etc.
+// magnetic orderings (see MAGNETIC_ORDERING_CATEGORY, the default), electronic classes,
+// crystallinity, defect types, etc.
 export interface EntryCategoryConfig {
   label: string // controls-pane row + tooltip label, e.g. 'Magnetic', 'Electronic', 'Structure'
   // Entry properties holding the category value, checked in order. Each property is
@@ -77,28 +76,17 @@ export interface EntryCategoryConfig {
 // Magnetic ordering classifications (matching Materials Project conventions)
 export type MagneticOrdering = `FM` | `FiM` | `AFM` | `NM`
 
-// Built-in preset for magnetic orderings (MP/pymatgen conventions). This is the default
-// entry_category of all convex hull components, so entries carrying magnetic_ordering
-// (or an MP-style `ordering` field) automatically render as shape-coded points with
-// FM/FiM/AFM/NM filter toggles.
+// Built-in preset for magnetic orderings (MP/pymatgen conventions) and the default
+// entry_category of all convex hull components: entries carrying magnetic_ordering
+// (or an MP-style `ordering` field) auto-render as shape-coded points with filter toggles
 export const MAGNETIC_ORDERING_CATEGORY: EntryCategoryConfig = {
   label: `Magnetic`,
   property: [`magnetic_ordering`, `ordering`],
   markers: { FM: `triangle`, FiM: `diamond`, AFM: `square`, NM: `circle` },
-  labels: {
-    FM: `Ferromagnetic`,
-    FiM: `Ferrimagnetic`,
-    AFM: `Antiferromagnetic`,
-    NM: `Non-magnetic`,
-  },
-  aliases: {
-    ferromagnetic: `FM`,
-    ferrimagnetic: `FiM`,
-    antiferromagnetic: `AFM`,
-    'non-magnetic': `NM`,
-    nonmagnetic: `NM`,
-    diamagnetic: `NM`,
-  },
+  // oxfmt-ignore
+  labels: { FM: `Ferromagnetic`, FiM: `Ferrimagnetic`, AFM: `Antiferromagnetic`, NM: `Non-magnetic` },
+  // oxfmt-ignore
+  aliases: { ferromagnetic: `FM`, ferrimagnetic: `FiM`, antiferromagnetic: `AFM`, 'non-magnetic': `NM`, nonmagnetic: `NM`, diamagnetic: `NM` },
 }
 
 // Processed phase data for convex hull calculations

--- a/src/lib/convex-hull/types.ts
+++ b/src/lib/convex-hull/types.ts
@@ -48,6 +48,57 @@ export interface PhaseData {
 
   // Materials Project-specific fields (optional)
   attributes?: Record<string, unknown>
+
+  // Magnetic ordering (optional). Free-form strings (e.g. 'ferromagnetic') are
+  // normalized via MAGNETIC_ORDERING_CATEGORY aliases; unrecognized values are ignored.
+  magnetic_ordering?: MagneticOrdering | (string & {})
+}
+
+// === Entry categories (generic categorical classification) ===
+
+// Categorical classification of hull entries, rendered as distinct marker shapes with
+// show/hide filter toggles in the controls pane. Works for any categorical property:
+// magnetic orderings (see MAGNETIC_ORDERING_CATEGORY, the default), electronic classes
+// (metal/semimetal/semiconductor/insulator), crystallinity (crystalline/amorphous/glass),
+// defect types, etc.
+export interface EntryCategoryConfig {
+  label: string // controls-pane row + tooltip label, e.g. 'Magnetic', 'Electronic', 'Structure'
+  // Entry properties holding the category value, checked in order. Each property is
+  // looked up top-level, then in the pymatgen `data` and MP `attributes` dicts.
+  property: string | string[]
+  // Category value -> marker shape. Key order defines toggle display order. Raw values
+  // match case-insensitively; unrecognized values are ignored (default marker, never
+  // filtered). Explicit entry.marker values take precedence over this mapping.
+  markers: Record<string, MarkerSymbol>
+  labels?: Record<string, string> // optional long names for toggle/tooltip hints
+  aliases?: Record<string, string> // lowercase alias -> canonical value, e.g. { ferromagnetic: 'FM' }
+}
+
+// Magnetic ordering classifications (matching Materials Project conventions)
+export type MagneticOrdering = `FM` | `FiM` | `AFM` | `NM`
+
+// Built-in preset for magnetic orderings (MP/pymatgen conventions). This is the default
+// entry_category of all convex hull components, so entries carrying magnetic_ordering
+// (or an MP-style `ordering` field) automatically render as shape-coded points with
+// FM/FiM/AFM/NM filter toggles.
+export const MAGNETIC_ORDERING_CATEGORY: EntryCategoryConfig = {
+  label: `Magnetic`,
+  property: [`magnetic_ordering`, `ordering`],
+  markers: { FM: `triangle`, FiM: `diamond`, AFM: `square`, NM: `circle` },
+  labels: {
+    FM: `Ferromagnetic`,
+    FiM: `Ferrimagnetic`,
+    AFM: `Antiferromagnetic`,
+    NM: `Non-magnetic`,
+  },
+  aliases: {
+    ferromagnetic: `FM`,
+    ferrimagnetic: `FiM`,
+    antiferromagnetic: `AFM`,
+    'non-magnetic': `NM`,
+    nonmagnetic: `NM`,
+    diamagnetic: `NM`,
+  },
 }
 
 // Processed phase data for convex hull calculations

--- a/src/routes/(demos)/convex-hull/+page.svelte
+++ b/src/routes/(demos)/convex-hull/+page.svelte
@@ -3,9 +3,10 @@
   import type { ElementSymbol } from '$lib'
   import type {
     ConvexHullEntry,
+    EntryCategoryConfig,
     GasSpecies,
     GasThermodynamicsConfig,
-    MarkerSymbol,
+    MagneticOrdering,
     PhaseData,
     PhaseStats,
   } from '$lib/convex-hull'
@@ -49,7 +50,7 @@
   let side_unstable = $state<ConvexHullEntry[]>([])
   let clicked_entry_id = $state<string | undefined>(undefined)
   let selected_quinary_path = $state<string>(``)
-  const deferred_sections = [`stats`, `highlight`, `markers`, `temperature`, `gas`, `quinary`] as const
+  const deferred_sections = [`stats`, `highlight`, `magnetic`, `temperature`, `gas`, `quinary`] as const
   type DemoSection = typeof deferred_sections[number]
   let mounted_demo_count = $state(0)
   const section_mounted = (section: DemoSection): boolean =>
@@ -157,28 +158,6 @@
     ),
   )
 
-  // Helper to assign marker based on entry properties
-  const get_marker = (
-    entry: PhaseData,
-    selected_id?: string,
-    stable_marker: MarkerSymbol = `diamond`,
-  ): MarkerSymbol => {
-    if (entry.entry_id === selected_id) return `star`
-    if (entry.is_stable || (entry.e_above_hull ?? 1) < 0.01) return stable_marker
-    if ((entry.e_above_hull ?? 0) > 0.3) return `triangle`
-    if ((entry.e_above_hull ?? 0) > 0.1) return `cross`
-    return `circle`
-  }
-
-  // Marker symbol demo state
-  let selected_marker_entry = $state<ConvexHullEntry | null>(null)
-  const marker_demo_entries = $derived(
-    na_fe_o_entries.map((entry) => ({
-      ...entry,
-      marker: get_marker(entry, selected_marker_entry?.entry_id),
-    })),
-  )
-
   // Create four binary examples from the two quaternary datasets
   const binary_examples = $derived.by(() => {
     const na_fe_p_o = loaded_data.get(
@@ -206,26 +185,53 @@
     ),
   )
 
-  // Binary marker demo
-  let selected_binary_entry = $state<ConvexHullEntry | null>(null)
-  const binary_marker_entries = $derived(
-    (binary_examples[0]?.entries ?? []).map((entry) => ({
+  // === Magnetic states demo ===
+  // Assign synthetic magnetic orderings deterministically by entry-ID hash (real data
+  // would carry magnetic_ordering from DFT, e.g. Materials Project's `ordering` field)
+  const magnetic_ternary_entries = $derived(
+    na_fe_o_entries.map((entry) => {
+      const has_magnetic_elem = [`Fe`, `Co`, `Ni`].some(
+        (elem) => (entry.composition[elem as ElementSymbol] ?? 0) > 0,
+      )
+      const id_hash = [...(entry.entry_id ?? ``)]
+        .reduce((acc, char) => acc + char.charCodeAt(0), 0)
+      const magnetic_ordering: MagneticOrdering = has_magnetic_elem
+        ? ([`FM`, `FiM`, `AFM`] as const)[id_hash % 3]
+        : `NM`
+      return { ...entry, magnetic_ordering }
+    }),
+  )
+  let hidden_orderings = $state<string[]>([])
+  const magnetic_marker_legend = [
+    `△ FM (ferromagnetic)`,
+    `◆ FiM (ferrimagnetic)`,
+    `■ AFM (antiferromagnetic)`,
+    `● NM (non-magnetic)`,
+  ]
+
+  // Custom category demo: synthetic crystallinity labels on the Co-O binary show the
+  // generic entry_category API — the magnetic preset uses the exact same machinery
+  const crystallinity_category: EntryCategoryConfig = {
+    label: `Structure`,
+    property: `crystallinity`,
+    markers: { crystalline: `circle`, amorphous: `cross`, glass: `star` },
+  }
+  const crystallinity_entries = $derived(
+    (binary_examples[2]?.entries ?? []).map((entry, idx) => ({
       ...entry,
-      marker: get_marker(entry, selected_binary_entry?.entry_id, `square`),
+      crystallinity: [`crystalline`, `amorphous`, `glass`][idx % 3],
     })),
   )
+  const crystallinity_marker_legend = [
+    `● crystalline`,
+    `✚ amorphous`,
+    `★ glass`,
+  ]
+
   const ternary_examples = $derived([
     { title: `Na-Fe-O`, entries: na_fe_o_entries },
     { title: `Li-Co-O`, entries: li_co_ni_o_data },
   ])
-  const marker_legend_primary = [
-    `★ Selected`,
-    `◆ Stable`,
-    `△ High E<sub>hull</sub>`,
-    `+ Medium E<sub>hull</sub>`,
-    `● Default`,
-  ]
-  const marker_legend_binary = [`★ Selected`, `■ Stable`, `● Default`]
   const get_entry_href = (entry: ConvexHullEntry): string | null =>
     entry.entry_id ? `#${entry.entry_id}` : null
   const ternary_features = [
@@ -257,9 +263,11 @@
     `<b>Tooltip badge</b> — hover to see "★ Highlighted" on marked entries`,
     `<b>Cross-dimensional</b> — works on 2D, 3D, and 4D diagrams`,
   ]
-  const marker_features = [
-    `<b>Custom shapes</b> — assign per-entry marker symbols (★ ◆ △ + ■ ●)`,
-    `<b>Click to select</b> — selected entry shown as ★, updates dynamically`,
+  const magnetic_features = [
+    `<b>Shape-coded orderings</b> — entries with <code>magnetic_ordering</code> render as △ FM, ◆ FiM, ■ AFM, ● NM (built-in default <code>entry_category</code>)`,
+    `<b>Filter toggles</b> — show/hide magnetic subsets via the controls pane (bindable <code>hidden_categories</code>)`,
+    `<b>Generic API</b> — pass a custom <code>EntryCategoryConfig</code> to shape-code any classification (right plot: crystallinity; works equally for metal/semiconductor/insulator, defect types, ...)`,
+    `<b>Manual override</b> — a per-entry <code>marker</code> field always takes precedence over category shapes`,
   ]
   const temp_features = [
     `<b>Temperature slider</b> — appears when entries include <code>temperatures</code> + <code>free_energies</code> arrays`,
@@ -548,42 +556,43 @@
     </section>
   {/if}
 
-  {#if section_mounted(`markers`)}
+  {#if section_mounted(`magnetic`)}
     <section class="demo-section">
-    <h2>Marker Symbols</h2>
-    {@render feature_list(marker_features)}
+    <h2>Magnetic States & Custom Categories</h2>
+    {@render feature_list(magnetic_features)}
+    <p class="section-note">
+      Currently hidden orderings: {
+        hidden_orderings.length > 0 ? hidden_orderings.join(`, `) : `none`
+      } (synthetic demo data — categories assigned by entry ID hash. Missing pure element
+      references are automatically added with E<sub>form</sub> = 0 eV/atom.)
+    </p>
     <div class="ternary-grid">
       <div>
         <div class="marker-legend">
-          {#each marker_legend_primary as legend_item (legend_item)}
-            <span>{@html sanitize_html(legend_item)}</span>
+          {#each magnetic_marker_legend as legend_item (legend_item)}
+            <span>{legend_item}</span>
           {/each}
         </div>
         <ConvexHull3D
-          entries={marker_demo_entries}
-          controls={{ title: `Na-Fe-O with Markers` }}
-          bind:selected_entry={selected_marker_entry}
+          entries={magnetic_ternary_entries}
+          controls={{ title: `Na-Fe-O Magnetic Orderings` }}
+          bind:hidden_categories={hidden_orderings}
         />
       </div>
       <div>
         <div class="marker-legend">
-          {#each marker_legend_binary as legend_item (legend_item)}
-            <span>{@html sanitize_html(legend_item)}</span>
+          {#each crystallinity_marker_legend as legend_item (legend_item)}
+            <span>{legend_item}</span>
           {/each}
         </div>
         <ConvexHull2D
-          entries={binary_marker_entries}
-          controls={{ title: `Na-O with Markers` }}
-          bind:selected_entry={selected_binary_entry}
+          entries={crystallinity_entries}
+          entry_category={crystallinity_category}
+          controls={{ title: `Co-O Crystallinity (custom entry_category)` }}
           style="height: 100%"
         />
       </div>
     </div>
-
-    <p class="section-note">
-      <strong>Note:</strong> Missing pure element references are automatically added with
-      E<sub>form</sub> = 0 eV/atom.
-    </p>
     </section>
   {/if}
 

--- a/src/routes/(demos)/convex-hull/+page.svelte
+++ b/src/routes/(demos)/convex-hull/+page.svelte
@@ -202,12 +202,8 @@
     }),
   )
   let hidden_orderings = $state<string[]>([])
-  const magnetic_marker_legend = [
-    `△ FM (ferromagnetic)`,
-    `◆ FiM (ferrimagnetic)`,
-    `■ AFM (antiferromagnetic)`,
-    `● NM (non-magnetic)`,
-  ]
+  // oxfmt-ignore
+  const magnetic_marker_legend = [`△ FM (ferromagnetic)`, `◆ FiM (ferrimagnetic)`, `■ AFM (antiferromagnetic)`, `● NM (non-magnetic)`]
 
   // Custom category demo: synthetic crystallinity labels on the Co-O binary show the
   // generic entry_category API — the magnetic preset uses the exact same machinery
@@ -222,11 +218,7 @@
       crystallinity: [`crystalline`, `amorphous`, `glass`][idx % 3],
     })),
   )
-  const crystallinity_marker_legend = [
-    `● crystalline`,
-    `✚ amorphous`,
-    `★ glass`,
-  ]
+  const crystallinity_marker_legend = [`● crystalline`, `✚ amorphous`, `★ glass`]
 
   const ternary_examples = $derived([
     { title: `Na-Fe-O`, entries: na_fe_o_entries },
@@ -569,9 +561,7 @@
     <div class="ternary-grid">
       <div>
         <div class="marker-legend">
-          {#each magnetic_marker_legend as legend_item (legend_item)}
-            <span>{legend_item}</span>
-          {/each}
+          {#each magnetic_marker_legend as item (item)}<span>{item}</span>{/each}
         </div>
         <ConvexHull3D
           entries={magnetic_ternary_entries}
@@ -581,9 +571,7 @@
       </div>
       <div>
         <div class="marker-legend">
-          {#each crystallinity_marker_legend as legend_item (legend_item)}
-            <span>{legend_item}</span>
-          {/each}
+          {#each crystallinity_marker_legend as item (item)}<span>{item}</span>{/each}
         </div>
         <ConvexHull2D
           entries={crystallinity_entries}

--- a/src/routes/test/convex-hull-performance/+page.svelte
+++ b/src/routes/test/convex-hull-performance/+page.svelte
@@ -18,6 +18,7 @@
   let max_hull_dist = $state(0.5)
   let color_mode = $state<`stability` | `energy`>(`energy`)
   let enable_click_selection = $state(true)
+  let magnetic_orderings = $state(false)
   let render_start = $state(0)
   let render_time_ms = $state(0)
   let custom_title = $state<string | undefined>(undefined)
@@ -28,7 +29,7 @@
     '4d': [`Li`, `Co`, `Ni`, `O`],
   }
 
-  function generate_entries(count: number, dim: Dimension): PhaseData[] {
+  function generate_entries(count: number, dim: Dimension, magnetic: boolean): PhaseData[] {
     const elements = ELEMENTS[dim]
     const entries: PhaseData[] = elements.map((el) => ({
       composition: { [el]: 1 } as Partial<Record<ElementSymbol, number>>,
@@ -75,6 +76,10 @@
         e_form_per_atom: e_form,
         reduced_formula: formula.join(``),
         structure,
+        // Deterministic round-robin orderings for testing magnetic filters/markers
+        ...(magnetic
+          ? { magnetic_ordering: ([`FM`, `FiM`, `AFM`, `NM`] as const)[idx % 4] }
+          : {}),
       })
     }
     return entries
@@ -85,7 +90,7 @@
     render_start = performance.now()
     await tick()
     const start = performance.now()
-    generated_entries = generate_entries(entry_count, dimension)
+    generated_entries = generate_entries(entry_count, dimension, magnetic_orderings)
     generation_time_ms = performance.now() - start
     is_generating = false
   }
@@ -113,6 +118,7 @@
     if (!isNaN(hull) && hull >= 0) max_hull_dist = hull
     const click_sel = params.get(`click_selection`)
     if (click_sel !== null) enable_click_selection = click_sel !== `false`
+    magnetic_orderings = params.get(`magnetic`) === `true`
     const title_param = params.get(`title`)
     if (title_param !== null) custom_title = title_param
     // Initial generation after URL params are loaded

--- a/src/routes/test/convex-hull-performance/+page.svelte
+++ b/src/routes/test/convex-hull-performance/+page.svelte
@@ -132,6 +132,7 @@
     params.set(`count`, String(entry_count))
     params.set(`hull_dist`, String(max_hull_dist))
     if (!enable_click_selection) params.set(`click_selection`, `false`)
+    if (magnetic_orderings) params.set(`magnetic`, `true`)
     if (custom_title) params.set(`title`, custom_title)
     replaceState(`?${params.toString()}`, {})
   }

--- a/tests/playwright/convex-hull/convex-hull-2d.test.ts
+++ b/tests/playwright/convex-hull/convex-hull-2d.test.ts
@@ -144,10 +144,10 @@ test.describe(`ConvexHull2D (Binary)`, () => {
     const controls = pd2d.locator(`.draggable-pane.convex-hull-controls-pane`)
     await expect(controls.getByText(`Magnetic`, { exact: true })).toBeVisible()
 
-    // One toggle per ordering present in data (round-robin FM/FiM/AFM/NM), with swatches
+    // One toggle per ordering present in data (round-robin FM/FiM/AFM/NM); swatch
+    // rendering is covered by ConvexHullControls vitest
     const toggles = controls.locator(`.category-filters .legend-item`)
     await expect(toggles).toHaveCount(4)
-    await expect(toggles.first().locator(`svg path`)).toHaveAttribute(`d`, /.+/)
 
     // Hide FM entries -> fewer markers in the scatter plot
     const fm_toggle = toggles.filter({ hasText: /\bFM \(/ }).first()

--- a/tests/playwright/convex-hull/convex-hull-2d.test.ts
+++ b/tests/playwright/convex-hull/convex-hull-2d.test.ts
@@ -5,6 +5,9 @@ import { dom_click, open_info_and_controls } from './utils'
 test.describe(`ConvexHull2D (Binary)`, () => {
   test.beforeEach(async ({ page }) => {
     test.skip(IS_CI, `ConvexHull2D tests timeout in CI`)
+    // Extend the default 30s test timeout: it would kill the 50s data-load wait below
+    // before it can succeed when parallel workers load this heavy page simultaneously
+    test.setTimeout(90_000)
     await page.goto(`/convex-hull`, { waitUntil: `networkidle` })
     // Wait for data to load - the binary-grid only renders after loaded_data.size > 0
     // The 50s timeout accounts for downloading ~2MB of gzipped JSON files that decompress
@@ -118,6 +121,44 @@ test.describe(`ConvexHull2D (Binary)`, () => {
     const count_after = await markers.count()
     expect(count_after).toBeGreaterThan(0)
     expect(count_after).toBeLessThanOrEqual(count_before)
+  })
+
+  test(`magnetic ordering filter toggle hides and restores shaped markers`, async ({
+    page,
+  }) => {
+    // Use the isolated performance test page (synthetic data, single hull, no rAF pulse
+    // loops) instead of the heavy demo page, which starves protocol calls under load
+    test.setTimeout(30000)
+    await page.goto(`/test/convex-hull-performance?dim=2d&count=40&magnetic=true`, {
+      waitUntil: `networkidle`,
+      timeout: 15000,
+    })
+    const pd2d = page.locator(`.scatter.convex-hull-2d`)
+    await expect(pd2d).toBeVisible()
+
+    const markers = pd2d.locator(`path.marker`)
+    await expect.poll(() => markers.count(), { timeout: 15000 }).toBeGreaterThan(0)
+    const count_before = await markers.count()
+
+    await dom_click(pd2d.locator(`.legend-controls-btn`))
+    const controls = pd2d.locator(`.draggable-pane.convex-hull-controls-pane`)
+    await expect(controls.getByText(`Magnetic`, { exact: true })).toBeVisible()
+
+    // One toggle per ordering present in data (round-robin FM/FiM/AFM/NM), with swatches
+    const toggles = controls.locator(`.category-filters .legend-item`)
+    await expect(toggles).toHaveCount(4)
+    await expect(toggles.first().locator(`svg path`)).toHaveAttribute(`d`, /.+/)
+
+    // Hide FM entries -> fewer markers in the scatter plot
+    const fm_toggle = toggles.filter({ hasText: /\bFM \(/ }).first()
+    await dom_click(fm_toggle)
+    await expect(fm_toggle).toHaveAttribute(`aria-pressed`, `false`)
+    await expect.poll(() => markers.count(), { timeout: 15000 }).toBeLessThan(count_before)
+
+    // Re-show FM -> marker count restored
+    await dom_click(fm_toggle)
+    await expect(fm_toggle).toHaveAttribute(`aria-pressed`, `true`)
+    await expect.poll(() => markers.count(), { timeout: 15000 }).toBe(count_before)
   })
 
   test(`stability mode 'Above hull' toggle hides unstable points (info pane)`, async ({

--- a/tests/playwright/convex-hull/convex-hull-3d.test.ts
+++ b/tests/playwright/convex-hull/convex-hull-3d.test.ts
@@ -63,6 +63,63 @@ test.describe(`ConvexHull3D (Ternary)`, () => {
     }
   })
 
+  test(`magnetic category toggle re-renders canvas (hide + restore)`, async ({ page }) => {
+    // Isolated perf page: synthetic magnetic data, single hull, fast + deterministic.
+    // Guards the visible_entries dep in the 3D re-render effect — without it the canvas
+    // silently freezes when category (or stable/unstable) visibility toggles change.
+    test.setTimeout(45000)
+    await page.goto(`/test/convex-hull-performance?dim=3d&count=60&magnetic=true`, {
+      waitUntil: `networkidle`,
+      timeout: 15000,
+    })
+    const diagram = page.locator(`.convex-hull-3d`)
+    const canvas = diagram.locator(`canvas`).first()
+    await expect(canvas).toBeVisible()
+
+    // Wait until the canvas bitmap is stable for 3 consecutive samples (late label/
+    // font/resize passes drift pixels for a few seconds after first paint)
+    const wait_for_stable_canvas = async (): Promise<string> => {
+      let [hash, consecutive_equal] = [await get_canvas_hash(canvas), 0]
+      await expect
+        .poll(
+          async () => {
+            const next_hash = await get_canvas_hash(canvas)
+            consecutive_equal = next_hash === hash ? consecutive_equal + 1 : 0
+            hash = next_hash
+            return consecutive_equal
+          },
+          { timeout: 20000, intervals: [500] },
+        )
+        .toBeGreaterThanOrEqual(3)
+      return hash
+    }
+    await wait_for_stable_canvas()
+
+    const controls = await open_controls_pane(page, diagram)
+    await expect(controls.getByText(`Magnetic`, { exact: true })).toBeVisible()
+    const toggles = controls.locator(`.category-filters .legend-item`)
+    await expect(toggles).toHaveCount(4) // round-robin FM/FiM/AFM/NM
+    const fm_toggle = toggles.filter({ hasText: /\bFM \(/ }).first()
+
+    // Warm-up toggle cycle: the very first re-render can differ from the initial paint
+    // (font/text settling), so flush it before capturing the comparison baseline
+    await dom_click(fm_toggle)
+    await dom_click(fm_toggle)
+    await expect(fm_toggle).toHaveAttribute(`aria-pressed`, `true`)
+    const hash_before = await wait_for_stable_canvas()
+
+    // Hide FM -> canvas must redraw with fewer points. get_canvas_hash reads the canvas
+    // bitmap directly, so the opened controls pane overlay cannot pollute the comparison.
+    await dom_click(fm_toggle)
+    await expect(fm_toggle).toHaveAttribute(`aria-pressed`, `false`)
+    await expect.poll(() => get_canvas_hash(canvas), { timeout: 10000 }).not.toBe(hash_before)
+
+    // Re-show FM -> canvas restored to the exact original pixels
+    await dom_click(fm_toggle)
+    await expect(fm_toggle).toHaveAttribute(`aria-pressed`, `true`)
+    await expect.poll(() => get_canvas_hash(canvas), { timeout: 10000 }).toBe(hash_before)
+  })
+
   test(`renders ternary diagram canvas and toggles hull faces`, async ({ page }) => {
     await expect(page.getByRole(`heading`, { name: `Convex Hulls` })).toBeVisible()
     const ternary_grid = page.locator(`.ternary-grid`).first()

--- a/tests/playwright/convex-hull/utils.ts
+++ b/tests/playwright/convex-hull/utils.ts
@@ -70,23 +70,24 @@ export async function open_info_and_controls(
   return { info, controls }
 }
 
-// Simple pixel hash of a canvas — sum of every 100th pixel's red channel
+// Position-sensitive rolling hash over every 4th canvas pixel. The previous
+// sum-of-every-100th-pixel hash only sampled 8 fixed columns (stride 100 pixels in
+// row-major order), so small marker changes between those columns went undetected.
 export const get_canvas_hash = (canvas: Locator): Promise<string> =>
   canvas.evaluate((el) => {
     const ctx = (el as HTMLCanvasElement).getContext(`2d`)
     if (!ctx) return ``
     const { data } = ctx.getImageData(0, 0, el.clientWidth, el.clientHeight)
     let hash = 0
-    for (let idx = 0; idx < data.length; idx += 400) hash += data[idx]
+    // Math.imul wraps to 32 bits, keeping the rolling hash in safe-integer range
+    for (let idx = 0; idx < data.length; idx += 16) {
+      hash = Math.imul(hash, 31) + data[idx]
+    }
     return hash.toString()
   })
 
-export async function dom_click(target: Locator): Promise<void> {
-  const handle = await target.elementHandle()
-  if (handle) {
-    await handle.evaluate((btn) => (btn as HTMLButtonElement).click())
-    await handle.dispose()
-  } else {
-    await target.click({ force: true })
-  }
-}
+// Single protocol round-trip (locator.evaluate auto-waits for the element). The previous
+// elementHandle -> evaluate -> dispose dance took 3 round-trips, which stalled for 80+ s
+// on main-thread-saturated pages (10+ canvases with rAF pulse loops on the demo page).
+export const dom_click = (target: Locator): Promise<void> =>
+  target.evaluate((el) => (el as HTMLElement).click())

--- a/tests/vitest/convex-hull/ConvexHullControls.test.ts
+++ b/tests/vitest/convex-hull/ConvexHullControls.test.ts
@@ -1,0 +1,142 @@
+// Tests for ConvexHullControls category filter toggles (magnetic orderings by default)
+import ConvexHullControls from '$lib/convex-hull/ConvexHullControls.svelte'
+import { default_controls } from '$lib/convex-hull/index'
+import type { ConvexHullEntry, PhaseData } from '$lib/convex-hull/types'
+import { flushSync, mount } from 'svelte'
+import { beforeEach, describe, expect, test } from 'vitest'
+
+const mock_entry = (overrides: Partial<PhaseData> = {}): ConvexHullEntry => ({
+  composition: { Fe: 1, O: 1 },
+  energy: -1,
+  x: 0.5,
+  y: -0.5,
+  z: 0,
+  is_element: false,
+  ...overrides,
+})
+
+const mount_controls = (
+  props: {
+    stable_entries?: ConvexHullEntry[]
+    unstable_entries?: ConvexHullEntry[]
+    hidden_categories?: string[]
+  } = {},
+) =>
+  mount(ConvexHullControls, {
+    target: document.body,
+    props: {
+      controls_open: true,
+      stable_entries: [],
+      unstable_entries: [],
+      merged_controls: default_controls,
+      ...props,
+    },
+  })
+
+const magnetic_toggles = () => [
+  ...document.querySelectorAll<HTMLElement>(`.category-filters .legend-item`),
+]
+
+describe(`ConvexHullControls category filters (magnetic default)`, () => {
+  beforeEach(() => {
+    document.body.innerHTML = ``
+  })
+
+  test(`hides category row when no entry has magnetic ordering data`, () => {
+    mount_controls({ stable_entries: [mock_entry()], unstable_entries: [mock_entry()] })
+    expect(document.querySelector(`.category-filters`)).toBeNull()
+    expect(document.body.textContent).not.toContain(`Magnetic`)
+  })
+
+  test(`shows one toggle per ordering present in data with counts and shape swatches`, () => {
+    mount_controls({
+      stable_entries: [
+        mock_entry({ magnetic_ordering: `FM` }),
+        mock_entry({ magnetic_ordering: `AFM` }),
+      ],
+      unstable_entries: [
+        mock_entry({ magnetic_ordering: `FM` }),
+        mock_entry(), // entry without ordering shouldn't produce a toggle
+      ],
+    })
+    const toggles = magnetic_toggles()
+    expect(toggles.map((toggle) => toggle.textContent?.trim())).toEqual([`FM (2)`, `AFM (1)`])
+    // Each toggle renders a non-empty SVG marker shape swatch
+    for (const toggle of toggles) {
+      expect(toggle.querySelector(`svg path`)?.getAttribute(`d`)).toBe(true)
+    }
+    // FiM/NM absent from data -> no toggles
+    expect(document.body.textContent).not.toContain(`FiM`)
+    expect(document.body.textContent).not.toContain(`NM`)
+  })
+
+  test(`clicking a toggle hides/shows that ordering`, () => {
+    mount_controls({
+      stable_entries: [
+        mock_entry({ magnetic_ordering: `FM` }),
+        mock_entry({ magnetic_ordering: `NM` }),
+      ],
+    })
+    const [fm_toggle] = magnetic_toggles()
+    expect(fm_toggle.classList.contains(`active`)).toBe(true)
+    expect(fm_toggle.getAttribute(`aria-pressed`)).toBe(`true`)
+    expect(fm_toggle.textContent?.trim()).toBe(`FM (1)`)
+
+    fm_toggle.click()
+    flushSync()
+    expect(fm_toggle.classList.contains(`inactive`)).toBe(true)
+    expect(fm_toggle.getAttribute(`aria-pressed`)).toBe(`false`)
+    expect(fm_toggle.textContent?.trim()).toBe(`FM (0/1)`) // hidden -> shown/total format
+
+    fm_toggle.click()
+    flushSync()
+    expect(fm_toggle.classList.contains(`active`)).toBe(true)
+    expect(fm_toggle.textContent?.trim()).toBe(`FM (1)`)
+  })
+
+  test.each([
+    { key: `Enter`, expect_toggled: true },
+    { key: ` `, expect_toggled: true }, // Space must toggle AND not scroll the page
+    { key: `a`, expect_toggled: false },
+  ])(
+    `keydown '$key' on category toggle: toggled=$expect_toggled`,
+    ({ key, expect_toggled }) => {
+      mount_controls({ stable_entries: [mock_entry({ magnetic_ordering: `FM` })] })
+      const [fm_toggle] = magnetic_toggles()
+      const event = new KeyboardEvent(`keydown`, { key, bubbles: true, cancelable: true })
+      fm_toggle.dispatchEvent(event)
+      flushSync()
+      // preventDefault stops Space from scrolling the page on keyboard activation
+      expect(event.defaultPrevented).toBe(expect_toggled)
+      expect(fm_toggle.classList.contains(`inactive`)).toBe(expect_toggled)
+    },
+  )
+
+  test(`Space key also activates the stable/unstable legend toggles`, () => {
+    mount_controls({ stable_entries: [mock_entry()] })
+    // Points row (stability mode) renders stable + unstable toggles outside .category-filters
+    const stable_toggle = [...document.querySelectorAll<HTMLElement>(`.legend-item`)].find(
+      (item) => item.textContent?.includes(`Stable`),
+    )
+    if (!stable_toggle) throw new Error(`Stable legend toggle not found`)
+    expect(stable_toggle.getAttribute(`aria-pressed`)).toBe(`true`)
+    const event = new KeyboardEvent(`keydown`, { key: ` `, bubbles: true, cancelable: true })
+    stable_toggle.dispatchEvent(event)
+    flushSync()
+    expect(event.defaultPrevented).toBe(true)
+    expect(stable_toggle.getAttribute(`aria-pressed`)).toBe(`false`)
+  })
+
+  test(`initially hidden orderings render as inactive`, () => {
+    mount_controls({
+      stable_entries: [
+        mock_entry({ magnetic_ordering: `FM` }),
+        mock_entry({ magnetic_ordering: `AFM` }),
+      ],
+      hidden_categories: [`AFM`],
+    })
+    const [fm_toggle, afm_toggle] = magnetic_toggles()
+    expect(fm_toggle.classList.contains(`active`)).toBe(true)
+    expect(afm_toggle.classList.contains(`inactive`)).toBe(true)
+  })
+})

--- a/tests/vitest/convex-hull/ConvexHullControls.test.ts
+++ b/tests/vitest/convex-hull/ConvexHullControls.test.ts
@@ -1,27 +1,22 @@
 // Tests for ConvexHullControls category filter toggles (magnetic orderings by default)
 import ConvexHullControls from '$lib/convex-hull/ConvexHullControls.svelte'
 import { default_controls } from '$lib/convex-hull/index'
-import type { ConvexHullEntry, PhaseData } from '$lib/convex-hull/types'
+import type { ConvexHullEntry } from '$lib/convex-hull/types'
+import type { ComponentProps } from 'svelte'
 import { flushSync, mount } from 'svelte'
 import { beforeEach, describe, expect, test } from 'vitest'
 
-const mock_entry = (overrides: Partial<PhaseData> = {}): ConvexHullEntry => ({
+const mag = (magnetic_ordering?: string): ConvexHullEntry => ({
   composition: { Fe: 1, O: 1 },
   energy: -1,
   x: 0.5,
   y: -0.5,
   z: 0,
   is_element: false,
-  ...overrides,
+  magnetic_ordering,
 })
 
-const mount_controls = (
-  props: {
-    stable_entries?: ConvexHullEntry[]
-    unstable_entries?: ConvexHullEntry[]
-    hidden_categories?: string[]
-  } = {},
-) =>
+const mount_controls = (props: Partial<ComponentProps<typeof ConvexHullControls>> = {}) =>
   mount(ConvexHullControls, {
     target: document.body,
     props: {
@@ -36,6 +31,12 @@ const mount_controls = (
 const magnetic_toggles = () => [
   ...document.querySelectorAll<HTMLElement>(`.category-filters .legend-item`),
 ]
+const press = (toggle: HTMLElement, key: string): KeyboardEvent => {
+  const event = new KeyboardEvent(`keydown`, { key, bubbles: true, cancelable: true })
+  toggle.dispatchEvent(event)
+  flushSync()
+  return event
+}
 
 describe(`ConvexHullControls category filters (magnetic default)`, () => {
   beforeEach(() => {
@@ -43,27 +44,25 @@ describe(`ConvexHullControls category filters (magnetic default)`, () => {
   })
 
   test(`hides category row when no entry has magnetic ordering data`, () => {
-    mount_controls({ stable_entries: [mock_entry()], unstable_entries: [mock_entry()] })
+    mount_controls({ stable_entries: [mag()], unstable_entries: [mag()] })
     expect(document.querySelector(`.category-filters`)).toBeNull()
     expect(document.body.textContent).not.toContain(`Magnetic`)
   })
 
-  test(`shows one toggle per ordering present in data with counts and shape swatches`, () => {
+  test(`shows one toggle per ordering in data with counts, swatches, initial hidden state`, () => {
     mount_controls({
-      stable_entries: [
-        mock_entry({ magnetic_ordering: `FM` }),
-        mock_entry({ magnetic_ordering: `AFM` }),
-      ],
-      unstable_entries: [
-        mock_entry({ magnetic_ordering: `FM` }),
-        mock_entry(), // entry without ordering shouldn't produce a toggle
-      ],
+      stable_entries: [mag(`FM`), mag(`AFM`)],
+      unstable_entries: [mag(`FM`), mag()], // ordering-less entry -> no toggle
+      hidden_categories: [`AFM`], // initially hidden -> inactive + 0/total count
     })
     const toggles = magnetic_toggles()
-    expect(toggles.map((toggle) => toggle.textContent?.trim())).toEqual([`FM (2)`, `AFM (1)`])
-    // Each toggle renders a non-empty SVG marker shape swatch (d3 paths start with M).
-    // NB: don't assert via toBeTruthy() -- oxlint auto-rewrites it to toBe(true), which
-    // always fails against getAttribute's string|null return
+    expect(toggles.map((toggle) => toggle.textContent?.trim())).toEqual([
+      `FM (2)`,
+      `AFM (0/1)`,
+    ])
+    expect(toggles.map((toggle) => toggle.classList.contains(`active`))).toEqual([true, false])
+    // Each toggle renders a non-empty SVG shape swatch (d3 paths start with M). NB: don't
+    // assert via toBeTruthy() -- oxlint rewrites it to toBe(true), failing on string|null
     for (const toggle of toggles) {
       expect(toggle.querySelector(`svg path`)?.getAttribute(`d`)).toMatch(/^M/)
     }
@@ -73,12 +72,7 @@ describe(`ConvexHullControls category filters (magnetic default)`, () => {
   })
 
   test(`clicking a toggle hides/shows that ordering`, () => {
-    mount_controls({
-      stable_entries: [
-        mock_entry({ magnetic_ordering: `FM` }),
-        mock_entry({ magnetic_ordering: `NM` }),
-      ],
-    })
+    mount_controls({ stable_entries: [mag(`FM`), mag(`NM`)] })
     const [fm_toggle] = magnetic_toggles()
     expect(fm_toggle.classList.contains(`active`)).toBe(true)
     expect(fm_toggle.getAttribute(`aria-pressed`)).toBe(`true`)
@@ -96,49 +90,29 @@ describe(`ConvexHullControls category filters (magnetic default)`, () => {
     expect(fm_toggle.textContent?.trim()).toBe(`FM (1)`)
   })
 
+  // preventDefault stops Space from scrolling the page on keyboard activation
   test.each([
-    { key: `Enter`, expect_toggled: true },
-    { key: ` `, expect_toggled: true }, // Space must toggle AND not scroll the page
-    { key: `a`, expect_toggled: false },
-  ])(
-    `keydown '$key' on category toggle: toggled=$expect_toggled`,
-    ({ key, expect_toggled }) => {
-      mount_controls({ stable_entries: [mock_entry({ magnetic_ordering: `FM` })] })
-      const [fm_toggle] = magnetic_toggles()
-      const event = new KeyboardEvent(`keydown`, { key, bubbles: true, cancelable: true })
-      fm_toggle.dispatchEvent(event)
-      flushSync()
-      // preventDefault stops Space from scrolling the page on keyboard activation
-      expect(event.defaultPrevented).toBe(expect_toggled)
-      expect(fm_toggle.classList.contains(`inactive`)).toBe(expect_toggled)
-    },
-  )
+    [`Enter`, true],
+    [` `, true],
+    [`a`, false],
+  ])(`keydown '%s' on category toggle: toggled=%s`, (key, expect_toggled) => {
+    mount_controls({ stable_entries: [mag(`FM`)] })
+    const [fm_toggle] = magnetic_toggles()
+    const event = press(fm_toggle, key)
+    expect(event.defaultPrevented).toBe(expect_toggled)
+    expect(fm_toggle.classList.contains(`inactive`)).toBe(expect_toggled)
+  })
 
   test(`Space key also activates the stable/unstable legend toggles`, () => {
-    mount_controls({ stable_entries: [mock_entry()] })
+    mount_controls({ stable_entries: [mag()] })
     // Points row (stability mode) renders stable + unstable toggles outside .category-filters
     const stable_toggle = [...document.querySelectorAll<HTMLElement>(`.legend-item`)].find(
       (item) => item.textContent?.includes(`Stable`),
     )
     if (!stable_toggle) throw new Error(`Stable legend toggle not found`)
     expect(stable_toggle.getAttribute(`aria-pressed`)).toBe(`true`)
-    const event = new KeyboardEvent(`keydown`, { key: ` `, bubbles: true, cancelable: true })
-    stable_toggle.dispatchEvent(event)
-    flushSync()
+    const event = press(stable_toggle, ` `)
     expect(event.defaultPrevented).toBe(true)
     expect(stable_toggle.getAttribute(`aria-pressed`)).toBe(`false`)
-  })
-
-  test(`initially hidden orderings render as inactive`, () => {
-    mount_controls({
-      stable_entries: [
-        mock_entry({ magnetic_ordering: `FM` }),
-        mock_entry({ magnetic_ordering: `AFM` }),
-      ],
-      hidden_categories: [`AFM`],
-    })
-    const [fm_toggle, afm_toggle] = magnetic_toggles()
-    expect(fm_toggle.classList.contains(`active`)).toBe(true)
-    expect(afm_toggle.classList.contains(`inactive`)).toBe(true)
   })
 })

--- a/tests/vitest/convex-hull/ConvexHullControls.test.ts
+++ b/tests/vitest/convex-hull/ConvexHullControls.test.ts
@@ -61,9 +61,11 @@ describe(`ConvexHullControls category filters (magnetic default)`, () => {
     })
     const toggles = magnetic_toggles()
     expect(toggles.map((toggle) => toggle.textContent?.trim())).toEqual([`FM (2)`, `AFM (1)`])
-    // Each toggle renders a non-empty SVG marker shape swatch
+    // Each toggle renders a non-empty SVG marker shape swatch (d3 paths start with M).
+    // NB: don't assert via toBeTruthy() -- oxlint auto-rewrites it to toBe(true), which
+    // always fails against getAttribute's string|null return
     for (const toggle of toggles) {
-      expect(toggle.querySelector(`svg path`)?.getAttribute(`d`)).toBe(true)
+      expect(toggle.querySelector(`svg path`)?.getAttribute(`d`)).toMatch(/^M/)
     }
     // FiM/NM absent from data -> no toggles
     expect(document.body.textContent).not.toContain(`FiM`)

--- a/tests/vitest/convex-hull/ConvexHullSelection.test.ts
+++ b/tests/vitest/convex-hull/ConvexHullSelection.test.ts
@@ -1,5 +1,8 @@
+import { ConvexHull2D } from '$lib/convex-hull'
+import type { PhaseData } from '$lib/convex-hull/types'
 import { flushSync, mount, tick } from 'svelte'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { mount_sized } from '../setup'
 import ConvexHullSelectionHarness from './ConvexHullSelectionHarness.svelte'
 
 // Force the canvas hit-test to resolve to a real plot entry so hovering can be
@@ -101,6 +104,59 @@ describe(`convex hull replacement state`, () => {
       await tick()
 
       expect(document.querySelector(`[data-has-hover="true"]`)).not.toBeNull()
+    },
+  )
+})
+
+// End-to-end: magnetic_ordering -> pipeline marker assignment -> 2D SVG symbol rendering,
+// and hidden_categories -> pipeline visible_entries -> fewer rendered points
+describe(`magnetic ordering rendering (ConvexHull2D)`, () => {
+  beforeEach(() => {
+    document.body.innerHTML = ``
+  })
+
+  const compound = (
+    composition: Record<string, number>,
+    entry_id: string,
+    e_above_hull: number,
+    magnetic_ordering?: string,
+  ): PhaseData => ({
+    composition,
+    energy: -1,
+    e_form_per_atom: -0.5,
+    e_above_hull,
+    is_stable: e_above_hull === 0,
+    entry_id,
+    magnetic_ordering,
+  })
+  const magnetic_entries: PhaseData[] = [
+    compound({ Li: 1 }, `ref-li`, 0),
+    compound({ O: 1 }, `ref-o`, 0),
+    compound({ Li: 1, O: 1 }, `fm-1`, 0, `FM`),
+    compound({ Li: 2, O: 1 }, `afm-1`, 0.05, `AFM`),
+    compound({ Li: 1, O: 2 }, `plain-1`, 0.1),
+  ]
+
+  test.each([
+    { hidden: [] as string[], expected_markers: 5 },
+    { hidden: [`FM`], expected_markers: 4 },
+    // ordering-less entries are unaffected by category filters
+    { hidden: [`FM`, `AFM`], expected_markers: 3 },
+  ])(
+    `renders $expected_markers markers with hidden=$hidden`,
+    async ({ hidden, expected_markers }) => {
+      const plot = await mount_sized(
+        ConvexHull2D,
+        { entries: magnetic_entries, hidden_categories: hidden },
+        { selector: `.scatter` },
+      )
+      const marker_paths = [...plot.querySelectorAll<SVGPathElement>(`path.marker`)]
+      expect(marker_paths).toHaveLength(expected_markers)
+      if (hidden.length === 0) {
+        // FM triangle, AFM square, and default circles must yield distinct path shapes
+        const distinct_shapes = new Set(marker_paths.map((path) => path.getAttribute(`d`)))
+        expect(distinct_shapes.size).toBeGreaterThanOrEqual(3)
+      }
     },
   )
 })

--- a/tests/vitest/convex-hull/ConvexHullSelection.test.ts
+++ b/tests/vitest/convex-hull/ConvexHullSelection.test.ts
@@ -137,14 +137,14 @@ describe(`magnetic ordering rendering (ConvexHull2D)`, () => {
     compound({ Li: 1, O: 2 }, `plain-1`, 0.1),
   ]
 
+  // ordering-less entries are unaffected by category filters
   test.each([
-    { hidden: [] as string[], expected_markers: 5 },
-    { hidden: [`FM`], expected_markers: 4 },
-    // ordering-less entries are unaffected by category filters
-    { hidden: [`FM`, `AFM`], expected_markers: 3 },
-  ])(
-    `renders $expected_markers markers with hidden=$hidden`,
-    async ({ hidden, expected_markers }) => {
+    [[], 5],
+    [[`FM`], 4],
+    [[`FM`, `AFM`], 3],
+  ] as [string[], number][])(
+    `hidden=%s renders %i markers`,
+    async (hidden, expected_markers) => {
       const plot = await mount_sized(
         ConvexHull2D,
         { entries: magnetic_entries, hidden_categories: hidden },

--- a/tests/vitest/convex-hull/ConvexHullStats.test.ts
+++ b/tests/vitest/convex-hull/ConvexHullStats.test.ts
@@ -397,11 +397,8 @@ describe(`ConvexHullStats`, () => {
       mount_stats_table({
         stable_entries: [
           mock_entry({ magnetic_ordering: `FM`, entry_id: `id-fm`, reduced_formula: `FeO` }),
-          mock_entry({
-            magnetic_ordering: `AFM`,
-            entry_id: `id-afm`,
-            reduced_formula: `Fe2O3`,
-          }),
+          // oxfmt-ignore
+          mock_entry({ magnetic_ordering: `AFM`, entry_id: `id-afm`, reduced_formula: `Fe2O3` }),
         ],
         // no ordering -> unaffected by category filter
         unstable_entries: [mock_entry({ entry_id: `id-plain`, reduced_formula: `Fe3O4` })],

--- a/tests/vitest/convex-hull/ConvexHullStats.test.ts
+++ b/tests/vitest/convex-hull/ConvexHullStats.test.ts
@@ -40,6 +40,7 @@ type Props = {
   unstable_entries: ConvexHullEntry[]
   show_stable?: boolean
   show_unstable?: boolean
+  hidden_categories?: string[]
   layout?: `toggle` | `side-by-side`
   on_entry_click?: (entry: ConvexHullEntry) => void
   highlighted_entry_id?: string
@@ -390,6 +391,28 @@ describe(`ConvexHullStats`, () => {
         td.textContent?.trim(),
       )
       expect(cells).not.toContain(`Zr`)
+    })
+
+    test(`table excludes entries with hidden magnetic orderings`, () => {
+      mount_stats_table({
+        stable_entries: [
+          mock_entry({ magnetic_ordering: `FM`, entry_id: `id-fm`, reduced_formula: `FeO` }),
+          mock_entry({
+            magnetic_ordering: `AFM`,
+            entry_id: `id-afm`,
+            reduced_formula: `Fe2O3`,
+          }),
+        ],
+        // no ordering -> unaffected by category filter
+        unstable_entries: [mock_entry({ entry_id: `id-plain`, reduced_formula: `Fe3O4` })],
+        hidden_categories: [`FM`],
+      })
+      expect(document.querySelectorAll(`tbody tr`)).toHaveLength(2)
+      const table_text = doc_query(`tbody`).textContent ?? ``
+      expect(table_text).not.toContain(`id-fm`)
+      expect(table_text).toContain(`id-afm`)
+      expect(table_text).toContain(`id-plain`)
+      expect(doc_query(`.filter-count`).textContent).toContain(`2 entries`)
     })
 
     test.each([

--- a/tests/vitest/convex-hull/ConvexHullTooltip.test.ts
+++ b/tests/vitest/convex-hull/ConvexHullTooltip.test.ts
@@ -114,6 +114,32 @@ describe(`ConvexHullTooltip`, () => {
     )
   })
 
+  describe(`magnetic properties`, () => {
+    test.each([
+      { magnetic_ordering: `FM`, expected: `Magnetic: FM`, label: `Ferromagnetic` },
+      {
+        magnetic_ordering: `antiferromagnetic`,
+        expected: `Magnetic: AFM`,
+        label: `Antiferromagnetic`,
+      },
+    ])(
+      `shows normalized ordering for $magnetic_ordering`,
+      ({ magnetic_ordering, expected, label }) => {
+        mount_tooltip({ entry: mock_entry({ magnetic_ordering }) })
+        expect(document.body.textContent).toContain(expected)
+        expect(document.querySelector(`[title="${label}"]`)).not.toBeNull()
+      },
+    )
+
+    test.each([
+      { entry: mock_entry(), desc: `no magnetic fields` },
+      { entry: mock_entry({ magnetic_ordering: `Unknown` }), desc: `unrecognized ordering` },
+    ])(`omits magnetic line for $desc`, ({ entry }) => {
+      mount_tooltip({ entry })
+      expect(document.body.textContent).not.toContain(`Magnetic:`)
+    })
+  })
+
   describe(`highlight badge`, () => {
     test(`shows badge with color when highlight_style provided`, () => {
       mount_tooltip({ highlight_style: { color: `#00ff00` } })

--- a/tests/vitest/convex-hull/ConvexHullTooltip.test.ts
+++ b/tests/vitest/convex-hull/ConvexHullTooltip.test.ts
@@ -116,28 +116,22 @@ describe(`ConvexHullTooltip`, () => {
 
   describe(`magnetic properties`, () => {
     test.each([
-      { magnetic_ordering: `FM`, expected: `Magnetic: FM`, label: `Ferromagnetic` },
-      {
-        magnetic_ordering: `antiferromagnetic`,
-        expected: `Magnetic: AFM`,
-        label: `Antiferromagnetic`,
-      },
-    ])(
-      `shows normalized ordering for $magnetic_ordering`,
-      ({ magnetic_ordering, expected, label }) => {
-        mount_tooltip({ entry: mock_entry({ magnetic_ordering }) })
-        expect(document.body.textContent).toContain(expected)
-        expect(document.querySelector(`[title="${label}"]`)).not.toBeNull()
+      [`FM`, `Magnetic: FM`, `Ferromagnetic`],
+      [`antiferromagnetic`, `Magnetic: AFM`, `Antiferromagnetic`],
+    ])(`shows normalized ordering for %s`, (magnetic_ordering, expected, label) => {
+      mount_tooltip({ entry: mock_entry({ magnetic_ordering }) })
+      expect(document.body.textContent).toContain(expected)
+      expect(document.querySelector(`[title="${label}"]`)).not.toBeNull()
+    })
+
+    // entries without magnetic fields or with unrecognized orderings get no line
+    test.each([mock_entry(), mock_entry({ magnetic_ordering: `Unknown` })])(
+      `omits magnetic line for %o`,
+      (entry) => {
+        mount_tooltip({ entry })
+        expect(document.body.textContent).not.toContain(`Magnetic:`)
       },
     )
-
-    test.each([
-      { entry: mock_entry(), desc: `no magnetic fields` },
-      { entry: mock_entry({ magnetic_ordering: `Unknown` }), desc: `unrecognized ordering` },
-    ])(`omits magnetic line for $desc`, ({ entry }) => {
-      mount_tooltip({ entry })
-      expect(document.body.textContent).not.toContain(`Magnetic:`)
-    })
   })
 
   describe(`highlight badge`, () => {

--- a/tests/vitest/convex-hull/helpers.test.ts
+++ b/tests/vitest/convex-hull/helpers.test.ts
@@ -3,6 +3,7 @@ import type { D3InterpolateName } from '$lib/colors'
 import * as helpers from '$lib/convex-hull/helpers'
 import { get_convex_hull_stats } from '$lib/convex-hull/thermodynamics'
 import type { PhaseData } from '$lib/convex-hull/types'
+import { MAGNETIC_ORDERING_CATEGORY } from '$lib/convex-hull/types'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 
 class MockPath2D {
@@ -997,5 +998,187 @@ describe(`helpers: temperature interpolation`, () => {
       const with_order = helpers.get_entry_label(entry, [`Li`, `Fe`, `O`])
       expect(with_order).toBe(`Li2FeO3`)
     })
+  })
+})
+
+describe(`helpers: magnetic orderings`, () => {
+  const mag_entry = (overrides: Partial<PhaseData> = {}): PhaseData => ({
+    composition: { Fe: 1, O: 1 },
+    energy: -1,
+    ...overrides,
+  })
+
+  test.each([
+    { raw: `FM`, expected: `FM` },
+    { raw: `fm`, expected: `FM` },
+    { raw: ` Ferromagnetic `, expected: `FM` },
+    { raw: `FiM`, expected: `FiM` },
+    { raw: `ferrimagnetic`, expected: `FiM` },
+    { raw: `AFM`, expected: `AFM` },
+    { raw: `Antiferromagnetic`, expected: `AFM` },
+    { raw: `NM`, expected: `NM` },
+    { raw: `non-magnetic`, expected: `NM` },
+    { raw: `nonmagnetic`, expected: `NM` },
+    { raw: `diamagnetic`, expected: `NM` },
+    { raw: `Unknown`, expected: null },
+    { raw: ``, expected: null },
+  ])(`magnetic preset normalizes '$raw' to $expected`, ({ raw, expected }) => {
+    expect(
+      helpers.get_entry_category(
+        mag_entry({ magnetic_ordering: raw }),
+        MAGNETIC_ORDERING_CATEGORY,
+      ),
+    ).toBe(expected)
+  })
+
+  test.each([
+    { desc: `no magnetic fields`, entry: mag_entry(), expected: null },
+    { desc: `non-string field`, entry: mag_entry({ data: { ordering: 42 } }), expected: null },
+    {
+      desc: `data.magnetic_ordering`,
+      entry: mag_entry({ data: { magnetic_ordering: `AFM` } }),
+      expected: `AFM`,
+    },
+    {
+      desc: `data.ordering (MP convention)`,
+      entry: mag_entry({ data: { ordering: `FiM` } }),
+      expected: `FiM`,
+    },
+    {
+      desc: `attributes.magnetic_ordering`,
+      entry: mag_entry({ attributes: { magnetic_ordering: `NM` } }),
+      expected: `NM`,
+    },
+    {
+      desc: `attributes.ordering`,
+      entry: mag_entry({ attributes: { ordering: `fm` } }),
+      expected: `FM`,
+    },
+    {
+      desc: `top-level field wins over data dict`,
+      entry: mag_entry({ magnetic_ordering: `FM`, data: { ordering: `AFM` } }),
+      expected: `FM`,
+    },
+    {
+      desc: `unrecognized top-level falls through to recognized data value`,
+      entry: mag_entry({ magnetic_ordering: `Unknown`, data: { ordering: `AFM` } }),
+      expected: `AFM`,
+    },
+  ])(`get_entry_category reads from $desc`, ({ entry, expected }) => {
+    expect(helpers.get_entry_category(entry, MAGNETIC_ORDERING_CATEGORY)).toBe(expected)
+  })
+
+  test(`apply_category_markers assigns shapes by ordering, respects explicit markers`, () => {
+    const entries = [
+      mag_entry({ magnetic_ordering: `FM` }),
+      mag_entry({ magnetic_ordering: `FiM` }),
+      mag_entry({ magnetic_ordering: `AFM` }),
+      mag_entry({ magnetic_ordering: `NM` }),
+      { ...mag_entry({ magnetic_ordering: `FM` }), marker: `star` as const },
+      mag_entry(), // no ordering -> no marker assigned
+    ]
+    const result = helpers.apply_category_markers(entries, MAGNETIC_ORDERING_CATEGORY)
+    expect(result.map((entry) => entry.marker)).toEqual([
+      `triangle`,
+      `diamond`,
+      `square`,
+      `circle`,
+      `star`,
+      undefined,
+    ])
+  })
+
+  test.each([
+    {
+      desc: `no magnetic data`,
+      entries: [mag_entry(), mag_entry({ composition: { Li: 1 } })],
+      config: MAGNETIC_ORDERING_CATEGORY,
+    },
+    { desc: `null config`, entries: [mag_entry({ magnetic_ordering: `FM` })], config: null },
+  ])(
+    `apply_category_markers returns input array unchanged with $desc`,
+    ({ entries, config }) => {
+      expect(helpers.apply_category_markers(entries, config)).toBe(entries)
+    },
+  )
+
+  test(`count_entry_categories tallies recognized orderings only`, () => {
+    const counts = helpers.count_entry_categories(
+      [
+        mag_entry({ magnetic_ordering: `FM` }),
+        mag_entry({ magnetic_ordering: `ferromagnetic` }),
+        mag_entry({ magnetic_ordering: `AFM` }),
+        mag_entry({ magnetic_ordering: `Unknown` }),
+        mag_entry(),
+      ],
+      MAGNETIC_ORDERING_CATEGORY,
+    )
+    expect(counts).toEqual({ FM: 2, AFM: 1 })
+  })
+
+  test(`visible_entries filters by hidden category values`, () => {
+    const entries = [
+      mag_entry({ magnetic_ordering: `FM`, is_stable: true }),
+      mag_entry({ magnetic_ordering: `AFM`, is_stable: true }),
+      mag_entry({ magnetic_ordering: `AFM`, is_stable: false, e_above_hull: 0.1 }),
+      mag_entry({ is_stable: true }), // no ordering -> unaffected by category filters
+    ]
+    const magnetic = MAGNETIC_ORDERING_CATEGORY
+    expect(helpers.visible_entries(entries, true, true, magnetic, [`AFM`])).toEqual([
+      entries[0],
+      entries[3],
+    ])
+    // Stability filter still applies on top of the category filter
+    expect(helpers.visible_entries(entries, false, true, magnetic, [`FM`])).toEqual([
+      entries[2],
+    ])
+    // No hidden values or no category config -> all visible
+    expect(helpers.visible_entries(entries, true, true, magnetic, [])).toEqual(entries)
+    expect(helpers.visible_entries(entries, true, true, null, [`AFM`])).toEqual(entries)
+  })
+
+  test(`custom category config resolves values, markers and filtering`, () => {
+    const electronic = {
+      label: `Electronic`,
+      property: `electronic_class`,
+      markers: {
+        metal: `circle`,
+        semimetal: `wye`,
+        semiconductor: `diamond`,
+        insulator: `square`,
+      },
+      aliases: { 'semi-conductor': `semiconductor` },
+    } as const
+    const entry = (electronic_class?: string) =>
+      ({ composition: { Si: 1 }, energy: -1, electronic_class }) as PhaseData
+    // Case-insensitive canonical match + alias normalization
+    expect(helpers.get_entry_category(entry(`Metal`), electronic)).toBe(`metal`)
+    expect(helpers.get_entry_category(entry(`semi-conductor`), electronic)).toBe(
+      `semiconductor`,
+    )
+    expect(helpers.get_entry_category(entry(`half-metal`), electronic)).toBeNull()
+    // data dict fallback
+    expect(
+      helpers.get_entry_category(
+        { ...entry(), data: { electronic_class: `insulator` } },
+        electronic,
+      ),
+    ).toBe(`insulator`)
+    // Marker assignment + filtering use the same config
+    const entries = [entry(`metal`), entry(`insulator`), entry()]
+    expect(
+      helpers.apply_category_markers(entries, electronic).map((ent) => ent.marker),
+    ).toEqual([`circle`, `square`, undefined])
+    expect(helpers.visible_entries(entries, true, true, electronic, [`metal`])).toEqual([
+      entries[1],
+      entries[2],
+    ])
+  })
+
+  test(`build_entry_tooltip_text includes magnetic ordering when present`, () => {
+    const text = helpers.build_entry_tooltip_text(mag_entry({ magnetic_ordering: `FiM` }))
+    expect(text).toContain(`Magnetic: FiM`)
+    const plain_text = helpers.build_entry_tooltip_text(mag_entry())
+    expect(plain_text).not.toContain(`Magnetic`)
   })
 })

--- a/tests/vitest/convex-hull/helpers.test.ts
+++ b/tests/vitest/convex-hull/helpers.test.ts
@@ -1030,6 +1030,7 @@ describe(`helpers: entry categories (magnetic preset)`, () => {
     [`attributes.ordering`, mag_entry({ attributes: { ordering: `fm` } }), `FM`],
     [`top-level field winning over data dict`, mag_entry({ magnetic_ordering: `FM`, data: { ordering: `AFM` } }), `FM`],
     [`unrecognized top-level falling through to data`, mag_entry({ magnetic_ordering: `Unknown`, data: { ordering: `AFM` } }), `AFM`],
+    [`property order beats source order`, mag_entry({ ordering: `FM`, data: { magnetic_ordering: `AFM` } } as Partial<PhaseData>), `AFM`],
   ] as [string, PhaseData, string | null][])(
     `get_entry_category reads %s`,
     (_desc, entry, expected) => expect(cat(entry)).toBe(expected),

--- a/tests/vitest/convex-hull/helpers.test.ts
+++ b/tests/vitest/convex-hull/helpers.test.ts
@@ -1001,72 +1001,39 @@ describe(`helpers: temperature interpolation`, () => {
   })
 })
 
-describe(`helpers: magnetic orderings`, () => {
+describe(`helpers: entry categories (magnetic preset)`, () => {
   const mag_entry = (overrides: Partial<PhaseData> = {}): PhaseData => ({
     composition: { Fe: 1, O: 1 },
     energy: -1,
     ...overrides,
   })
+  const magnetic = MAGNETIC_ORDERING_CATEGORY
+  const cat = (entry: PhaseData) => helpers.get_entry_category(entry, magnetic)
 
+  // oxfmt-ignore
   test.each([
-    { raw: `FM`, expected: `FM` },
-    { raw: `fm`, expected: `FM` },
-    { raw: ` Ferromagnetic `, expected: `FM` },
-    { raw: `FiM`, expected: `FiM` },
-    { raw: `ferrimagnetic`, expected: `FiM` },
-    { raw: `AFM`, expected: `AFM` },
-    { raw: `Antiferromagnetic`, expected: `AFM` },
-    { raw: `NM`, expected: `NM` },
-    { raw: `non-magnetic`, expected: `NM` },
-    { raw: `nonmagnetic`, expected: `NM` },
-    { raw: `diamagnetic`, expected: `NM` },
-    { raw: `Unknown`, expected: null },
-    { raw: ``, expected: null },
-  ])(`magnetic preset normalizes '$raw' to $expected`, ({ raw, expected }) => {
-    expect(
-      helpers.get_entry_category(
-        mag_entry({ magnetic_ordering: raw }),
-        MAGNETIC_ORDERING_CATEGORY,
-      ),
-    ).toBe(expected)
+    [`FM`, `FM`], [`fm`, `FM`], [` Ferromagnetic `, `FM`], [`FiM`, `FiM`],
+    [`ferrimagnetic`, `FiM`], [`AFM`, `AFM`], [`Antiferromagnetic`, `AFM`], [`NM`, `NM`],
+    [`non-magnetic`, `NM`], [`nonmagnetic`, `NM`], [`diamagnetic`, `NM`],
+    [`Unknown`, null], [``, null],
+  ] as const)(`magnetic preset normalizes '%s' to %s`, (raw, expected) => {
+    expect(cat(mag_entry({ magnetic_ordering: raw }))).toBe(expected)
   })
 
+  // oxfmt-ignore
   test.each([
-    { desc: `no magnetic fields`, entry: mag_entry(), expected: null },
-    { desc: `non-string field`, entry: mag_entry({ data: { ordering: 42 } }), expected: null },
-    {
-      desc: `data.magnetic_ordering`,
-      entry: mag_entry({ data: { magnetic_ordering: `AFM` } }),
-      expected: `AFM`,
-    },
-    {
-      desc: `data.ordering (MP convention)`,
-      entry: mag_entry({ data: { ordering: `FiM` } }),
-      expected: `FiM`,
-    },
-    {
-      desc: `attributes.magnetic_ordering`,
-      entry: mag_entry({ attributes: { magnetic_ordering: `NM` } }),
-      expected: `NM`,
-    },
-    {
-      desc: `attributes.ordering`,
-      entry: mag_entry({ attributes: { ordering: `fm` } }),
-      expected: `FM`,
-    },
-    {
-      desc: `top-level field wins over data dict`,
-      entry: mag_entry({ magnetic_ordering: `FM`, data: { ordering: `AFM` } }),
-      expected: `FM`,
-    },
-    {
-      desc: `unrecognized top-level falls through to recognized data value`,
-      entry: mag_entry({ magnetic_ordering: `Unknown`, data: { ordering: `AFM` } }),
-      expected: `AFM`,
-    },
-  ])(`get_entry_category reads from $desc`, ({ entry, expected }) => {
-    expect(helpers.get_entry_category(entry, MAGNETIC_ORDERING_CATEGORY)).toBe(expected)
-  })
+    [`no magnetic fields`, mag_entry(), null],
+    [`non-string field`, mag_entry({ data: { ordering: 42 } }), null],
+    [`data.magnetic_ordering`, mag_entry({ data: { magnetic_ordering: `AFM` } }), `AFM`],
+    [`data.ordering (MP convention)`, mag_entry({ data: { ordering: `FiM` } }), `FiM`],
+    [`attributes.magnetic_ordering`, mag_entry({ attributes: { magnetic_ordering: `NM` } }), `NM`],
+    [`attributes.ordering`, mag_entry({ attributes: { ordering: `fm` } }), `FM`],
+    [`top-level field winning over data dict`, mag_entry({ magnetic_ordering: `FM`, data: { ordering: `AFM` } }), `FM`],
+    [`unrecognized top-level falling through to data`, mag_entry({ magnetic_ordering: `Unknown`, data: { ordering: `AFM` } }), `AFM`],
+  ] as [string, PhaseData, string | null][])(
+    `get_entry_category reads %s`,
+    (_desc, entry, expected) => expect(cat(entry)).toBe(expected),
+  )
 
   test(`apply_category_markers assigns shapes by ordering, respects explicit markers`, () => {
     const entries = [
@@ -1077,44 +1044,18 @@ describe(`helpers: magnetic orderings`, () => {
       { ...mag_entry({ magnetic_ordering: `FM` }), marker: `star` as const },
       mag_entry(), // no ordering -> no marker assigned
     ]
-    const result = helpers.apply_category_markers(entries, MAGNETIC_ORDERING_CATEGORY)
-    expect(result.map((entry) => entry.marker)).toEqual([
-      `triangle`,
-      `diamond`,
-      `square`,
-      `circle`,
-      `star`,
-      undefined,
-    ])
+    const markers = helpers.apply_category_markers(entries, magnetic).map((ent) => ent.marker)
+    expect(markers).toEqual([`triangle`, `diamond`, `square`, `circle`, `star`, undefined])
   })
 
   test.each([
-    {
-      desc: `no magnetic data`,
-      entries: [mag_entry(), mag_entry({ composition: { Li: 1 } })],
-      config: MAGNETIC_ORDERING_CATEGORY,
-    },
-    { desc: `null config`, entries: [mag_entry({ magnetic_ordering: `FM` })], config: null },
-  ])(
-    `apply_category_markers returns input array unchanged with $desc`,
-    ({ entries, config }) => {
-      expect(helpers.apply_category_markers(entries, config)).toBe(entries)
-    },
+    [`no magnetic data`, [mag_entry(), mag_entry({ composition: { Li: 1 } })], magnetic],
+    [`null config`, [mag_entry({ magnetic_ordering: `FM` })], null],
+  ] as [string, PhaseData[], typeof magnetic | null][])(
+    `apply_category_markers returns input array identity-unchanged with %s`,
+    (_desc, entries, config) =>
+      expect(helpers.apply_category_markers(entries, config)).toBe(entries),
   )
-
-  test(`count_entry_categories tallies recognized orderings only`, () => {
-    const counts = helpers.count_entry_categories(
-      [
-        mag_entry({ magnetic_ordering: `FM` }),
-        mag_entry({ magnetic_ordering: `ferromagnetic` }),
-        mag_entry({ magnetic_ordering: `AFM` }),
-        mag_entry({ magnetic_ordering: `Unknown` }),
-        mag_entry(),
-      ],
-      MAGNETIC_ORDERING_CATEGORY,
-    )
-    expect(counts).toEqual({ FM: 2, AFM: 1 })
-  })
 
   test(`visible_entries filters by hidden category values`, () => {
     const entries = [
@@ -1123,41 +1064,31 @@ describe(`helpers: magnetic orderings`, () => {
       mag_entry({ magnetic_ordering: `AFM`, is_stable: false, e_above_hull: 0.1 }),
       mag_entry({ is_stable: true }), // no ordering -> unaffected by category filters
     ]
-    const magnetic = MAGNETIC_ORDERING_CATEGORY
-    expect(helpers.visible_entries(entries, true, true, magnetic, [`AFM`])).toEqual([
-      entries[0],
-      entries[3],
-    ])
+    const visible = (...args: [boolean, boolean, typeof magnetic | null, string[]]) =>
+      helpers.visible_entries(entries, ...args)
+    expect(visible(true, true, magnetic, [`AFM`])).toEqual([entries[0], entries[3]])
     // Stability filter still applies on top of the category filter
-    expect(helpers.visible_entries(entries, false, true, magnetic, [`FM`])).toEqual([
-      entries[2],
-    ])
+    expect(visible(false, true, magnetic, [`FM`])).toEqual([entries[2]])
     // No hidden values or no category config -> all visible
-    expect(helpers.visible_entries(entries, true, true, magnetic, [])).toEqual(entries)
-    expect(helpers.visible_entries(entries, true, true, null, [`AFM`])).toEqual(entries)
+    expect(visible(true, true, magnetic, [])).toEqual(entries)
+    expect(visible(true, true, null, [`AFM`])).toEqual(entries)
   })
 
   test(`custom category config resolves values, markers and filtering`, () => {
     const electronic = {
       label: `Electronic`,
       property: `electronic_class`,
-      markers: {
-        metal: `circle`,
-        semimetal: `wye`,
-        semiconductor: `diamond`,
-        insulator: `square`,
-      },
+      markers: { metal: `circle`, semiconductor: `diamond`, insulator: `square` },
       aliases: { 'semi-conductor': `semiconductor` },
     } as const
     const entry = (electronic_class?: string) =>
       ({ composition: { Si: 1 }, energy: -1, electronic_class }) as PhaseData
-    // Case-insensitive canonical match + alias normalization
+    // Case-insensitive canonical match + alias normalization + data dict fallback
     expect(helpers.get_entry_category(entry(`Metal`), electronic)).toBe(`metal`)
     expect(helpers.get_entry_category(entry(`semi-conductor`), electronic)).toBe(
       `semiconductor`,
     )
     expect(helpers.get_entry_category(entry(`half-metal`), electronic)).toBeNull()
-    // data dict fallback
     expect(
       helpers.get_entry_category(
         { ...entry(), data: { electronic_class: `insulator` } },
@@ -1176,9 +1107,9 @@ describe(`helpers: magnetic orderings`, () => {
   })
 
   test(`build_entry_tooltip_text includes magnetic ordering when present`, () => {
-    const text = helpers.build_entry_tooltip_text(mag_entry({ magnetic_ordering: `FiM` }))
-    expect(text).toContain(`Magnetic: FiM`)
-    const plain_text = helpers.build_entry_tooltip_text(mag_entry())
-    expect(plain_text).not.toContain(`Magnetic`)
+    expect(
+      helpers.build_entry_tooltip_text(mag_entry({ magnetic_ordering: `FiM` })),
+    ).toContain(`Magnetic: FiM`)
+    expect(helpers.build_entry_tooltip_text(mag_entry())).not.toContain(`Magnetic`)
   })
 })


### PR DESCRIPTION
## Summary

- New `EntryCategoryConfig` lets convex hull diagrams (2D/3D/4D) shape-code entries by any categorical property — electronic class (metal/semimetal/semiconductor/insulator), crystallinity (crystalline/amorphous/glass), defect type, magnetic ordering, etc. Each category value maps to a d3 marker symbol, and the controls pane grows a filter row with shape swatches, per-value counts, and show/hide toggles (bindable `hidden_categories`).
- Category values resolve from top-level entry fields or the pymatgen `data` / Materials Project `attributes` dicts, with case-insensitive matching and alias normalization (e.g. `ferromagnetic` → `FM`); unrecognized values are never hidden or restyled, and explicit per-entry `marker` overrides always win. Filtering composes with the existing stable/unstable toggles and is respected by info-pane visible counts, the stats table, tooltips, and copied entry text.
- A built-in preset for magnetic orderings (`MAGNETIC_ORDERING_CATEGORY`, the default `entry_category`) makes datasets carrying e.g. MP-style `ordering` fields light up without configuration; pass any custom config or `null` to disable. The demo page shows the default config next to a custom crystallinity classification.

## Drive-by fixes

- 3D/4D canvases failed to re-render when point-visibility state changed (`s`/`u` toggles and the new filters) — the lazily-derived `visible_entries` was only read inside the untracked rAF callback, so the render effect never re-fired.
- Legend toggles no longer scroll the page on Space and expose `aria-pressed`.
- Hull playwright utils hardened: `dom_click` down to one protocol round-trip, `get_canvas_hash` switched from a sum over every 100th pixel (which only sampled 8 fixed columns) to a position-sensitive rolling hash, plus coherent test timeouts for the data-heavy demo page.