### PR TITLE
Fix camera freezing/rotation reset after applying a supercell

### DIFF
--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -174,7 +174,7 @@ export const read_file = async (file_path: string): Promise<FileData> => {
 
   // Files we serialize as base64 for the webview (compressed OR binary)
   const is_base64_payload =
-    COMPRESSION_EXTENSIONS_REGEX.test(filename) || /\.(traj|h5|hdf5)$/i.test(filename)
+    COMPRESSION_EXTENSIONS_REGEX.test(filename) || /\.(?:traj|h5|hdf5)$/i.test(filename)
 
   // Check file size to avoid loading huge files into memory
   let file_size: number

--- a/extensions/vscode/src/types.ts
+++ b/extensions/vscode/src/types.ts
@@ -11,7 +11,7 @@ export type ViewType =
   | `json_browser`
 
 // Filename patterns for specialized file types (shared between extension host and webview)
-export const FERMI_FILE_RE = /\.(bxsf|frmsf)$/i
+export const FERMI_FILE_RE = /\.(?:bxsf|frmsf)$/i
 export const VOLUMETRIC_EXT_RE = /\.cube$/i
 export const VOLUMETRIC_VASP_RE =
-  /(?:^|[\\/_.-])(chgcar|aeccar[012]?|elfcar|locpot|parchg)(?:[\\/_.-]|$)/i
+  /(?:^|[\\/_.-])(?:chgcar|aeccar[012]?|elfcar|locpot|parchg)(?:[\\/_.-]|$)/i

--- a/extensions/vscode/src/webview/JsonBrowser.svelte
+++ b/extensions/vscode/src/webview/JsonBrowser.svelte
@@ -574,8 +574,7 @@
   }
 
   function mount_all_panels(): void {
-    for (let idx = 0; idx < panels.length; idx++) {
-      const panel = panels[idx]
+    for (const panel of panels) {
       if (panel.component) continue // already mounted
       const el = document.querySelector<HTMLElement>(`#${panel.id}`)
       if (!el) continue
@@ -730,7 +729,7 @@
     // Parse path segments: handles dotted keys like ["foo.bar"], array indices like [0],
     // and regular dotted paths like a.b.c
     const segments: string[] = []
-    const segment_re = /\["([^"]+)"\]|\[(\d+)\]|([^.[\]]+)/g
+    const segment_re = /\["(?<quoted_key>[^"]+)"\]|\[(?<array_index>\d+)\]|(?<bare_key>[^.[\]]+)/g
     let match: RegExpExecArray | null
     while ((match = segment_re.exec(path)) !== null) {
       segments.push(match[1] ?? match[2] ?? match[3])

--- a/extensions/vscode/src/webview/JsonBrowser.svelte
+++ b/extensions/vscode/src/webview/JsonBrowser.svelte
@@ -30,7 +30,9 @@
   import { mount, unmount } from 'svelte'
   import {
     detect_view_type,
+    resolve_path,
     scan_renderable_paths,
+    structure_props,
     TYPE_COLORS,
     TYPE_LABELS,
   } from './detect'
@@ -440,25 +442,6 @@
     return val
   }
 
-  // Map user defaults to structure component props (mirrors main.ts structure_props)
-  function struct_props(merged: DefaultSettings): Record<string, unknown> {
-    const { structure } = merged
-    return {
-      scene_props: { ...structure, gizmo: structure.show_gizmo },
-      lattice_props: {
-        show_cell_vectors: structure.show_cell_vectors,
-        cell_edge_opacity: structure.cell_edge_opacity,
-        cell_surface_opacity: structure.cell_surface_opacity,
-        cell_edge_color: structure.cell_edge_color,
-        cell_surface_color: structure.cell_surface_color,
-      },
-      color_scheme: merged.color_scheme,
-      background_color: merged.background_color,
-      background_opacity: merged.background_opacity,
-      show_image_atoms: structure.show_image_atoms,
-    }
-  }
-
   // Merge defaults once (reused across all panel mounts)
   const merged_defaults = $derived(merge(defaults))
   const common_props = { fullscreen_toggle: false, style: `height:100%` }
@@ -485,7 +468,7 @@
     const struct_common = {
       allow_file_drop: false,
       enable_tips: false,
-      ...struct_props(merged_defaults),
+      ...structure_props(merged_defaults),
       ...common_props,
     }
 
@@ -722,25 +705,6 @@
       const detected = detect_view_type(val)
       if (detected) replace_or_add_panel(data_path, detected, val)
     }, 150)
-  }
-
-  function resolve_path(root: unknown, path: string): unknown {
-    if (!path) return root
-    // Parse path segments: handles dotted keys like ["foo.bar"], array indices like [0],
-    // and regular dotted paths like a.b.c
-    const segments: string[] = []
-    const segment_re = /\["(?<quoted_key>[^"]+)"\]|\[(?<array_index>\d+)\]|(?<bare_key>[^.[\]]+)/g
-    let match: RegExpExecArray | null
-    while ((match = segment_re.exec(path)) !== null) {
-      segments.push(match[1] ?? match[2] ?? match[3])
-    }
-    let current: unknown = root
-    for (const segment of segments) {
-      if (current === null || current === undefined || typeof current !== `object`)
-        return undefined
-      current = (current as Record<string, unknown>)[segment]
-    }
-    return current
   }
 
   // The first split direction determines the flex layout direction

--- a/extensions/vscode/src/webview/detect.ts
+++ b/extensions/vscode/src/webview/detect.ts
@@ -2,6 +2,7 @@
 // Used by JsonBrowser to detect renderable items in JSON trees and by main.ts
 // to decide whether to show the browser or render directly.
 
+import type { DefaultSettings } from '$lib/settings'
 import { is_optimade_raw } from '$lib/structure/parse'
 
 // Visualization types that can be rendered in the extension
@@ -441,4 +442,47 @@ export function scan_renderable_paths(
 
   walk(obj, prefix, 0)
   return results
+}
+
+// Resolve a path produced by scan_renderable_paths back to its value (inverse walk).
+// Handles dotted keys ["foo.bar"], array indices [0], and bare dotted paths a.b.c.
+export function resolve_path(root: unknown, path: string): unknown {
+  if (!path) return root
+  const segments: string[] = []
+  const segment_re =
+    /\["(?<quoted_key>[^"]+)"\]|\[(?<array_index>\d+)\]|(?<bare_key>[^.[\]]+)/g
+  let match: RegExpExecArray | null
+  while ((match = segment_re.exec(path)) !== null) {
+    segments.push(match[1] ?? match[2] ?? match[3])
+  }
+  let current: unknown = root
+  for (const segment of segments) {
+    if (current === null || current === undefined || typeof current !== `object`) {
+      return undefined
+    }
+    current = (current as Record<string, unknown>)[segment]
+  }
+  return current
+}
+
+// Map centralized settings defaults to Structure component props.
+// TIGHT COUPLING WARNING: this mapping ties the settings schema (src/lib/settings.ts)
+// to the Structure prop interface — changes on either side need a manual update here.
+// Shared by the webview entry (main.ts) and the JSON browser panel mounts (JsonBrowser.svelte).
+export const structure_props = (defaults: DefaultSettings) => {
+  const { structure } = defaults
+  return {
+    scene_props: { ...structure, gizmo: structure.show_gizmo },
+    lattice_props: {
+      show_cell_vectors: structure.show_cell_vectors,
+      cell_edge_opacity: structure.cell_edge_opacity,
+      cell_surface_opacity: structure.cell_surface_opacity,
+      cell_edge_color: structure.cell_edge_color,
+      cell_surface_color: structure.cell_surface_color,
+    },
+    color_scheme: defaults.color_scheme,
+    background_color: defaults.background_color,
+    background_opacity: defaults.background_opacity,
+    show_image_atoms: structure.show_image_atoms,
+  }
 }

--- a/extensions/vscode/src/webview/main.ts
+++ b/extensions/vscode/src/webview/main.ts
@@ -52,7 +52,7 @@ const DETECTION_TO_VIEW_TYPE: Partial<Record<RenderableType, ViewType>> = {
   phase_diagram: `phase_diagram`,
 }
 
