### PR TITLE
Sanitize 3D chemical-potential labels and SSR fallbacks

### DIFF
--- a/src/lib/chempot-diagram/ChemPotDiagram3D.svelte
+++ b/src/lib/chempot-diagram/ChemPotDiagram3D.svelte
@@ -21,6 +21,7 @@
   import DraggablePane from '$lib/overlays/DraggablePane.svelte'
   import { ColorBar, ScatterPlot3DControls } from '$lib/plot'
   import { page_visibility } from '$lib/scene'
+  import { sanitize_html } from '$lib/sanitize'
   import { constrain_tooltip_position, pad_rect, rects_overlap } from '$lib/plot/core/layout'
   import type {
     AxisConfig3D,
@@ -2485,7 +2486,9 @@
                 portal={wrapper}
                 zIndexRange={[1, 0]}
               >
-                <span class="axis-label" style:color={gc.color}>{@html gc.label}</span>
+                <span class="axis-label" style:color={gc.color}
+                  >{@html sanitize_html(gc.label)}</span
+                >
               </extras.HTML>
             {/if}
           {/each}

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -14,6 +14,14 @@ const ensure_token = (value: string, token: string): string => {
   return [...tokens].join(` `)
 }
 
+const escape_html = (value: string): string =>
+  value
+    .replaceAll(`&`, `&amp;`)
+    .replaceAll(`<`, `&lt;`)
+    .replaceAll(`>`, `&gt;`)
+    .replaceAll(`"`, `&quot;`)
+    .replaceAll(`'`, `&#39;`)
+
 // undefined = not yet checked, null = no DOM available, instance = ready
 let purify: ReturnType<typeof DOMPurify> | null | undefined
 
@@ -51,7 +59,7 @@ function sanitize_svg_content(
   allowed_attrs: string[],
 ): string {
   const dp = get_purify()
-  if (!dp) return html
+  if (!dp) return escape_html(html)
   const wrapped = dp.sanitize(`<svg>${html}</svg>`, {
     ALLOWED_TAGS: [...allowed_tags, `svg`],
     ALLOWED_ATTR: allowed_attrs,
@@ -89,7 +97,7 @@ export function sanitize_html(html: unknown): string {
   const cached = sanitize_cache.get(str)
   if (cached !== undefined) return cached
   const dp = get_purify()
-  if (!dp) return str // no DOM (SSR): return as-is, don't cache
+  if (!dp) return escape_html(str) // no DOM (SSR): render inert text, don't cache
   // oxfmt-ignore
   const safe = dp.sanitize(str, { ADD_ATTR: [`target`], FORBID_TAGS: [
     `script`, `style`, `iframe`, `object`, `embed`, `form`, `input`, `textarea`,

--- a/tests/vitest/chempot-diagram/MockThrelteNode.svelte
+++ b/tests/vitest/chempot-diagram/MockThrelteNode.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  let { children, ref = $bindable(), ...rest } = $props()
+</script>
+
+{@render children?.()}

--- a/tests/vitest/chempot-diagram/rendering.test.ts
+++ b/tests/vitest/chempot-diagram/rendering.test.ts
@@ -1,12 +1,46 @@
 import { readFileSync } from 'node:fs'
 import process from 'node:process'
-import { sanitize_html } from '$lib/sanitize'
-import { describe, expect, test } from 'vitest'
+import type { PhaseData } from '$lib/convex-hull/types'
+import MockThrelteNode from './MockThrelteNode.svelte'
+import { mount, tick, unmount } from 'svelte'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+vi.mock(`@threlte/core`, () => ({
+  Canvas: MockThrelteNode,
+  T: new Proxy({}, { get: () => MockThrelteNode }),
+}))
+vi.mock(`@threlte/extras`, () => ({
+  HTML: MockThrelteNode,
+  OrbitControls: MockThrelteNode,
+  interactivity: vi.fn(),
+}))
+
+const { default: ChemPotDiagram3D } = await import(
+  `$lib/chempot-diagram/ChemPotDiagram3D.svelte`
+)
 
 const chempot_3d_source = readFileSync(
   `${process.cwd()}/src/lib/chempot-diagram/ChemPotDiagram3D.svelte`,
   `utf8`,
 )
+
+const entries: PhaseData[] = [
+  { composition: { Fe: 1 }, energy: -6.7, energy_per_atom: -6.7 },
+  { composition: { Li: 1 }, energy: -1.9, energy_per_atom: -1.9 },
+  { composition: { O: 1 }, energy: -8.0, energy_per_atom: -8.0 },
+  { composition: { Fe: 1, O: 1 }, energy: -17.0, energy_per_atom: -8.5 },
+  { composition: { Li: 1, O: 1 }, energy: -10.5, energy_per_atom: -5.25 },
+  { composition: { Fe: 1, Li: 1, O: 2 }, energy: -29.0, energy_per_atom: -7.25 },
+]
+
+let mounted: ReturnType<typeof mount> | undefined
+
+afterEach(() => {
+  if (mounted) {
+    void unmount(mounted)
+    mounted = undefined
+  }
+})
 
 describe(`ChemPotDiagram3D rendering contracts`, () => {
   test(`clips HTML portal labels at the component root`, () => {
@@ -16,14 +50,45 @@ describe(`ChemPotDiagram3D rendering contracts`, () => {
     )
   })
 
-  test(`sanitizes generated and custom axis labels at the raw-HTML sink`, () => {
-    expect(chempot_3d_source).toContain(`import { sanitize_html } from '$lib/sanitize'`)
-    expect(chempot_3d_source).toMatch(/\{@html sanitize_html\(gc\.label\)\}/)
+  test(`sanitizes custom axis labels at the rendered raw-HTML sink`, async () => {
+    Object.defineProperty(globalThis, `WebGLRenderingContext`, {
+      value: class WebGLRenderingContext {
+        getExtension(): null {
+          return null
+        }
+      },
+      configurable: true,
+    })
+    mounted = mount(ChemPotDiagram3D, {
+      target: document.body,
+      props: {
+        entries,
+        config: { elements: [`Fe`, `Li`, `O`], formal_chempots: false },
+        width: 850,
+        height: 650,
+        controls_open: true,
+        fullscreen_toggle: false,
+      },
+    })
+    for (let idx = 0; idx < 8; idx++) await tick()
 
-    const payload = `Δμ<sub><img src=x onerror=alert(1)></sub> <span class="axis-unit">(eV)</span>`
-    const rendered = sanitize_html(payload)
-    expect(rendered).not.toContain(`<img`)
-    expect(rendered).not.toMatch(/onerror\s*=/i)
-    expect(rendered).toContain(`<span class="axis-unit">(eV)</span>`)
+    const input = document.querySelector<HTMLInputElement>(`input[aria-label="X label"]`)
+    if (!(input instanceof HTMLInputElement)) {
+      throw new Error(`Expected X label input to render`)
+    }
+    const payload = `MZ_AXIS_SENTINEL <img src=x onerror=alert(1)> <span class="axis-unit">(eV)</span>`
+    input.value = payload
+    input.dispatchEvent(new Event(`input`, { bubbles: true }))
+    await tick()
+
+    const axis_label = Array.from(document.querySelectorAll<HTMLElement>(`.axis-label`)).find(
+      (label) => label.textContent?.includes(`MZ_AXIS_SENTINEL`),
+    )
+    if (!(axis_label instanceof HTMLElement)) {
+      throw new Error(`Expected custom axis label to render`)
+    }
+    expect(axis_label.querySelector(`img`)).toBeNull()
+    expect(axis_label.innerHTML).not.toMatch(/\son\w+\s*=/i)
+    expect(axis_label.querySelector(`span.axis-unit`)?.textContent).toBe(`(eV)`)
   })
 })

--- a/tests/vitest/chempot-diagram/rendering.test.ts
+++ b/tests/vitest/chempot-diagram/rendering.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs'
 import process from 'node:process'
+import { sanitize_html } from '$lib/sanitize'
 import { describe, expect, test } from 'vitest'
 
 const chempot_3d_source = readFileSync(
@@ -13,5 +14,16 @@ describe(`ChemPotDiagram3D rendering contracts`, () => {
     expect(chempot_3d_source).toMatch(
       /\.chempot-diagram-3d\s*\{\s*position:\s*relative;\s*overflow:\s*clip;/,
     )
+  })
+
+  test(`sanitizes generated and custom axis labels at the raw-HTML sink`, () => {
+    expect(chempot_3d_source).toContain(`import { sanitize_html } from '$lib/sanitize'`)
+    expect(chempot_3d_source).toMatch(/\{@html sanitize_html\(gc\.label\)\}/)
+
+    const payload = `Δμ<sub><img src=x onerror=alert(1)></sub> <span class="axis-unit">(eV)</span>`
+    const rendered = sanitize_html(payload)
+    expect(rendered).not.toContain(`<img`)
+    expect(rendered).not.toMatch(/onerror\s*=/i)
+    expect(rendered).toContain(`<span class="axis-unit">(eV)</span>`)
   })
 })

--- a/tests/vitest/sanitize-ssr.test.ts
+++ b/tests/vitest/sanitize-ssr.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test, vi } from 'vitest'
+
+type Sanitizers = {
+  sanitize_html: (html: unknown) => string
+  sanitize_svg: (html: string) => string
+  sanitize_icon_svg: (html: string) => string
+}
+
+const without_browser_dom = async (run: (sanitizers: Sanitizers) => void) => {
+  const win = globalThis.window
+  try {
+    // @ts-expect-error - SSR simulation
+    globalThis.window = undefined
+    vi.resetModules()
+    const sanitizers = await import(`$lib/sanitize`)
+    run(sanitizers)
+  } finally {
+    globalThis.window = win
+    vi.resetModules()
+  }
+}
+
+describe(`sanitizers without a browser DOM`, () => {
+  test.each([
+    `<img src=x onerror=alert(1)>`,
+    `<script>alert(1)</script>`,
+    `<a href="javascript:alert(1)">click</a>`,
+  ])(`escapes unsafe HTML instead of returning markup: %s`, async (payload) => {
+    await without_browser_dom(({ sanitize_html }) => {
+      const result = sanitize_html(payload)
+      expect(result).not.toContain(`<`)
+      expect(result).toContain(`&lt;`)
+    })
+  })
+
+  test(`escapes otherwise-safe formatting because it cannot be verified`, async () => {
+    await without_browser_dom(({ sanitize_html }) => {
+      expect(sanitize_html(`Li<sub>2</sub>O`)).toBe(`Li&lt;sub&gt;2&lt;/sub&gt;O`)
+    })
+  })
+
+  test.each([`sanitize_svg`, `sanitize_icon_svg`] as const)(
+    `escapes SVG markup when DOMPurify is unavailable`,
+    async (sanitizer_name) => {
+      await without_browser_dom((sanitizers) => {
+        const result = sanitizers[sanitizer_name](`<path d="M0 0" onload="alert(1)" />`)
+        expect(result).not.toContain(`<path`)
+        expect(result).toContain(`&lt;path`)
+      })
+    },
+  )
+})


### PR DESCRIPTION
## Summary

This draft PR fixes two security findings from the Codex global code scan after reproducing both issues locally:

- Fixes #378 by sanitizing `ChemPotDiagram3D` axis labels at the final raw HTML sink.
- Fixes #379 by making sanitizer SSR/no-DOM fallbacks render escaped inert text instead of returning raw markup.

## Root Cause

`ChemPotDiagram3D` rendered `gc.label` with Svelte `{@html}`. Axis labels can be customized through the 3D plot controls, so a malicious label could become real DOM under `.axis-label`.

The shared sanitizer helpers also returned raw input when DOMPurify was unavailable. In SSR or other no-DOM contexts, that meant callers could receive unescaped HTML/SVG instead of inert text.

## What Changed

- Route 3D chemical-potential axis labels through `sanitize_html(gc.label)` at the render sink.
- Add a component-level regression test that mounts `ChemPotDiagram3D`, drives the existing `X label` control with a malicious payload, and inspects the rendered `.axis-label` DOM.
- Add no-DOM regression coverage for `sanitize_html`, `sanitize_svg`, and `sanitize_icon_svg`.
- Escape no-DOM sanitizer output without writing those escaped values into the browser sanitizer cache.

## Notes

I am opening this as a draft for maintainer review because it comes from a repository-wide Codex scan and is intentionally scoped to the reproduced security issues.