### PR TITLE
Correct nonorthogonal coordinate and normal transforms

### DIFF
--- a/src/lib/brillouin/geometry.ts
+++ b/src/lib/brillouin/geometry.ts
@@ -39,11 +39,11 @@ export function polyhedron_geometry(
   return geometry
 }
 
-// Inverse of the reciprocal lattice for Cartesian -> fractional conversion; null if the lattice is missing or singular
+// Inverse of the transposed row-vector reciprocal lattice for Cartesian -> fractional conversion
 export function k_lattice_inverse(k_lattice: Matrix3x3 | undefined): Matrix3x3 | null {
   if (!k_lattice) return null
   try {
-    return math.matrix_inverse_3x3(k_lattice)
+    return math.create_cart_to_frac_matrix(k_lattice)
   } catch {
     return null
   }

--- a/src/lib/marching-cubes.ts
+++ b/src/lib/marching-cubes.ts
@@ -1,6 +1,6 @@
 // Marching Cubes algorithm for isosurface extraction
 // Based on the classic algorithm by Lorensen & Cline (1987)
-import type { Matrix3x3, Vec3 } from '$lib/math'
+import { mat3x3_vec3_multiply, matrix_inverse_3x3, type Matrix3x3, type Vec3 } from '$lib/math'
 
 const wrap_grid_idx = (val: number, dim: number) => ((val % dim) + dim) % dim
 const clamp_grid_idx = (val: number, max: number) => Math.max(0, Math.min(val, max))
@@ -362,14 +362,17 @@ function compute_gradient(
     ? [wrap_grid_idx(iz - 1, nz), wrap_grid_idx(iz + 1, nz)]
     : [Math.max(0, iz - 1), Math.min(nz - 1, iz + 1)]
 
-  const dx = (grid[ix_p][iy_w][iz_w] - grid[ix_m][iy_w][iz_w]) * 0.5
-  const dy = (grid[ix_w][iy_p][iz_w] - grid[ix_w][iy_m][iz_w]) * 0.5
-  const dz = (grid[ix_w][iy_w][iz_p] - grid[ix_w][iy_w][iz_m]) * 0.5
+  const dx =
+    (grid[ix_p][iy_w][iz_w] - grid[ix_m][iy_w][iz_w]) *
+    (periodic ? 0.5 : 1 / Math.max(1, ix_p - ix_m))
+  const dy =
+    (grid[ix_w][iy_p][iz_w] - grid[ix_w][iy_m][iz_w]) *
+    (periodic ? 0.5 : 1 / Math.max(1, iy_p - iy_m))
+  const dz =
+    (grid[ix_w][iy_w][iz_p] - grid[ix_w][iy_w][iz_m]) *
+    (periodic ? 0.5 : 1 / Math.max(1, iz_p - iz_m))
 
-  const len_sq = dx * dx + dy * dy + dz * dz
-  if (len_sq < 1e-20) return [0, 0, 1]
-  const inv_len = 1 / Math.sqrt(len_sq)
-  return [-dx * inv_len, -dy * inv_len, -dz * inv_len]
+  return [-dx, -dy, -dz]
 }
 
 // Main marching cubes algorithm (optimized version)
@@ -434,6 +437,7 @@ function marching_cubes_raw(
   const inv_nx = 1 / (periodic ? nx : nx - 1)
   const inv_ny = 1 / (periodic ? ny : ny - 1)
   const inv_nz = 1 / (periodic ? nz : nz - 1)
+  const normal_transform = compute_norms ? matrix_inverse_3x3(k_lattice) : null
 
   // Get or create vertex on an edge (fully optimized with flat array lookups)
   const get_vertex_on_edge = (
@@ -508,8 +512,28 @@ function marching_cubes_raw(
     )
 
     // Compute normal from grid gradient (skip if caller will compute from geometry)
-    if (compute_norms) {
-      const normal = compute_gradient(grid, ix + ox1, iy + oy1, iz + oz1, nx, ny, nz, periodic)
+    if (normal_transform) {
+      const grid_gradient = compute_gradient(
+        grid,
+        ix + ox1,
+        iy + oy1,
+        iz + oz1,
+        nx,
+        ny,
+        nz,
+        periodic,
+      )
+      const fractional_gradient: Vec3 = [
+        grid_gradient[0] / inv_nx,
+        grid_gradient[1] / inv_ny,
+        grid_gradient[2] / inv_nz,
+      ]
+      const cartesian_normal = mat3x3_vec3_multiply(normal_transform, fractional_gradient)
+      const length = Math.hypot(...cartesian_normal)
+      const normal: Vec3 =
+        length > 1e-10
+          ? (cartesian_normal.map((component) => component / length) as Vec3)
+          : [0, 0, 1]
       normals.push(normal[0], normal[1], normal[2])
     }
 

--- a/tests/vitest/brillouin-compute.test.ts
+++ b/tests/vitest/brillouin-compute.test.ts
@@ -632,6 +632,19 @@ describe(`k_lattice_inverse + cartesian_to_fractional`, () => {
     expect(cartesian_to_fractional(inv, [1, 1, 1])).toEqual([0.5, 0.25, 0.125])
   })
 
+  test(`round-trips coordinates for a non-orthogonal row lattice`, () => {
+    const skewed: Matrix3x3 = [
+      [1, 0, 0],
+      [0.5, Math.sqrt(3) / 2, 0],
+      [0, 0, 1],
+    ]
+    const inverse = k_lattice_inverse(skewed)
+    const fractional = cartesian_to_fractional(inverse, [0.5, Math.sqrt(3) / 2, 0])
+    expect(fractional?.[0]).toBeCloseTo(0, 12)
+    expect(fractional?.[1]).toBeCloseTo(1, 12)
+    expect(fractional?.[2]).toBeCloseTo(0, 12)
+  })
+
   test(`returns null for missing or singular lattice`, () => {
     expect(k_lattice_inverse(undefined)).toBeNull()
     expect(

--- a/tests/vitest/marching-cubes.test.ts
+++ b/tests/vitest/marching-cubes.test.ts
@@ -189,6 +189,68 @@ describe(`marching_cubes`, () => {
     ).toBe(true)
   })
 
+  test(`returns Cartesian normals perpendicular to a skewed constant-x surface`, () => {
+    const skewed: Matrix3x3 = [
+      [1, 0, 0],
+      [0.5, Math.sqrt(3) / 2, 0],
+      [0, 0, 1],
+    ]
+    const grid = Array.from({ length: 4 }, (_, ix) =>
+      Array.from({ length: 5 }, () => Array.from({ length: 6 }, () => ix)),
+    )
+    const { normals } = marching_cubes(grid, 1.5, skewed, {
+      periodic: false,
+      centered: false,
+    })
+    expect(normals.length).toBeGreaterThan(0)
+    for (const normal of normals) {
+      expect(normal[0] * skewed[1][0] + normal[1] * skewed[1][1]).toBeCloseTo(0, 6)
+      expect(normal[2]).toBeCloseTo(0, 6)
+      expect(Math.hypot(...normal)).toBeCloseTo(1, 6)
+    }
+  })
+
+  test(`accounts for unequal grid spacing before normalizing`, () => {
+    const [nx, ny, nz] = [3, 5, 4]
+    const grid = Array.from({ length: nx }, (_x, ix) =>
+      Array.from({ length: ny }, (_y, iy) =>
+        Array.from({ length: nz }, () => ix / (nx - 1) + iy / (ny - 1)),
+      ),
+    )
+    const { normals } = marching_cubes(grid, 0.75, IDENTITY, {
+      periodic: false,
+      centered: false,
+    })
+    expect(normals.length).toBeGreaterThan(0)
+    for (const [x, y, z] of normals) {
+      expect(Math.abs(x)).toBeCloseTo(Math.SQRT1_2, 5)
+      expect(Math.abs(y)).toBeCloseTo(Math.SQRT1_2, 5)
+      expect(z).toBeCloseTo(0, 5)
+    }
+  })
+
+  test(`skips singular-lattice normal transform when normals are disabled`, () => {
+    const singular_lattice: Matrix3x3 = [
+      [1, 0, 0],
+      [1, 0, 0],
+      [0, 0, 1],
+    ]
+    const grid = Array.from({ length: 4 }, (_x, ix) =>
+      Array.from({ length: 4 }, () => Array.from({ length: 4 }, () => ix)),
+    )
+    let result: ReturnType<typeof marching_cubes> | undefined
+    expect(() => {
+      result = marching_cubes(grid, 1.5, singular_lattice, {
+        periodic: false,
+        centered: false,
+        normals: false,
+      })
+    }).not.toThrow()
+    expect(result?.vertices.length).toBeGreaterThan(0)
+    expect(result?.faces.length).toBeGreaterThan(0)
+    expect(result?.normals).toEqual([])
+  })
+
   test(`higher isovalue produces fewer faces for a blob`, () => {
     const grid = gaussian_grid(8)
     const low = marching_cubes(grid, 0.3, IDENTITY, NON_PERIODIC)


### PR DESCRIPTION
## Summary

This draft PR fixes two issues found during the Codex global code scan and reproduced before implementation:

- Fixes #380 by using the existing row-vector Cartesian-to-fractional lattice helper for Brillouin-zone hover coordinates.
- Fixes #381 by transforming marching-cubes normals as Cartesian covectors for skewed/nonorthogonal lattices, including unequal grid spacing.
- Preserves `normals:false` behavior so singular lattices are not inverted when normals are not requested.

Umbrella tracking issue: #401

## Reproduction

- #380 was reproduced with a skewed row-vector reciprocal lattice where Cartesian `[0.5, sqrt(3) / 2, 0]` should map to fractional `[0, 1, 0]`; the old direct inverse path reported the wrong fractional coordinate.
- #381 was reproduced with skewed and unequal-spacing scalar fields where old index-space normalized normals were not perpendicular in Cartesian space or ignored grid spacing.
- The new tests were RED/GREEN checked against the old behavior before committing the fixes.