-export type { ViewType }
+export type { ViewType } from '../types'
 export interface FileData {
   filename: string
   content: string
@@ -377,7 +377,7 @@ export const parse_file_content = async (
     const buffer = base64_to_array_buffer(content)
 
     // Binary trajectory formats: pass buffer directly to trajectory parser
-    if (/\.(h5|hdf5|traj)$/i.test(filename)) {
+    if (/\.(?:h5|hdf5|traj)$/i.test(filename)) {
       const data = await parse_trajectory_data(buffer, filename)
       return { type: `trajectory`, filename, data }
     }

--- a/extensions/vscode/src/webview/main.ts
+++ b/extensions/vscode/src/webview/main.ts
@@ -37,7 +37,7 @@ import { mount, unmount } from 'svelte'
 import type { ViewType } from '../types'
 import { FERMI_FILE_RE, VOLUMETRIC_EXT_RE, VOLUMETRIC_VASP_RE } from '../types'
 import type { RenderableType } from './detect'
-import { detect_view_type } from './detect'
+import { detect_view_type, structure_props } from './detect'
 import JsonBrowser from './JsonBrowser.svelte'
 import { to_error } from '$lib/utils'
 
@@ -614,28 +614,6 @@ const create_display = (
 
   vscode_api?.postMessage({ command: `info`, text: log_message })
   return app
-}
-
-// Map defaults in settings.ts to structure component props
-// TIGHT COUPLING WARNING: settings-to-props mapping functions create a direct dependency between the centralized settings schema
-// (src/lib/settings.ts) and component prop interfaces. Changes to either side
-// require manual updates here.
-const structure_props = (defaults: DefaultSettings) => {
-  const { structure } = defaults
-  return {
-    scene_props: { ...structure, gizmo: structure.show_gizmo },
-    lattice_props: {
-      show_cell_vectors: structure.show_cell_vectors,
-      cell_edge_opacity: structure.cell_edge_opacity,
-      cell_surface_opacity: structure.cell_surface_opacity,
-      cell_edge_color: structure.cell_edge_color,
-      cell_surface_color: structure.cell_surface_color,
-    },
-    color_scheme: defaults.color_scheme,
-    background_color: defaults.background_color,
-    background_opacity: defaults.background_opacity,
-    show_image_atoms: structure.show_image_atoms,
-  }
 }
 
 // Map defaults to trajectory component props

--- a/extensions/vscode/tests/detect.test.ts
+++ b/extensions/vscode/tests/detect.test.ts
@@ -454,7 +454,8 @@ describe(`scan_renderable_paths`, () => {
     function resolve_path(root: unknown, path: string): unknown {
       if (!path) return root
       const segments: string[] = []
-      const segment_re = /\["([^"]+)"\]|\[(\d+)\]|([^.[\]]+)/g
+      const segment_re =
+        /\["(?<quoted_key>[^"]+)"\]|\[(?<array_index>\d+)\]|(?<bare_key>[^.[\]]+)/g
       let match: RegExpExecArray | null
       while ((match = segment_re.exec(path)) !== null) {
         segments.push(match[1] ?? match[2] ?? match[3])

--- a/extensions/vscode/tests/detect.test.ts
+++ b/extensions/vscode/tests/detect.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test } from 'vitest'
 import {
   detect_view_type,
   is_plottable_data,
+  resolve_path,
   scan_renderable_paths,
 } from '../src/webview/detect'
 
@@ -450,25 +451,6 @@ describe(`scan_renderable_paths`, () => {
   )
 
   test(`all scanned paths resolve back to the original value`, () => {
-    // resolve_path mirror (same logic as JsonBrowser.svelte)
-    function resolve_path(root: unknown, path: string): unknown {
-      if (!path) return root
-      const segments: string[] = []
-      const segment_re =
-        /\["(?<quoted_key>[^"]+)"\]|\[(?<array_index>\d+)\]|(?<bare_key>[^.[\]]+)/g
-      let match: RegExpExecArray | null
-      while ((match = segment_re.exec(path)) !== null) {
-        segments.push(match[1] ?? match[2] ?? match[3])
-      }
-      let current: unknown = root
-      for (const segment of segments) {
-        if (current === null || current === undefined || typeof current !== `object`) {
-          return undefined
-        }
-        current = (current as Record<string, unknown>)[segment]
-      }
-      return current
-    }
     for (const [path] of fixture_paths) {
       const resolved = resolve_path(fixture, path)
       expect(resolved, `resolve_path failed for '${path}'`).toBeDefined()

--- a/extensions/vscode/tests/extension.test.ts
+++ b/extensions/vscode/tests/extension.test.ts
@@ -193,7 +193,7 @@ describe(`MatterViz Extension`, () => {
         const regex_str = pattern
           .replaceAll(`.`, `\\.`) // escape dots
           .replaceAll(`*`, `.*`) // * → .*
-          .replaceAll(/\{([^}]+)\}/g, (_, group) => `(${group.split(`,`).join(`|`)})`) // {a,b} → (a|b)
+          .replaceAll(/\{(?<braced>[^}]+)\}/g, (_, group) => `(${group.split(`,`).join(`|`)})`) // {a,b} → (a|b)
         const regex = new RegExp(`^${regex_str}$`, `i`)
         if (regex.test(filename)) return true
       }
@@ -383,7 +383,9 @@ describe(`MatterViz Extension`, () => {
     expect(html).toContain(JSON.stringify(webview_data_with_theme))
 
     // Step 5: Verify the exact data structure that would be sent to webview
-    const parsed_data = JSON.parse(/matterviz_data=(\{[\s\S]*?\});/.exec(html)?.[1] ?? `{}`)
+    const parsed_data = JSON.parse(
+      /matterviz_data=(?<json>\{[\s\S]*?\});/.exec(html)?.[1] ?? `{}`,
+    )
     expect(parsed_data.type).toBe(`trajectory`)
     expect(parsed_data.data.filename).toBe(ase_filename)
     expect(parsed_data.data.is_base64).toBe(true)
@@ -1045,7 +1047,7 @@ describe(`MatterViz Extension`, () => {
 
     for (let idx = 0; idx < 1000; idx++) {
       const html = create_html(mock_webview, mock_context, data)
-      const nonce_match = /nonce="([a-zA-Z0-9]+)"/.exec(html)
+      const nonce_match = /nonce="(?<nonce>[a-zA-Z0-9]+)"/.exec(html)
       if (nonce_match) nonces.add(nonce_match[1])
     }
 
@@ -1073,7 +1075,7 @@ describe(`MatterViz Extension`, () => {
 
       expect(html).toContain(escaped_json)
       // Ensure no raw </script> inside the JSON data breaks out of the script tag
-      const data_script = /window\.matterviz_data=(.*?);/s.exec(html)
+      const data_script = /window\.matterviz_data=(?<json>.*?);/s.exec(html)
       if (data_script) {
         expect(data_script[1]).not.toContain(`</script>`)
       }
@@ -1133,7 +1135,9 @@ describe(`MatterViz Extension`, () => {
 
       const html = create_html(mock_webview, mock_context, data)
 
-      const parsed_data = JSON.parse(/matterviz_data=(\{[\s\S]*?\});/.exec(html)?.[1] ?? `{}`)
+      const parsed_data = JSON.parse(
+        /matterviz_data=(?<json>\{[\s\S]*?\});/.exec(html)?.[1] ?? `{}`,
+      )
       expect(parsed_data.theme).toBe(`dark`)
     })
 
@@ -1793,7 +1797,7 @@ H 0.0 1.0 0.0`
       })
 
       const multi_frame_parsed_data = JSON.parse(
-        /matterviz_data=(\{[\s\S]*?\});/.exec(multi_frame_html)?.[1] ?? `{}`,
+        /matterviz_data=(?<json>\{[\s\S]*?\});/.exec(multi_frame_html)?.[1] ?? `{}`,
       )
 
       expect(multi_frame_parsed_data.type).toBe(`trajectory`)
@@ -1810,7 +1814,7 @@ H 0.0 1.0 0.0`
       })
 
       const single_frame_parsed_data = JSON.parse(
-        /matterviz_data=(\{[\s\S]*?\});/.exec(single_frame_html)?.[1] ?? `{}`,
+        /matterviz_data=(?<json>\{[\s\S]*?\});/.exec(single_frame_html)?.[1] ?? `{}`,
       )
 
       expect(single_frame_parsed_data.type).toBe(`structure`)
@@ -1823,7 +1827,7 @@ H 0.0 1.0 0.0`
       })
 
       const compressed_parsed_data = JSON.parse(
-        /matterviz_data=(\{[\s\S]*?\});/.exec(compressed_html)?.[1] ?? `{}`,
+        /matterviz_data=(?<json>\{[\s\S]*?\});/.exec(compressed_html)?.[1] ?? `{}`,
       )
 
       expect(compressed_parsed_data.type).toBe(`trajectory`) // Should be trajectory since filename contains trajectory keyword
@@ -1848,7 +1852,9 @@ H 0.0 1.0 0.0`
         theme: `light`,
       })
 
-      const parsed_data = JSON.parse(/matterviz_data=(\{[\s\S]*?\});/.exec(html)?.[1] ?? `{}`)
+      const parsed_data = JSON.parse(
+        /matterviz_data=(?<json>\{[\s\S]*?\});/.exec(html)?.[1] ?? `{}`,
+      )
 
       // Should be 'trajectory' since filename contains trajectory keyword
       expect(parsed_data.type).toBe(`trajectory`)

--- a/extensions/vscode/tests/vite-plugin-json-gz.test.ts
+++ b/extensions/vscode/tests/vite-plugin-json-gz.test.ts
@@ -85,7 +85,7 @@ describe(`inline vite-plugin-json-gz query handling`, () => {
 })
 
 describe(`inline vite-plugin-raw-text query handling`, () => {
-  const TEXT_EXT_RE = /\.(xyz|extxyz|cif|poscar|lammpstrj|yaml\.gz)$/
+  const TEXT_EXT_RE = /\.(?:xyz|extxyz|cif|poscar|lammpstrj|yaml\.gz)$/
 
   const should_handle = (source: string): boolean => {
     if (source.includes(`url`)) return false

--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
     "d3-scale-chromatic": "^3.1.0",
     "d3-shape": "^3.2.0",
     "d3-time-format": "^4.1.0",
-    "dompurify": "3.4.10",
+    "dompurify": "3.4.7",
     "fflate": "^0.8.3",
     "h5wasm": "^0.10.3",
     "js-yaml": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -187,7 +187,7 @@
   },
   "dependencies": {
     "@spglib/moyo-wasm": "^0.12.0",
-    "@sveltejs/kit": "2.65.1",
+    "@sveltejs/kit": "2.65.2",
     "@threlte/core": "^8.5.16",
     "@threlte/extras": "^9.21.0",
     "d3-array": "^3.2.4",
@@ -200,7 +200,7 @@
     "d3-scale-chromatic": "^3.1.0",
     "d3-shape": "^3.2.0",
     "d3-time-format": "^4.1.0",
-    "dompurify": "3.4.7",
+    "dompurify": "3.4.10",
     "fflate": "^0.8.3",
     "h5wasm": "^0.10.3",
     "js-yaml": "^4.2.0",
@@ -209,7 +209,7 @@
   },
   "devDependencies": {
     "@janosh/vite-config": "github:janosh/dotfiles",
-    "@playwright/test": "^1.60.0",
+    "@playwright/test": "^1.61.0",
     "@sveltejs/adapter-static": "3.0.10",
     "@sveltejs/package": "^2.5.8",
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
@@ -226,11 +226,11 @@
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.9.3",
     "@types/three": "^0.184.1",
-    "@typescript/native-preview": "7.0.0-dev.20260614.1",
-    "@vitest/coverage-v8": "4.1.8",
+    "@typescript/native-preview": "7.0.0-dev.20260616.1",
+    "@vitest/coverage-v8": "4.1.9",
     "@wooorm/starry-night": "^3.10.0",
-    "happy-dom": "^20.10.3",
-    "knip": "^6.16.1",
+    "happy-dom": "^20.10.5",
+    "knip": "^6.17.1",
     "mdsvex": "^0.12.7",
     "publint": "^0.3.21",
     "rehype-katex": "^7.0.1",
@@ -239,8 +239,8 @@
     "svelte-check-rs": "0.10.1",
     "typescript": "6.0.3",
     "vite": "^8.0.16",
-    "vite-plus": "latest",
-    "vitest": "4.1.8"
+    "vite-plus": "^0.2.0",
+    "vitest": "4.1.9"
   },
   "peerDependencies": {
     "svelte": "^5.0.0"

--- a/src/lib/MillerIndexInput.svelte
+++ b/src/lib/MillerIndexInput.svelte
@@ -20,7 +20,7 @@
     }
     // Fall back to compact single-digit format: "001", "-101"
     const compact = input.replaceAll(/\s+/g, ``)
-    const match = compact.match(/^(-?\d)(-?\d)(-?\d)$/)
+    const match = compact.match(/^(?<h>-?\d)(?<k>-?\d)(?<l>-?\d)$/)
     if (match) return [Number(match[1]), Number(match[2]), Number(match[3])] as Vec3
     return null
   }

--- a/src/lib/chempot-diagram/async-compute.svelte.ts
+++ b/src/lib/chempot-diagram/async-compute.svelte.ts
@@ -85,7 +85,7 @@ export function compute_chempot_async(
     pending.set(id, { resolve, reject })
     try {
       // $state.snapshot strips Svelte $state proxies (not structured-cloneable)
-      // eslint-disable-next-line unicorn/require-post-message-target-origin
+      // oxlint-disable-next-line unicorn/require-post-message-target-origin
       wkr.postMessage($state.snapshot({ id, entries, config }))
     } catch (err) {
       pending.delete(id)

--- a/src/lib/composition/FormulaFilter.svelte
+++ b/src/lib/composition/FormulaFilter.svelte
@@ -389,7 +389,7 @@
   function is_valid_constraint(constraint: string): boolean {
     if (!constraint) return true
     return /^\d+$/.test(constraint) || /^\d+-\d+$/.test(constraint) ||
-      /^(>=|<=|>|<)\d+$/.test(constraint)
+      /^(?:>=|<=|>|<)\d+$/.test(constraint)
   }
 
   function strip_operator_prefix(

--- a/src/lib/composition/format.ts
+++ b/src/lib/composition/format.ts
@@ -124,7 +124,7 @@ export function get_formula_label_segments(formula: string): FormulaLabelSegment
   const segments: FormulaLabelSegment[] = []
   let cursor = 0
 
-  for (const match of formula.matchAll(/([A-Za-z])(\d+(?:\.\d+)?)/g)) {
+  for (const match of formula.matchAll(/(?<letter>[A-Za-z])(?<amount>\d+(?:\.\d+)?)/g)) {
     const match_idx = match.index ?? 0
     const prefix = match[1]
     const amount = match[2]

--- a/src/lib/composition/parse.ts
+++ b/src/lib/composition/parse.ts
@@ -77,11 +77,11 @@ export const atomic_symbol_to_num = (
 const expand_parentheses = (formula: string): string => {
   while (formula.includes(`(`)) {
     const expanded = formula.replaceAll(
-      /\(([^()]+)\)(\d+(?:\.\d+)?|\.\d+)?/g,
+      /\((?<group>[^()]+)\)(?<multiplier>\d+(?:\.\d+)?|\.\d+)?/g,
       (_match, group, multiplier) => {
         const mult = parse_count(multiplier)
         return group.replaceAll(
-          /([A-Z][a-z]?)(\d+(?:\.\d+)?|\.\d+)?/g,
+          /(?<element>[A-Z][a-z]?)(?<count>\d+(?:\.\d+)?|\.\d+)?/g,
           (_m: string, element: string, count: string) => {
             const count_str = format_count(parse_count(count) * mult)
             return element + (count_str === `1` ? `` : count_str)
@@ -110,7 +110,9 @@ export const parse_formula = (formula: string): CompositionType => {
     const coeff = seg_idx > 0 ? /^(?:\d+(?:\.\d+)?|\.\d+)/.exec(segment)?.[0] : undefined
     const multiplier = coeff ? parseFloat(coeff) : 1
     const expanded = expand_parentheses(segment.slice(coeff?.length ?? 0))
-    for (const match of expanded.matchAll(/([A-Z][a-z]?)(\d+(?:\.\d+)?|\.\d+)?/g)) {
+    for (const match of expanded.matchAll(
+      /(?<element>[A-Z][a-z]?)(?<count>\d+(?:\.\d+)?|\.\d+)?/g,
+    )) {
       const [, element, count] = match
       if (!is_elem_symbol(element)) throw new Error(`Invalid element symbol: ${element}`)
       composition[element] = (composition[element] ?? 0) + parse_count(count) * multiplier
@@ -264,7 +266,9 @@ const parse_oxidation_state = (oxidation_str: string): number => {
     return oxidation_str === `+` ? 1 : -1
   }
   // Handle formats like "2+", "+2", "2-", "-2"
-  const ox_match = /([+-]?)(\d+)([+-]?)/.exec(oxidation_str)
+  const ox_match = /(?<sign_before>[+-]?)(?<number>\d+)(?<sign_after>[+-]?)/.exec(
+    oxidation_str,
+  )
   if (!ox_match) return 0
 
   const [, sign_before, number, sign_after] = ox_match
@@ -293,7 +297,7 @@ export const parse_formula_with_oxidation = (
   //          - just count: count
   //          - neither
   const regex =
-    /([A-Z][a-z]?)(?:(?:\^([+-]?\d+[+-]?|[+-])|\[([+-]?\d+[+-]?|[+-])\])((?:\d+(?:\.\d+)?|\.\d+)?)|((?:\d+(?:\.\d+)?|\.\d+))(?:\^([+-]?\d+[+-]?|[+-])|\[([+-]?\d+[+-]?|[+-])\])?)?/g
+    /(?<element>[A-Z][a-z]?)(?:(?:\^(?<oxi_caret>[+-]?\d+[+-]?|[+-])|\[(?<oxi_bracket>[+-]?\d+[+-]?|[+-])\])(?<count_after>(?:\d+(?:\.\d+)?|\.\d+)?)|(?<count_before>(?:\d+(?:\.\d+)?|\.\d+))(?:\^(?<oxi_caret_2>[+-]?\d+[+-]?|[+-])|\[(?<oxi_bracket_2>[+-]?\d+[+-]?|[+-])\])?)?/g
 
   let match: RegExpExecArray | null
   let orig_idx = 0
@@ -502,7 +506,8 @@ export function parse_formula_with_wildcards(formula: string): WildcardFormulaTo
   // Regex to match either:
   // 1. Standard element symbol with optional decimal count
   // 2. Wildcard with optional decimal count
-  const regex = /([A-Z][a-z]?)((?:\d+(?:\.\d+)?|\.\d+)?)|(\*)((?:\d+(?:\.\d+)?|\.\d+)?)/g
+  const regex =
+    /(?<element>[A-Z][a-z]?)(?<count>(?:\d+(?:\.\d+)?|\.\d+)?)|(?<wildcard>\*)(?<wildcard_count>(?:\d+(?:\.\d+)?|\.\d+)?)/g
 
   let match: RegExpExecArray | null
   while ((match = regex.exec(cleaned)) !== null) {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -79,12 +79,13 @@ export const STRUCT_KEYWORDS_STRICT_REGEX = new RegExp(
 
 export const TRAJ_KEYWORDS_SIMPLE_REGEX = new RegExp(`(${TRAJ_KEYWORDS.join(`|`)})`, `i`)
 
+// Build a case-insensitive `\.(ext1|ext2|...)$` regex from extensions (leading dots stripped)
+const ext_regex = (exts: readonly string[]): RegExp =>
+  new RegExp(`\\.(${exts.map((ext) => ext.slice(1)).join(`|`)})$`, `i`)
+
 // File extensions for different file types
 export const TRAJ_EXTENSIONS = Object.freeze([`.traj`, `.xtc`, `.lammpstrj`])
-export const TRAJ_EXTENSIONS_REGEX = new RegExp(
-  `\\.(${TRAJ_EXTENSIONS.map((ext) => ext.slice(1)).join(`|`)})$`,
-  `i`,
-)
+export const TRAJ_EXTENSIONS_REGEX = ext_regex(TRAJ_EXTENSIONS)
 export const STRUCTURE_EXTENSIONS = Object.freeze([
   `.cif`,
   `.mcif`,
@@ -100,10 +101,7 @@ export const STRUCTURE_EXTENSIONS = Object.freeze([
   `.sdf`,
   `.mmcif`,
 ])
-export const STRUCTURE_EXTENSIONS_REGEX = new RegExp(
-  `\\.(${STRUCTURE_EXTENSIONS.map((ext) => ext.slice(1)).join(`|`)})$`,
-  `i`,
-)
+export const STRUCTURE_EXTENSIONS_REGEX = ext_regex(STRUCTURE_EXTENSIONS)
 export const TRAJ_FALLBACK_EXTENSIONS = Object.freeze([
   `.dat`,
   `.data`,
@@ -111,10 +109,7 @@ export const TRAJ_FALLBACK_EXTENSIONS = Object.freeze([
   `.out`,
   `.json`,
 ])
-export const TRAJ_FALLBACK_EXTENSIONS_REGEX = new RegExp(
-  `\\.(${TRAJ_FALLBACK_EXTENSIONS.map((ext) => ext.slice(1)).join(`|`)})$`,
-  `i`,
-)
+export const TRAJ_FALLBACK_EXTENSIONS_REGEX = ext_regex(TRAJ_FALLBACK_EXTENSIONS)
 
 // Special regex patterns
 export const VASP_FILES_REGEX =
@@ -128,7 +123,4 @@ export const MD_SIM_EXCLUDE_REGEX = /md_simulation\.(?:out|txt|yml|py|csv|html|c
 export const XYZ_EXTXYZ_REGEX = /\.(?:xyz|extxyz)$/i
 
 // Compression extensions regex (shared across files)
-export const COMPRESSION_EXTENSIONS_REGEX = new RegExp(
-  `\\.(${COMPRESSION_EXTENSIONS.map((ext) => ext.slice(1)).join(`|`)})$`,
-  `i`,
-)
+export const COMPRESSION_EXTENSIONS_REGEX = ext_regex(COMPRESSION_EXTENSIONS)

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -118,14 +118,14 @@ export const TRAJ_FALLBACK_EXTENSIONS_REGEX = new RegExp(
 
 // Special regex patterns
 export const VASP_FILES_REGEX =
-  /(?:^|[\\/_.-])(poscar|contcar|potcar|incar|kpoints|outcar)(?:[\\/_.-]|$)/i
+  /(?:^|[\\/_.-])(?:poscar|contcar|potcar|incar|kpoints|outcar)(?:[\\/_.-]|$)/i
 export const VASP_VOLUMETRIC_REGEX =
-  /(?:^|[\\/_.-])(chgcar|aeccar[012]?|elfcar|locpot|parchg)(?:[\\/_.-]|$)/i
+  /(?:^|[\\/_.-])(?:chgcar|aeccar[012]?|elfcar|locpot|parchg)(?:[\\/_.-]|$)/i
 export const XDATCAR_REGEX = /xdatcar/i
 export const CONFIG_DIRS_REGEX =
-  /(?:^|[\\/])(\.vscode|\.idea|\.nyc_output|\.cache|\.tmp|\.temp|node_modules|dist|build|coverage)(?:[\\/]|$)/i
-export const MD_SIM_EXCLUDE_REGEX = /md_simulation\.(out|txt|yml|py|csv|html|css|md|js|ts)$/i
-export const XYZ_EXTXYZ_REGEX = /\.(xyz|extxyz)$/i
+  /(?:^|[\\/])(?:\.vscode|\.idea|\.nyc_output|\.cache|\.tmp|\.temp|node_modules|dist|build|coverage)(?:[\\/]|$)/i
+export const MD_SIM_EXCLUDE_REGEX = /md_simulation\.(?:out|txt|yml|py|csv|html|css|md|js|ts)$/i
+export const XYZ_EXTXYZ_REGEX = /\.(?:xyz|extxyz)$/i
 
 // Compression extensions regex (shared across files)
 export const COMPRESSION_EXTENSIONS_REGEX = new RegExp(

--- a/src/lib/convex-hull/ConvexHull3D.svelte
+++ b/src/lib/convex-hull/ConvexHull3D.svelte
@@ -276,7 +276,7 @@
     const cam = gizmo_cam_ref
     if (!cam) return
     const { x: cx, y: cy, z: cz } = cam.position
-    const dist = Math.sqrt(cx * cx + cy * cy + cz * cz)
+    const dist = Math.hypot(cx, cy, cz)
     if (dist < 1e-6) return
     const elev_rad = Math.acos(Math.max(-1, Math.min(1, cz / dist)))
     const sin_elev = Math.sin(elev_rad)
@@ -570,7 +570,7 @@
       const [x, y] = TRIANGLE_VERTICES[idx]
       const dx = x - centroid.x
       const dy = y - centroid.y
-      const length = Math.sqrt(dx * dx + dy * dy)
+      const length = Math.hypot(dx, dy)
       const distance = 0.05
 
       const label_pos = {

--- a/src/lib/convex-hull/ConvexHullStats.svelte
+++ b/src/lib/convex-hull/ConvexHullStats.svelte
@@ -285,7 +285,7 @@
   // stoichiometric input before parsing/reordering.
   const normalize_formula_markup = (formula: string): string =>
     unescape_html(formula)
-      .replaceAll(/<sub>\s*([^<]+?)\s*<\/sub>/gi, `$1`)
+      .replaceAll(/<sub>\s*(?<content>[^<]+?)\s*<\/sub>/gi, `$1`)
       .replaceAll(/<[^>]+>/g, ``)
       .replaceAll(/\s+/g, ``)
   const sanitize_href = (href: string | null | undefined): string | null => {

--- a/src/lib/convex-hull/GasPressureControls.svelte
+++ b/src/lib/convex-hull/GasPressureControls.svelte
@@ -68,7 +68,7 @@
 
   // Format gas name for display (subscript numbers)
   const format_gas_name = (gas: GasSpecies): string =>
-    gas.replaceAll(/(\d+)/g, `<sub>$1</sub>`)
+    gas.replaceAll(/(?<digits>\d+)/g, `<sub>$1</sub>`)
 
   // Format pressure as plain text (no HTML) for the number input
   function format_pressure(P: number): string {

--- a/src/lib/convex-hull/helpers.ts
+++ b/src/lib/convex-hull/helpers.ts
@@ -19,9 +19,9 @@ import type {
   MarkerSymbol,
   PhaseData,
 } from './types'
-import { DEFAULT_GAS_TEMP, MAGNETIC_ORDERING_CATEGORY } from './types'
+import { MAGNETIC_ORDERING_CATEGORY } from './types'
 
-export { DEFAULT_GAS_TEMP }
+export { DEFAULT_GAS_TEMP } from './types'
 
 // Tolerance for classifying a phase as on the convex hull (eV/atom)
 export const HULL_STABILITY_TOL = 1e-6

--- a/src/lib/element/data.ts
+++ b/src/lib/element/data.ts
@@ -9,6 +9,4 @@
 
 // Source of truth is data.json.gz. During npm packaging, scripts/package-dist-assets.ts
 // rewrites dist/element/data.js to inline decompressed JSON for sync consumers.
-import data from './data.json.gz'
-
-export default data
+export { default } from './data.json.gz'

--- a/src/lib/fermi-surface/compute.ts
+++ b/src/lib/fermi-surface/compute.ts
@@ -287,7 +287,7 @@ export function compute_surface_area(surface: Isosurface): number {
     const cz = e1x * e2y - e1y * e2x
 
     // Area is half the magnitude of cross product
-    total_area += Math.sqrt(cx * cx + cy * cy + cz * cz) * 0.5
+    total_area += Math.hypot(cx, cy, cz) * 0.5
   }
 
   return total_area

--- a/src/lib/fermi-surface/parse.ts
+++ b/src/lib/fermi-surface/parse.ts
@@ -145,7 +145,7 @@ function parse_bxsf(content: string): BandGridData {
     const lower = line.toLowerCase()
     if (lower.includes(`fermi`) && lower.includes(`energy`)) {
       // Match patterns like "Fermi Energy = 5.123" or "fermi_energy: -0.5"
-      const match = /(?:=|:)\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)/i.exec(line)
+      const match = /(?:=|:)\s*(?<value>[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)/i.exec(line)
       if (match) {
         fermi_energy = parseFloat(match[1])
         break

--- a/src/lib/io/export.ts
+++ b/src/lib/io/export.ts
@@ -393,7 +393,7 @@ export async function export_trajectory_video(
 
       try {
         const blob = new Blob(chunks, { type: `video/webm` })
-        const webm_filename = filename.replace(/\.(mp4|webm)$/i, `.webm`)
+        const webm_filename = filename.replace(/\.(?:mp4|webm)$/i, `.webm`)
         download(blob, webm_filename, `video/webm`)
         on_progress?.(100)
         resolve()

--- a/src/lib/io/url-drop.ts
+++ b/src/lib/io/url-drop.ts
@@ -8,19 +8,19 @@ const BINARY_EXTENSIONS = new Set(
 const TEXT_EXTENSIONS = new Set(
   `xyz extxyz json cif poscar yaml yml txt md py js ts css html xml`.split(` `),
 )
-const VASP_BASENAME_RE = /^(poscar|xdatcar|contcar)$/i
-const GZ_EXT_RE = /\.(gz|gzip)$/i
+const VASP_BASENAME_RE = /^(?:poscar|xdatcar|contcar)$/i
+const GZ_EXT_RE = /\.(?:gz|gzip)$/i
 
 // Extract filename from Content-Disposition header, falling back to url_basename.
 function extract_filename(headers: Headers | undefined, fallback: string): string {
   if (!headers) return fallback
   const content_disposition_str = headers.get(`content-disposition`)
   if (!content_disposition_str) return fallback
-  const star_match = /filename\*=([^;]+)/i.exec(content_disposition_str)
+  const star_match = /filename\*=(?<value>[^;]+)/i.exec(content_disposition_str)
   if (star_match?.[1]) {
     let raw = star_match[1].trim().replaceAll(/^"|"$/g, ``)
     // Strip any RFC 5987 charset'language' prefix; bare values pass through unchanged
-    const ext_value_match = /^[\w!#$%&+^`{}~-]+'[\w-]*'(.*)$/.exec(raw)
+    const ext_value_match = /^[\w!#$%&+^`{}~-]+'[\w-]*'(?<value>.*)$/.exec(raw)
     if (ext_value_match) raw = ext_value_match[1]
     try {
       return decodeURIComponent(raw)
@@ -28,7 +28,7 @@ function extract_filename(headers: Headers | undefined, fallback: string): strin
       return raw
     }
   }
-  const plain_match = /filename\s*=\s*"?([^";]+)"?/i.exec(content_disposition_str)
+  const plain_match = /filename\s*=\s*"?(?<value>[^";]+)"?/i.exec(content_disposition_str)
   // truthiness check (not ??) so whitespace-only `filename=` values fall back too
   const name = plain_match?.[1]?.trim()
   if (!name) return fallback

--- a/src/lib/labels.ts
+++ b/src/lib/labels.ts
@@ -49,7 +49,7 @@ export function format_value(value: number, formatter?: string): string {
   // Handle percentage formatting - remove trailing zeros
   if (formatter.includes(`%`)) {
     return formatted.includes(`.`)
-      ? formatted.replace(/(\.\d*?)0+%$/, `$1%`).replace(/\.%$/, `%`)
+      ? formatted.replace(/(?<decimals>\.\d*?)0+%$/, `$1%`).replace(/\.%$/, `%`)
       : formatted
   }
 
@@ -60,7 +60,7 @@ export function format_value(value: number, formatter?: string): string {
 
   // Remove trailing zeros after decimal point
   const out = formatted.includes(`.`)
-    ? formatted.replace(/(\.\d*?)0+$/, `$1`).replace(/\.$/, ``)
+    ? formatted.replace(/(?<decimals>\.\d*?)0+$/, `$1`).replace(/\.$/, ``)
     : formatted
   return out === `-0` ? `0` : out
 }
@@ -184,11 +184,11 @@ export function parse_si_float<T extends string | number | null | undefined>(
   // if not string, return as is
   if (typeof value !== `string`) return value
   // Remove whitespace and commas
-  const cleaned = value.trim().replaceAll(/(\d),(\d)/g, `$1$2`)
+  const cleaned = value.trim().replaceAll(/(?<before>\d),(?<after>\d)/g, `$1$2`)
 
   // SI-formatted number (e.g. "1.23k", "789µ"). Suffixes are case-sensitive (m=milli vs
   // M=mega), so no `i` flag: mismatched-case suffixes return the string as-is.
-  const match = /^([-+]?\d*\.?\d+)\s*([yzafpnµmkMGTPEZY])?$/.exec(cleaned)
+  const match = /^(?<num_part>[-+]?\d*\.?\d+)\s*(?<suffix>[yzafpnµmkMGTPEZY])?$/.exec(cleaned)
   if (match) {
     const [, num_part, suffix] = match
     let multiplier = 1

--- a/src/lib/layout/json-tree/utils.ts
+++ b/src/lib/layout/json-tree/utils.ts
@@ -325,9 +325,7 @@ export function parse_path(path: string): (string | number)[] {
   let current = ``
   let in_bracket = false
 
-  for (let idx = 0; idx < path.length; idx++) {
-    const char = path[idx]
-
+  for (const char of path) {
     if (char === `.` && !in_bracket) {
       if (current) segments.push(current)
       current = ``
@@ -341,7 +339,7 @@ export function parse_path(path: string): (string | number)[] {
         const num = Number(current)
         if (Number.isNaN(num)) {
           // Remove surrounding quotes and unescape internal quotes
-          const unquoted = current.replaceAll(/^"|"$/g, ``).replaceAll('\\"', `"`)
+          const unquoted = current.replaceAll(/^"|"$/g, ``).replaceAll(String.raw`\"`, `"`)
           segments.push(unquoted)
         } else segments.push(num)
       }
@@ -356,7 +354,7 @@ export function parse_path(path: string): (string | number)[] {
       // Apply same numeric/quoted-string logic as inside brackets
       const num = Number(current)
       if (Number.isNaN(num)) {
-        const unquoted = current.replaceAll(/^"|"$/g, ``).replaceAll('\\"', `"`)
+        const unquoted = current.replaceAll(/^"|"$/g, ``).replaceAll(String.raw`\"`, `"`)
         segments.push(unquoted)
       } else segments.push(num)
     } else segments.push(current)

--- a/src/lib/phase-diagram/build-diagram.ts
+++ b/src/lib/phase-diagram/build-diagram.ts
@@ -33,7 +33,7 @@ export function parse_curve_ref(ref: string): CurveRef {
   }
 
   // Check for slice suffix [start:end]
-  const slice_match = /^(.+)\[(-?\d*):(-?\d*)\]$/.exec(name)
+  const slice_match = /^(?<base>.+)\[(?<start>-?\d*):(?<end>-?\d*)\]$/.exec(name)
   if (slice_match) {
     name = slice_match[1]
     start = slice_match[2] ? parseInt(slice_match[2], 10) : null

--- a/src/lib/phase-diagram/parse.ts
+++ b/src/lib/phase-diagram/parse.ts
@@ -149,7 +149,8 @@ const LINE_PARSERS: LineParser[] = [
   {
     // ELEMENT AL FCC_A1 2.698154E-02 4.5773304E+03 2.871870E+01!
     prefix: `ELEMENT `,
-    pattern: /ELEMENT\s+(\S+)\s+(\S+)\s+([\d.E+-]+)\s+([\d.E+-]+)\s+([\d.E+-]+)/i,
+    pattern:
+      /ELEMENT\s+(?<symbol>\S+)\s+(?<reference_phase>\S+)\s+(?<mass>[\d.E+-]+)\s+(?<enthalpy>[\d.E+-]+)\s+(?<entropy>[\d.E+-]+)/i,
     handler: (match, data) => {
       data.elements.push({
         symbol: match[1].toUpperCase(),
@@ -163,7 +164,7 @@ const LINE_PARSERS: LineParser[] = [
   {
     // PHASE LIQUID % 1 1.0 !
     prefix: `PHASE `,
-    pattern: /PHASE\s+(\S+)\s+(%\S*)\s+(\d+)\s+(.+?)!/i,
+    pattern: /PHASE\s+(?<name>\S+)\s+(?<model_hints>%\S*)\s+(?<count>\d+)\s+(?<sites>.+?)!/i,
     handler: (match, data) => {
       const sublattice_sites = match[4]
         .trim()
@@ -181,7 +182,7 @@ const LINE_PARSERS: LineParser[] = [
   {
     // CONSTITUENT FCC_A1 :AL,ZN : VA : !
     prefix: `CONSTITUENT `,
-    pattern: /CONSTITUENT\s+(\S+)\s*:\s*(.+?)!/i,
+    pattern: /CONSTITUENT\s+(?<phase_name>\S+)\s*:\s*(?<constituents>.+?)!/i,
     handler: (match, data) => {
       const phase_name = match[1]
       const constituents = match[2].split(`:`).map((sub) =>
@@ -199,7 +200,7 @@ const LINE_PARSERS: LineParser[] = [
   {
     // FUNCTION GHSERAL 298.15 expr1; 700 Y expr2; 933.47 Y expr3; 2900 N !
     prefix: `FUNCTION `,
-    pattern: /FUNCTION\s+(\S+)\s+(.+?)!/i,
+    pattern: /FUNCTION\s+(?<name>\S+)\s+(?<body>.+?)!/i,
     handler: (match, data) => {
       const ranges = parse_temperature_ranges(match[2])
       if (ranges.length > 0) {
@@ -214,9 +215,9 @@ const LINE_PARSERS: LineParser[] = [
   {
     // PARAMETER G(LIQUID,AL;0) 298.15 +GHSERAL+11005.029-11.841867*T; 6000 N !
     prefix: `PARAMETER `,
-    pattern: /PARAMETER\s+(\w+)\(([^)]+)\)\s+(.+?)!/i,
+    pattern: /PARAMETER\s+(?<type>\w+)\((?<spec>[^)]+)\)\s+(?<expression>.+?)!/i,
     handler: (match, data) => {
-      const spec_match = /([^,]+),([^;]+);(\d+)/.exec(match[2])
+      const spec_match = /(?<phase>[^,]+),(?<constituents>[^;]+);(?<order>\d+)/.exec(match[2])
       if (spec_match) {
         data.parameters.push({
           type: match[1],
@@ -236,7 +237,7 @@ function parse_temperature_ranges(body: string): { min: number; max: number; exp
   for (const segment of body.split(/;\s*/)) {
     const trimmed = segment.trim()
     if (!trimmed) continue
-    const temp_match = /^([\d.E+-]+)\s+(.+)/i.exec(trimmed)
+    const temp_match = /^(?<temp>[\d.E+-]+)\s+(?<expr>.+)/i.exec(trimmed)
     if (temp_match) {
       const next_temp = parseFloat(temp_match[1])
       const expr = temp_match[2].replace(/\s+[YN]\s*$/, ``).trim()
@@ -257,7 +258,7 @@ function parse_tdb_line(line: string, data: TdbData): void {
       if (match) parser.handler(match, data)
       else if (parser.prefix === `ELEMENT `) {
         // Fallback for simpler ELEMENT format: ELEMENT AL FCC_A1!
-        const simple_match = /ELEMENT\s+(\S+)\s+(\S+)/i.exec(line)
+        const simple_match = /ELEMENT\s+(?<symbol>\S+)\s+(?<reference_phase>\S+)/i.exec(line)
         if (simple_match) {
           data.elements.push({
             symbol: simple_match[1].toUpperCase(),

--- a/src/lib/phase-diagram/svg-to-diagram.ts
+++ b/src/lib/phase-diagram/svg-to-diagram.ts
@@ -823,7 +823,7 @@ function infer_mpds_components(doc: Document): [string, string] {
 
 // Parse stroke-width from style attribute or direct attribute (returns 0 if not found)
 function parse_stroke_width(el: Element): number {
-  const style_match = /stroke-width:\s*([\d.]+)/.exec(el.getAttribute(`style`) ?? ``)
+  const style_match = /stroke-width:\s*(?<width>[\d.]+)/.exec(el.getAttribute(`style`) ?? ``)
   if (style_match) return parseFloat(style_match[1])
   const attr = el.getAttribute(`stroke-width`)
   return attr ? parseFloat(attr) || 0 : 0
@@ -875,8 +875,8 @@ function find_comment_text(group: Element): string | null {
 // Clean LaTeX subscript notation: "La$_2$NiO$_4$" -> "La2NiO4"
 const clean_latex = (text: string): string =>
   text
-    .replaceAll(/\$_\{([^}]*)\}\$/g, `$1`) // $_{10}$ -> 10
-    .replaceAll(/\$_(\d)\$/g, `$1`) // $_2$ -> 2
+    .replaceAll(/\$_\{(?<digits>[^}]*)\}\$/g, `$1`) // $_{10}$ -> 10
+    .replaceAll(/\$_(?<digit>\d)\$/g, `$1`) // $_2$ -> 2
     .replaceAll(`$`, ``) // remove any remaining $
     .replaceAll(/\s+/g, ` `)
     .trim()
@@ -979,7 +979,7 @@ function parse_ml_path(
 // Parse translate(x, y) or translate(x) from a transform attribute
 // Single-arg translate uses implicit y=0 per SVG spec
 function parse_translate(el: Element | null): Vec2 | null {
-  const match = /translate\(\s*([\d.eE+-]+)(?:\s*[,\s]\s*([\d.eE+-]+))?\s*\)/.exec(
+  const match = /translate\(\s*(?<x>[\d.eE+-]+)(?:\s*[,\s]\s*(?<y>[\d.eE+-]+))?\s*\)/.exec(
     el?.getAttribute(`transform`) ?? ``,
   )
   if (!match) return null

--- a/src/lib/phase-diagram/utils.ts
+++ b/src/lib/phase-diagram/utils.ts
@@ -678,7 +678,7 @@ function format_label_parts(
 ): string {
   if (!use_subscripts) return label
   return label
-    .split(/(\s*\+\s*)/)
+    .split(/(?<separator>\s*\+\s*)/)
     .map((part) => {
       if (part.trim() === `+`) return part
       return formatter(part.trim(), use_subscripts)

--- a/src/lib/plot/core/auto-place.ts
+++ b/src/lib/plot/core/auto-place.ts
@@ -25,7 +25,7 @@ export const placed_coords = (
 // True when the user pinned a decoration via its style (an edge property or position:absolute),
 // in which case auto-placement must leave it alone.
 export const has_explicit_position = (style?: string | null): boolean =>
-  /(^|[;{]\s*)(top|bottom|left|right)\s*:|position\s*:\s*absolute/.test(style ?? ``)
+  /(?:^|[;{]\s*)(?:top|bottom|left|right)\s*:|position\s*:\s*absolute/.test(style ?? ``)
 
 // A decoration's pixel footprint: its rendered box once laid out, else `fallback` (offset dims read
 // 0 before first render). Used to decide crowding before the real size is known.

--- a/src/lib/plot/core/reference-line.ts
+++ b/src/lib/plot/core/reference-line.ts
@@ -283,7 +283,7 @@ export function calculate_annotation_position(
   // Calculate base position with edge padding applied along line direction
   const dx = x2 - x1
   const dy = y2 - y1
-  const len = Math.sqrt(dx * dx + dy * dy)
+  const len = Math.hypot(dx, dy)
 
   let base_x = x1 + frac * dx
   let base_y = y1 + frac * dy

--- a/src/lib/plot/core/utils/label-placement.ts
+++ b/src/lib/plot/core/utils/label-placement.ts
@@ -78,7 +78,7 @@ const copy_state = (target: LabelState, source: LabelState) => {
 
 export function parse_font_size(size_str?: string): number {
   if (!size_str) return 12
-  const match = /^(\d+(?:\.\d+)?)(px|em|rem)?$/.exec(size_str)
+  const match = /^(?<size>\d+(?:\.\d+)?)(?<unit>px|em|rem)?$/.exec(size_str)
   if (!match) return 12
   const value = parseFloat(match[1])
   return match[2] === `em` || match[2] === `rem` ? value * 16 : value

--- a/src/lib/plot/scatter/BinnedScatterPlot.svelte
+++ b/src/lib/plot/scatter/BinnedScatterPlot.svelte
@@ -275,8 +275,8 @@
     const bin_w = plot_width / density_result.x_bins
     const bin_h = plot_height / density_result.y_bins
     let occupied_count = 0
-    for (let idx = 0; idx < density_result.counts.length; idx++) {
-      if (density_result.counts[idx]) occupied_count++
+    for (const count of density_result.counts) {
+      if (count) occupied_count++
     }
     const stride = Math.max(1, Math.ceil(occupied_count / max_placement_bins))
     let occupied_idx = 0
@@ -338,8 +338,7 @@
     const values: number[] = []
     for (const srs of series) {
       if (!srs.size_values) continue
-      for (let idx = 0; idx < srs.size_values.length; idx++) {
-        const size_value = srs.size_values[idx]
+      for (const size_value of Array.from(srs.size_values)) {
         if (size_value == null || !Number.isFinite(size_value)) continue
         values.push(size_value)
       }

--- a/src/lib/plot/scatter/ScatterPlot.svelte
+++ b/src/lib/plot/scatter/ScatterPlot.svelte
@@ -917,7 +917,7 @@
     // Skip auto-placement if user set explicit position in style
     const legend_style = legend?.style ?? ``
     if (
-      /(^|[;{]\s*)(top|bottom|left|right)\s*:|position\s*:\s*absolute/.test(
+      /(?:^|[;{]\s*)(?:top|bottom|left|right)\s*:|position\s*:\s*absolute/.test(
         legend_style,
       )
     ) return null

--- a/src/lib/plot/scatter/scatter-data.ts
+++ b/src/lib/plot/scatter/scatter-data.ts
@@ -11,7 +11,7 @@ import {
 import { is_fill_gradient } from '$lib/plot/core/fill-utils'
 import { type AxisRanges, DEFAULT_MARKERS } from '$lib/plot/core/types'
 
-export type { AxisRanges }
+export { type AxisRanges } from '$lib/plot/core/types'
 
 const in_range = (val: number | null | undefined, lo: number, hi: number) =>
   val != null && !isNaN(val) && val >= Math.min(lo, hi) && val <= Math.max(lo, hi)
@@ -237,7 +237,7 @@ const is_transparent_or_none = (color: string | undefined | null): boolean =>
   !color ||
   color === `none` ||
   color === `transparent` ||
-  /rgba\([^)]+[,/]\s*0(\.0*)?\s*\)$/.test(color)
+  /rgba\([^)]+[,/]\s*0(?:\.0*)?\s*\)$/.test(color)
 
 // Type-guard negation of is_transparent_or_none so usable colors narrow to string
 const is_opaque_color = (color: string | undefined | null): color is string =>

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -5,7 +5,7 @@ const SAFE_TAGS = [`a`, `b`, `i`, `em`, `strong`, `sub`, `sup`, `br`, `span`, `c
 const SAFE_ATTRS = [`style`, `class`, `title`, `href`, `target`, `rel`]
 // only allow safe CSS properties for text formatting
 const SAFE_STYLE_RE =
-  /^\s*(color|font-weight|font-style|font-size|text-decoration|vertical-align)\s*:/
+  /^\s*(?:color|font-weight|font-style|font-size|text-decoration|vertical-align)\s*:/
 
 // Add a token to a space-separated string if not already present
 const ensure_token = (value: string, token: string): string => {

--- a/src/lib/scene/bind-renderer.svelte.ts
+++ b/src/lib/scene/bind-renderer.svelte.ts
@@ -9,11 +9,15 @@ export function bind_renderer(
 ) {
   const threlte = useThrelte()
   $effect(() => {
-    on_bind(threlte.scene, threlte.camera.current)
+    // `camera.current` is not reactive, so subscribe to be notified when the active camera changes
+    const unsubscribe = threlte.camera.subscribe((camera) => {
+      on_bind(threlte.scene, camera)
+    })
     if (threlte.renderer) {
       on_renderer?.(threlte.renderer)
       renderer_registry.set(threlte.renderer.domElement, threlte.renderer)
     }
+    return unsubscribe
   })
   return threlte
 }

--- a/src/lib/spectral/Bands.svelte
+++ b/src/lib/spectral/Bands.svelte
@@ -299,8 +299,7 @@
     }
     const ordered_segments = helpers.get_ordered_segments(canonical, segments_to_plot)
 
-    for (let seg_idx = 0; seg_idx < ordered_segments.length; seg_idx++) {
-      const segment_key = ordered_segments[seg_idx]
+    for (const segment_key of ordered_segments) {
       if (positions[segment_key]) continue
 
       const [start_label, end_label] = segment_key.split(`_`)

--- a/src/lib/spectral/helpers.ts
+++ b/src/lib/spectral/helpers.ts
@@ -126,7 +126,7 @@ export function pretty_sym_point(symbol: string): string {
     .replaceAll(/\\?SIGMA/gi, `Σ`)
     .replaceAll(/\\?LAMBDA/gi, `Λ`)
     .replaceAll(
-      /(\p{L})(\d+)/gu,
+      /(?<letter>\p{L})(?<num>\d+)/gu,
       (_, letter, num) =>
         letter +
         num
@@ -1279,7 +1279,7 @@ export function compute_frequency_range(
 
 // Parse axis label: "Frequency (THz)" → { name: "Frequency", unit: "THz" }
 function parse_axis_label(label: string): { name: string; unit?: string } {
-  const match = /^(.+?)\s*\(([^)]+)\)$/.exec(label)
+  const match = /^(?<name>.+?)\s*\((?<unit>[^)]+)\)$/.exec(label)
   return match ? { name: match[1], unit: match[2] } : { name: label }
 }
 

--- a/src/lib/structure/StructureControls.svelte
+++ b/src/lib/structure/StructureControls.svelte
@@ -154,9 +154,9 @@
     }
   }
 
-  const hex_color_pattern = /^#[0-9a-f]{3}([0-9a-f]{3})?$/i
+  const hex_color_pattern = /^#[0-9a-f]{3}(?:[0-9a-f]{3})?$/i
   const color_mix_pattern =
-    /^color-mix\(in srgb,\s*(#[0-9a-f]{3}(?:[0-9a-f]{3})?)\s+(\d+(?:\.\d+)?)%,\s*transparent\)$/i
+    /^color-mix\(in srgb,\s*(?<hex>#[0-9a-f]{3}(?:[0-9a-f]{3})?)\s+(?<pct>\d+(?:\.\d+)?)%,\s*transparent\)$/i
 
   const as_hex_color = (color: string | undefined, fallback: string): string =>
     color?.match(hex_color_pattern)?.[0] ?? fallback

--- a/src/lib/structure/export.ts
+++ b/src/lib/structure/export.ts
@@ -626,17 +626,10 @@ export function structure_to_poscar_str(structure?: AnyStructure): string {
 
   const lattice = structure.lattice
   if (lattice.matrix && Array.isArray(lattice.matrix) && lattice.matrix.length >= 3) {
-    // Convert 3x3 matrix to 3 vectors
-    const matrix = lattice.matrix
-    lines.push(
-      `${matrix[0][0].toFixed(8)} ${matrix[0][1].toFixed(8)} ${matrix[0][2].toFixed(8)}`,
-    )
-    lines.push(
-      `${matrix[1][0].toFixed(8)} ${matrix[1][1].toFixed(8)} ${matrix[1][2].toFixed(8)}`,
-    )
-    lines.push(
-      `${matrix[2][0].toFixed(8)} ${matrix[2][1].toFixed(8)} ${matrix[2][2].toFixed(8)}`,
-    )
+    // One line per lattice vector, exactly 3 components at 8-decimal fixed precision
+    for (const vec of lattice.matrix.slice(0, 3)) {
+      lines.push([vec[0], vec[1], vec[2]].map((coord) => coord.toFixed(8)).join(` `))
+    }
   } else {
     throw new Error(`No valid lattice matrix for POSCAR export`)
   }

--- a/src/lib/structure/export.ts
+++ b/src/lib/structure/export.ts
@@ -142,13 +142,10 @@ export function generate_mtl_content(scene: Scene): string {
       // Get diffuse color (main color)
       if (has_color_property(mat)) {
         const color = mat.color
-        lines.push(`Kd ${color.r.toFixed(6)} ${color.g.toFixed(6)} ${color.b.toFixed(6)}`)
+        const fmt = (val: number) => val.toFixed(6)
+        lines.push(`Kd ${fmt(color.r)} ${fmt(color.g)} ${fmt(color.b)}`)
         // Ambient is typically a fraction of diffuse
-        lines.push(
-          `Ka ${(color.r * 0.2).toFixed(6)} ${(color.g * 0.2).toFixed(6)} ${(
-            color.b * 0.2
-          ).toFixed(6)}`,
-        )
+        lines.push(`Ka ${fmt(color.r * 0.2)} ${fmt(color.g * 0.2)} ${fmt(color.b * 0.2)}`)
       } else {
         // Default white if no color
         lines.push(`Kd 1.000000 1.000000 1.000000`)

--- a/src/lib/structure/parse.ts
+++ b/src/lib/structure/parse.ts
@@ -143,9 +143,9 @@ function parse_coordinate_line(line: string): number[] {
     const sanitized = line
       .trim()
       // Add space when '-' follows a digit and precedes a digit or dot
-      .replaceAll(/(\d)-(?=[\d.])/g, `$1 -`)
+      .replaceAll(/(?<digit>\d)-(?=[\d.])/g, `$1 -`)
       // Revert accidental spaces after exponent markers
-      .replaceAll(/([eE])\s-\s/g, `$1-`)
+      .replaceAll(/(?<exp_marker>[eE])\s-\s/g, `$1-`)
     tokens = sanitized.split(/\s+/)
   }
 
@@ -470,7 +470,7 @@ export function parse_xyz(content: string): ParsedStructure | null {
     let lattice: ParsedStructure[`lattice`] | undefined
 
     // Check for extended XYZ lattice information in comment line
-    const lattice_match = /Lattice="([^"]+)"/.exec(comment_line)
+    const lattice_match = /Lattice="(?<lattice>[^"]+)"/.exec(comment_line)
     if (lattice_match) {
       const lattice_values = lattice_match[1].split(/\s+/).map(parse_coordinate)
       if (lattice_values.length === 9) {
@@ -558,8 +558,7 @@ const parse_symmetry_expression = (
   const tokens: string[] = []
   let current_token = ``
 
-  for (let idx = 0; idx < expr.length; idx++) {
-    const char = expr[idx]
+  for (const char of expr) {
     if ((char === `+` || char === `-`) && current_token.length > 0) {
       tokens.push(current_token)
       current_token = char
@@ -571,7 +570,7 @@ const parse_symmetry_expression = (
 
   for (const token of tokens) {
     // Check if this token is a variable term (x, y, or z with optional sign)
-    const var_match = /^([+-]?)([xyz])$/.exec(token)
+    const var_match = /^(?<sign>[+-]?)(?<axis>[xyz])$/.exec(token)
     if (var_match) {
       const sign = var_match[1] === `-` ? -1 : 1
       const var_char = var_match[2]
@@ -638,7 +637,7 @@ const apply_symmetry_ops = (
   equivalent_atoms.push({ ...atom, coords: base_coords })
 
   for (const operation of symmetry_ops) {
-    const operation_match = /['"]([^'"]+)['"]/.exec(operation)
+    const operation_match = /['"](?<expr>[^'"]+)['"]/.exec(operation)
     const expr_str = operation_match ? operation_match[1] : operation.trim()
     const parts = expr_str.split(`,`).map((part) => part.trim())
     if (parts.length !== 3) continue
@@ -781,8 +780,9 @@ const parse_cif_atom_data = (
       ? parseFloat(raw_data[occupancy].split(`(`)[0]) || 1.0
       : 1.0
 
-  const from_symbol = symbol >= 0 ? /^([A-Z][a-z]*)/.exec(raw_data[symbol])?.[1] : undefined
-  const element_symbol = from_symbol ?? raw_data[label]?.match(/([A-Z][a-z]*)/g)?.[0]
+  const from_symbol =
+    symbol >= 0 ? /^(?<element>[A-Z][a-z]*)/.exec(raw_data[symbol])?.[1] : undefined
+  const element_symbol = from_symbol ?? raw_data[label]?.match(/(?:[A-Z][a-z]*)/g)?.[0]
   if (!element_symbol) {
     throw new Error(`Could not extract element symbol from: ${raw_data.join(` `)}`)
   }
@@ -958,7 +958,7 @@ export function parse_cif(
 
     // Normalize symmetry operations (trim/strip quotes) but preserve duplicates; we deduplicate positions later
     const normalized_ops = symmetry_ops
-      .map((op) => /['"]([^'"]+)['"]/.exec(op)?.[1] ?? op.trim())
+      .map((op) => /['"](?<expr>[^'"]+)['"]/.exec(op)?.[1] ?? op.trim())
       .map((op) => op.replaceAll(/\s+/g, ``))
 
     // Rely on symmetry operations list for all centering/translations to avoid double-counting
@@ -979,7 +979,7 @@ export function parse_cif(
         const toks = split_cif_tokens(line)
         if (toks.length > Math.max(sym_idx, num_idx)) {
           // Normalize type symbol to bare element (e.g. 'Sn2+' -> 'Sn')
-          const match = /^([A-Z][a-z]*)/.exec(toks[sym_idx])
+          const match = /^(?<element>[A-Z][a-z]*)/.exec(toks[sym_idx])
           const sym = match ? match[1] : toks[sym_idx]
           const num = parseInt(toks[num_idx], 10)
           if (sym && !Number.isNaN(num)) atom_type_counts[sym] = num
@@ -1117,7 +1117,7 @@ export function parse_phonopy_yaml(
 
       // Check if we're still in the phonon_displacements section
       if (skip_displacements) {
-        if (/^[a-zA-Z_]/.exec(line)) {
+        if (/^[a-zA-Z_]/.test(line)) {
           // New top-level key, stop skipping
           skip_displacements = false
         } else continue // Still in phonon_displacements, skip this line
@@ -1632,17 +1632,17 @@ export function is_structure_file(filename: string): boolean {
   const name = filename.toLowerCase()
 
   // Trajectory-only formats (can't be structures)
-  if (/\.(traj|xtc|h5|hdf5)$/i.test(name) || /xdatcar/i.test(name)) return false
+  if (/\.(?:traj|xtc|h5|hdf5)$/i.test(name) || /xdatcar/i.test(name)) return false
 
   // Always structure formats
   if (STRUCTURE_EXTENSIONS_REGEX.test(name)) return true
   if (VASP_FILES_REGEX.test(name)) return true
 
   // .xyz/.extxyz files: structure unless they have trajectory keywords
-  if (/\.(xyz|extxyz)$/i.test(name)) return !TRAJ_KEYWORDS_REGEX.test(name)
+  if (/\.(?:xyz|extxyz)$/i.test(name)) return !TRAJ_KEYWORDS_REGEX.test(name)
 
   // Keyword-based detection for YAML/XML
-  if (/\.(yaml|yml|xml)$/i.test(name) && STRUCT_KEYWORDS_REGEX.test(name)) return true
+  if (/\.(?:yaml|yml|xml)$/i.test(name) && STRUCT_KEYWORDS_REGEX.test(name)) return true
 
   // More restrictive keyword detection for JSON files
   if (

--- a/src/lib/structure/parse.ts
+++ b/src/lib/structure/parse.ts
@@ -647,11 +647,7 @@ const apply_symmetry_ops = (
     for (let dim = 0; dim < 3; dim++) {
       const { coefficients, translation } = parse_symmetry_expression(parts[dim])
       // Apply: new_coord = coeff_x * x + coeff_y * y + coeff_z * z + translation
-      new_coords[dim] =
-        coefficients[0] * atom.coords[0] +
-        coefficients[1] * atom.coords[1] +
-        coefficients[2] * atom.coords[2] +
-        translation
+      new_coords[dim] = math.dot(coefficients, atom.coords) + translation
     }
 
     // Wrap and deduplicate transformed coordinates
@@ -716,6 +712,30 @@ const build_cif_atom_site_header_indices = (headers: string[]): Record<string, n
   return indices
 }
 
+// Which coordinate triple a CIF atom-site loop provides (fractional preferred), or null
+const cif_coords_type = (indices: Record<string, number>): `fract` | `cart` | null => {
+  if (indices.x !== undefined && indices.y !== undefined && indices.z !== undefined) {
+    return `fract`
+  }
+  if (
+    indices.cart_x !== undefined &&
+    indices.cart_y !== undefined &&
+    indices.cart_z !== undefined
+  ) {
+    return `cart`
+  }
+  return null
+}
+
+// The 3 column indices for the requested coordinate type
+const cif_coord_indices = (
+  indices: Record<string, number>,
+  coords_type: `fract` | `cart`,
+): number[] =>
+  coords_type === `fract`
+    ? [indices.x, indices.y, indices.z]
+    : [indices.cart_x, indices.cart_y, indices.cart_z]
+
 type CifAtom = {
   id: string
   element: string
@@ -754,10 +774,7 @@ const parse_cif_atom_data = (
   coords_type: `fract` | `cart`,
 ): CifAtom => {
   const { label = 0, symbol = -1, occupancy = -1 } = indices
-  const coord_indices =
-    coords_type === `fract`
-      ? [indices.x, indices.y, indices.z]
-      : [indices.cart_x, indices.cart_y, indices.cart_z]
+  const coord_indices = cif_coord_indices(indices, coords_type)
 
   if (coord_indices.some((idx) => idx === undefined)) {
     throw new Error(`Missing coordinate indices`)
@@ -843,15 +860,7 @@ export function parse_cif(
 
       // Check if this loop contains coordinate headers
       const indices_preview = build_cif_atom_site_header_indices(headers)
-      const has_coords =
-        (indices_preview.x !== undefined &&
-          indices_preview.y !== undefined &&
-          indices_preview.z !== undefined) ||
-        (indices_preview.cart_x !== undefined &&
-          indices_preview.cart_y !== undefined &&
-          indices_preview.cart_z !== undefined)
-
-      if (!has_coords) continue
+      if (cif_coords_type(indices_preview) === null) continue
 
       // This is the desired atom-site loop with coordinates: collect data lines
       atom_headers = headers
@@ -885,16 +894,7 @@ export function parse_cif(
     const header_indices = build_cif_atom_site_header_indices(atom_headers)
 
     // Determine available coordinate type
-    const coords_type: `fract` | `cart` | null =
-      header_indices.x !== undefined &&
-      header_indices.y !== undefined &&
-      header_indices.z !== undefined
-        ? `fract`
-        : header_indices.cart_x !== undefined &&
-            header_indices.cart_y !== undefined &&
-            header_indices.cart_z !== undefined
-          ? `cart`
-          : null
+    const coords_type = cif_coords_type(header_indices)
 
     if (!coords_type) {
       diag_error(`CIF atom site loop missing coordinates (fract or Cartn)`)
@@ -902,10 +902,7 @@ export function parse_cif(
     }
 
     // Collect required coordinate indices
-    const required_indices =
-      coords_type === `fract`
-        ? [header_indices.x, header_indices.y, header_indices.z]
-        : [header_indices.cart_x, header_indices.cart_y, header_indices.cart_z]
+    const required_indices = cif_coord_indices(header_indices, coords_type)
 
     const atoms = atom_data_lines
       .map(split_cif_tokens)

--- a/src/lib/structure/supercell.ts
+++ b/src/lib/structure/supercell.ts
@@ -134,14 +134,10 @@ export function make_supercell(
 
   const orig_matrix = structure.lattice.matrix
   // Create new scaled lattice
-  const new_lattice_matrix = math.scale_lattice_matrix(orig_matrix, supercell_scaling)
-  const lattice_params = math.calc_lattice_params(new_lattice_matrix)
+  const new_matrix = math.scale_lattice_matrix(orig_matrix, supercell_scaling)
+  const lattice_params = math.calc_lattice_params(new_matrix)
 
-  const new_lattice = {
-    ...structure.lattice,
-    matrix: new_lattice_matrix,
-    ...lattice_params,
-  }
+  const new_lattice = { ...structure.lattice, matrix: new_matrix, ...lattice_params }
 
   // Pre-allocate sites array
   const n_sites = structure.sites.length
@@ -149,7 +145,6 @@ export function make_supercell(
 
   // Destructure lattice vectors for fast inline arithmetic (avoid function calls in hot loop)
   const [[ax, ay, az], [bx, by, bz], [cx, cy, cz]] = orig_matrix
-  const [sx, sy, sz] = supercell_scaling
 
   let write_idx = 0
   const sites = structure.sites
@@ -170,9 +165,9 @@ export function make_supercell(
           const site = sites[site_idx]
 
           // new_abc = (old_abc + [ii, jj, kk]) / supercell_scaling
-          let new_a = (site.abc[0] + ii) / sx
-          let new_b = (site.abc[1] + jj) / sy
-          let new_c = (site.abc[2] + kk) / sz
+          let new_a = (site.abc[0] + ii) / scale_x
+          let new_b = (site.abc[1] + jj) / scale_y
+          let new_c = (site.abc[2] + kk) / scale_z
 
           if (to_unit_cell) {
             new_a = wrap_frac_coord(new_a)

--- a/src/lib/structure/supercell.ts
+++ b/src/lib/structure/supercell.ts
@@ -1,7 +1,6 @@
 // Supercell generation utilities for Crystal
 import type { Vec3 } from '$lib/math'
 import * as math from '$lib/math'
-import { scale_lattice_matrix } from '$lib/math'
 import type { Crystal, Site, StructureBond } from './index'
 import { wrap_frac_coord } from './pbc'
 import { normalize_structure_bond } from './bonding'
@@ -110,7 +109,7 @@ export function generate_lattice_points(scaling_factors: Vec3): Vec3[] {
 }
 
 // Re-export from $lib/math for backward compatibility
-export { scale_lattice_matrix }
+export { scale_lattice_matrix } from '$lib/math'
 
 // Create a supercell from a Crystal
 // Takes original structure, scaling factors, and whether to fold coordinates back to unit cell (default: true)
@@ -135,7 +134,7 @@ export function make_supercell(
 
   const orig_matrix = structure.lattice.matrix
   // Create new scaled lattice
-  const new_lattice_matrix = scale_lattice_matrix(orig_matrix, supercell_scaling)
+  const new_lattice_matrix = math.scale_lattice_matrix(orig_matrix, supercell_scaling)
   const lattice_params = math.calc_lattice_params(new_lattice_matrix)
 
   const new_lattice = {

--- a/src/lib/table/HeatmapTable.svelte
+++ b/src/lib/table/HeatmapTable.svelte
@@ -85,7 +85,7 @@
   }
 
   const NUMERIC_WITH_ERROR_RE =
-    /^([-+−]?(?:\d+\.?\d*|\d*\.\d+)(?:[eE][-+−]?\d+)?)\s*(?:±|\+[-−]|\()/
+    /^(?<numeric>[-+−]?(?:\d+\.?\d*|\d*\.\d+)(?:[eE][-+−]?\d+)?)\s*(?:±|\+[-−]|\()/
 
   const parse_numeric_string = (val: string): number | null => {
     const numeric_str = val.match(NUMERIC_WITH_ERROR_RE)?.[1] ?? val
@@ -98,7 +98,7 @@
   const get_sort_val = (val: CellVal): string | number => {
     if (typeof val === `string`) {
       // Check for HTML data-sort-value attribute first
-      const sort_attr_match = val.match(/data-sort-value="([^"]*)"/)
+      const sort_attr_match = val.match(/data-sort-value="(?<value>[^"]*)"/)
       if (sort_attr_match) {
         const num = Number(sort_attr_match[1])
         return isNaN(num) ? sort_attr_match[1] : num

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -501,7 +501,7 @@
       reader.addEventListener(`error`, () => reject(new Error(`Failed to read file`)))
 
       // Read as text for text-based formats, binary for others
-      if (file.name.toLowerCase().match(/\.(xyz|json|extxyz|lammpstrj)$/)) {
+      if (/\.(?:xyz|json|extxyz|lammpstrj)$/.test(file.name.toLowerCase())) {
         reader.readAsText(file)
       } else reader.readAsArrayBuffer(file)
     })

--- a/src/lib/trajectory/format-detect.ts
+++ b/src/lib/trajectory/format-detect.ts
@@ -13,7 +13,7 @@ import { count_xyz_frames } from './helpers'
 // Extensions that explicitly identify a format — when present, format detection trusts
 // the extension instead of sniffing content
 const KNOWN_FORMAT_EXT_REGEX =
-  /\.(xyz|extxyz|traj|h5|hdf5|lammpstrj|json|cif|poscar|vasp|yaml|yml|xml|csv)$/
+  /\.(?:xyz|extxyz|traj|h5|hdf5|lammpstrj|json|cif|poscar|vasp|yaml|yml|xml|csv)$/
 
 // Classify the filename hint for a format whose extensions match ext_regex:
 // true = filename matches, false = filename names a different known format,
@@ -41,7 +41,7 @@ export const FORMAT_PATTERNS = {
   },
 
   hdf5: (data: unknown, filename?: string) => {
-    if (ext_hint(filename, /\.(h5|hdf5)$/) === false) return false
+    if (ext_hint(filename, /\.(?:h5|hdf5)$/) === false) return false
     if (!(data instanceof ArrayBuffer) || data.byteLength < 8) return false
     const signature = new Uint8Array(data.slice(0, 8))
     return [0x89, 0x48, 0x44, 0x46, 0x0d, 0x0a, 0x1a, 0x0a].every(
@@ -62,7 +62,7 @@ export const FORMAT_PATTERNS = {
   },
 
   xyz_multi: (data: string, filename?: string) => {
-    if (ext_hint(filename, /\.(xyz|extxyz)$/) === false) return false
+    if (ext_hint(filename, /\.(?:xyz|extxyz)$/) === false) return false
     return count_xyz_frames(data) >= 2
   },
 
@@ -78,7 +78,7 @@ export function is_trajectory_file(filename: string, content?: string): boolean 
   const base_name = strip_compression_extensions(filename)
 
   // For xyz/extxyz files, use content-based detection if available
-  if (/\.(xyz|extxyz)$/i.test(base_name)) {
+  if (/\.(?:xyz|extxyz)$/i.test(base_name)) {
     if (content) return count_xyz_frames(content) >= 2
     return TRAJ_KEYWORDS_SIMPLE_REGEX.test(base_name)
   }
@@ -90,7 +90,7 @@ export function is_trajectory_file(filename: string, content?: string): boolean 
   if (MD_SIM_EXCLUDE_REGEX.test(base_name)) return false
 
   // For .h5/.hdf5 files, require trajectory keywords
-  if (/\.(h5|hdf5)$/i.test(base_name)) {
+  if (/\.(?:h5|hdf5)$/i.test(base_name)) {
     return TRAJ_KEYWORDS_SIMPLE_REGEX.test(base_name)
   }
 

--- a/src/lib/trajectory/parse/index.ts
+++ b/src/lib/trajectory/parse/index.ts
@@ -5,7 +5,7 @@ import type { AnyStructure } from '$lib/structure/index'
 import { is_parsed_structure, parse_xyz } from '$lib/structure/parse'
 import { INDEX_SAMPLE_RATE, LARGE_FILE_THRESHOLD } from '$lib/trajectory/constants'
 import { strip_compression_extensions } from '$lib/io'
-import { ext_hint, FORMAT_PATTERNS, is_trajectory_file } from '$lib/trajectory/format-detect'
+import { ext_hint, FORMAT_PATTERNS } from '$lib/trajectory/format-detect'
 import { TrajFrameReader } from '$lib/trajectory/frame-reader'
 import { count_xyz_frames } from '$lib/trajectory/helpers'
 import type {
@@ -41,7 +41,8 @@ export {
   MAX_TEXT_FILE_SIZE,
 } from '$lib/trajectory/constants'
 export type { AtomTypeMapping, LoadingOptions } from '$lib/trajectory/types'
-export { is_trajectory_file, TrajFrameReader }
+export { is_trajectory_file } from '$lib/trajectory/format-detect'
+export { TrajFrameReader } from '$lib/trajectory/frame-reader'
 
 export async function parse_trajectory_data(
   data: unknown,
@@ -67,7 +68,7 @@ export async function parse_trajectory_data(
 
     // Single XYZ fallback (content-sniffed when the filename gives no format hint,
     // e.g. blob: object URLs whose basenames are UUIDs)
-    const xyz_hint = ext_hint(filename, /\.(xyz|extxyz)$/)
+    const xyz_hint = ext_hint(filename, /\.(?:xyz|extxyz)$/)
     if (xyz_hint || (xyz_hint === null && count_xyz_frames(content) === 1)) {
       try {
         const structure = parse_xyz(content)
@@ -211,9 +212,9 @@ export async function parse_trajectory_async(
     // prefix for XYZ frames so large extensionless files still get indexed.
     const base_filename = strip_compression_extensions(filename)
     const can_index =
-      /\.(xyz|extxyz|traj)$/.test(base_filename) ||
+      /\.(?:xyz|extxyz|traj)$/.test(base_filename) ||
       (typeof data === `string` &&
-        ext_hint(filename, /\.(xyz|extxyz)$/) === null &&
+        ext_hint(filename, /\.(?:xyz|extxyz)$/) === null &&
         count_xyz_frames(data.slice(0, 2 ** 20)) >= 1)
     if (should_use_indexing && can_index) {
       return attach_parse_warnings(
@@ -310,7 +311,7 @@ async function parse_with_unified_loader(
 
 // Factory function for frame loader (simplified)
 export function create_frame_loader(filename: string): FrameLoader {
-  if (!/\.(xyz|extxyz|traj)$/.exec(filename.toLowerCase())) {
+  if (!/\.(?:xyz|extxyz|traj)$/.test(filename.toLowerCase())) {
     throw new Error(`Unsupported format for frame loading: ${filename}`)
   }
   return new TrajFrameReader(filename)

--- a/src/lib/trajectory/parse/vasp.ts
+++ b/src/lib/trajectory/parse/vasp.ts
@@ -82,7 +82,7 @@ export function parse_vasp_xdatcar(content: string, filename?: string): Trajecto
 
     const config_line = lines[config_idx]
     line_idx = config_idx + 1
-    const step_match = /configuration=\s*(\d+)/.exec(config_line)
+    const step_match = /configuration=\s*(?<step>\d+)/.exec(config_line)
     const step = step_match ? parseInt(step_match[1], 10) : frames.length + 1
 
     const positions = []

--- a/src/lib/trajectory/parse/xyz.ts
+++ b/src/lib/trajectory/parse/xyz.ts
@@ -14,7 +14,8 @@ import type { TrajectoryFrame, TrajectoryType } from '$lib/trajectory/index'
 // name:type:ncols triples (e.g. "species:S:1:pos:R:3:forces:R:3"), falling back
 // to the conventional "symbol x y z" layout when absent or malformed
 function parse_extxyz_columns(comment: string) {
-  const fields = /Properties\s*=\s*"?([^"\s]+)"?/i.exec(comment)?.[1].split(`:`) ?? []
+  const fields =
+    /Properties\s*=\s*"?(?<properties>[^"\s]+)"?/i.exec(comment)?.[1].split(`:`) ?? []
   // Well-formed Properties is name:type:ncols triples; a non-multiple of 3 is malformed,
   // so bail to the conventional default rather than trusting a partial layout
   let layout: Record<string, { offset: number; ncols: number }> | null =
@@ -34,7 +35,11 @@ function parse_extxyz_columns(comment: string) {
 
 // Parse Lattice="ax ay az bx by bz cx cy cz" from an extxyz comment line
 function parse_extxyz_lattice(comment: string): math.Matrix3x3 | undefined {
-  const vals = /Lattice\s*=\s*"([^"]+)"/i.exec(comment)?.[1].trim().split(/\s+/).map(Number)
+  const vals = /Lattice\s*=\s*"(?<lattice>[^"]+)"/i
+    .exec(comment)?.[1]
+    .trim()
+    .split(/\s+/)
+    .map(Number)
   if (vals?.length !== 9 || !vals.every(Number.isFinite)) return undefined
   return [vals.slice(0, 3), vals.slice(3, 6), vals.slice(6, 9)] as math.Matrix3x3
 }
@@ -62,7 +67,7 @@ export function parse_xyz_comment_metadata(comment: string): {
     const match = pattern.exec(comment)
     if (match) properties[key] = parseFloat(match[1])
   }
-  const step = /(?:^|\s)(?:step|frame|ionic_step)\s*[=:]?\s*(\d+)/i.exec(comment)?.[1]
+  const step = /(?:^|\s)(?:step|frame|ionic_step)\s*[=:]?\s*(?<step>\d+)/i.exec(comment)?.[1]
   return { step: step ? parseInt(step, 10) : undefined, properties }
 }
 

--- a/src/lib/trajectory/plotting.ts
+++ b/src/lib/trajectory/plotting.ts
@@ -13,6 +13,12 @@ const DEFAULT_VISIBLE = new Set([`energy`, `force_max`, `stress_frobenius`])
 
 type VisibleProp = Readonly<{ property: string; unit: string }>
 
+// Shared per-series line/point styling derived from a single color
+const series_color_styles = (color: string) => ({
+  line_style: { stroke: color, stroke_width: 2 },
+  point_style: { fill: color, radius: 4, stroke: color, stroke_width: 1 },
+})
+
 export interface PlotSeriesOptions {
   property_config?: Record<string, { label: string; unit: string }>
   colors?: readonly string[]
@@ -153,8 +159,7 @@ function create_series_from_stats(
       visible: false, // Will be assigned
       markers: n_values < 30 ? `line+points` : `line`,
       metadata: Array.from({ length: n_values }, () => series_metadata),
-      line_style: { stroke: color, stroke_width: 2 },
-      point_style: { fill: color, radius: 4, stroke: color, stroke_width: 1 },
+      ...series_color_styles(color),
     })
     color_idx++
   }
@@ -409,8 +414,7 @@ export function generate_streaming_plot_series(
         series_label: unit ? `${clean_label} (${unit})` : clean_label,
         property_key, // Store original property key for robust lookups
       })),
-      line_style: { stroke: color, stroke_width: 2 },
-      point_style: { fill: color, radius: 4, stroke: color, stroke_width: 1 },
+      ...series_color_styles(color),
     })
 
     color_idx++

--- a/src/lib/trajectory/plotting.ts
+++ b/src/lib/trajectory/plotting.ts
@@ -139,6 +139,11 @@ function create_series_from_stats(
     const { clean_label, unit } = extract_label_and_unit(key, property_config)
     const color = colors[color_idx % colors.length]
 
+    // shared per-series metadata (consumers only read metadata[0]); one object, not n copies
+    const series_metadata = {
+      series_label: unit ? `${clean_label} (${unit})` : clean_label,
+      property_key: key, // Store original property key for robust lookups
+    }
     all_series.push({
       x: Array.from({ length: n_values }, (_, idx) => idx),
       y: stat.values,
@@ -147,10 +152,7 @@ function create_series_from_stats(
       y_axis: `y1`, // Will be reassigned
       visible: false, // Will be assigned
       markers: n_values < 30 ? `line+points` : `line`,
-      metadata: Array(n_values).fill({
-        series_label: unit ? `${clean_label} (${unit})` : clean_label,
-        property_key: key, // Store original property key for robust lookups
-      }),
+      metadata: Array.from({ length: n_values }, () => series_metadata),
       line_style: { stroke: color, stroke_width: 2 },
       point_style: { fill: color, radius: 4, stroke: color, stroke_width: 1 },
     })
@@ -178,13 +180,13 @@ function group_and_assign_series(
   const groups = Array.from(unit_map.entries())
     .map(([unit, group_series]) => {
       const priority = calculate_priority(unit, group_series)
-      const has_default_visible = group_series.some((srs) => {
+      const is_visible = group_series.some((srs) => {
         const metadata = Array.isArray(srs.metadata) ? srs.metadata[0] : srs.metadata
         const property_key = ((metadata?.property_key as string) || srs.label) ?? ``
         return is_default_visible(property_key, default_visible_properties)
       })
 
-      return { unit, series: group_series, priority, is_visible: has_default_visible }
+      return { unit, series: group_series, priority, is_visible }
     })
     .sort((a, b) => a.priority - b.priority)
 

--- a/src/lib/xrd/XrdPlot.svelte
+++ b/src/lib/xrd/XrdPlot.svelte
@@ -332,7 +332,7 @@
           const compression_format = detect_compression_format(lower_name)
           // Get base filename without compression extension
           const base_name = compression_format
-            ? lower_name.replace(/\.(gz|gzip)$/i, ``)
+            ? lower_name.replace(/\.(?:gz|gzip)$/i, ``)
             : lower_name
           const base_ext = base_name.split(`.`).pop()
 

--- a/src/lib/xrd/parse.ts
+++ b/src/lib/xrd/parse.ts
@@ -171,12 +171,12 @@ export function parse_ras_file(content: string): XrdPattern | null {
 
   // Extract header values (used as fallback for single-column data)
   const header_start =
-    extract_header_value(lines, /\*MEAS_SCAN_START\s*=\s*([\d.+-]+)/i) ??
-    extract_header_value(lines, /\*SCAN_START\s*=\s*([\d.+-]+)/i) ??
+    extract_header_value(lines, /\*MEAS_SCAN_START\s*=\s*(?<value>[\d.+-]+)/i) ??
+    extract_header_value(lines, /\*SCAN_START\s*=\s*(?<value>[\d.+-]+)/i) ??
     0
   const header_step =
-    extract_header_value(lines, /\*MEAS_SCAN_STEP\s*=\s*([\d.+-]+)/i) ??
-    extract_header_value(lines, /\*SCAN_STEP\s*=\s*([\d.+-]+)/i) ??
+    extract_header_value(lines, /\*MEAS_SCAN_STEP\s*=\s*(?<value>[\d.+-]+)/i) ??
+    extract_header_value(lines, /\*SCAN_STEP\s*=\s*(?<value>[\d.+-]+)/i) ??
     DEFAULT_STEP_SIZE
 
   // Find intensity data section between *RAS_INT_START and *RAS_INT_END
@@ -249,12 +249,12 @@ export function parse_uxd_file(content: string): XrdPattern | null {
 
   // Extract header values (underscore-prefixed keys)
   const start =
-    extract_header_value(lines, /_2THETA_?START\s*=?\s*([\d.+-]+)/i) ??
-    extract_header_value(lines, /_START\s*=?\s*([\d.+-]+)/i) ??
+    extract_header_value(lines, /_2THETA_?START\s*=?\s*(?<value>[\d.+-]+)/i) ??
+    extract_header_value(lines, /_START\s*=?\s*(?<value>[\d.+-]+)/i) ??
     0
   const step =
-    extract_header_value(lines, /_STEP_?SIZE\s*=?\s*([\d.+-]+)/i) ??
-    extract_header_value(lines, /_STEPWIDTH\s*=?\s*([\d.+-]+)/i) ??
+    extract_header_value(lines, /_STEP_?SIZE\s*=?\s*(?<value>[\d.+-]+)/i) ??
+    extract_header_value(lines, /_STEPWIDTH\s*=?\s*(?<value>[\d.+-]+)/i) ??
     DEFAULT_STEP_SIZE
 
   // Find intensity data after _COUNTS marker
@@ -299,7 +299,10 @@ export function parse_gsas_file(content: string): XrdPattern | null {
   let found_bank = false
 
   for (const line of lines) {
-    const bank_match = /BANK\s+\d+\s+(\d+)\s+\d+\s+(\w+)\s+([\d.+-]+)\s+([\d.+-]+)/i.exec(line)
+    const bank_match =
+      /BANK\s+\d+\s+(?<npts>\d+)\s+\d+\s+(?<bin_type>\w+)\s+(?<bcoef1>[\d.+-]+)\s+(?<bcoef2>[\d.+-]+)/i.exec(
+        line,
+      )
     if (bank_match) {
       bin_type = bank_match[2].toUpperCase()
       // For CONST type: BCOEF1 is start*100 (centidegrees), BCOEF2 is step*100
@@ -397,9 +400,9 @@ function parse_bruker_raw_v1(view: DataView, bytes: Uint8Array): XrdPattern | nu
     const header_text = String.fromCharCode(...bytes.slice(0, 512))
 
     // Try to find scan parameters in ASCII header
-    const start_match = /START\s*=\s*([\d.+-]+)/i.exec(header_text)
-    const step_match = /STEP\s*=\s*([\d.+-]+)/i.exec(header_text)
-    const count_match = /(?:COUNT|POINTS|NPTS)\s*=\s*(\d+)/i.exec(header_text)
+    const start_match = /START\s*=\s*(?<value>[\d.+-]+)/i.exec(header_text)
+    const step_match = /STEP\s*=\s*(?<value>[\d.+-]+)/i.exec(header_text)
+    const count_match = /(?:COUNT|POINTS|NPTS)\s*=\s*(?<value>\d+)/i.exec(header_text)
 
     const start = start_match ? parseFloat(start_match[1]) : 0
     const step = step_match ? parseFloat(step_match[1]) : DEFAULT_STEP_SIZE
@@ -468,11 +471,15 @@ function parse_rigaku_raw_file(data: ArrayBuffer): XrdPattern | null {
     // Try to find ASCII header section with scan parameters
     const header_text = String.fromCharCode(...bytes.slice(0, Math.min(2048, bytes.length)))
 
-    const start_match = /(?:START|2THETA_START|SCAN_START)\s*[:=]?\s*([\d.+-]+)/i.exec(
+    const start_match = /(?:START|2THETA_START|SCAN_START)\s*[:=]?\s*(?<value>[\d.+-]+)/i.exec(
       header_text,
     )
-    const step_match = /(?:STEP|STEP_SIZE|SCAN_STEP)\s*[:=]?\s*([\d.+-]+)/i.exec(header_text)
-    const count_match = /(?:COUNT|POINTS|NPTS|STEPS)\s*[:=]?\s*(\d+)/i.exec(header_text)
+    const step_match = /(?:STEP|STEP_SIZE|SCAN_STEP)\s*[:=]?\s*(?<value>[\d.+-]+)/i.exec(
+      header_text,
+    )
+    const count_match = /(?:COUNT|POINTS|NPTS|STEPS)\s*[:=]?\s*(?<value>\d+)/i.exec(
+      header_text,
+    )
 
     if (!start_match && !step_match && !count_match) return null // Not a recognizable Rigaku format
 

--- a/src/lib/xrd/parse.ts
+++ b/src/lib/xrd/parse.ts
@@ -32,6 +32,20 @@ const parse_number_list = (text: string): number[] =>
     .map(parseFloat)
     .filter((val) => !isNaN(val))
 
+// Return the first parseable number from the text content of any of `tags`
+// (in order) that also passes the optional `ok` predicate. Null when none match.
+const query_first_number = (
+  doc: Document,
+  tags: readonly string[],
+  ok: (val: number) => boolean = () => true,
+): number | null => {
+  for (const tag of tags) {
+    const val = parseFloat(doc.querySelector(tag)?.textContent ?? ``)
+    if (!isNaN(val) && ok(val)) return val
+  }
+  return null
+}
+
 // Extract numeric value from header line matching "KEY=VALUE" or "KEY VALUE" pattern.
 // Returns null if not found or not a valid number.
 function extract_header_value(lines: string[], key_pattern: RegExp): number | null {
@@ -72,21 +86,21 @@ function normalize_and_subsample(
 // Subsample data while preserving peaks (local maxima).
 // Uses a combination of uniform sampling and peak preservation.
 function subsample_preserve_peaks(
-  x_values: number[],
-  y_values: number[],
+  x_vals: number[],
+  y_vals: number[],
   target_points: number,
 ): { x: number[]; y: number[] } {
-  const num_points = x_values.length
-  if (num_points <= target_points) return { x: x_values, y: y_values }
+  const num_points = x_vals.length
+  if (num_points <= target_points) return { x: x_vals, y: y_vals }
 
   // Find peaks (local maxima with significant height)
   const peaks: number[] = []
-  const threshold = Math.max(...y_values) * 0.05 // 5% of max as significance threshold
+  const threshold = Math.max(...y_vals) * 0.05 // 5% of max as significance threshold
   for (let idx = 1; idx < num_points - 1; idx++) {
     if (
-      y_values[idx] > y_values[idx - 1] &&
-      y_values[idx] > y_values[idx + 1] &&
-      y_values[idx] > threshold
+      y_vals[idx] > y_vals[idx - 1] &&
+      y_vals[idx] > y_vals[idx + 1] &&
+      y_vals[idx] > threshold
     ) {
       peaks.push(idx)
     }
@@ -98,7 +112,7 @@ function subsample_preserve_peaks(
 
   // Select top peaks by height
   const top_peaks = peaks
-    .map((idx) => ({ idx, y: y_values[idx] }))
+    .map((idx) => ({ idx, y: y_vals[idx] }))
     .sort((a, b) => b.y - a.y)
     .slice(0, peak_slots)
     .map((peak) => peak.idx)
@@ -118,8 +132,8 @@ function subsample_preserve_peaks(
   const selected = [...new Set([...uniform_indices, ...top_peaks])].sort((a, b) => a - b)
 
   return {
-    x: selected.map((idx) => x_values[idx]),
-    y: selected.map((idx) => y_values[idx]),
+    x: selected.map((idx) => x_vals[idx]),
+    y: selected.map((idx) => y_vals[idx]),
   }
 }
 
@@ -677,10 +691,7 @@ function extract_scan_parameters_xml(
   if (!intensities?.length) return null
 
   // Extract scan range parameters
-  let start_angle = 0
-  let step_size = DEFAULT_STEP_SIZE
-
-  // Try to find start angle - multiple possible locations
+  // Try multiple possible tag names, returning the first that parses (and passes `ok`)
   const start_candidates = [
     `Start`,
     `TwoThetaStart`,
@@ -689,18 +700,6 @@ function extract_scan_parameters_xml(
     `ScanAxisBeginPosition`,
     `Begin`,
   ]
-  for (const tag of start_candidates) {
-    const el = doc.querySelector(tag)
-    if (el?.textContent) {
-      const val = parseFloat(el.textContent)
-      if (!isNaN(val)) {
-        start_angle = val
-        break
-      }
-    }
-  }
-
-  // Try to find step size - multiple possible locations
   const step_candidates = [
     `Step`,
     `StepSize`,
@@ -709,16 +708,9 @@ function extract_scan_parameters_xml(
     `ScanAxisIncrement`,
     `StepWidth`,
   ]
-  for (const tag of step_candidates) {
-    const el = doc.querySelector(tag)
-    if (el?.textContent) {
-      const val = parseFloat(el.textContent)
-      if (!isNaN(val) && val > 0) {
-        step_size = val
-        break
-      }
-    }
-  }
+  const start_angle = query_first_number(doc, start_candidates) ?? 0
+  let step_size =
+    query_first_number(doc, step_candidates, (val) => val > 0) ?? DEFAULT_STEP_SIZE
 
   // Alternative: calculate step from start/end and count
   if (step_size === DEFAULT_STEP_SIZE) {

--- a/src/routes/(demos)/plot/heatmap-matrix/+page.svelte
+++ b/src/routes/(demos)/plot/heatmap-matrix/+page.svelte
@@ -87,7 +87,7 @@
   const bin_values: number[][] = property_bins.map((_y_bin, y_idx) =>
     property_bins.map((_x_bin, x_idx) => {
       // Generate a synthetic heatmap: Gaussian-ish distribution centered near (3,3)
-      const dist = Math.sqrt((x_idx - 3) ** 2 + (y_idx - 3) ** 2)
+      const dist = Math.hypot(x_idx - 3, y_idx - 3)
       return Math.round(100 * Math.exp(-dist * 0.4))
     })
   )

--- a/src/routes/404/+page.svelte
+++ b/src/routes/404/+page.svelte
@@ -2,7 +2,7 @@
   import { goto } from '$app/navigation'
   import { page } from '$app/state'
 
-  if (page.url.pathname.match(/^\/mp-\d+$/)) {
+  if (/^\/mp-\d+$/.test(page.url.pathname)) {
     goto(page.url.pathname)
   }
 </script>

--- a/src/site/PhononSpectraDemo.svelte
+++ b/src/site/PhononSpectraDemo.svelte
@@ -8,7 +8,7 @@
 
   let { ...rest }: HTMLAttributes<HTMLDivElement> = $props()
 
-  const METHOD_SUFFIX = /-(pbe|m3gnet|chgnet-v[\d.]+|mace-[\w-]+)$/
+  const METHOD_SUFFIX = /-(?:pbe|m3gnet|chgnet-v[\d.]+|mace-[\w-]+)$/
 
   const method_label = (material: string, key: string) => {
     const method = key.slice(material.length + 1)
@@ -28,7 +28,8 @@
     }
     return [...by_material.entries()]
       .map(([material, keys]) => {
-        const [, mp_id = ``, formula = material] = /^(mp-\d+)-(.+)$/.exec(material) ?? []
+        const [, mp_id = ``, formula = material] =
+          /^(?<mp_id>mp-\d+)-(?<formula>.+)$/.exec(material) ?? []
         return { material, keys, label: mp_id ? `${formula} (${mp_id})` : material }
       })
       .sort((grp_a, grp_b) => grp_a.label.localeCompare(grp_b.label))

--- a/src/site/electronic/bands/index.ts
+++ b/src/site/electronic/bands/index.ts
@@ -10,7 +10,7 @@ const imports = import.meta.glob<BaseBandStructure>([`./*-bands.json`, `./*-band
 // Export with IDs extracted from filenames (e.g. ./cao-2605-bands.json -> cao_2605)
 export const electronic_bands = Object.fromEntries(
   Object.entries(imports).map(([path, data]) => [
-    /\/([^/]+)-bands\.json(?:\.gz)?$/.exec(path)?.[1]?.replaceAll('-', `_`) ?? path,
+    /\/(?<id>[^/]+)-bands\.json(?:\.gz)?$/.exec(path)?.[1]?.replaceAll(`-`, `_`) ?? path,
     data,
   ]),
 ) as Record<string, BaseBandStructure>

--- a/src/site/phase-diagrams/index.ts
+++ b/src/site/phase-diagrams/index.ts
@@ -78,7 +78,7 @@ export async function load_binary_phase_diagram(
   }
 
   // Handle legacy .json.gz URLs - try to extract system name
-  const match = /([A-Za-z0-9]+-[A-Za-z0-9]+)\.json/.exec(url)
+  const match = /(?<system>[A-Za-z0-9]+-[A-Za-z0-9]+)\.json/.exec(url)
   if (match) {
     const system = match[1]
     const diagram = find_precomputed_diagram(system)

--- a/src/site/phonons/index.ts
+++ b/src/site/phonons/index.ts
@@ -159,7 +159,7 @@ export const phonon_bands: Record<string, PhononBandStructure> = {}
 export const phonon_dos: Record<string, PhononDos> = {}
 
 for (const [path, data] of Object.entries(raw_imports)) {
-  const id = /\/([^/]+)\.json(?:\.gz)?$/.exec(path)?.[1] ?? path
+  const id = /\/(?<id>[^/]+)\.json(?:\.gz)?$/.exec(path)?.[1] ?? path
   phonon_data[id] = data
   if (data?.phonon_bandstructure) {
     phonon_bands[id] = transform_band_structure(data.phonon_bandstructure)

--- a/src/site/trajectories/index.ts
+++ b/src/site/trajectories/index.ts
@@ -8,10 +8,10 @@ export const trajectory_files = import.meta.glob(`$site/trajectories/*`, {
 
 // Determines the trajectory file type based on filename
 export function get_trajectory_type(file: FileInfo): TrajectoryFormat {
-  if (/\.(h5|hdf5)$/i.exec(file.name)) return `hdf5`
-  if (/\.json$/i.exec(file.name)) return `json`
-  if (/\.(xyz|extxyz)$/i.exec(file.name)) return `xyz`
-  if (/xdatcar/i.exec(file.name)) return `xdatcar`
-  if (/\.traj$/i.exec(file.name)) return `traj`
+  if (/\.(?:h5|hdf5)$/i.test(file.name)) return `hdf5`
+  if (/\.json$/i.test(file.name)) return `json`
+  if (/\.(?:xyz|extxyz)$/i.test(file.name)) return `xyz`
+  if (/xdatcar/i.test(file.name)) return `xdatcar`
+  if (/\.traj$/i.test(file.name)) return `traj`
   return `unknown`
 }

--- a/tests/playwright/convex-hull/convex-hull-2d.test.ts
+++ b/tests/playwright/convex-hull/convex-hull-2d.test.ts
@@ -92,7 +92,7 @@ test.describe(`ConvexHull2D (Binary)`, () => {
     const get_visible_unstable = async () => {
       const text = await info.getByTestId(`hull-visible-unstable`).textContent()
       // Format: Visible unstable: X / Y
-      const match = text?.match(/(\d+)\s*\/\s*(\d+)/)
+      const match = text?.match(/(?<x>\d+)\s*\/\s*(?<y>\d+)/)
       return match ? { x: parseInt(match[1], 10), y: parseInt(match[2], 10) } : { x: 0, y: 0 }
     }
 
@@ -182,7 +182,7 @@ test.describe(`ConvexHull2D (Binary)`, () => {
 
     const get_visible_unstable = async () => {
       const text = await info.getByTestId(`hull-visible-unstable`).textContent()
-      const match = text?.match(/(\d+)\s*\/\s*(\d+)/)
+      const match = text?.match(/(?<visible>\d+)\s*\/\s*(?:\d+)/)
       return match ? parseInt(match[1], 10) : 0
     }
     const before = await get_visible_unstable()

--- a/tests/playwright/convex-hull/convex-hull-3d.test.ts
+++ b/tests/playwright/convex-hull/convex-hull-3d.test.ts
@@ -163,7 +163,7 @@ test.describe(`ConvexHull3D (Ternary)`, () => {
 
     // Regression: verify unstable phases > 0 (catches possible e_above_hull placeholder bugs)
     const unstable_text = await info.getByTestId(`hull-visible-unstable`).textContent()
-    const unstable_match = unstable_text?.match(/(\d+)/)
+    const unstable_match = unstable_text?.match(/(?<count>\d+)/)
     const unstable_count = unstable_match ? parseInt(unstable_match[1], 10) : 0
     expect(unstable_count).toBeGreaterThan(0)
   })

--- a/tests/playwright/convex-hull/convex-hull-4d.test.ts
+++ b/tests/playwright/convex-hull/convex-hull-4d.test.ts
@@ -116,12 +116,12 @@ test.describe(`ConvexHull4D (Quaternary)`, () => {
 
     // Verify unstable/stable counts are finite numbers
     const unstable_text = await info.getByTestId(`hull-visible-unstable`).textContent()
-    const unstable_match = unstable_text?.match(/([0-9]+)\s*\/\s*([0-9]+)/)
+    const unstable_match = unstable_text?.match(/(?<visible>[0-9]+)\s*\/\s*(?:[0-9]+)/)
     expect(unstable_match).toBeTruthy()
     expect(Number.isFinite(Number(unstable_match?.[1]))).toBe(true)
 
     const stable_text = await info.getByTestId(`hull-visible-stable`).textContent()
-    const stable_match = stable_text?.match(/([0-9]+)\s*\/\s*([0-9]+)/)
+    const stable_match = stable_text?.match(/(?<visible>[0-9]+)\s*\/\s*(?:[0-9]+)/)
     expect(stable_match).toBeTruthy()
     expect(Number(stable_match?.[1])).toBeGreaterThanOrEqual(4) // At least elemental refs
   })

--- a/tests/playwright/optimade.test.ts
+++ b/tests/playwright/optimade.test.ts
@@ -44,7 +44,7 @@ test.describe(`OPTIMADE route`, () => {
           return json({ data: providers })
         }
         if (decoded.includes(`/structures`)) {
-          const match = /\/structures\/([^/?]+)/.exec(decoded)
+          const match = /\/structures\/(?<id>[^/?]+)/.exec(decoded)
           if (match?.[1] && structures[match[1]]) {
             return json({ data: structures[match[1]] })
           }

--- a/tests/playwright/plot/bar-plot.test.ts
+++ b/tests/playwright/plot/bar-plot.test.ts
@@ -212,7 +212,7 @@ test.describe(`BarPlot Component Tests`, () => {
     // Change x tick format
     const x_format = pane.locator(`input[type="text"]`).first()
     await x_format.fill(`.1r`)
-    await expect(plot.locator(`g.x-axis .tick text`).first()).toHaveText(/^\d+(\.\d+)?$/)
+    await expect(plot.locator(`g.x-axis .tick text`).first()).toHaveText(/^\d+(?:\.\d+)?$/)
   })
 
   test(`orientation switch flips bar orientation`, async ({ page }) => {

--- a/tests/playwright/plot/scatter-plot.test.ts
+++ b/tests/playwright/plot/scatter-plot.test.ts
@@ -1025,14 +1025,14 @@ test.describe(`ScatterPlot Component Tests`, () => {
         if (!marker_bbox) return Infinity
         const dx = legend_center_x - (marker_bbox.x + marker_bbox.width / 2)
         const dy = legend_center_y - (marker_bbox.y + marker_bbox.height / 2)
-        return Math.sqrt(dx * dx + dy * dy)
+        return Math.hypot(dx, dy)
       }),
     )
 
     // Use percentage-based threshold relative to plot size
     // 5% of plot diagonal is a reasonable minimum distance for small datasets
     // (larger percentages may not be achievable when data is concentrated in one area)
-    const plot_diagonal = Math.sqrt(plot_bbox.width ** 2 + plot_bbox.height ** 2)
+    const plot_diagonal = Math.hypot(plot_bbox.width, plot_bbox.height)
     const distance_threshold = plot_diagonal * 0.05
 
     // Legend should not be too close to any data point (smart placement should avoid markers)

--- a/tests/playwright/spectral/dos.test.ts
+++ b/tests/playwright/spectral/dos.test.ts
@@ -103,7 +103,7 @@ test.describe(`DOS Component Tests`, () => {
 
     // Assert axis labels reflect horizontal swap
     await expect(plot.locator(`.x-label`)).toContainText(/Density/i)
-    await expect(plot.locator(`.y-label`)).toContainText(/(Frequency|Energy)/i)
+    await expect(plot.locator(`.y-label`)).toContainText(/(?:Frequency|Energy)/i)
   })
 
   test(`converts frequencies to different units`, async ({ page }) => {
@@ -177,7 +177,7 @@ test.describe(`DOS Component Tests`, () => {
     expect(tooltip_text).toMatch(/Density.*:/)
 
     // Tooltip should show frequency/energy with unit (x-axis)
-    expect(tooltip_text).toMatch(/(Frequency|Energy)/)
+    expect(tooltip_text).toMatch(/(?:Frequency|Energy)/)
   })
 
   test(`tooltip shows series label with multiple DOS`, async ({ page }) => {

--- a/tests/playwright/structure/structure.test.ts
+++ b/tests/playwright/structure/structure.test.ts
@@ -215,7 +215,7 @@ test.describe(`Structure Component Tests`, () => {
     await expect(fullscreen_button).toBeEnabled()
     await expect(fullscreen_button).toHaveAttribute(
       `data-original-title`,
-      /(Exit|Enter) fullscreen/,
+      /(?:Exit|Enter) fullscreen/,
     )
     await fullscreen_button.click({ force: true })
     expect(error_occurred).toBe(false)

--- a/tests/playwright/trajectory-performance.test.ts
+++ b/tests/playwright/trajectory-performance.test.ts
@@ -53,7 +53,7 @@ test.describe(`Trajectory Performance Tests`, () => {
     await expect(step_info).toBeVisible()
 
     const step_text = await step_info.textContent()
-    const max_step_match = step_text?.match(/\/ (\d+)/)
+    const max_step_match = step_text?.match(/\/ (?<max>\d+)/)
     const max_step = max_step_match ? parseInt(max_step_match[1], 10) : 0
 
     expect(max_step).toBeGreaterThanOrEqual(200)

--- a/tests/vitest/anywidget-renderers.test.ts
+++ b/tests/vitest/anywidget-renderers.test.ts
@@ -10,7 +10,7 @@ import { latest_stub, reset_stub } from './reactive-renderer-registry'
 // pulling the built dist bundle. The theme/css imports are stubbed for the same
 // reason (mount_spec never calls into them directly).
 vi.mock(`matterviz`, async () => {
-  const Stub = (await import(`./reactive-renderer-stub.svelte`)).default
+  const stub_module = await import(`./reactive-renderer-stub.svelte`)
   const component_names = [
     `Bands`,
     `BandsAndDos`,
@@ -33,7 +33,7 @@ vi.mock(`matterviz`, async () => {
     `Trajectory`,
     `XrdPlot`,
   ]
-  return Object.fromEntries(component_names.map((name) => [name, Stub]))
+  return Object.fromEntries(component_names.map((name) => [name, stub_module.default]))
 })
 vi.mock(`matterviz/app.css?raw`, () => ({ default: `` }))
 vi.mock(`matterviz/colors`, () => ({ luminance: () => 0 }))

--- a/tests/vitest/brillouin-compute.test.ts
+++ b/tests/vitest/brillouin-compute.test.ts
@@ -22,7 +22,7 @@ import type { Matrix3x3, Vec3 } from '$lib/math'
 import * as math from '$lib/math'
 import type { MoyoDataset } from '@spglib/moyo-wasm'
 import { describe, expect, test } from 'vitest'
-import { col_major, load_json } from './setup'
+import { col_major, cubic_matrix, IDENTITY_MATRIX3 as IDENTITY_MAT, load_json } from './setup'
 
 type BzReference = {
   real_lattice: number[][]
@@ -35,16 +35,7 @@ const reference_data = load_json<Record<string, BzReference>>(
 )
 
 // Common test constants
-const CUBIC_5: Matrix3x3 = [
-  [5, 0, 0],
-  [0, 5, 0],
-  [0, 0, 5],
-]
-const IDENTITY_MAT: Matrix3x3 = [
-  [1, 0, 0],
-  [0, 1, 0],
-  [0, 0, 1],
-]
+const CUBIC_5 = cubic_matrix(5)
 const INVERSION_MAT: Matrix3x3 = [
   [-1, 0, 0],
   [0, -1, 0],

--- a/tests/vitest/brillouin-compute.test.ts
+++ b/tests/vitest/brillouin-compute.test.ts
@@ -184,9 +184,7 @@ describe(`BZ edge filtering`, () => {
       const bz = compute_brillouin_zone(data.reciprocal_lattice as Matrix3x3, 1)
       const max_len = Math.cbrt(bz.volume) * 10
       for (const [v1, v2] of bz.edges) {
-        const len = Math.sqrt(
-          (v2[0] - v1[0]) ** 2 + (v2[1] - v1[1]) ** 2 + (v2[2] - v1[2]) ** 2,
-        )
+        const len = Math.hypot(v2[0] - v1[0], v2[1] - v1[1], v2[2] - v1[2])
         expect(len).toBeGreaterThan(0)
         expect(len).toBeLessThan(max_len)
       }

--- a/tests/vitest/chempot-diagram/compute.test.ts
+++ b/tests/vitest/chempot-diagram/compute.test.ts
@@ -98,15 +98,9 @@ const sort_rows = (pts: number[][]): number[][] =>
       return 0
     })
 
-function dedup_vertices(pts: number[][], tol: number = 1e-4): number[][] {
-  const result: number[][] = []
-  for (const pt of pts) {
-    if (!result.some((ex) => ex.every((val, idx) => Math.abs(val - pt[idx]) < tol))) {
-      result.push(pt)
-    }
-  }
-  return result
-}
+// Thin wrapper over production dedup_points (keeps just the unique points)
+const dedup_vertices = (pts: number[][], tol: number = 1e-4): number[][] =>
+  dedup_points(pts, tol).unique
 
 // === Pymatgen parity tests ===
 

--- a/tests/vitest/chempot-diagram/compute.test.ts
+++ b/tests/vitest/chempot-diagram/compute.test.ts
@@ -319,8 +319,8 @@ describe(`physical invariants`, () => {
     // chemical potential than the pure element)
     for (const pts of Object.values(cpd_ternary_formal.domains)) {
       for (const pt of pts) {
-        for (let dim = 0; dim < pt.length; dim++) {
-          expect(pt[dim], `Formal chempot should be <= 0`).toBeLessThanOrEqual(1e-4)
+        for (const chempot of pt) {
+          expect(chempot, `Formal chempot should be <= 0`).toBeLessThanOrEqual(1e-4)
         }
       }
     }

--- a/tests/vitest/composition/Formula.test.ts
+++ b/tests/vitest/composition/Formula.test.ts
@@ -5,8 +5,14 @@ import {
   oxi_composition_to_elements,
   parse_formula_with_oxidation,
 } from '$lib/composition'
-import { mount } from 'svelte'
+import { type ComponentProps, mount } from 'svelte'
 import { expect, test, vi } from 'vitest'
+
+// Mount Formula into document.body and return its rendered `.formula` root (or null)
+const mount_formula = (props: ComponentProps<typeof Formula>): HTMLElement | null => {
+  mount(Formula, { target: document.body, props })
+  return document.querySelector<HTMLElement>(`.formula`)
+}
 
 test(`parse_formula_with_oxidation parses simple formulas`, () => {
   const result = parse_formula_with_oxidation(`H2O`)
@@ -186,16 +192,14 @@ test(`oxi_composition_to_elements converts correctly`, () => {
 })
 
 test(`Formula component renders with string formula`, () => {
-  mount(Formula, { target: document.body, props: { formula: `H2O` } })
-  const element = document.querySelector(`.formula`)
+  const element = mount_formula({ formula: `H2O` })
   expect(element).toBeInstanceOf(HTMLElement)
   expect(element?.textContent).toContain(`H`)
   expect(element?.textContent).toContain(`O`)
 })
 
 test(`Formula component renders with oxidation states (caret syntax)`, () => {
-  mount(Formula, { target: document.body, props: { formula: `Fe^2+O3` } })
-  const element = document.querySelector(`.formula`)
+  const element = mount_formula({ formula: `Fe^2+O3` })
   expect(element).toBeInstanceOf(HTMLElement)
   expect(element?.textContent).toContain(`Fe`)
   expect(element?.textContent).toContain(`+2`)
@@ -203,8 +207,7 @@ test(`Formula component renders with oxidation states (caret syntax)`, () => {
 })
 
 test(`Formula component renders with oxidation states (bracket syntax)`, () => {
-  mount(Formula, { target: document.body, props: { formula: `Fe[2+]O3` } })
-  const element = document.querySelector(`.formula`)
+  const element = mount_formula({ formula: `Fe[2+]O3` })
   expect(element).toBeInstanceOf(HTMLElement)
   expect(element?.textContent).toContain(`Fe`)
   expect(element?.textContent).toContain(`+2`)
@@ -216,10 +219,7 @@ test.each([
   { scheme: `Jmol` as const, expected_color_present: true },
   { scheme: `Alloy` as const, expected_color_present: true },
 ])(`Formula applies $scheme color scheme correctly`, ({ scheme, expected_color_present }) => {
-  mount(Formula, {
-    target: document.body,
-    props: { formula: `H2O`, color_scheme: scheme },
-  })
+  mount_formula({ formula: `H2O`, color_scheme: scheme })
   const symbols = document.querySelectorAll(`.element-symbol`)
   expect(symbols).toHaveLength(2)
 
@@ -229,33 +229,21 @@ test.each([
 })
 
 test(`Formula component ordering: original`, () => {
-  // Mounting to document.body
-  mount(Formula, {
-    target: document.body,
-    props: { formula: `OHFe`, ordering: `original` },
-  })
+  mount_formula({ formula: `OHFe`, ordering: `original` })
   const symbols = Array.from(document.querySelectorAll(`.element-symbol`))
   const text = symbols.map((elem) => elem.textContent).join(``)
   expect(text).toBe(`OHFe`)
 })
 
 test(`Formula component ordering: alphabetical`, () => {
-  // Mounting to document.body
-  mount(Formula, {
-    target: document.body,
-    props: { formula: `OHFe`, ordering: `alphabetical` },
-  })
+  mount_formula({ formula: `OHFe`, ordering: `alphabetical` })
   const symbols = Array.from(document.querySelectorAll(`.element-symbol`))
   const text = symbols.map((elem) => elem.textContent).join(``)
   expect(text).toBe(`FeHO`)
 })
 
 test(`Formula component ordering: electronegativity`, () => {
-  // Mounting to document.body
-  mount(Formula, {
-    target: document.body,
-    props: { formula: `ONa`, ordering: `electronegativity` },
-  })
+  mount_formula({ formula: `ONa`, ordering: `electronegativity` })
   const symbols = Array.from(document.querySelectorAll(`.element-symbol`))
   const text = symbols.map((elem) => elem.textContent).join(``)
   // Na has lower electronegativity than O, so it should come first
@@ -263,8 +251,7 @@ test(`Formula component ordering: electronegativity`, () => {
 })
 
 test(`Formula component ordering: hill`, () => {
-  // Mounting to document.body
-  mount(Formula, { target: document.body, props: { formula: `C2H6O`, ordering: `hill` } })
+  mount_formula({ formula: `C2H6O`, ordering: `hill` })
   const symbols = Array.from(document.querySelectorAll(`.element-symbol`))
   const text = symbols.map((elem) => elem.textContent).join(``)
   // Hill notation: C first, H second (if C present), then alphabetical
@@ -272,23 +259,20 @@ test(`Formula component ordering: hill`, () => {
 })
 
 test(`Formula component renders subscripts for amounts > 1`, () => {
-  // Mounting to document.body
-  mount(Formula, { target: document.body, props: { formula: `H2O` } })
+  mount_formula({ formula: `H2O` })
   const subscripts = document.querySelectorAll(`sub`)
   expect(subscripts).toHaveLength(1)
   expect(subscripts[0].textContent).toBe(`2`)
 })
 
 test(`Formula component does not render subscripts for amount = 1`, () => {
-  // Mounting to document.body
-  mount(Formula, { target: document.body, props: { formula: `HO` } })
+  mount_formula({ formula: `HO` })
   const subscripts = document.querySelectorAll(`sub`)
   expect(subscripts).toHaveLength(0)
 })
 
 test(`Formula component renders superscripts for oxidation states`, () => {
-  // Mounting to document.body
-  mount(Formula, { target: document.body, props: { formula: `Fe^2+O^2-` } })
+  mount_formula({ formula: `Fe^2+O^2-` })
   const superscripts = document.querySelectorAll(`sup`)
   expect(superscripts).toHaveLength(2)
 
@@ -304,8 +288,7 @@ test(`Formula component does not render superscripts for zero oxidation`, () => 
     Fe: { amount: 1, oxidation_state: 0 },
     O: { amount: 1, oxidation_state: 0 },
   } as OxiComposition
-  // Mounting to document.body
-  mount(Formula, { target: document.body, props: { formula: composition } })
+  mount_formula({ formula: composition })
   const superscripts = document.querySelectorAll(`sup`)
   expect(superscripts).toHaveLength(0)
 })
@@ -315,9 +298,7 @@ test(`Formula component accepts OxiComposition input`, () => {
     Fe: { amount: 2, oxidation_state: 3 },
     O: { amount: 3, oxidation_state: -2 },
   } as OxiComposition
-  // Mounting to document.body
-  mount(Formula, { target: document.body, props: { formula: composition } })
-  const element = document.querySelector(`.formula`)
+  const element = mount_formula({ formula: composition })
   expect(element).toBeInstanceOf(HTMLElement)
   expect(element?.textContent).toContain(`Fe`)
   expect(element?.textContent).toContain(`O`)
@@ -334,8 +315,7 @@ test.each([
   { as_value: `em` },
   { as_value: `p` },
 ])(`Formula renders with as="$as_value"`, ({ as_value }) => {
-  // Mounting to document.body
-  mount(Formula, { target: document.body, props: { formula: `H2O`, as: as_value } })
+  mount_formula({ formula: `H2O`, as: as_value })
   const element = document.querySelector(as_value)
   expect(element).toBeInstanceOf(HTMLElement)
   expect(element?.classList.contains(`formula`)).toBe(true)
@@ -351,22 +331,13 @@ test.each([
   { scheme: `Muted` as const },
   { scheme: `Dark Mode` as const },
 ])(`Formula renders with color scheme "$scheme"`, ({ scheme }) => {
-  // Mounting to document.body
-  mount(Formula, {
-    target: document.body,
-    props: { formula: `H2O`, color_scheme: scheme },
-  })
-  const element = document.querySelector(`.formula`)
+  const element = mount_formula({ formula: `H2O`, color_scheme: scheme })
   expect(element).toBeInstanceOf(HTMLElement)
   expect(element?.querySelectorAll(`.element-symbol`).length).toBe(2)
 })
 
 test(`Formula formats amounts with custom format string`, () => {
-  // Mounting to document.body
-  mount(Formula, {
-    target: document.body,
-    props: { formula: `H2O`, amount_format: `.2f` },
-  })
+  mount_formula({ formula: `H2O`, amount_format: `.2f` })
   const subscript = document.querySelector(`sub`)
   expect(subscript?.textContent).toBe(`2.00`)
 })
@@ -380,9 +351,7 @@ test.each([
 ])(
   `Formula handles complex formula "$formula"`,
   ({ formula, expected_elements, expected_superscripts }) => {
-    // Mounting to document.body
-    mount(Formula, { target: document.body, props: { formula } })
-    const element = document.querySelector(`.formula`)
+    const element = mount_formula({ formula })
     expect(element).toBeInstanceOf(HTMLElement)
 
     // Check that all expected elements are present
@@ -409,10 +378,7 @@ function normalize_to_hex(color: string): string {
 test.each([`Vesta`, `Jmol`] as const)(
   `Formula tooltip ElementTile uses same color scheme as symbol text (%s)`,
   async (color_scheme) => {
-    mount(Formula, {
-      target: document.body,
-      props: { formula: `Fe2O3`, color_scheme },
-    })
+    mount_formula({ formula: `Fe2O3`, color_scheme })
 
     const element_group = document.querySelector(`.element-group`) as HTMLElement
     expect(element_group).toBeInstanceOf(HTMLElement)
@@ -480,7 +446,7 @@ test.each([
   [`Ca(OH)2`, `Ca O2 H2`],
   [`Fe^3+2O^2-3`, `Fe(+3)2 O(-2)3`], // oxidation in parens to avoid "Fe+32" ambiguity
 ])(`Formula copy: "%s" -> "%s"`, (formula, expected) => {
-  mount(Formula, { target: document.body, props: { formula } })
+  mount_formula({ formula })
   const { text, type, prevented } = simulate_copy()
   expect(prevented).toBe(true)
   expect(type).toBe(`text/plain`)
@@ -488,32 +454,26 @@ test.each([
 })
 
 test(`Formula copy skipped when selection collapsed`, () => {
-  mount(Formula, { target: document.body, props: { formula: `H2O` } })
+  mount_formula({ formula: `H2O` })
   const { text, prevented } = simulate_copy(true)
   expect(prevented).toBe(false)
   expect(text).toBe(``)
 })
 
 test(`Formula copy skipped when selection extends outside formula`, () => {
-  mount(Formula, { target: document.body, props: { formula: `H2O` } })
+  mount_formula({ formula: `H2O` })
   const { text, prevented } = simulate_copy(false, true) // selection_outside = true
   expect(prevented).toBe(false)
   expect(text).toBe(``)
 })
 
 test(`Formula copy respects ordering prop`, () => {
-  mount(Formula, {
-    target: document.body,
-    props: { formula: `OHFe`, ordering: `alphabetical` },
-  })
+  mount_formula({ formula: `OHFe`, ordering: `alphabetical` })
   expect(simulate_copy().text).toBe(`Fe H O`)
 })
 
 test(`Formula copy handles fractional amounts`, () => {
   const composition = { Li: { amount: 0.5 }, O: { amount: 1 } } as OxiComposition
-  mount(Formula, {
-    target: document.body,
-    props: { formula: composition, amount_format: `.2f` },
-  })
+  mount_formula({ formula: composition, amount_format: `.2f` })
   expect(simulate_copy().text).toBe(`Li0.50 O`)
 })

--- a/tests/vitest/composition/Formula.test.ts
+++ b/tests/vitest/composition/Formula.test.ts
@@ -399,7 +399,7 @@ test.each([
 // Normalize any color format to lowercase hex
 function normalize_to_hex(color: string): string {
   if (color.startsWith(`#`)) return color.toLowerCase()
-  const match = /rgb\((\d+),\s*(\d+),\s*(\d+)\)/.exec(color)
+  const match = /rgb\((?<red>\d+),\s*(?<green>\d+),\s*(?<blue>\d+)\)/.exec(color)
   if (!match) return color
   const [, red, green, blue] = match
   const to_hex = (num_str: string) => parseInt(num_str, 10).toString(16).padStart(2, `0`)

--- a/tests/vitest/fixtures/xrd/index.ts
+++ b/tests/vitest/fixtures/xrd/index.ts
@@ -6,7 +6,7 @@ export const fixture_id = (path_or_name: string) =>
   path_or_name
     .split(`/`)
     .at(-1)
-    ?.replace(/\.json(\.gz)?$/, ``) ?? path_or_name
+    ?.replace(/\.json(?:\.gz)?$/, ``) ?? path_or_name
 
 // Precomputed XRD pattern index. Large fixtures are gzipped (.json.gz, decompressed
 // by the json_gz vite plugin); small ones stay plain .json for readable git diffs.

--- a/tests/vitest/instanced-mesh-limit.test.ts
+++ b/tests/vitest/instanced-mesh-limit.test.ts
@@ -36,7 +36,10 @@ describe(`InstancedMesh limits`, () => {
     ).toHaveLength(2)
     // match up to the closing brace at the function's own indent (group 1), so the
     // pattern tolerates reindentation and skips deeper-nested braces (e.g. template literals)
-    const key_fn = /\n( *)function instanced_atom_group_key\([\s\S]*?\n\1\}/.exec(source)?.[0]
+    const key_fn =
+      /\n(?<indent> *)function instanced_atom_group_key\([\s\S]*?\n\k<indent>\}/.exec(
+        source,
+      )?.[0]
     if (!key_fn) throw new Error(`instanced_atom_group_key function not found`)
     for (const token of [`format_num(radius, \`.3~\`)`, `edit_mode_image`, `atoms.length`]) {
       expect(key_fn).toContain(token)

--- a/tests/vitest/package-exports.test.ts
+++ b/tests/vitest/package-exports.test.ts
@@ -16,8 +16,8 @@ const source_extensions = [`.ts`, `.svelte`, `.js`, `.mjs`]
 // This way an export pointing at a flat file when the source is a directory (or vice versa) fails.
 function source_candidates(dist_target: string): string[] {
   const rel = dist_target.replace(/^\.\/dist\//, ``).replace(/\.d\.ts$/, ``)
-  if (/\.(css|json)$/.test(rel)) return [join(lib_dir, rel)] // assets copied verbatim
-  const base = rel.replace(/\.(js|mjs|cjs)$/, ``)
+  if (/\.(?:css|json)$/.test(rel)) return [join(lib_dir, rel)] // assets copied verbatim
+  const base = rel.replace(/\.(?:js|mjs|cjs)$/, ``)
   // Subpath-pattern export (e.g. plot/*/index): expand the single `*` segment against the
   // real subdirectories so the wildcard is validated to point at >= 1 source file.
   if (base.includes(`*`)) {

--- a/tests/vitest/plot/BarPlot.test.ts
+++ b/tests/vitest/plot/BarPlot.test.ts
@@ -2,7 +2,7 @@ import { BarPlot } from '$lib'
 import type { BarHandlerProps, BarMode, BarSeries, Orientation } from '$lib/plot'
 import { type ComponentProps, createRawSnippet, mount, tick } from 'svelte'
 import { describe, expect, test, vi } from 'vitest'
-import { inside_clip_path, mount_sized } from '../setup'
+import { axis_label_pivot_y, inside_clip_path, mount_sized } from '../setup'
 
 const basic: BarSeries = {
   x: [1, 2, 3, 4, 5],
@@ -115,13 +115,7 @@ describe(`BarPlot`, () => {
     })
     // both y titles rotate about the plot's vertical center; a stale label_shift default
     // used to push the y2 title 60px below center
-    const pivot_y = (selector: string) => {
-      const transform =
-        plot.querySelector(selector)?.closest(`foreignObject`)?.getAttribute(`transform`) ?? ``
-      const match = /rotate\(-90,\s*[\d.-]+,\s*(?<pivot>[\d.-]+)\)/.exec(transform)
-      if (!match) throw new Error(`no rotate transform on ${selector}: "${transform}"`)
-      return Number(match[1])
-    }
+    const pivot_y = (selector: string) => axis_label_pivot_y(plot, selector)
     expect(pivot_y(`.axis-label.y2-label`)).toBeCloseTo(pivot_y(`.axis-label.y-label`), 5)
   })
 

--- a/tests/vitest/plot/BarPlot.test.ts
+++ b/tests/vitest/plot/BarPlot.test.ts
@@ -118,7 +118,7 @@ describe(`BarPlot`, () => {
     const pivot_y = (selector: string) => {
       const transform =
         plot.querySelector(selector)?.closest(`foreignObject`)?.getAttribute(`transform`) ?? ``
-      const match = /rotate\(-90,\s*[\d.-]+,\s*([\d.-]+)\)/.exec(transform)
+      const match = /rotate\(-90,\s*[\d.-]+,\s*(?<pivot>[\d.-]+)\)/.exec(transform)
       if (!match) throw new Error(`no rotate transform on ${selector}: "${transform}"`)
       return Number(match[1])
     }
@@ -241,7 +241,8 @@ describe(`BarPlot`, () => {
         plot.querySelectorAll(`.bar-series[data-series-idx="${idx}"] path[role="button"]`),
         (path) => {
           const [, y_str, h_str] =
-            path.getAttribute(`d`)?.match(/^M[\d.-]+,([\d.-]+)h[\d.-]+v([\d.-]+)/) ?? []
+            path.getAttribute(`d`)?.match(/^M[\d.-]+,(?<y>[\d.-]+)h[\d.-]+v(?<h>[\d.-]+)/) ??
+            []
           return { top: Number(y_str), bottom: Number(y_str) + Number(h_str) }
         },
       )

--- a/tests/vitest/plot/Histogram.test.ts
+++ b/tests/vitest/plot/Histogram.test.ts
@@ -2,7 +2,7 @@ import { Histogram, type Vec2 } from '$lib'
 import { bin, max as d3max } from 'd3-array'
 import { mount, tick } from 'svelte'
 import { describe, expect, test } from 'vitest'
-import { resize_element } from '../setup'
+import { axis_label_pivot_y, resize_element } from '../setup'
 
 function mount_histogram(props: Record<string, unknown>) {
   document.body.innerHTML = ``
@@ -247,16 +247,7 @@ describe(`Histogram`, () => {
     await resize_element(plot, 400, 300) // axis labels only render once the plot has a size
     // both y titles rotate about the plot's vertical center; a stale label_shift default
     // used to push the y2 title 60px below center
-    const pivot_y = (selector: string) => {
-      const transform =
-        document
-          .querySelector(selector)
-          ?.closest(`foreignObject`)
-          ?.getAttribute(`transform`) ?? ``
-      const match = /rotate\(-90,\s*[\d.-]+,\s*(?<pivot>[\d.-]+)\)/.exec(transform)
-      if (!match) throw new Error(`no rotate transform on ${selector}: "${transform}"`)
-      return Number(match[1])
-    }
+    const pivot_y = (selector: string) => axis_label_pivot_y(document, selector)
     expect(pivot_y(`.axis-label.y2-label`)).toBeCloseTo(pivot_y(`.axis-label.y-label`), 5)
   })
 

--- a/tests/vitest/plot/Histogram.test.ts
+++ b/tests/vitest/plot/Histogram.test.ts
@@ -253,7 +253,7 @@ describe(`Histogram`, () => {
           .querySelector(selector)
           ?.closest(`foreignObject`)
           ?.getAttribute(`transform`) ?? ``
-      const match = /rotate\(-90,\s*[\d.-]+,\s*([\d.-]+)\)/.exec(transform)
+      const match = /rotate\(-90,\s*[\d.-]+,\s*(?<pivot>[\d.-]+)\)/.exec(transform)
       if (!match) throw new Error(`no rotate transform on ${selector}: "${transform}"`)
       return Number(match[1])
     }

--- a/tests/vitest/plot/Surface3D.test.ts
+++ b/tests/vitest/plot/Surface3D.test.ts
@@ -210,7 +210,7 @@ describe(`Surface3D configuration logic`, () => {
       for (const u_val of [0, Math.PI / 4, Math.PI / 2, Math.PI]) {
         for (const v_val of [0, 0.25, 0.5, 0.75, 1]) {
           const pt = parametric_fn(u_val, v_val)
-          const xy_radius = Math.sqrt(pt.x * pt.x + pt.y * pt.y)
+          const xy_radius = Math.hypot(pt.x, pt.y)
           expect(xy_radius).toBeCloseTo(radius, 10)
         }
       }
@@ -341,7 +341,7 @@ describe(`Surface3D configuration logic`, () => {
       expect(points).toHaveLength(4)
       type Point3D = (typeof points)[0]
       const distance = (p1: Point3D, p2: Point3D) =>
-        Math.sqrt((p1.x - p2.x) ** 2 + (p1.y - p2.y) ** 2 + (p1.z - p2.z) ** 2)
+        Math.hypot(p1.x - p2.x, p1.y - p2.y, p1.z - p2.z)
 
       // All 6 edges of a tetrahedron
       const edges = [

--- a/tests/vitest/plot/label-placement.test.ts
+++ b/tests/vitest/plot/label-placement.test.ts
@@ -1,4 +1,4 @@
-import type { DataSeries, InternalPoint } from '$lib/plot'
+import type { DataSeries } from '$lib/plot'
 import type { PlotScaleFn } from '$lib/plot/core/scales'
 import type { LabelPlacementConfig } from '$lib/plot/core/types'
 import {
@@ -370,25 +370,23 @@ const default_config: LabelPlacementConfig = {
 }
 
 function make_labeled_series(points: { x: number; y: number; text: string }[]): DataSeries[] {
-  const filtered_data: InternalPoint[] = points.map((pt, idx) => ({
-    x: pt.x,
-    y: pt.y,
-    series_idx: 0,
-    point_idx: idx,
+  const series = {
+    x: points.map((pt) => pt.x),
+    y: points.map((pt) => pt.y),
     point_style: { fill: `blue`, radius: 4 },
-    point_label: { text: pt.text, auto_placement: true, font_size: `10px` },
-  }))
-  return [
-    {
-      x: points.map((pt) => pt.x),
-      y: points.map((pt) => pt.y),
+    filtered_data: points.map((pt, idx) => ({
+      x: pt.x,
+      y: pt.y,
+      series_idx: 0,
+      point_idx: idx,
       point_style: { fill: `blue`, radius: 4 },
-      filtered_data,
-    },
-  ]
+      point_label: { text: pt.text, auto_placement: true, font_size: `10px` },
+    })),
+  }
+  return [series]
 }
 
-function place_and_expect_finite(
+function placeAndExpectFinite(
   points: { x: number; y: number; text: string }[],
   config = default_config,
 ): Record<string, { x: number; y: number }> {
@@ -443,8 +441,8 @@ describe(`compute_label_positions`, () => {
   })
 
   test(`places labels at finite positions for single and boundary points`, () => {
-    place_and_expect_finite([{ x: 50, y: 50, text: `Only` }])
-    place_and_expect_finite([
+    placeAndExpectFinite([{ x: 50, y: 50, text: `Only` }])
+    placeAndExpectFinite([
       { x: 15, y: 15, text: `Corner` },
       { x: 385, y: 285, text: `FarCorner` },
     ])
@@ -476,7 +474,7 @@ describe(`compute_label_positions`, () => {
       { x: 50, y: 50, text: `A` },
       { x: 200, y: 200, text: `B` },
     ]
-    const result = place_and_expect_finite(anchors)
+    const result = placeAndExpectFinite(anchors)
     for (const [idx, key] of Object.keys(result).entries()) {
       const dist = Math.hypot(result[key].x - anchors[idx].x, result[key].y - anchors[idx].y)
       expect(dist).toBeLessThan(40)
@@ -490,7 +488,7 @@ describe(`compute_label_positions`, () => {
       y: idx * 30,
       text: `P${idx}`,
     }))
-    const result = place_and_expect_finite(points, { ...default_config, max_labels: 5 })
+    const result = placeAndExpectFinite(points, { ...default_config, max_labels: 5 })
     // All fallback positions must stay within plot bounds (pad=10 each side)
     for (const pos of Object.values(result)) {
       expect(pos.x).toBeGreaterThanOrEqual(10)
@@ -513,7 +511,7 @@ describe(`compute_label_positions`, () => {
       { x: 50, y: 50, text: `OK` },
       { x: 380, y: 150, text: `RR` },
     ]
-    const result = place_and_expect_finite(points, { ...default_config, max_labels: 1 })
+    const result = placeAndExpectFinite(points, { ...default_config, max_labels: 1 })
     const edge_key = Object.keys(result)[1]
     const label_w = estimate_label_width(`RR`)
     expect(result[edge_key].x).toBe(390 - label_w)
@@ -548,7 +546,7 @@ describe(`compute_label_positions`, () => {
       { x: 103, y: 102, text: `Epsilon` },
       { x: 98, y: 100, text: `Zeta` },
     ]
-    const result = place_and_expect_finite(points, { ...default_config, sa_iterations: 2000 })
+    const result = placeAndExpectFinite(points, { ...default_config, sa_iterations: 2000 })
     const entries = Object.entries(result)
 
     const font_size = 10

--- a/tests/vitest/rdf/calc-rdf.test.ts
+++ b/tests/vitest/rdf/calc-rdf.test.ts
@@ -23,12 +23,7 @@ const make_site = (element: ElementSymbol, xyz: number[]) => ({
 })
 
 // Helper to check basic RDF properties that all RDFs should satisfy
-function check_basic_rdf_properties(
-  radii: number[],
-  g_r: number[],
-  n_bins: number,
-  _name = ``,
-): void {
+function check_basic_rdf_properties(radii: number[], g_r: number[], n_bins: number): void {
   expect(radii).toHaveLength(n_bins)
   expect(g_r).toHaveLength(n_bins)
   expect(g_r.every((val) => val >= 0)).toBe(true)
@@ -340,13 +335,7 @@ describe(`calculate_rdf`, () => {
       // Check that fractional coordinates were calculated correctly
       // For at least one site, verify xyz = lattice · abc
       const site = structure.sites[0]
-      const [[l00, l01, l02], [l10, l11, l12], [l20, l21, l22]] = lattice
-      const [a0, a1, a2] = site.abc
-      const xyz_from_abc = [
-        l00 * a0 + l10 * a1 + l20 * a2,
-        l01 * a0 + l11 * a1 + l21 * a2,
-        l02 * a0 + l12 * a1 + l22 * a2,
-      ]
+      const xyz_from_abc = math.create_frac_to_cart(lattice)(site.abc)
       expect(xyz_from_abc[0]).toBeCloseTo(site.xyz[0], 10)
       expect(xyz_from_abc[1]).toBeCloseTo(site.xyz[1], 10)
       expect(xyz_from_abc[2]).toBeCloseTo(site.xyz[2], 10)

--- a/tests/vitest/rdf/calc-rdf.test.ts
+++ b/tests/vitest/rdf/calc-rdf.test.ts
@@ -340,16 +340,12 @@ describe(`calculate_rdf`, () => {
       // Check that fractional coordinates were calculated correctly
       // For at least one site, verify xyz = lattice · abc
       const site = structure.sites[0]
+      const [[l00, l01, l02], [l10, l11, l12], [l20, l21, l22]] = lattice
+      const [a0, a1, a2] = site.abc
       const xyz_from_abc = [
-        lattice[0][0] * site.abc[0] +
-          lattice[1][0] * site.abc[1] +
-          lattice[2][0] * site.abc[2],
-        lattice[0][1] * site.abc[0] +
-          lattice[1][1] * site.abc[1] +
-          lattice[2][1] * site.abc[2],
-        lattice[0][2] * site.abc[0] +
-          lattice[1][2] * site.abc[1] +
-          lattice[2][2] * site.abc[2],
+        l00 * a0 + l10 * a1 + l20 * a2,
+        l01 * a0 + l11 * a1 + l21 * a2,
+        l02 * a0 + l12 * a1 + l22 * a2,
       ]
       expect(xyz_from_abc[0]).toBeCloseTo(site.xyz[0], 10)
       expect(xyz_from_abc[1]).toBeCloseTo(site.xyz[1], 10)

--- a/tests/vitest/sanitize.test.ts
+++ b/tests/vitest/sanitize.test.ts
@@ -32,7 +32,7 @@ const XSS_PAYLOADS = [
   `<svg><foreignObject><body onload=alert(1)></body></foreignObject></svg>`,
 ]
 
-function assert_no_xss(result: string): void {
+function assertNoXss(result: string): void {
   expect(result).not.toContain(`<script`)
   expect(result).not.toMatch(/on\w+\s*=/i)
   expect(result).not.toMatch(/javascript:/i)
@@ -48,7 +48,7 @@ function assert_no_xss(result: string): void {
 
 describe(`sanitize_html`, () => {
   test.each(XSS_PAYLOADS)(`strips XSS from: %s`, (payload) => {
-    assert_no_xss(sanitize_html(payload))
+    assertNoXss(sanitize_html(payload))
   })
 
   test.each([
@@ -80,7 +80,7 @@ describe(`sanitize_html`, () => {
 
   test(`merges noopener into existing rel without overwriting`, () => {
     const result = sanitize_html(`<a href="/x" rel="noreferrer">x</a>`)
-    const rel_tokens = /rel="([^"]+)"/.exec(result)?.[1]?.split(/\s+/) ?? []
+    const rel_tokens = /rel="(?<rel>[^"]+)"/.exec(result)?.[1]?.split(/\s+/) ?? []
     expect(rel_tokens).toContain(`noreferrer`)
     expect(rel_tokens).toContain(`noopener`)
   })
@@ -134,7 +134,7 @@ describe(`sanitize_html`, () => {
     [`double-encoded entities`, `<img src=x onerror=&#97;&#108;&#101;&#114;&#116;(1)>`],
     [`null byte injection`, `<scr\u0000ipt>alert(1)</script>`],
   ] as const)(`bypass attempt: %s`, (_name, input) => {
-    assert_no_xss(sanitize_html(input))
+    assertNoXss(sanitize_html(input))
   })
 
   test(`deeply nested dangerous content is stripped`, () => {
@@ -160,8 +160,8 @@ describe(`sanitize_formula`, () => {
   })
 
   test(`strips XSS injected via formula string`, () => {
-    assert_no_xss(sanitize_formula(`<script>alert(1)</script>`))
-    assert_no_xss(sanitize_formula(`Fe<img src=x onerror=alert(1)>2O3`))
+    assertNoXss(sanitize_formula(`<script>alert(1)</script>`))
+    assertNoXss(sanitize_formula(`Fe<img src=x onerror=alert(1)>2O3`))
   })
 })
 
@@ -187,7 +187,7 @@ describe(`compact formula helpers`, () => {
 
 describe(`sanitize_svg`, () => {
   test.each(XSS_PAYLOADS)(`strips XSS from: %s`, (payload) => {
-    assert_no_xss(sanitize_svg(payload))
+    assertNoXss(sanitize_svg(payload))
   })
 
   test.each([
@@ -217,7 +217,7 @@ describe(`sanitize_svg`, () => {
 
 describe(`sanitize_icon_svg`, () => {
   test.each(XSS_PAYLOADS)(`strips XSS from: %s`, (payload) => {
-    assert_no_xss(sanitize_icon_svg(payload))
+    assertNoXss(sanitize_icon_svg(payload))
   })
 
   test.each([

--- a/tests/vitest/scene/bind-renderer.test.svelte.ts
+++ b/tests/vitest/scene/bind-renderer.test.svelte.ts
@@ -1,0 +1,66 @@
+import { bind_renderer } from '$lib/scene/bind-renderer.svelte'
+import { flushSync } from 'svelte'
+import type { Camera, Scene } from 'three'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+// Minimal stand-in for Threlte's CurrentWritable<Camera>: exposes `.current` and
+// `.subscribe`, and notifies subscribers when the active camera is replaced.
+function make_camera_store(initial: Camera) {
+  const subscribers = new Set<(camera: Camera) => void>()
+  return {
+    current: initial,
+    subscribe(fn: (camera: Camera) => void) {
+      fn(this.current)
+      subscribers.add(fn)
+      return () => subscribers.delete(fn)
+    },
+    set(camera: Camera) {
+      this.current = camera
+      for (const fn of subscribers) fn(camera)
+    },
+  }
+}
+
+let fake_threlte: {
+  scene: Scene
+  camera: ReturnType<typeof make_camera_store>
+  renderer: undefined
+}
+
+// Keep every real @threlte/core export; only stub useThrelte to hand back our fake.
+vi.mock(`@threlte/core`, async (original) => ({
+  ...(await original<typeof import('@threlte/core')>()),
+  useThrelte: () => fake_threlte,
+}))
+
+const fake_camera = (id: number) => ({ id }) as unknown as Camera
+
+afterEach(() => vi.restoreAllMocks())
+
+describe(`bind_renderer`, () => {
+  test(`re-binds when Threlte replaces the active camera (cell/supercell remount)`, () => {
+    const cam1 = fake_camera(1)
+    const cam2 = fake_camera(2)
+    fake_threlte = {
+      scene: { name: `scene` } as unknown as Scene,
+      camera: make_camera_store(cam1),
+      renderer: undefined,
+    }
+
+    const bound: Camera[] = []
+    const cleanup = $effect.root(() => {
+      bind_renderer((_scene, camera) => bound.push(camera))
+    })
+    flushSync()
+
+    expect(bound).toEqual([cam1]) // initial bind
+
+    // Threlte swaps the active camera (e.g. the camera is remounted on a supercell
+    // change). Subscribing should re-fire on_bind so consumers follow the new camera.
+    fake_threlte.camera.set(cam2)
+    flushSync()
+    expect(bound).toEqual([cam1, cam2])
+
+    cleanup()
+  })
+})

--- a/tests/vitest/scene/bind-renderer.test.svelte.ts
+++ b/tests/vitest/scene/bind-renderer.test.svelte.ts
@@ -1,66 +1,66 @@
+import { renderer_registry } from '$lib/io/export'
 import { bind_renderer } from '$lib/scene/bind-renderer.svelte'
+import { currentWritable } from '@threlte/core'
+import type * as threlte_core from '@threlte/core'
 import { flushSync } from 'svelte'
-import type { Camera, Scene } from 'three'
-import { afterEach, describe, expect, test, vi } from 'vitest'
+import type { Camera, Scene, WebGLRenderer } from 'three'
+import { describe, expect, test, vi } from 'vitest'
 
-// Minimal stand-in for Threlte's CurrentWritable<Camera>: exposes `.current` and
-// `.subscribe`, and notifies subscribers when the active camera is replaced.
-function make_camera_store(initial: Camera) {
-  const subscribers = new Set<(camera: Camera) => void>()
-  return {
-    current: initial,
-    subscribe(fn: (camera: Camera) => void) {
-      fn(this.current)
-      subscribers.add(fn)
-      return () => subscribers.delete(fn)
-    },
-    set(camera: Camera) {
-      this.current = camera
-      for (const fn of subscribers) fn(camera)
-    },
-  }
-}
-
+// Stub only useThrelte and keep the real @threlte/core exports - using the real
+// currentWritable makes the camera store behave authentically: `.current` is a
+// non-reactive read while `.subscribe` is the reactive channel the fix depends on.
 let fake_threlte: {
   scene: Scene
-  camera: ReturnType<typeof make_camera_store>
-  renderer: undefined
+  camera: ReturnType<typeof currentWritable<Camera>>
+  renderer?: WebGLRenderer
 }
-
-// Keep every real @threlte/core export; only stub useThrelte to hand back our fake.
 vi.mock(`@threlte/core`, async (original) => ({
-  ...(await original<typeof import('@threlte/core')>()),
+  ...(await original<typeof threlte_core>()),
   useThrelte: () => fake_threlte,
 }))
 
 const fake_camera = (id: number) => ({ id }) as unknown as Camera
-
-afterEach(() => vi.restoreAllMocks())
+const fake_scene = { name: `scene` } as unknown as Scene
 
 describe(`bind_renderer`, () => {
-  test(`re-binds when Threlte replaces the active camera (cell/supercell remount)`, () => {
-    const cam1 = fake_camera(1)
-    const cam2 = fake_camera(2)
-    fake_threlte = {
-      scene: { name: `scene` } as unknown as Scene,
-      camera: make_camera_store(cam1),
-      renderer: undefined,
-    }
+  test(`re-binds on every camera swap, then stops after teardown`, () => {
+    const [cam1, cam2, cam3] = [fake_camera(1), fake_camera(2), fake_camera(3)]
+    fake_threlte = { scene: fake_scene, camera: currentWritable(cam1) }
+    const on_bind = vi.fn()
 
-    const bound: Camera[] = []
     const cleanup = $effect.root(() => {
-      bind_renderer((_scene, camera) => bound.push(camera))
+      bind_renderer(on_bind)
+    })
+    flushSync()
+    expect(on_bind.mock.calls).toEqual([[fake_scene, cam1]]) // initial bind
+
+    // Threlte replaces the active camera (e.g. remount on a cell/supercell change);
+    // the subscription must re-fire on_bind so consumers follow the new camera.
+    fake_threlte.camera.set(cam2)
+    expect(on_bind.mock.calls).toEqual([
+      [fake_scene, cam1],
+      [fake_scene, cam2],
+    ])
+
+    // After teardown the subscription is gone: further swaps must not re-bind.
+    cleanup()
+    fake_threlte.camera.set(cam3)
+    expect(on_bind).toHaveBeenCalledTimes(2)
+  })
+
+  test(`reports the renderer and registers its canvas for export lookup`, () => {
+    const dom_element = document.createElement(`canvas`)
+    const renderer = { domElement: dom_element } as unknown as WebGLRenderer
+    fake_threlte = { scene: fake_scene, camera: currentWritable(fake_camera(1)), renderer }
+    const on_renderer = vi.fn()
+
+    const cleanup = $effect.root(() => {
+      bind_renderer(() => {}, on_renderer)
     })
     flushSync()
 
-    expect(bound).toEqual([cam1]) // initial bind
-
-    // Threlte swaps the active camera (e.g. the camera is remounted on a supercell
-    // change). Subscribing should re-fire on_bind so consumers follow the new camera.
-    fake_threlte.camera.set(cam2)
-    flushSync()
-    expect(bound).toEqual([cam1, cam2])
-
+    expect(on_renderer).toHaveBeenCalledExactlyOnceWith(renderer)
+    expect(renderer_registry.get(dom_element)).toBe(renderer)
     cleanup()
   })
 })

--- a/tests/vitest/setup.ts
+++ b/tests/vitest/setup.ts
@@ -133,7 +133,7 @@ export const press_window_key = (event_init: KeyboardEventInit): KeyboardEvent =
 // value (a step counter, a toggle flag, ...) — the shortcut is deemed to have
 // "fired" whenever that value changes between checks, so it works for both
 // counters and toggles.
-export async function assert_hover_scoped_shortcut(opts: {
+export async function assertHoverScopedShortcut(opts: {
   viewer: HTMLElement
   fire: () => void
   read_state: () => unknown

--- a/tests/vitest/setup.ts
+++ b/tests/vitest/setup.ts
@@ -82,6 +82,16 @@ export const doc_query = <T extends HTMLElement>(
 
 export const svg_query = (selector: string): SVGElement => query_required(selector)
 
+// Extract the rotation pivot-y from an axis label's enclosing foreignObject
+// `rotate(-90, x, pivot)` transform. Used to assert y/y2 axis titles share a pivot.
+export const axis_label_pivot_y = (root: ParentNode, selector: string): number => {
+  const transform =
+    root.querySelector(selector)?.closest(`foreignObject`)?.getAttribute(`transform`) ?? ``
+  const match = /rotate\(-90,\s*[\d.-]+,\s*(?<pivot>[\d.-]+)\)/.exec(transform)
+  if (!match) throw new Error(`no rotate transform on ${selector}: "${transform}"`)
+  return Number(match[1])
+}
+
 // Walk up from `el` to the owning <svg>: true if any ancestor applies a clip-path.
 // Used to assert reference-line annotations render unclipped at the plot edges.
 export const inside_clip_path = (el: Element | null | undefined): boolean => {
@@ -369,13 +379,7 @@ export function create_test_structure(
   frac_coords?: Vec3[],
 ): Crystal {
   const lattice_matrix: math.Matrix3x3 =
-    typeof lattice === `number`
-      ? [
-          [lattice, 0.0, 0.0],
-          [0.0, lattice, 0.0],
-          [0.0, 0.0, lattice],
-        ]
-      : lattice
+    typeof lattice === `number` ? cubic_matrix(lattice) : lattice
 
   // Calculate lattice parameters from matrix
   const { a, b, c, alpha, beta, gamma, volume } = math.calc_lattice_params(lattice_matrix)
@@ -451,13 +455,7 @@ export function make_crystal(
   options: { pbc?: Pbc; charge?: number } = {},
 ): Crystal {
   const lattice_matrix: math.Matrix3x3 =
-    typeof lattice_input === `number`
-      ? [
-          [lattice_input, 0, 0],
-          [0, lattice_input, 0],
-          [0, 0, lattice_input],
-        ]
-      : lattice_input
+    typeof lattice_input === `number` ? cubic_matrix(lattice_input) : lattice_input
 
   // Use standard pymatgen convention for frac↔cart conversion:
   // xyz = transpose(lattice) · abc, abc = inv(transpose(lattice)) · xyz
@@ -519,6 +517,20 @@ export function make_symmetry_structure(
     ? { ...crystal, lattice: { ...crystal.lattice, ...lattice_params } }
     : crystal
 }
+
+// Shared 3x3 matrix fixtures
+export const IDENTITY_MATRIX3: math.Matrix3x3 = [
+  [1, 0, 0],
+  [0, 1, 0],
+  [0, 0, 1],
+]
+
+// Diagonal cubic lattice matrix with edge length `a`
+export const cubic_matrix = (a: number): math.Matrix3x3 => [
+  [a, 0, 0],
+  [0, a, 0],
+  [0, 0, a],
+]
 
 // Encode a 3x3 matrix as a flat 9-array in COLUMN-major order — how moyo/nalgebra serialize
 // rotation matrices on the wire (inverse of mat3_from_flat_col_major in symmetry-elements).

--- a/tests/vitest/spectral/helpers.test.ts
+++ b/tests/vitest/spectral/helpers.test.ts
@@ -1724,7 +1724,7 @@ describe(`generate_ribbon_path`, () => {
 
   it(`generates valid SVG path with lower edge reversed`, () => {
     const path = generate_ribbon_path([0, 1, 2], [0, 0, 0], [1, 1, 1], id, id, 5)
-    expect(path).toMatch(/^M[\d.,-]+( L[\d.,-]+)+ Z$/)
+    expect(path).toMatch(/^M[\d.,-]+(?: L[\d.,-]+)+ Z$/)
     // Verify polygon structure: upper edge 0→1→2, lower edge 2→1→0
     const points = path.match(/[\d.-]+,[\d.-]+/g) ?? []
     expect(points).toHaveLength(6)

--- a/tests/vitest/spectral/helpers.test.ts
+++ b/tests/vitest/spectral/helpers.test.ts
@@ -31,6 +31,7 @@ import {
 } from '$lib/spectral/helpers'
 import type { BaseBandStructure, RibbonConfig } from '$lib/spectral/types'
 import { describe, expect, it, vi } from 'vitest'
+import { IDENTITY_MATRIX3 } from '../setup'
 
 describe(`is_valid_range`, () => {
   it.each([
@@ -450,11 +451,7 @@ describe(`find_qpoint_at_distance`, () => {
 })
 
 describe(`extract_k_path_points`, () => {
-  const identity_lattice: Matrix3x3 = [
-    [1, 0, 0],
-    [0, 1, 0],
-    [0, 0, 1],
-  ]
+  const identity_lattice = IDENTITY_MATRIX3
 
   it(`converts fractional coordinates to Cartesian reciprocal space`, () => {
     const band_struct: BaseBandStructure = {
@@ -582,11 +579,7 @@ describe(`extract_k_path_points`, () => {
 })
 
 describe(`find_qpoint_at_rescaled_x`, () => {
-  const identity_lattice: Matrix3x3 = [
-    [1, 0, 0],
-    [0, 1, 0],
-    [0, 0, 1],
-  ]
+  const identity_lattice = IDENTITY_MATRIX3
 
   // Test band structure: Γ→X→K with rescaled segments
   const rescaled_bs: BaseBandStructure = {
@@ -714,11 +707,7 @@ describe(`find_qpoint_at_rescaled_x`, () => {
 })
 
 describe(`normalize_band_structure`, () => {
-  const ident: Matrix3x3 = [
-    [1, 0, 0],
-    [0, 1, 0],
-    [0, 0, 1],
-  ]
+  const ident = IDENTITY_MATRIX3
   const make_pmg = (opts: Record<string, unknown>) => ({
     '@class': `PhononBandStructureSymmLine`,
     ...opts,

--- a/tests/vitest/structure/Structure.test.svelte.ts
+++ b/tests/vitest/structure/Structure.test.svelte.ts
@@ -5,7 +5,7 @@ import { DEFAULTS } from '$lib/settings'
 import type { StructureHandlerData } from '$lib/structure'
 import * as exports from '$lib/structure/export'
 import { structures } from '$site/structures'
-import { flushSync, mount, tick } from 'svelte'
+import { type ComponentProps, flushSync, mount, tick } from 'svelte'
 import { describe, expect, test, vi } from 'vitest'
 import {
   assertHoverScopedShortcut,
@@ -16,6 +16,11 @@ import {
 } from '../setup'
 
 const structure = structures[0]
+
+// Mount Structure into document.body (queries are left to each test via doc_query)
+const mount_structure = (props: ComponentProps<typeof Structure>): void => {
+  mount(Structure, { target: document.body, props })
+}
 
 // Shared test utilities to reduce duplication
 const SAMPLE_POSCAR_CONTENT = `BaTiO3 tetragonal
@@ -62,7 +67,7 @@ describe(`Structure`, () => {
       warns.push(args.map(String).join(` `))
     })
     try {
-      mount(Structure, { target: document.body, props: { structure } })
+      mount_structure({ structure })
       flushSync()
       await tick()
       flushSync()
@@ -76,10 +81,7 @@ describe(`Structure`, () => {
   })
 
   test(`open control pane when clicking toggle button`, () => {
-    mount(Structure, {
-      target: document.body,
-      props: { structure, controls_open: false, show_controls: true },
-    })
+    mount_structure({ structure, controls_open: false, show_controls: true })
 
     // Check that the controls toggle button exists and is clickable
     const controls_toggle = doc_query(`button.structure-controls-toggle`)
@@ -92,7 +94,7 @@ describe(`Structure`, () => {
   })
 
   test(`hides atom color mode toggle until viewer hover or focus`, async () => {
-    mount(Structure, { target: document.body, props: { structure } })
+    mount_structure({ structure })
     await tick()
 
     const viewer = doc_query(`.structure`)
@@ -121,10 +123,7 @@ describe(`Structure`, () => {
 
   test(`window keydown shortcuts are scoped to the hovered viewer`, async () => {
     const state = { info_pane_open: false }
-    mount(Structure, {
-      target: document.body,
-      props: bind_props({ structure, enable_info_pane: true }, state),
-    })
+    mount_structure(bind_props({ structure, enable_info_pane: true }, state))
     await tick()
 
     await assertHoverScopedShortcut({
@@ -136,10 +135,7 @@ describe(`Structure`, () => {
 
   test(`hover keydown path bails in edit modes so destructive keys need focus`, async () => {
     const state = { info_pane_open: false, measure_mode: `edit-atoms` as MeasureMode }
-    mount(Structure, {
-      target: document.body,
-      props: bind_props({ structure, enable_info_pane: true }, state),
-    })
+    mount_structure(bind_props({ structure, enable_info_pane: true }, state))
     await tick()
     expect(state.measure_mode, `edit-atoms should stick for a plain structure`).toBe(
       `edit-atoms`,
@@ -154,10 +150,7 @@ describe(`Structure`, () => {
 
   test(`edit-atoms Delete shortcut deletes the selected atom and prevents default`, async () => {
     const state = { structure: structures[0], selected_sites: [] as number[] }
-    mount(Structure, {
-      target: document.body,
-      props: bind_props({ measure_mode: `edit-atoms` as MeasureMode }, state),
-    })
+    mount_structure(bind_props({ measure_mode: `edit-atoms` as MeasureMode }, state))
     await tick()
     state.selected_sites = [0] // select after mount (on-load effect clears selection)
     const n_before = state.structure.sites.length
@@ -180,19 +173,16 @@ describe(`Structure`, () => {
     { props: { cell_type: `conventional` }, reason: `transformed cell` },
   ] as const)(`disables edit-bonds mode for $reason views`, async ({ props }) => {
     let measure_mode: MeasureMode = `distance`
-    mount(Structure, {
-      target: document.body,
-      props: {
-        structure,
-        show_controls: true,
-        get measure_mode() {
-          return measure_mode
-        },
-        set measure_mode(value) {
-          measure_mode = value
-        },
-        ...props,
+    mount_structure({
+      structure,
+      show_controls: true,
+      get measure_mode() {
+        return measure_mode
       },
+      set measure_mode(value) {
+        measure_mode = value
+      },
+      ...props,
     })
 
     doc_query<HTMLButtonElement>(`button[title="Measure / Edit"]`).click()
@@ -209,14 +199,7 @@ describe(`Structure`, () => {
   })
 
   test(`shows safe bond editing controls by default`, async () => {
-    mount(Structure, {
-      target: document.body,
-      props: {
-        structure,
-        measure_mode: `edit-bonds`,
-        show_controls: true,
-      },
-    })
+    mount_structure({ structure, measure_mode: `edit-bonds`, show_controls: true })
     await tick()
 
     expect(doc_query(`.bond-edit-toolbar`)).toBeInstanceOf(HTMLElement)
@@ -246,14 +229,11 @@ describe(`Structure`, () => {
   ] as const)(
     `selection limit badge visibility in $mode mode`,
     async ({ mode, shows_limit }) => {
-      mount(Structure, {
-        target: document.body,
-        props: {
-          structure,
-          measured_sites: [0, 1, 2, 3, 4, 5, 6, 7],
-          measure_mode: mode,
-          show_controls: true,
-        },
+      mount_structure({
+        structure,
+        measured_sites: [0, 1, 2, 3, 4, 5, 6, 7],
+        measure_mode: mode,
+        show_controls: true,
       })
       await tick()
 
@@ -290,15 +270,12 @@ describe(`Structure`, () => {
   test.each(selection_control_cases)(
     `selection controls visibility in $mode mode`,
     async ({ mode, measured_sites, selected_sites, shows_reset }) => {
-      mount(Structure, {
-        target: document.body,
-        props: {
-          structure,
-          measured_sites,
-          selected_sites,
-          measure_mode: mode,
-          show_controls: true,
-        },
+      mount_structure({
+        structure,
+        measured_sites,
+        selected_sites,
+        measure_mode: mode,
+        show_controls: true,
       })
       await tick()
 
@@ -326,10 +303,7 @@ describe(`Structure`, () => {
         : vi.spyOn(exports.STRUCT_TEXT_FORMATS[fmt], `to_str`)
     export_spy.mockClear() // spies are shared across test.each runs
 
-    mount(Structure, {
-      target: document.body,
-      props: { structure, show_controls: true },
-    })
+    mount_structure({ structure, show_controls: true })
     const structure_controls_toggle = doc_query<HTMLButtonElement>(
       `button.structure-controls-toggle`,
     )
@@ -379,10 +353,7 @@ describe(`Structure`, () => {
     const requestFullscreenMock = vi.fn().mockResolvedValue(undefined)
     const exitFullscreenMock = vi.fn()
 
-    mount(Structure, {
-      target: document.body,
-      props: { structure, show_controls: true },
-    })
+    mount_structure({ structure, show_controls: true })
 
     // Find the wrapper element that was created by the component
     const wrapper = document.querySelector(`.structure`) as HTMLElement
@@ -422,15 +393,12 @@ describe(`Structure`, () => {
     let resolve_drop!: () => void
     const drop_done = new Promise<void>((resolve) => (resolve_drop = resolve))
 
-    mount(Structure, {
-      target: document.body,
-      props: {
-        structure: undefined,
-        show_controls: true,
-        on_file_drop: (_content: string | ArrayBuffer, _filename: string) => {
-          structure_loaded = true
-          resolve_drop()
-        },
+    mount_structure({
+      structure: undefined,
+      show_controls: true,
+      on_file_drop: (_content: string | ArrayBuffer, _filename: string) => {
+        structure_loaded = true
+        resolve_drop()
       },
     })
 
@@ -455,16 +423,13 @@ describe(`Structure`, () => {
     let resolve_drop!: () => void
     const drop_done = new Promise<void>((resolve) => (resolve_drop = resolve))
 
-    mount(Structure, {
-      target: document.body,
-      props: {
-        structure: undefined,
-        show_controls: true,
-        on_file_drop: (content: string | ArrayBuffer, _filename: string) => {
-          event_handled = true
-          file_content = content
-          resolve_drop()
-        },
+    mount_structure({
+      structure: undefined,
+      show_controls: true,
+      on_file_drop: (content: string | ArrayBuffer, _filename: string) => {
+        event_handled = true
+        file_content = content
+        resolve_drop()
       },
     })
 
@@ -491,15 +456,12 @@ describe(`Structure`, () => {
     let resolve_load!: () => void
     const load_done = new Promise<void>((resolve) => (resolve_load = resolve))
 
-    mount(Structure, {
-      target: document.body,
-      props: {
-        structure: undefined,
-        show_controls: true,
-        on_file_load: (data: StructureHandlerData) => {
-          loaded = data
-          resolve_load()
-        },
+    mount_structure({
+      structure: undefined,
+      show_controls: true,
+      on_file_load: (data: StructureHandlerData) => {
+        loaded = data
+        resolve_load()
       },
     })
 
@@ -523,17 +485,9 @@ describe(`Structure`, () => {
       selected_sites: [] as number[],
     }
 
-    mount(Structure, {
-      target: document.body,
-      props: bind_props(
-        {
-          structure,
-          info_pane_open: true,
-          show_controls: true,
-        },
-        state,
-      ),
-    })
+    mount_structure(
+      bind_props({ structure, info_pane_open: true, show_controls: true }, state),
+    )
     await tick()
 
     const first_site_row = document.querySelector(
@@ -652,10 +606,7 @@ describe(`Structure component nested JSON handling`, () => {
       },
     ],
   ])(`renders successfully with %s`, (_description, test_structure) => {
-    mount(Structure, {
-      target: document.body,
-      props: { structure: test_structure as AnyStructure },
-    })
+    mount_structure({ structure: test_structure as AnyStructure })
 
     expect(document.body.textContent).not.toContain(`No sites found in structure`)
     expect(document.body.textContent).not.toContain(`No structure provided`)
@@ -670,10 +621,7 @@ describe(`Structure component nested JSON handling`, () => {
     [`structure with empty sites array`, { sites: [] }],
     [`structure with undefined sites`, { sites: undefined } as unknown],
   ])(`shows appropriate error for %s`, (_description, test_structure) => {
-    mount(Structure, {
-      target: document.body,
-      props: { structure: test_structure as AnyStructure },
-    })
+    mount_structure({ structure: test_structure as AnyStructure })
 
     if (!test_structure) {
       expect(document.body.textContent).toContain(`No structure provided`)
@@ -695,10 +643,7 @@ describe(`Structure component nested JSON handling`, () => {
     expect(nested_structure.sites.length).toBeGreaterThan(0)
 
     // Test component renders without errors
-    mount(Structure, {
-      target: document.body,
-      props: { structure: nested_structure as AnyStructure },
-    })
+    mount_structure({ structure: nested_structure as AnyStructure })
 
     expect(document.body.textContent).not.toContain(`No sites found in structure`)
     expect(document.body.textContent).not.toContain(`No structure provided`)
@@ -716,10 +661,7 @@ test.each([
       camera_projection: initial_projection,
       auto_rotate: 0.5,
     }
-    mount(Structure, {
-      target: document.body,
-      props: { structure, controls_open: true, show_controls: true, scene_props },
-    })
+    mount_structure({ structure, controls_open: true, show_controls: true, scene_props })
     await tick()
 
     // Test 1: UI controls are accessible with correct options
@@ -798,14 +740,11 @@ describe(`atom label controls`, () => {
     const offset = [0, 0, 0] as Vec3
     offset[idx] = initial
 
-    mount(Structure, {
-      target: document.body,
-      props: {
-        structure,
-        controls_open: true,
-        show_controls: true,
-        scene_props: { show_site_labels: true, site_label_offset: offset },
-      },
+    mount_structure({
+      structure,
+      controls_open: true,
+      show_controls: true,
+      scene_props: { show_site_labels: true, site_label_offset: offset },
     })
 
     const offset_inputs = document.querySelectorAll(
@@ -822,14 +761,11 @@ describe(`atom label controls`, () => {
   })
 
   test(`color controls work correctly`, () => {
-    mount(Structure, {
-      target: document.body,
-      props: {
-        structure,
-        controls_open: true,
-        show_controls: true,
-        scene_props: { show_site_labels: true, site_label_color: `#ff0000` },
-      },
+    mount_structure({
+      structure,
+      controls_open: true,
+      show_controls: true,
+      scene_props: { show_site_labels: true, site_label_color: `#ff0000` },
     })
 
     const color_inputs = document.querySelectorAll(`input[type="color"]`)
@@ -857,17 +793,14 @@ describe(`atom label controls`, () => {
   })
 
   test(`size and padding controls work correctly`, () => {
-    mount(Structure, {
-      target: document.body,
-      props: {
-        structure,
-        controls_open: true,
-        show_controls: true,
-        scene_props: {
-          show_site_labels: true,
-          site_label_size: 1.2,
-          site_label_padding: 4,
-        },
+    mount_structure({
+      structure,
+      controls_open: true,
+      show_controls: true,
+      scene_props: {
+        show_site_labels: true,
+        site_label_size: 1.2,
+        site_label_padding: 4,
       },
     })
 
@@ -891,14 +824,11 @@ describe(`atom label controls`, () => {
   })
 
   test(`input constraints are correct`, () => {
-    mount(Structure, {
-      target: document.body,
-      props: {
-        structure,
-        controls_open: true,
-        show_controls: true,
-        scene_props: { show_site_labels: true },
-      },
+    mount_structure({
+      structure,
+      controls_open: true,
+      show_controls: true,
+      scene_props: { show_site_labels: true },
     })
 
     const size_input = document.querySelector(
@@ -934,25 +864,19 @@ describe(`atom label controls`, () => {
 
   test(`state isolation between instances works`, () => {
     // Mount first instance
-    mount(Structure, {
-      target: document.body,
-      props: {
-        structure,
-        controls_open: true,
-        show_controls: true,
-        scene_props: { show_site_labels: true, site_label_offset: [0, 0.75, 0.2] },
-      },
+    mount_structure({
+      structure,
+      controls_open: true,
+      show_controls: true,
+      scene_props: { show_site_labels: true, site_label_offset: [0, 0.75, 0.2] },
     })
 
     // Mount second instance
-    mount(Structure, {
-      target: document.body,
-      props: {
-        structure,
-        controls_open: true,
-        show_controls: true,
-        scene_props: { show_site_labels: true, site_label_offset: [0, 0.75, 0.7] },
-      },
+    mount_structure({
+      structure,
+      controls_open: true,
+      show_controls: true,
+      scene_props: { show_site_labels: true, site_label_offset: [0, 0.75, 0.7] },
     })
 
     const all_offset_inputs = document.querySelectorAll(
@@ -1016,21 +940,18 @@ describe(`Structure string parsing`, () => {
       let parse_state = $state<{ parsed?: AnyStructure }>({})
       let loaded = false
 
-      mount(Structure, {
-        target: document.body,
-        props: {
-          structure_string: content,
-          get structure() {
-            return parse_state.parsed
-          },
-          set structure(val) {
-            parse_state.parsed = val
-          },
-          on_file_load: (data: StructureHandlerData) => {
-            loaded = true
-            expect(data.total_atoms).toBe(atoms)
-            expect(data.filename).toBe(`string`)
-          },
+      mount_structure({
+        structure_string: content,
+        get structure() {
+          return parse_state.parsed
+        },
+        set structure(val) {
+          parse_state.parsed = val
+        },
+        on_file_load: (data: StructureHandlerData) => {
+          loaded = true
+          expect(data.total_atoms).toBe(atoms)
+          expect(data.filename).toBe(`string`)
         },
       })
 
@@ -1056,26 +977,20 @@ describe(`Structure string parsing`, () => {
     [`malformed JSON`, `{bad`],
   ])(`handles %s gracefully`, async (_, content) => {
     let errored = false
-    mount(Structure, {
-      target: document.body,
-      props: { structure_string: content, on_error: () => (errored = true) },
-    })
+    mount_structure({ structure_string: content, on_error: () => (errored = true) })
     await tick()
     expect(errored).toBe(true)
   })
 
   test(`loading state works correctly`, async () => {
     let loading_state = $state({ loading: false })
-    mount(Structure, {
-      target: document.body,
-      props: {
-        structure_string: SAMPLE_POSCAR_CONTENT,
-        get loading() {
-          return loading_state.loading
-        },
-        set loading(val) {
-          loading_state.loading = val
-        },
+    mount_structure({
+      structure_string: SAMPLE_POSCAR_CONTENT,
+      get loading() {
+        return loading_state.loading
+      },
+      set loading(val) {
+        loading_state.loading = val
       },
     })
     await tick()
@@ -1084,13 +999,10 @@ describe(`Structure string parsing`, () => {
 
   test(`file size emission works correctly`, async () => {
     let size = 0
-    mount(Structure, {
-      target: document.body,
-      props: {
-        structure_string: SAMPLE_POSCAR_CONTENT,
-        on_file_load: (data: StructureHandlerData) => {
-          size = data.file_size ?? 0
-        },
+    mount_structure({
+      structure_string: SAMPLE_POSCAR_CONTENT,
+      on_file_load: (data: StructureHandlerData) => {
+        size = data.file_size ?? 0
       },
     })
     await tick()
@@ -1103,13 +1015,10 @@ describe(`Structure string parsing`, () => {
       ok: true,
       text: () => Promise.resolve(SAMPLE_POSCAR_CONTENT),
     })
-    mount(Structure, {
-      target: document.body,
-      props: {
-        data_url: `/test.poscar`,
-        structure_string: `ignored`,
-        on_file_load: (data: StructureHandlerData) => (filename = data.filename ?? ``),
-      },
+    mount_structure({
+      data_url: `/test.poscar`,
+      structure_string: `ignored`,
+      on_file_load: (data: StructureHandlerData) => (filename = data.filename ?? ``),
     })
     await tick()
     expect(filename).toBe(`test.poscar`)
@@ -1121,12 +1030,7 @@ describe(`Structure string parsing`, () => {
       status: 404,
       text: () => Promise.resolve(``),
     })
-    mount(Structure, {
-      target: document.body,
-      props: {
-        data_url: `/missing-structure.json`,
-      },
-    })
+    mount_structure({ data_url: `/missing-structure.json` })
     await tick()
     await tick()
 

--- a/tests/vitest/structure/Structure.test.svelte.ts
+++ b/tests/vitest/structure/Structure.test.svelte.ts
@@ -8,7 +8,7 @@ import { structures } from '$site/structures'
 import { flushSync, mount, tick } from 'svelte'
 import { describe, expect, test, vi } from 'vitest'
 import {
-  assert_hover_scoped_shortcut,
+  assertHoverScopedShortcut,
   bind_props,
   doc_query,
   press_window_key,
@@ -127,7 +127,7 @@ describe(`Structure`, () => {
     })
     await tick()
 
-    await assert_hover_scoped_shortcut({
+    await assertHoverScopedShortcut({
       viewer: doc_query(`.structure`),
       fire: () => press_window_key({ key: `i`, ctrlKey: true }),
       read_state: () => state.info_pane_open,

--- a/tests/vitest/structure/atom-label-placement.test.ts
+++ b/tests/vitest/structure/atom-label-placement.test.ts
@@ -8,7 +8,7 @@ import {
 import { Object3D, OrthographicCamera } from 'three'
 import { describe, expect, test } from 'vitest'
 
-const expect_vec_close = (actual: Vec3, expected: Vec3): void => {
+const expectVecClose = (actual: Vec3, expected: Vec3): void => {
   for (const [idx, val] of actual.entries()) {
     expect(val).toBeCloseTo(expected[idx])
   }
@@ -31,7 +31,7 @@ describe(`label placement`, () => {
 
     const offset = choose_site_label_offset(bond_directions, base_offset)
 
-    expect_vec_close(offset, [0, -0.5, 0])
+    expectVecClose(offset, [0, -0.5, 0])
   })
 
   test(`preserves label offset length when choosing another direction`, () => {

--- a/tests/vitest/structure/export.test.ts
+++ b/tests/vitest/structure/export.test.ts
@@ -193,11 +193,6 @@ describe(`Export functionality`, () => {
 
   describe(`Round-trip exporters (fixtures)`, () => {
     const TOL = 8
-    const reconstruct = (abc: number[], L: number[][]) => [
-      abc[0] * L[0][0] + abc[1] * L[1][0] + abc[2] * L[2][0],
-      abc[0] * L[0][1] + abc[1] * L[1][1] + abc[2] * L[2][1],
-      abc[0] * L[0][2] + abc[1] * L[1][2] + abc[2] * L[2][2],
-    ]
     const to_any = (ps: {
       sites: AnyStructure[`sites`]
       lattice?: Omit<LatticeType, `pbc`> & Partial<Pick<LatticeType, `pbc`>>
@@ -232,12 +227,12 @@ describe(`Export functionality`, () => {
       const reparsed = parse_structure_file(exported)
       assert(reparsed?.lattice, `failed to reparse`)
       expect(reparsed.sites).toHaveLength(parsed.sites.length)
-      const lattice_matrix = reparsed.lattice.matrix
+      const frac_to_cart = math.create_frac_to_cart(reparsed.lattice.matrix)
       reparsed.sites.forEach((site, idx) => {
         expect(site.abc[0]).toBeCloseTo(parsed.sites[idx].abc[0], TOL)
         expect(site.abc[1]).toBeCloseTo(parsed.sites[idx].abc[1], TOL)
         expect(site.abc[2]).toBeCloseTo(parsed.sites[idx].abc[2], TOL)
-        const recon = reconstruct(site.abc, lattice_matrix)
+        const recon = frac_to_cart(site.abc)
         expect(recon[0]).toBeCloseTo(site.xyz[0], TOL)
         expect(recon[1]).toBeCloseTo(site.xyz[1], TOL)
         expect(recon[2]).toBeCloseTo(site.xyz[2], TOL)

--- a/tests/vitest/structure/export.test.ts
+++ b/tests/vitest/structure/export.test.ts
@@ -394,13 +394,13 @@ describe(`Export functionality`, () => {
         name: `basic structure with ID`,
         structure: {
           id: `water_molecule`,
-          sites: Array(2).fill({
+          sites: Array.from({ length: 2 }, () => ({
             species: [{ element: `H`, occu: 1, oxidation_state: 1 }],
             abc: [0, 0, 0],
             xyz: [0, 0, 0],
             label: `H`,
             properties: {},
-          }),
+          })),
         } as AnyStructure,
         extension: `xyz`,
         should_contain: [`water_molecule`, `2sites`, `.xyz`],
@@ -409,13 +409,13 @@ describe(`Export functionality`, () => {
         name: `structure with many sites`,
         structure: {
           id: `complex_crystal`,
-          sites: Array(24).fill({
+          sites: Array.from({ length: 24 }, () => ({
             species: [{ element: `Si`, occu: 1, oxidation_state: 4 }],
             abc: [0, 0, 0],
             xyz: [0, 0, 0],
             label: `Si`,
             properties: {},
-          }),
+          })),
         } as AnyStructure,
         extension: `json`,
         should_contain: [`complex_crystal`, `24sites`, `.json`],
@@ -432,13 +432,13 @@ describe(`Export functionality`, () => {
       )
       const structure = {
         id: `lithium_oxide`,
-        sites: Array(3).fill({
+        sites: Array.from({ length: 3 }, () => ({
           species: [{ element: `Li`, occu: 1, oxidation_state: 1 }],
           abc: [0, 0, 0],
           xyz: [0, 0, 0],
           label: `Li`,
           properties: {},
-        }),
+        })),
       } as AnyStructure
       const result = create_structure_filename(structure, `xyz`)
       expect(result).toContain(`Li2O`)
@@ -453,13 +453,13 @@ describe(`Export functionality`, () => {
       mock_get_electro_neg_formula.mockReturnValue(`Li4 Fe4 P4 O16`)
       const structure = {
         id: `mp-19017`,
-        sites: Array(28).fill({
+        sites: Array.from({ length: 28 }, () => ({
           species: [{ element: `Li`, occu: 1, oxidation_state: 1 }],
           abc: [0, 0, 0],
           xyz: [0, 0, 0],
           label: `Li`,
           properties: {},
-        }),
+        })),
       } as AnyStructure
       const result = create_structure_filename(structure, `png`)
       expect(result).toBe(`mp-19017-Li4Fe4P4O16-28sites.png`)
@@ -898,7 +898,7 @@ describe(`Export functionality`, () => {
       const cif_content = structure_to_cif_str(disordered)
       const atom_rows = cif_content
         .split(`\n`)
-        .filter((line) => /^\S+ (Cu|Au) /.test(line.trim()))
+        .filter((line) => /^\S+ (?:Cu|Au) /.test(line.trim()))
       expect(atom_rows).toHaveLength(2)
 
       // each element's row carries the site coords and its OWN occupancy (col order:

--- a/tests/vitest/structure/supercell-performance.test.ts
+++ b/tests/vitest/structure/supercell-performance.test.ts
@@ -86,8 +86,13 @@ describe(`supercell performance profiling`, () => {
       math.scale(structure.lattice.matrix[2], nz),
     ]
     const orig_lattice_T = math.transpose_3x3_matrix(structure.lattice.matrix)
+    const [[orig00, orig01, orig02], [orig10, orig11, orig12], [orig20, orig21, orig22]] =
+      orig_lattice_T
     const new_lattice_T = math.transpose_3x3_matrix(new_lattice_matrix)
     const new_lattice_T_inv = math.matrix_inverse_3x3(new_lattice_T)
+    const [[inv00, inv01, inv02], [inv10, inv11, inv12], [inv20, inv21, inv22]] =
+      new_lattice_T_inv
+    const [[lat00, lat01, lat02], [lat10, lat11, lat12], [lat20, lat21, lat22]] = new_lattice_T
     timings.matrix_setup = performance.now() - start
 
     // Phase 2: Translation vector computation
@@ -97,12 +102,9 @@ describe(`supercell performance profiling`, () => {
     for (let kk = 0; kk < nz; kk++) {
       for (let jj = 0; jj < ny; jj++) {
         for (let ii = 0; ii < nx; ii++) {
-          translations[trans_idx++] =
-            orig_lattice_T[0][0] * ii + orig_lattice_T[0][1] * jj + orig_lattice_T[0][2] * kk
-          translations[trans_idx++] =
-            orig_lattice_T[1][0] * ii + orig_lattice_T[1][1] * jj + orig_lattice_T[1][2] * kk
-          translations[trans_idx++] =
-            orig_lattice_T[2][0] * ii + orig_lattice_T[2][1] * jj + orig_lattice_T[2][2] * kk
+          translations[trans_idx++] = orig00 * ii + orig01 * jj + orig02 * kk
+          translations[trans_idx++] = orig10 * ii + orig11 * jj + orig12 * kk
+          translations[trans_idx++] = orig20 * ii + orig21 * jj + orig22 * kk
         }
       }
     }
@@ -121,26 +123,16 @@ describe(`supercell performance profiling`, () => {
           const tz = translations[trans_idx++]
           const label_suffix = `_${ii}${jj}${kk}`
 
-          for (let orig_idx = 0; orig_idx < structure.sites.length; orig_idx++) {
-            const orig_site = structure.sites[orig_idx]
+          for (const orig_site of structure.sites) {
             const [ox, oy, oz] = orig_site.xyz
 
             const new_x = ox + tx
             const new_y = oy + ty
             const new_z = oz + tz
 
-            let abc_x =
-              new_lattice_T_inv[0][0] * new_x +
-              new_lattice_T_inv[0][1] * new_y +
-              new_lattice_T_inv[0][2] * new_z
-            let abc_y =
-              new_lattice_T_inv[1][0] * new_x +
-              new_lattice_T_inv[1][1] * new_y +
-              new_lattice_T_inv[1][2] * new_z
-            let abc_z =
-              new_lattice_T_inv[2][0] * new_x +
-              new_lattice_T_inv[2][1] * new_y +
-              new_lattice_T_inv[2][2] * new_z
+            let abc_x = inv00 * new_x + inv01 * new_y + inv02 * new_z
+            let abc_y = inv10 * new_x + inv11 * new_y + inv12 * new_z
+            let abc_z = inv20 * new_x + inv21 * new_y + inv22 * new_z
 
             // Wrap coordinates
             abc_x %= 1
@@ -153,18 +145,9 @@ describe(`supercell performance profiling`, () => {
             if (abc_z < 0) abc_z += 1
             if (abc_z >= 1 - 1e-10) abc_z = 0
 
-            const final_x =
-              new_lattice_T[0][0] * abc_x +
-              new_lattice_T[0][1] * abc_y +
-              new_lattice_T[0][2] * abc_z
-            const final_y =
-              new_lattice_T[1][0] * abc_x +
-              new_lattice_T[1][1] * abc_y +
-              new_lattice_T[1][2] * abc_z
-            const final_z =
-              new_lattice_T[2][0] * abc_x +
-              new_lattice_T[2][1] * abc_y +
-              new_lattice_T[2][2] * abc_z
+            const final_x = lat00 * abc_x + lat01 * abc_y + lat02 * abc_z
+            const final_y = lat10 * abc_x + lat11 * abc_y + lat12 * abc_z
+            const final_z = lat20 * abc_x + lat21 * abc_y + lat22 * abc_z
 
             new_sites[site_idx++] = {
               species: orig_site.species,
@@ -180,27 +163,18 @@ describe(`supercell performance profiling`, () => {
     timings.site_generation = performance.now() - start
 
     const total = Object.values(timings).reduce((sum, time) => sum + time, 0)
+    const { matrix_setup, translation_vectors, site_generation } = timings
+    const pct = (ms: number) => ((ms / total) * 100).toFixed(1)
 
     console.warn(
       `\nSupercell generation phases (100 sites → ${structure.sites.length * det} sites):`,
     )
+    console.warn(`  Matrix setup: ${matrix_setup.toFixed(2)}ms (${pct(matrix_setup)}%)`)
     console.warn(
-      `  Matrix setup: ${timings.matrix_setup.toFixed(2)}ms (${(
-        (timings.matrix_setup / total) *
-        100
-      ).toFixed(1)}%)`,
+      `  Translation vectors: ${translation_vectors.toFixed(2)}ms (${pct(translation_vectors)}%)`,
     )
     console.warn(
-      `  Translation vectors: ${timings.translation_vectors.toFixed(2)}ms (${(
-        (timings.translation_vectors / total) *
-        100
-      ).toFixed(1)}%)`,
-    )
-    console.warn(
-      `  Site generation: ${timings.site_generation.toFixed(2)}ms (${(
-        (timings.site_generation / total) *
-        100
-      ).toFixed(1)}%)`,
+      `  Site generation: ${site_generation.toFixed(2)}ms (${pct(site_generation)}%)`,
     )
     console.warn(`  Total: ${total.toFixed(2)}ms`)
 

--- a/tests/vitest/symmetry/symmetry-elements.test.ts
+++ b/tests/vitest/symmetry/symmetry-elements.test.ts
@@ -14,13 +14,13 @@ import {
 import type { SymmetryElement } from '$lib/symmetry'
 import { operations_from_number } from '@spglib/moyo-wasm'
 import { beforeAll, describe, expect, test } from 'vitest'
-import { col_major, init_moyo_for_tests } from '../setup'
+import {
+  col_major,
+  cubic_matrix,
+  IDENTITY_MATRIX3 as IDENTITY,
+  init_moyo_for_tests,
+} from '../setup'
 
-const IDENTITY: Matrix3x3 = [
-  [1, 0, 0],
-  [0, 1, 0],
-  [0, 0, 1],
-]
 const INVERSION: Matrix3x3 = [
   [-1, 0, 0],
   [0, -1, 0],
@@ -356,11 +356,7 @@ describe(`symmetry_elements_from_ops: space group inventories`, () => {
 })
 
 describe(`cell clipping helpers`, () => {
-  const cubic_2: Matrix3x3 = [
-    [2, 0, 0],
-    [0, 2, 0],
-    [0, 0, 2],
-  ]
+  const cubic_2 = cubic_matrix(2)
 
   test(`clip_line_to_cell: axis along z through the origin spans the cell`, () => {
     const seg = clip_line_to_cell([0, 0, 0], [0, 0, 1], cubic_2)

--- a/tests/vitest/symmetry/symmetry-elements.test.ts
+++ b/tests/vitest/symmetry/symmetry-elements.test.ts
@@ -314,7 +314,7 @@ describe(`symmetry_elements_from_ops: space group inventories`, () => {
       for (const op of ops) {
         const elem = classify_symmetry_op(op.rotation, op.translation, centerings)
         if (elem === null) continue
-        expect(elem.label).toMatch(/^(-?[1-6](_[1-5])?|[mabcndg])$/)
+        expect(elem.label).toMatch(/^(?:-?[1-6](?:_[1-5])?|[mabcndg])$/)
         if (elem.axis) {
           // axes are reduced integer vectors with canonical sign
           expect(elem.axis.every((val) => Number.isInteger(val))).toBe(true)
@@ -347,7 +347,7 @@ describe(`symmetry_elements_from_ops: space group inventories`, () => {
     // get intrinsic translation 5/6 along <111> and a bogus "3_0" label
     const elements = elements_for(199)
     for (const elem of elements) {
-      expect(elem.label).toMatch(/^(-?[1-6](_[1-5])?|[mabcndg])$/)
+      expect(elem.label).toMatch(/^(?:-?[1-6](?:_[1-5])?|[mabcndg])$/)
     }
     const labels = new Set(elements.map((elem) => elem.label))
     expect(labels).toContain(`3`)

--- a/tests/vitest/table/index.test.ts
+++ b/tests/vitest/table/index.test.ts
@@ -159,8 +159,8 @@ describe(`calc_cell_color`, () => {
     `interpolateYlOrRd`,
   ] as const)(`produces valid colors with %s scale`, (scale) => {
     const result = calc_cell_color(50, [1, 50, 100], `higher`, scale)
-    expect(result.bg).toMatch(/^(rgb|#)/)
-    expect(result.text).toMatch(/^(black|white)$/)
+    expect(result.bg).toMatch(/^(?:rgb|#)/)
+    expect(result.text).toMatch(/^(?:black|white)$/)
   })
 
   it.each([

--- a/tests/vitest/trajectory/parse.test.ts
+++ b/tests/vitest/trajectory/parse.test.ts
@@ -1620,7 +1620,7 @@ describe(`Trajectory Files with Exact Reference Data`, () => {
   it.each(TRAJECTORY_REFERENCE_DATA)(
     `$file: $frames frames, $atoms atoms`,
     async ({ file, frames, atoms, elements, periodic, format }) => {
-      const is_binary = /\.(h5|hdf5|traj)$/.exec(file)
+      const is_binary = /\.(?:h5|hdf5|traj)$/.exec(file)
       const content = is_binary ? read_binary_test_file(file) : read_test_file(file)
 
       const traj = await parse_trajectory_data(content, file)
@@ -1675,7 +1675,7 @@ describe(`Comprehensive File Coverage`, () => {
   it.each(all_trajectory_files)(
     `should successfully parse sample file: %s`,
     async (filename) => {
-      const is_binary = /\.(h5|hdf5|traj)$/.exec(filename)
+      const is_binary = /\.(?:h5|hdf5|traj)$/.exec(filename)
       const content = is_binary ? read_binary_test_file(filename) : read_test_file(filename)
 
       // Should not throw an error

--- a/tests/vitest/trajectory/trajectory-keyboard.test.ts
+++ b/tests/vitest/trajectory/trajectory-keyboard.test.ts
@@ -3,7 +3,7 @@ import type { TrajectoryType } from '$lib/trajectory'
 import { type ComponentProps, mount, tick, unmount } from 'svelte'
 import { afterEach, describe, expect, test } from 'vitest'
 import {
-  assert_hover_scoped_shortcut,
+  assertHoverScopedShortcut,
   bind_props,
   doc_query,
   make_trajectory_frame,
@@ -50,11 +50,9 @@ describe(`Trajectory keyboard shortcuts`, () => {
     const state = { current_step_idx: 0 }
     const viewer = await mount_trajectory(state)
 
-    await assert_hover_scoped_shortcut({
-      viewer,
-      fire: () => press_window_key({ key: `ArrowRight` }),
-      read_state: () => state.current_step_idx,
-    })
+    const fire = () => press_window_key({ key: `ArrowRight` })
+    const read_state = () => state.current_step_idx
+    await assertHoverScopedShortcut({ viewer, fire, read_state })
   })
 
   test(`suppresses the browser default only for keys it handles`, async () => {

--- a/tests/vitest/xrd/calc-xrd.test.ts
+++ b/tests/vitest/xrd/calc-xrd.test.ts
@@ -20,7 +20,7 @@ const make_simple_cubic_structure = (a_len: number): Crystal =>
 function list_matching_pairs() {
   const pairs = []
   for (const file_name of fs.readdirSync(structures_dir)) {
-    if (!/\.json(\.gz)?$/.test(file_name)) continue
+    if (!/\.json(?:\.gz)?$/.test(file_name)) continue
     const expected: XrdPattern | undefined = xrd_patterns[fixture_id(file_name)]
     if (!expected) continue
     pairs.push({

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,7 @@ import { defineConfig, type PluginOption } from 'vite-plus'
 // @ts-expect-error Node ESM config load needs the .ts extension here
 import { mock_vscode } from './extensions/vscode/tests/vscode-mock.ts'
 
-const TEXT_EXT_RE = /\.(xyz|extxyz|cif|poscar|lammpstrj|yaml\.gz)$/
+const TEXT_EXT_RE = /\.(?:xyz|extxyz|cif|poscar|lammpstrj|yaml\.gz)$/
 const strip_query = (path: string) => path.replace(/\?.*$/, ``)
 const split_query = (path: string): [clean: string, query: string] => {
   const clean = strip_query(path)
@@ -30,7 +30,7 @@ const starry_night_theme_plugin: Plugin = {
   transform(code, id) {
     if (!id.includes(`starry-night/style/both.css`)) return null
     const dark_query =
-      /@media \(prefers-color-scheme:\s*dark\)\s*\{\s*:root\s*\{([^}]*)\}\s*\}/u
+      /@media \(prefers-color-scheme:\s*dark\)\s*\{\s*:root\s*\{(?<dark_rules>[^}]*)\}\s*\}/u
     // warn (don't silently no-op) if upstream restructured both.css and the regex stops matching
     if (!dark_query.test(code))
       this.warn(`starry-night dark-palette query not found; update regex`)


### PR DESCRIPTION
Hi,

first off, thanks for the great work, this extension has proven super useful for me and I use it daily.

I'm currently experiencing a bug where the rotation constantly resets during dragging after changing the supercell settings. I've traced it to a stale camera handle that is not refreshed after supercell settings are changed, making rotation impossible. 
                                                                                                                                                     
### Why                                                                                                                                                 
                                                                                                                                                     
 `bind_renderer` (src/lib/scene/bind-renderer.svelte.ts) reads the active camera once via `threlte.camera.current` in an `$effect`. However, `.current` isn't reactive, so the reference never updates. Then, when a supercell swaps in a new camera, the old one is still held.                                       
                                                                                                                                                     
 The camera-pose write-back in Structure.svelte then reads that stale camera every 200 ms and re-applies its frozen pose to the live camera, which causes the snapping.       
                                                                                                                                                     
### Fix                                                                                                                                                 
                                                                                                                                                     
Subscribe to the camera store rather than reading `.current` once:
 `.current` is not reactively tracked, so a one-shot read goes stale when Threlte's active camera is replaced (e.g. a cell/supercell change remounts the camera). A stale reference leaves consumers — the camera-move write-back, export panes — pointing at a frozen orphan camera while OrbitControls drives the real one, which pins the live camera back to the orphan's pose and breaks rotation. Subscribing re-fires `on_bind` on every camera swap, keeping the bound reference live.