### PR TITLE
Default Dash wrapper sync script to repo dist

### DIFF
--- a/extensions/dash/scripts/sync_typed_wrappers.py
+++ b/extensions/dash/scripts/sync_typed_wrappers.py
@@ -8,10 +8,9 @@ This script adds *typed* Python wrappers (subclasses of MatterViz) for IDE disco
 
 How props are discovered
 ------------------------
-The MatterViz npm package ships TypeScript declaration files next to its compiled Svelte
-components:
+MatterViz ships TypeScript declaration files next to its compiled Svelte components:
 
-  node_modules/matterviz/dist/**/<Component>.svelte.d.ts
+  <matterviz-dist>/**/<Component>.svelte.d.ts
 
 These contain a `type $$ComponentProps = ...` (often) or a `type Props = ...` plus a Svelte
 component declaration like:
@@ -29,7 +28,7 @@ Usage
 -----
   python scripts/sync_typed_wrappers.py \
       --manifest component_manifest.toml \
-      --matterviz-dist node_modules/matterviz/dist \
+      --matterviz-dist ../../dist \
       --out matterviz_dash_components/typed.py
 """
 
@@ -757,9 +756,11 @@ def main() -> None:
 
     ap = argparse.ArgumentParser()
     ap.add_argument("--manifest", default=f"{dash_root}/component_manifest.toml")
-    ap.add_argument(
-        "--matterviz-dist", default=f"{dash_root}/node_modules/matterviz/dist"
-    )
+    # Default to the repo's own build output (what CI uses), NOT the copy under
+    # extensions/dash/node_modules: pnpm snapshots the `file:../..` dependency at
+    # install time, so that copy silently goes stale as repo components evolve.
+    repo_root = os.path.dirname(os.path.dirname(dash_root))
+    ap.add_argument("--matterviz-dist", default=f"{repo_root}/dist")
     ap.add_argument("--out", default=f"{dash_root}/matterviz_dash_components/typed.py")
     ap.add_argument(
         "--check",
@@ -776,7 +777,9 @@ def main() -> None:
         raise SystemExit(f"Manifest not found: {manifest_path}")
     if not os.path.isdir(dist_dir):
         raise SystemExit(
-            f"MatterViz dist not found: {dist_dir}\nRun `pnpm install` first."
+            f"MatterViz dist not found: {dist_dir}\n"
+            "Build it with `pnpm package:dist` at the repo root (or pass "
+            "--matterviz-dist pointing at a built matterviz dist directory)."
         )
 
     with open(manifest_path, encoding="utf-8") as fh:


### PR DESCRIPTION
- `sync_typed_wrappers.py` defaulted to `extensions/dash/node_modules/matterviz/dist`, but pnpm snapshots the `file:../..` matterviz dependency at install time — that copy silently goes stale as repo components evolve, and the script then crashes with `FileNotFoundError` on declaration files for newer components (this bit an agent generating wrappers for new convex hull props this week).
- The default is now the repo's own build output `dist/` (resolved absolutely from the script location, so cwd-independent) — the same directory CI already passes explicitly via `--matterviz-dist ../../dist`.
- The missing-dist error now says how to fix it (`pnpm package:dist` at the repo root) instead of suggesting `pnpm install`, which would reinstall yet another snapshot of a possibly-stale tree.

Verified: running the script with no flags now generates successfully against a freshly built `dist/`, and the deliberate-failure path prints the actionable message and exits 1.