### PR TITLE
Simplifier pass: dedupe $lib helpers and drop redundant branches across extension, components, demos

### DIFF
--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -2,6 +2,7 @@
 // so unicorn's require-post-message-target-origin is a false positive here.
 // oxlint-disable eslint-plugin-unicorn/require-post-message-target-origin
 import { COMPRESSION_EXTENSIONS_REGEX } from '$lib/constants'
+import { to_error } from '$lib/utils'
 import { detect_compression_format } from '$lib/io/decompress'
 import { format_bytes } from '$lib/labels'
 import { DEFAULTS, type DefaultSettings, merge } from '$lib/settings'
@@ -182,17 +183,12 @@ export const read_file = async (file_path: string): Promise<FileData> => {
     file_size = (await vscode.workspace.fs.stat(uri)).size
   } catch (error) {
     console.warn(`Failed to get file stats for ${filename}:`, error)
-    throw new Error(
-      `Failed to access file ${filename}: ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-      { cause: error },
-    )
+    throw new Error(`Failed to access file ${filename}: ${to_error(error).message}`, {
+      cause: error,
+    })
   }
 
-  const threshold = MAX_VSCODE_FILE_SIZE
-
-  if (file_size > threshold) {
+  if (file_size > MAX_VSCODE_FILE_SIZE) {
     return {
       filename,
       content: `LARGE_FILE:${file_path}:${file_size}`,
@@ -208,10 +204,9 @@ export const read_file = async (file_path: string): Promise<FileData> => {
       : Buffer.from(uint8array).toString(`utf8`)
     return { filename, content, is_base64: is_base64_payload }
   } catch (error) {
-    throw new Error(
-      `Failed to read file ${filename}: ${error instanceof Error ? error.message : String(error)}`,
-      { cause: error },
-    )
+    throw new Error(`Failed to read file ${filename}: ${to_error(error).message}`, {
+      cause: error,
+    })
   }
 }
 
@@ -431,7 +426,7 @@ export const handle_msg = async (msg: MessageData, webview?: WebviewLike): Promi
         file_path,
       })
     } catch (error) {
-      const error_message = error instanceof Error ? error.message : String(error)
+      const error_message = to_error(error).message
       console.error(`Failed to setup indexed parsing:`, error_message)
       const { request_id } = msg
       webview.postMessage({ command, request_id, error: error_message })
@@ -454,7 +449,7 @@ export const handle_msg = async (msg: MessageData, webview?: WebviewLike): Promi
       const command = `frame_response`
       webview.postMessage({ command, request_id, frame, frame_index })
     } catch (error) {
-      const error_message = error instanceof Error ? error.message : String(error)
+      const error_message = to_error(error).message
       console.error(`Failed to load frame ${msg.frame_index}:`, error_message)
       webview.postMessage({
         command: `frame_response`,
@@ -471,7 +466,7 @@ export const handle_msg = async (msg: MessageData, webview?: WebviewLike): Promi
         filters: { Files: [`*`] },
       })
 
-      if (uri && msg.content) {
+      if (uri) {
         if (msg.is_binary) {
           is_binary_save = true
           const base64_data = msg.content.replace(/^data:[^;]+;base64,/, ``)
@@ -486,7 +481,7 @@ export const handle_msg = async (msg: MessageData, webview?: WebviewLike): Promi
         vscode.window.showInformationMessage(`Saved: ${path.basename(uri.fsPath)}`)
       }
     } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error)
+      const message = to_error(error).message
       const error_type = is_binary_save ? `binary data` : `text file`
       vscode.window.showErrorMessage(`Failed to save ${error_type}: ${message}`)
     }
@@ -597,10 +592,8 @@ function stop_watching_file(file_path: string): void {
     active_watchers.delete(file_path)
   }
 
-  // Also clean up frame loader for this file
-  if (active_frame_loaders.has(file_path)) {
-    active_frame_loaders.delete(file_path)
-  }
+  // Also clean up frame loader for this file (no-op when absent)
+  active_frame_loaders.delete(file_path)
 }
 
 // Resolve which ViewColumn to use based on user settings and explicit override
@@ -686,7 +679,7 @@ export const render = async (
 
     create_webview_panel(context, file, file_path)
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error)
+    const message = to_error(error).message
     vscode.window.showErrorMessage(`Failed: ${message}`)
   }
 }
@@ -766,7 +759,7 @@ class Provider implements vscode.CustomReadonlyEditorProvider {
       })
       // Note: webview_panel disposal is managed by VSCode for custom editors
     } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error)
+      const message = to_error(error).message
       vscode.window.showErrorMessage(`Failed: ${message}`)
     }
   }
@@ -802,8 +795,9 @@ export const activate = (context: vscode.ExtensionContext) => {
           clearTimeout(existing_timer)
           auto_render_timers.delete(file_path)
         }
-        if (active_auto_render_panels.has(file_path)) {
-          active_auto_render_panels.get(file_path)?.reveal(vscode.ViewColumn.One)
+        const existing_panel = active_auto_render_panels.get(file_path)
+        if (existing_panel) {
+          existing_panel.reveal(vscode.ViewColumn.One)
           return
         }
 
@@ -962,7 +956,7 @@ async function report_bug(): Promise<void> {
       )
     }
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error)
+    const message = to_error(error).message
     vscode.window.showErrorMessage(`Failed to collect debug information: ${message}`)
   }
 }

--- a/extensions/vscode/src/webview/parse.ts
+++ b/extensions/vscode/src/webview/parse.ts
@@ -13,6 +13,7 @@ import { parse_volumetric_file } from '$lib/isosurface/parse'
 import { is_vaspwave_filename, parse_vaspwave_charge } from '$lib/isosurface/parse-vaspwave'
 import { parse_structure_file } from '$lib/structure/parse'
 import type { TrajectoryType } from '$lib/trajectory'
+import { parse_num_token } from '$lib/utils'
 import { is_trajectory_file, parse_trajectory_data } from '$lib/trajectory/parse'
 import type { VaspoutElectronicData } from '$lib/trajectory/parse/vaspout-electronic'
 import type { ViewType } from '../types'
@@ -72,10 +73,9 @@ export const parse_large_file_marker = (
   if (size_separator_idx <= 0) throw new Error(`Malformed large file marker`)
 
   const file_path = payload.slice(0, size_separator_idx)
-  const size_text = payload.slice(size_separator_idx + 1)
-  const file_size = Number(size_text)
-  // reject empty/whitespace size segments explicitly since Number(``) === 0
-  if (!size_text.trim() || !Number.isSafeInteger(file_size) || file_size < 0) {
+  // parse_num_token maps empty/whitespace size segments to NaN (Number(``) is 0)
+  const file_size = parse_num_token(payload.slice(size_separator_idx + 1))
+  if (!Number.isSafeInteger(file_size) || file_size < 0) {
     throw new Error(`Malformed large file size`)
   }
   return { file_path, file_size }

--- a/src/lib/chempot-diagram/ChemPotDiagram3D.svelte
+++ b/src/lib/chempot-diagram/ChemPotDiagram3D.svelte
@@ -1769,9 +1769,8 @@
     const projections = display.projections
     if (!projections) return []
     const [r0, r1, r2] = niced_range
-    const s0 = (r0[1] - r0[0]) * (display.projection_scale ?? 0.5)
-    const s1 = (r1[1] - r1[0]) * (display.projection_scale ?? 0.5)
-    const s2 = (r2[1] - r2[0]) * (display.projection_scale ?? 0.5)
+    const projection_scale = display.projection_scale ?? 0.5
+    const [s0, s1, s2] = niced_range.map(([lo, hi]) => (hi - lo) * projection_scale)
     const planes: {
       key: string
       pos: Vec3
@@ -2100,7 +2099,7 @@
             <label>
               <input
                 type="checkbox"
-                checked={formulas_to_draw.includes(formula)}
+                checked={formula_overlay_idx !== -1}
                 onchange={() => toggle_formula_selection(formula)}
               />
               <span

--- a/src/lib/convex-hull/ConvexHull3D.svelte
+++ b/src/lib/convex-hull/ConvexHull3D.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { D3InterpolateName } from '$lib/colors'
+  import { clamp01 } from '$lib/utils'
   import {
     add_alpha,
     AXIS_COLORS,
@@ -796,7 +797,7 @@
     const denom = Math.max(1e-6, max_fe - min_fe)
     return (value: number) => {
       // alpha 0 at 0 eV, goes to hull_face_opacity at most negative energy
-      const energy_fraction = Math.max(0, Math.min(1, (value - min_fe) / denom))
+      const energy_fraction = clamp01((value - min_fe) / denom)
       const alpha = (1 - energy_fraction) * hull_face_opacity
       return add_alpha(hull_face_color, alpha)
     }

--- a/src/lib/fermi-surface/FermiSurfaceScene.svelte
+++ b/src/lib/fermi-surface/FermiSurfaceScene.svelte
@@ -208,9 +208,6 @@
 
   // Get color for a surface/vertex
   function get_surface_color(surface: Isosurface, vertex_idx?: number): string {
-    if (color_property === `band`) {
-      return constants.BAND_COLORS[surface.band_index % constants.BAND_COLORS.length]
-    }
     if (
       (color_property === `velocity` || color_property === `custom`) &&
       surface.properties &&

--- a/src/lib/fermi-surface/parse.ts
+++ b/src/lib/fermi-surface/parse.ts
@@ -1,7 +1,12 @@
 // Parsers for Fermi surface file formats (BXSF, FRMSF, JSON)
 import type { Matrix3x3, Vec3 } from '$lib/math'
 import * as math from '$lib/math'
-import { is_plain_object, normalize_scientific_notation, parse_leading_num } from '$lib/utils'
+import {
+  is_plain_object,
+  normalize_scientific_notation,
+  parse_leading_num,
+  to_error,
+} from '$lib/utils'
 import * as constants from './constants'
 import { compute_vertex_normals } from '$lib/marching-cubes'
 import type {
@@ -522,7 +527,7 @@ export function parse_fermi_file(
     try {
       return parse()
     } catch (error) {
-      errors.push(`${format}: ${error instanceof Error ? error.message : String(error)}`)
+      errors.push(`${format}: ${to_error(error).message}`)
       console.error(`${format} parse error:`, error)
       return null
     }

--- a/src/lib/io/decompress.ts
+++ b/src/lib/io/decompress.ts
@@ -70,13 +70,14 @@ export async function decompress_file(
   file: File,
 ): Promise<{ content: string | ArrayBuffer; filename: string }> {
   const format = detect_compression_format(file.name)
-  const is_supported_compression =
-    format !== null && format !== `zip` && format !== `xz` && format !== `bz2`
+  // zip/xz/bz2 are handled by their own code paths; null = not compressed
+  const decompressible =
+    format !== null && format !== `zip` && format !== `xz` && format !== `bz2` ? format : null
   const buffer = await file.arrayBuffer()
 
-  if (is_supported_compression && format) {
+  if (decompressible) {
     const filename = file.name.replace(COMPRESSION_EXTENSIONS_REGEX, ``)
-    const decompressed = await decompress_data_binary(buffer, format)
+    const decompressed = await decompress_data_binary(buffer, decompressible)
     return { content: to_content(filename, decompressed), filename }
   }
   return { content: to_content(file.name, buffer), filename: file.name }

--- a/src/lib/layout/fullscreen.ts
+++ b/src/lib/layout/fullscreen.ts
@@ -17,12 +17,10 @@ export type InfoItem = Readonly<{
 export async function toggle_fullscreen(wrapper?: HTMLDivElement): Promise<void> {
   if (!wrapper || !wrapper.isConnected) return
   try {
-    if (!document.fullscreenElement) {
-      await wrapper.requestFullscreen()
-    } else if (document.fullscreenElement === wrapper) {
+    if (document.fullscreenElement === wrapper) {
       await document.exitFullscreen()
     } else {
-      await document.exitFullscreen()
+      if (document.fullscreenElement) await document.exitFullscreen()
       await wrapper.requestFullscreen()
     }
   } catch (error) {

--- a/src/lib/layout/json-tree/utils.ts
+++ b/src/lib/layout/json-tree/utils.ts
@@ -325,6 +325,14 @@ export function parse_path(path: string): (string | number)[] {
   let current = ``
   let in_bracket = false
 
+  // Bracket tokens are numeric indices or quoted keys (quotes stripped, \" unescaped)
+  const push_bracket_token = (token: string): void => {
+    const num = Number(token)
+    if (Number.isNaN(num)) {
+      segments.push(token.replaceAll(/^"|"$/g, ``).replaceAll(String.raw`\"`, `"`))
+    } else segments.push(num)
+  }
+
   for (const char of path) {
     if (char === `.` && !in_bracket) {
       if (current) segments.push(current)
@@ -334,15 +342,7 @@ export function parse_path(path: string): (string | number)[] {
       current = ``
       in_bracket = true
     } else if (char === `]`) {
-      if (current) {
-        // Check if it's a number index
-        const num = Number(current)
-        if (Number.isNaN(num)) {
-          // Remove surrounding quotes and unescape internal quotes
-          const unquoted = current.replaceAll(/^"|"$/g, ``).replaceAll(String.raw`\"`, `"`)
-          segments.push(unquoted)
-        } else segments.push(num)
-      }
+      if (current) push_bracket_token(current)
       current = ``
       in_bracket = false
     } else current += char
@@ -350,14 +350,8 @@ export function parse_path(path: string): (string | number)[] {
 
   // Handle trailing content (e.g., unclosed bracket like "a[0")
   if (current) {
-    if (in_bracket) {
-      // Apply same numeric/quoted-string logic as inside brackets
-      const num = Number(current)
-      if (Number.isNaN(num)) {
-        const unquoted = current.replaceAll(/^"|"$/g, ``).replaceAll(String.raw`\"`, `"`)
-        segments.push(unquoted)
-      } else segments.push(num)
-    } else segments.push(current)
+    if (in_bracket) push_bracket_token(current)
+    else segments.push(current)
   }
 
   return segments

--- a/src/lib/phase-diagram/utils.ts
+++ b/src/lib/phase-diagram/utils.ts
@@ -145,8 +145,7 @@ export function get_phase_color_key(name: string): PhaseColorKey {
 
 // Get phase color - returns rgba() by default, or RGB string if format='rgb'
 export function get_phase_color(name: string, format: `rgba` | `rgb` = `rgba`): string {
-  const lower = name.toLowerCase().trim()
-  const key: PhaseColorKey = lower.includes(`+`) ? `two_phase` : get_phase_color_key(name)
+  const key: PhaseColorKey = name.includes(`+`) ? `two_phase` : get_phase_color_key(name)
   return format === `rgb` ? PHASE_COLOR_RGB[key] : PHASE_COLORS[key]
 }
 

--- a/src/lib/plot/scatter/ScatterPlot.svelte
+++ b/src/lib/plot/scatter/ScatterPlot.svelte
@@ -966,8 +966,7 @@
 
     // Fallback estimate (with room for tick labels) used before the colorbar first
     // renders; compute_element_placement measures the real footprint once it's laid out
-    const is_horizontal = (color_bar.orientation ?? `horizontal`) === `horizontal`
-    const colorbar_size = is_horizontal
+    const colorbar_size = colorbar_is_horizontal
       ? COLOR_BAR_DEFAULTS.horizontal_footprint
       : COLOR_BAR_DEFAULTS.vertical_footprint
 

--- a/src/lib/spectral/helpers.ts
+++ b/src/lib/spectral/helpers.ts
@@ -1261,11 +1261,14 @@ export function compute_frequency_range(
   }
 
   if (!Number.isFinite(min_val) || !Number.isFinite(max_val)) return undefined
-  const clamp_min =
+  // clamp phonon noise to 0
+  if (
     is_phonon &&
-    min_val < 0 && // clamp phonon noise to 0
+    min_val < 0 &&
     negative_fraction(all_freqs) < IMAGINARY_MODE_NOISE_THRESHOLD
-  if (clamp_min) min_val = 0
+  ) {
+    min_val = 0
+  }
   // Calculate padding from (possibly clamped) range for consistency with Bands.svelte
   const padding = (max_val - min_val) * padding_factor
   return [min_val === 0 ? 0 : min_val - padding, max_val + padding]

--- a/src/lib/structure/StructureControls.svelte
+++ b/src/lib/structure/StructureControls.svelte
@@ -377,6 +377,7 @@
     </label>
     {#if available_vector_keys.length > 0}
       {#each available_vector_keys as key, idx (key)}
+        {@const key_visible = is_key_visible(key)}
         <label
           {@attach tooltip({
             content: `Toggle ${key} vectors`,
@@ -385,8 +386,8 @@
         >
           <input
             type="checkbox"
-            checked={is_key_visible(key)}
-            onchange={() => update_vector_config(key, { visible: !is_key_visible(key) })}
+            checked={key_visible}
+            onchange={() => update_vector_config(key, { visible: !key_visible })}
           />
           <input
             type="color"

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -400,7 +400,6 @@
       if (measure_mode === `edit-atoms`) {
         const site = structure?.sites?.[hovered_idx]
         if (site?.properties?.orig_site_idx != null) return `not-allowed`
-        return `pointer`
       }
       return `pointer`
     }

--- a/src/routes/(demos)/plot/data-cleaning/+page.svelte
+++ b/src/routes/(demos)/plot/data-cleaning/+page.svelte
@@ -157,12 +157,9 @@
   })
 
   // Derived: instability detection result
-  let instability_result = $derived.by(() => {
-    return detect_instability(raw_data.x, raw_data.y, {
-      oscillation_threshold,
-      window_size,
-    })
-  })
+  let instability_result = $derived(
+    detect_instability(raw_data.x, raw_data.y, { oscillation_threshold, window_size }),
+  )
 
   // Shared helper: find interpolated value at an index by averaging nearest valid neighbors
   // Used by removed_points, find_nan_positions, and find_trajectory_nan_positions
@@ -253,12 +250,12 @@
     return { x: time, y_arrays: [temperature, pressure] }
   })
 
-  let multi_series_cleaned = $derived.by(() => {
-    return clean_multi_series(multi_series_data.x, multi_series_data.y_arrays, {
+  let multi_series_cleaned = $derived(
+    clean_multi_series(multi_series_data.x, multi_series_data.y_arrays, {
       invalid_values: invalid_mode,
       in_place: false,
-    })
-  })
+    }),
+  )
 
   // Helper: find interpolated y-value for NaN positions in an array
   function find_nan_positions(

--- a/src/routes/(demos)/structure/coordination/+page.svelte
+++ b/src/routes/(demos)/structure/coordination/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { sanitize_html } from '$lib/sanitize'
+  import { clamp01 } from '$lib/utils'
   import { type Crystal, SETTINGS_CONFIG } from '$lib'
   import { PLOT_COLORS } from '$lib/colors'
   import { get_electro_neg_formula } from '$lib/composition'
@@ -16,8 +17,7 @@
 
   // Helper: convert #rrggbb to #rrggbbaa
   function hex_with_alpha(hex_color: string, alpha_frac: number): string {
-    const clamped = Math.max(0, Math.min(1, alpha_frac))
-    const alpha_byte = Math.round(clamped * 255)
+    const alpha_byte = Math.round(clamp01(alpha_frac) * 255)
     const alpha_hex = alpha_byte.toString(16).padStart(2, `0`)
     return hex_color.length === 7 ? `${hex_color}${alpha_hex}` : hex_color
   }

--- a/src/routes/(demos)/structure/isosurface/+page.svelte
+++ b/src/routes/(demos)/structure/isosurface/+page.svelte
@@ -70,7 +70,7 @@
       structure = parse_any_structure(text, filename)
       volumetric_data = undefined
     } catch (exc) {
-      error_msg = `Failed to parse ${filename}: ${exc instanceof Error ? exc.message : exc}`
+      error_msg = `Failed to parse ${filename}: ${to_error(exc).message}`
     }
   }
 

--- a/src/routes/(demos)/structure/xrd/+page.svelte
+++ b/src/routes/(demos)/structure/xrd/+page.svelte
@@ -9,7 +9,7 @@
   import { compute_xrd_pattern, XrdPlot } from '$lib/xrd'
   import { structures } from '$site/structures'
   import { SvelteMap } from 'svelte/reactivity'
-  import { to_error } from '$lib/utils'
+  import { clamp01, to_error } from '$lib/utils'
 
   // Auto-discover XRD data files from static/xrd/ (served at /xrd/<name>); restart the dev
   // server to pick up newly added files. Both plain and gzipped (.gz) formats are supported.
@@ -70,8 +70,7 @@
 
   // Helper: convert #rrggbb to #rrggbbaa
   function hex_with_alpha(hex_color: string, alpha_frac: number): string {
-    const clamped = Math.max(0, Math.min(1, alpha_frac))
-    const alpha_byte = Math.round(clamped * 255)
+    const alpha_byte = Math.round(clamp01(alpha_frac) * 255)
     const alpha_hex = alpha_byte.toString(16).padStart(2, `0`)
     return hex_color.length === 7 ? `${hex_color}${alpha_hex}` : hex_color
   }
@@ -90,11 +89,12 @@
     }
     try {
       compute_error = null
-      const cached = xrd_cache.get(get_struct_id(struct))
+      const struct_id = get_struct_id(struct)
+      const cached = xrd_cache.get(struct_id)
       if (cached) computed_pattern = cached
       else {
         const result = compute_xrd_pattern(struct)
-        xrd_cache.set(get_struct_id(struct), result)
+        xrd_cache.set(struct_id, result)
         computed_pattern = result
       }
     } catch (exc) {

--- a/src/site/FermiSurfaceDemo.svelte
+++ b/src/site/FermiSurfaceDemo.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { browser } from '$app/environment'
+  import { to_error } from '$lib/utils'
   import { goto } from '$app/navigation'
   import { page } from '$app/state'
   import type { FileInfo } from '$lib'
@@ -74,7 +75,7 @@
         }
       })
     } catch (error) {
-      error_msg = error instanceof Error ? error.message : String(error)
+      error_msg = to_error(error).message
     } finally {
       loading = false
     }


### PR DESCRIPTION
Salvaged remainder of the original simplify-pass-2 branch, rebuilt on current `main` (the stale pre-merge copy of #370 that made this PR show +12k lines and heavy conflicts is gone). One commit, 19 files, net −12 lines, all behavior-preserving:

- **extensions/vscode/extension.ts**: replace 8 hand-rolled `error instanceof Error ? error.message : String(error)` coercions with `$lib`'s `to_error`, drop a pointless `MAX_VSCODE_FILE_SIZE` alias, an unreachable `event_type` guard (the delete branch returns above it), a redundant `msg.content` re-check, and two has-before-get/delete Map dances
- **extensions/vscode/webview/parse.ts**: `parse_large_file_marker` uses `$lib`'s `parse_num_token` (maps empty/whitespace size segments to NaN) instead of `Number()` plus a manual blank-string check — re-targeted here from `main.ts` since the parse path moved in #372
- **Dedupe into `$lib` helpers**: `to_error` (fermi parse + isosurface/fermi demos), `clamp01` (ConvexHull3D + two demo `hex_with_alpha` copies)
- **ChemPotDiagram3D**: compute the projection scale once via a single `.map` over `niced_range` instead of three times; reuse `formula_overlay_idx` for the overlay checkbox
- **ScatterPlot**: reuse the existing `colorbar_is_horizontal` derived for the fallback footprint
- **StructureControls**: hoist `is_key_visible(key)` into an `{@const}` instead of calling it twice per vector row
- **StructureScene**: remove a redundant edit-atoms `return \`pointer\`` that falls through to the identical outer return
- **FermiSurfaceScene**: drop the band-color branch identical to the final fallback
- **Misc**: json-tree `parse_path` shares one `push_bracket_token` for its duplicated numeric/quoted-key logic; fullscreen toggle collapses to two branches; `get_phase_color` drops an unused lowercased copy; `decompress.ts` narrows the format once instead of double-checking; spectral `compute_frequency_range` inlines its single-use `clamp_min` flag

Dropped from the original pass because current `main` already has equivalent or newer code: the Structure.svelte supercell try/catch (superseded by `make_supercell_safe` + failure toast), the HeatmapTable `handle_drop` finally-reset (superseded by `reset_drag_state`), and the PeriodicTableDemo null-guard removal (the guard is still required for narrowing inside the closure).