### PR TITLE
Include per-atom energy in chemical-potential cache keys

### DIFF
--- a/src/lib/chempot-diagram/compute.ts
+++ b/src/lib/chempot-diagram/compute.ts
@@ -850,13 +850,14 @@ export function make_nd_cache_key(
 ): string {
   const keyed = entries
     .map((entry) =>
-      [
+      JSON.stringify([
         formula_key_from_composition(entry.composition),
-        entry.energy,
-        entry.is_stable ?? ``,
-        entry.e_above_hull ?? ``,
-        entry.exclude_from_hull ?? ``,
-      ].join(`:`),
+        entry.energy ?? null,
+        entry.energy_per_atom ?? null,
+        entry.is_stable ?? null,
+        entry.e_above_hull ?? null,
+        entry.exclude_from_hull ?? null,
+      ]),
     )
     .sort()
   return `${keyed.join(`,`)}|${formal_chempots}|${default_min_limit}|${JSON.stringify(limits ?? {})}`

--- a/tests/vitest/chempot-diagram/compute.test.ts
+++ b/tests/vitest/chempot-diagram/compute.test.ts
@@ -1936,6 +1936,38 @@ describe(`make_nd_cache_key`, () => {
     expect(make_nd_cache_key([oxygen, li], true, -50, undefined)).toBe(base_key())
   })
 
+  test(`key changes when energy_per_atom changes independently of total energy`, () => {
+    const key_a = make_nd_cache_key(
+      [{ composition: { Li: 2 }, energy: -6, energy_per_atom: -3 }],
+      true,
+      -50,
+      undefined,
+    )
+    const key_b = make_nd_cache_key(
+      [{ composition: { Li: 2 }, energy: -6, energy_per_atom: -2.5 }],
+      true,
+      -50,
+      undefined,
+    )
+    expect(key_b).not.toBe(key_a)
+  })
+
+  test(`key distinguishes absent energy_per_atom from explicit value`, () => {
+    const absent = make_nd_cache_key(
+      [{ composition: { Li: 1 }, energy: -3 }],
+      true,
+      -50,
+      undefined,
+    )
+    const explicit = make_nd_cache_key(
+      [{ composition: { Li: 1 }, energy: -3, energy_per_atom: -3 }],
+      true,
+      -50,
+      undefined,
+    )
+    expect(explicit).not.toBe(absent)
+  })
+
   test.each([
     {
       label: `different compositions`,


### PR DESCRIPTION
## Summary

This draft PR fixes #382, found during the Codex global code scan and reproduced before implementation.

- Includes `energy_per_atom` in every deterministic N-D chemical-potential cache entry tuple.
- Uses `null` as the absent sentinel so explicit `0` values remain distinct from missing values.
- Switches each entry tuple to `JSON.stringify([...])`, which also avoids delimiter collisions in the old colon-joined key.

Umbrella tracking issue: #401

## Root Cause

`compute_chempot_nd()` gives explicit `energy_per_atom` precedence, but `make_nd_cache_key()` only fingerprinted total `energy`. Two inputs with identical total energy and different per-atom energies could therefore reuse stale cached N-D results.

## Reproduction

The reproduced #382 case used two datasets with identical total energy but different `energy_per_atom`; both produced the same cache key and the second cached result retained the first O reference energy. The new tests were RED/GREEN checked against that old behavior.