### PR TITLE
Fix JSON path round-trips for arbitrary keys

### DIFF
--- a/src/lib/file-viewer/detect.ts
+++ b/src/lib/file-viewer/detect.ts
@@ -382,6 +382,14 @@ interface RenderablePath {
   label: string
 }
 
+const PATH_IDENTIFIER_RE = /^[A-Za-z_$][\w$]*$/u
+
+function append_object_key(path: string, key: string): string {
+  const segment = PATH_IDENTIFIER_RE.test(key) ? key : `[${JSON.stringify(key)}]`
+  if (!path) return segment
+  return segment.startsWith(`[`) ? `${path}${segment}` : `${path}.${segment}`
+}
+
 // Recursively scan a JSON object to find all paths that contain renderable data.
 // Returns a Map of JSON path strings to their detected type.
 // Used to show badges on JsonTree nodes indicating which subtrees contain visualizable data.
@@ -426,13 +434,7 @@ export function scan_renderable_paths(
       }
     } else {
       for (const [key, child_value] of Object.entries(value as Record<string, unknown>)) {
-        // Use bracket notation for keys containing dots to avoid ambiguity in resolve_path
-        const segment = key.includes(`.`) ? `["${key}"]` : key
-        const child_path = path
-          ? key.includes(`.`)
-            ? `${path}${segment}`
-            : `${path}.${segment}`
-          : segment
+        const child_path = append_object_key(path, key)
         walk(child_value, child_path, depth + 1)
       }
     }
@@ -443,16 +445,60 @@ export function scan_renderable_paths(
 }
 
 // Resolve a path produced by scan_renderable_paths back to its value (inverse walk).
-// Handles dotted keys ["foo.bar"], array indices [0], and bare dotted paths a.b.c.
+// Handles bare identifiers, array indices [0], and JSON-string object keys ["foo.bar"].
 export function resolve_path(root: unknown, path: string): unknown {
   if (!path) return root
   let current: unknown = root
-  for (const match of path.matchAll(
-    /\["(?<quoted_key>[^"]+)"\]|\[(?<array_index>\d+)\]|(?<bare_key>[^.[\]]+)/g,
-  )) {
+
+  for (let pos = 0; pos < path.length; ) {
     if (current == null || typeof current !== `object`) return undefined
-    const { quoted_key, array_index, bare_key } = match.groups ?? {}
-    current = (current as Record<string, unknown>)[quoted_key ?? array_index ?? bare_key ?? ``]
+
+    if (path[pos] === `.`) {
+      pos++
+      if (pos >= path.length) return undefined
+    }
+
+    let key: string
+    if (path[pos] === `[`) {
+      pos++
+      if (path[pos] === `"`) {
+        const json_start = pos
+        pos++
+        let escaped = false
+        while (pos < path.length) {
+          const char = path[pos]
+          if (escaped) {
+            escaped = false
+          } else if (char === `\\`) {
+            escaped = true
+          } else if (char === `"`) {
+            break
+          }
+          pos++
+        }
+        if (pos >= path.length) return undefined
+        try {
+          key = JSON.parse(path.slice(json_start, pos + 1)) as string
+        } catch {
+          return undefined
+        }
+        pos++
+      } else {
+        const index_start = pos
+        while (/\d/u.test(path[pos] ?? ``)) pos++
+        if (pos === index_start) return undefined
+        key = path.slice(index_start, pos)
+      }
+      if (path[pos] !== `]`) return undefined
+      pos++
+    } else {
+      const key_start = pos
+      while (pos < path.length && path[pos] !== `.` && path[pos] !== `[`) pos++
+      if (pos === key_start) return undefined
+      key = path.slice(key_start, pos)
+    }
+
+    current = (current as Record<string, unknown>)[key]
   }
   return current
 }

--- a/src/lib/file-viewer/detect.ts
+++ b/src/lib/file-viewer/detect.ts
@@ -1,7 +1,10 @@
 // Data type detection for JSON values -- determines which visualization component to use.
 // Used by JsonBrowser and the file renderer to select visualization components.
 
+import { build_path } from '$lib/json-path'
 import { is_optimade_raw } from '$lib/structure/parse'
+
+export { resolve_path } from '$lib/json-path'
 
 // Visualization types supported by the file viewer.
 export type RenderableType =
@@ -382,14 +385,6 @@ interface RenderablePath {
   label: string
 }
 
-const PATH_IDENTIFIER_RE = /^[A-Za-z_$][\w$]*$/u
-
-function append_object_key(path: string, key: string): string {
-  const segment = PATH_IDENTIFIER_RE.test(key) ? key : `[${JSON.stringify(key)}]`
-  if (!path) return segment
-  return segment.startsWith(`[`) ? `${path}${segment}` : `${path}.${segment}`
-}
-
 // Recursively scan a JSON object to find all paths that contain renderable data.
 // Returns a Map of JSON path strings to their detected type.
 // Used to show badges on JsonTree nodes indicating which subtrees contain visualizable data.
@@ -429,76 +424,15 @@ export function scan_renderable_paths(
       // For arrays, only scan first few elements to avoid huge arrays
       const scan_count = Math.min(value.length, 20)
       for (let idx = 0; idx < scan_count; idx++) {
-        const child_path = path ? `${path}[${idx}]` : `[${idx}]`
-        walk(value[idx], child_path, depth + 1)
+        walk(value[idx], build_path(path, idx), depth + 1)
       }
     } else {
       for (const [key, child_value] of Object.entries(value as Record<string, unknown>)) {
-        const child_path = append_object_key(path, key)
-        walk(child_value, child_path, depth + 1)
+        walk(child_value, build_path(path, key), depth + 1)
       }
     }
   }
 
   walk(obj, prefix, 0)
   return results
-}
-
-// Resolve a path produced by scan_renderable_paths back to its value (inverse walk).
-// Handles bare identifiers, array indices [0], and JSON-string object keys ["foo.bar"].
-export function resolve_path(root: unknown, path: string): unknown {
-  if (!path) return root
-  let current: unknown = root
-
-  for (let pos = 0; pos < path.length; ) {
-    if (current == null || typeof current !== `object`) return undefined
-
-    if (path[pos] === `.`) {
-      pos++
-      if (pos >= path.length) return undefined
-    }
-
-    let key: string
-    if (path[pos] === `[`) {
-      pos++
-      if (path[pos] === `"`) {
-        const json_start = pos
-        pos++
-        let escaped = false
-        while (pos < path.length) {
-          const char = path[pos]
-          if (escaped) {
-            escaped = false
-          } else if (char === `\\`) {
-            escaped = true
-          } else if (char === `"`) {
-            break
-          }
-          pos++
-        }
-        if (pos >= path.length) return undefined
-        try {
-          key = JSON.parse(path.slice(json_start, pos + 1)) as string
-        } catch {
-          return undefined
-        }
-        pos++
-      } else {
-        const index_start = pos
-        while (/\d/u.test(path[pos] ?? ``)) pos++
-        if (pos === index_start) return undefined
-        key = path.slice(index_start, pos)
-      }
-      if (path[pos] !== `]`) return undefined
-      pos++
-    } else {
-      const key_start = pos
-      while (pos < path.length && path[pos] !== `.` && path[pos] !== `[`) pos++
-      if (pos === key_start) return undefined
-      key = path.slice(key_start, pos)
-    }
-
-    current = (current as Record<string, unknown>)[key]
-  }
-  return current
 }

--- a/src/lib/json-path.ts
+++ b/src/lib/json-path.ts
@@ -1,0 +1,97 @@
+// Dot/bracket path codec for arbitrary JavaScript object keys.
+// Special keys use JSON.stringify so quotes/backslashes/brackets round-trip.
+
+const PATH_IDENTIFIER_RE = /^[A-Za-z_$][\w$]*$/u
+
+export function format_path_segment(
+  segment: string | number,
+  is_first: boolean = false,
+): string {
+  if (typeof segment === `number`) return `[${segment}]`
+  if (PATH_IDENTIFIER_RE.test(segment)) return is_first ? segment : `.${segment}`
+  return `[${JSON.stringify(segment)}]`
+}
+
+export const format_path = (segments: (string | number)[]): string =>
+  segments.map((segment, idx) => format_path_segment(segment, idx === 0)).join(``)
+
+export const build_path = (parent_path: string, key: string | number): string =>
+  parent_path ? parent_path + format_path_segment(key) : format_path_segment(key, true)
+
+export function parse_path(path: string): (string | number)[] {
+  if (!path) return []
+
+  const segments: (string | number)[] = []
+  let pos = 0
+
+  const push_bracket_token = (token: string): void => {
+    if (!token) return
+    const num = Number(token)
+    segments.push(Number.isNaN(num) ? token : num)
+  }
+
+  while (pos < path.length) {
+    if (path[pos] === `.`) {
+      pos++
+      continue
+    }
+
+    if (path[pos] === `[`) {
+      pos++
+      if (path[pos] === `]`) {
+        pos++
+        continue
+      }
+
+      if (path[pos] === `"`) {
+        const json_start = pos
+        const content_start = pos + 1
+        pos++
+        let escaped = false
+        while (pos < path.length) {
+          const char = path[pos]
+          if (escaped) escaped = false
+          else if (char === `\\`) escaped = true
+          else if (char === `"`) break
+          pos++
+        }
+
+        if (pos >= path.length) {
+          segments.push(path.slice(content_start))
+          break
+        }
+
+        try {
+          segments.push(JSON.parse(path.slice(json_start, pos + 1)) as string)
+        } catch {
+          segments.push(path.slice(content_start, pos))
+        }
+        pos++
+        if (path[pos] === `]`) pos++
+        continue
+      }
+
+      const token_start = pos
+      while (pos < path.length && path[pos] !== `]`) pos++
+      push_bracket_token(path.slice(token_start, pos))
+      if (path[pos] === `]`) pos++
+      continue
+    }
+
+    const token_start = pos
+    while (pos < path.length && path[pos] !== `.` && path[pos] !== `[`) pos++
+    if (pos > token_start) segments.push(path.slice(token_start, pos))
+  }
+
+  return segments
+}
+
+export function resolve_path(root: unknown, path: string): unknown {
+  if (!path) return root
+  let current: unknown = root
+  for (const key of parse_path(path)) {
+    if (current == null || typeof current !== `object`) return undefined
+    current = (current as Record<string | number, unknown>)[key]
+  }
+  return current
+}

--- a/src/lib/layout/json-tree/utils.ts
+++ b/src/lib/layout/json-tree/utils.ts
@@ -93,7 +93,7 @@ function format_path_segment(segment: string | number, is_first: boolean = false
     return is_first ? segment : `.${segment}`
   }
   // Use bracket notation for keys with special characters
-  return `["${segment.replaceAll('"', `\\"`)}"]`
+  return `[${JSON.stringify(segment)}]`
 }
 
 // Format a full path from segments
@@ -322,36 +322,69 @@ export function parse_path(path: string): (string | number)[] {
   if (!path) return []
 
   const segments: (string | number)[] = []
-  let current = ``
-  let in_bracket = false
+  let pos = 0
 
-  // Bracket tokens are numeric indices or quoted keys (quotes stripped, \" unescaped)
   const push_bracket_token = (token: string): void => {
+    if (!token) return
     const num = Number(token)
-    if (Number.isNaN(num)) {
-      segments.push(token.replaceAll(/^"|"$/g, ``).replaceAll(String.raw`\"`, `"`))
-    } else segments.push(num)
+    segments.push(Number.isNaN(num) ? token : num)
   }
 
-  for (const char of path) {
-    if (char === `.` && !in_bracket) {
-      if (current) segments.push(current)
-      current = ``
-    } else if (char === `[`) {
-      if (current) segments.push(current)
-      current = ``
-      in_bracket = true
-    } else if (char === `]`) {
-      if (current) push_bracket_token(current)
-      current = ``
-      in_bracket = false
-    } else current += char
-  }
+  while (pos < path.length) {
+    if (path[pos] === `.`) {
+      pos++
+      continue
+    }
 
-  // Handle trailing content (e.g., unclosed bracket like "a[0")
-  if (current) {
-    if (in_bracket) push_bracket_token(current)
-    else segments.push(current)
+    if (path[pos] === `[`) {
+      pos++
+      if (path[pos] === `]`) {
+        pos++
+        continue
+      }
+
+      if (path[pos] === `"`) {
+        const json_start = pos
+        const content_start = pos + 1
+        pos++
+        let escaped = false
+        while (pos < path.length) {
+          const char = path[pos]
+          if (escaped) {
+            escaped = false
+          } else if (char === `\\`) {
+            escaped = true
+          } else if (char === `"`) {
+            break
+          }
+          pos++
+        }
+
+        if (pos >= path.length) {
+          segments.push(path.slice(content_start))
+          break
+        }
+
+        try {
+          segments.push(JSON.parse(path.slice(json_start, pos + 1)) as string)
+        } catch {
+          segments.push(path.slice(content_start, pos))
+        }
+        pos++
+        if (path[pos] === `]`) pos++
+        continue
+      }
+
+      const token_start = pos
+      while (pos < path.length && path[pos] !== `]`) pos++
+      push_bracket_token(path.slice(token_start, pos))
+      if (path[pos] === `]`) pos++
+      continue
+    }
+
+    const token_start = pos
+    while (pos < path.length && path[pos] !== `.` && path[pos] !== `[`) pos++
+    if (pos > token_start) segments.push(path.slice(token_start, pos))
   }
 
   return segments

--- a/src/lib/layout/json-tree/utils.ts
+++ b/src/lib/layout/json-tree/utils.ts
@@ -1,8 +1,8 @@
 // JSON Tree utility functions
+import * as json_path from '$lib/json-path'
 import type { DiffEntry, JsonValueType } from './types'
 
-// Pre-compiled regex for valid JS identifiers (used in path formatting)
-const VALID_IDENTIFIER_RE = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/
+export { build_path, format_path, parse_path } from '$lib/json-path'
 
 // Circular-safe JSON.stringify helper (hoisted for reuse)
 function safe_stringify(val: unknown): string {
@@ -79,43 +79,6 @@ export function get_child_count(value: unknown): number {
   if (type === `map`) return (value as Map<unknown, unknown>).size
   if (type === `set`) return (value as Set<unknown>).size
   return 0
-}
-
-// Format a path segment for display
-// Handles both string keys and numeric indices
-// is_first: true for the first segment (no leading dot for valid identifiers)
-function format_path_segment(segment: string | number, is_first: boolean = false): string {
-  if (typeof segment === `number`) {
-    return `[${segment}]`
-  }
-  // Check if the key is a valid identifier (can use dot notation)
-  if (VALID_IDENTIFIER_RE.test(segment)) {
-    return is_first ? segment : `.${segment}`
-  }
-  // Use bracket notation for keys with special characters
-  return `[${JSON.stringify(segment)}]`
-}
-
-// Format a full path from segments
-// e.g., ["users", 0, "name"] -> "users[0].name"
-// e.g., [0, "name"] -> "[0].name" (root numeric index)
-// e.g., ["key.with.dot"] -> '["key.with.dot"]' (root special key)
-export function format_path(segments: (string | number)[]): string {
-  if (segments.length === 0) return ``
-
-  let result = format_path_segment(segments[0], true)
-  for (let idx = 1; idx < segments.length; idx++) {
-    result += format_path_segment(segments[idx])
-  }
-  return result
-}
-
-// Build a path string from parent path and key
-export function build_path(parent_path: string, key: string | number): string {
-  if (!parent_path) {
-    return format_path_segment(key, true)
-  }
-  return parent_path + format_path_segment(key)
 }
 
 // Format a primitive/special value to string (shared by serialize and preview)
@@ -253,7 +216,7 @@ export function collect_all_paths(
 
   const paths: string[] = current_path ? [current_path] : []
   for_each_child(value, type, (child_value, key) => {
-    const child_path = build_path(current_path, key)
+    const child_path = json_path.build_path(current_path, key)
     paths.push(
       ...collect_all_paths(child_value, child_path, max_depth, current_depth + 1, seen),
     )
@@ -285,7 +248,7 @@ export function find_matching_paths(
   }
 
   for_each_child(value, type, (child_value, key, map_key) => {
-    const child_path = build_path(current_path, key)
+    const child_path = json_path.build_path(current_path, key)
     // Also check if Map key matches
     if (
       map_key !== undefined &&
@@ -307,87 +270,13 @@ export function get_ancestor_paths(path: string): string[] {
   let current = ``
 
   // Parse the path to extract segments
-  const segments = parse_path(path)
+  const segments = json_path.parse_path(path)
   for (let idx = 0; idx < segments.length - 1; idx++) {
-    current = build_path(current, segments[idx])
+    current = json_path.build_path(current, segments[idx])
     ancestors.push(current)
   }
 
   return ancestors
-}
-
-// Parse a path string into segments
-// e.g., "users[0].name" -> ["users", 0, "name"]
-export function parse_path(path: string): (string | number)[] {
-  if (!path) return []
-
-  const segments: (string | number)[] = []
-  let pos = 0
-
-  const push_bracket_token = (token: string): void => {
-    if (!token) return
-    const num = Number(token)
-    segments.push(Number.isNaN(num) ? token : num)
-  }
-
-  while (pos < path.length) {
-    if (path[pos] === `.`) {
-      pos++
-      continue
-    }
-
-    if (path[pos] === `[`) {
-      pos++
-      if (path[pos] === `]`) {
-        pos++
-        continue
-      }
-
-      if (path[pos] === `"`) {
-        const json_start = pos
-        const content_start = pos + 1
-        pos++
-        let escaped = false
-        while (pos < path.length) {
-          const char = path[pos]
-          if (escaped) {
-            escaped = false
-          } else if (char === `\\`) {
-            escaped = true
-          } else if (char === `"`) {
-            break
-          }
-          pos++
-        }
-
-        if (pos >= path.length) {
-          segments.push(path.slice(content_start))
-          break
-        }
-
-        try {
-          segments.push(JSON.parse(path.slice(json_start, pos + 1)) as string)
-        } catch {
-          segments.push(path.slice(content_start, pos))
-        }
-        pos++
-        if (path[pos] === `]`) pos++
-        continue
-      }
-
-      const token_start = pos
-      while (pos < path.length && path[pos] !== `]`) pos++
-      push_bracket_token(path.slice(token_start, pos))
-      if (path[pos] === `]`) pos++
-      continue
-    }
-
-    const token_start = pos
-    while (pos < path.length && path[pos] !== `.` && path[pos] !== `[`) pos++
-    if (pos > token_start) segments.push(path.slice(token_start, pos))
-  }
-
-  return segments
 }
 
 // Check if two values are deeply equal (for change detection)
@@ -456,7 +345,7 @@ export function set_at_path(
   new_value: unknown,
   root_label?: string,
 ): unknown {
-  const segments = parse_path(path_str)
+  const segments = json_path.parse_path(path_str)
   const start = root_label && segments[0] === root_label ? 1 : 0
   if (start >= segments.length) return new_value
   const cloned = structuredClone(root)
@@ -551,9 +440,10 @@ export function build_ghost_map(diff_map: Map<string, DiffEntry>): Map<string, G
   const ghost_map = new Map<string, GhostEntry[]>()
   for (const [diff_path, entry] of diff_map) {
     if (entry.status !== `removed`) continue
-    const segments = parse_path(diff_path)
+    const segments = json_path.parse_path(diff_path)
     if (segments.length === 0) continue
-    const parent_path = segments.length === 1 ? `` : format_path(segments.slice(0, -1))
+    const parent_path =
+      segments.length === 1 ? `` : json_path.format_path(segments.slice(0, -1))
     const key = segments[segments.length - 1]
     const ghosts = ghost_map.get(parent_path) ?? []
     ghosts.push({ key, value: entry.old_value, path: diff_path })
@@ -633,7 +523,7 @@ export function compute_diff(
   function diff_indexed(old_items: unknown[], new_items: unknown[]): void {
     const max_len = Math.max(old_items.length, new_items.length)
     for (let idx = 0; idx < max_len; idx++) {
-      const child_path = build_path(current_path, idx)
+      const child_path = json_path.build_path(current_path, idx)
       if (idx >= old_items.length) {
         result.set(child_path, {
           status: `added`,
@@ -663,7 +553,7 @@ export function compute_diff(
     const new_obj = new_val as Record<string, unknown>
     const all_keys = new Set([...Object.keys(old_obj), ...Object.keys(new_obj)])
     for (const key of all_keys) {
-      const child_path = build_path(current_path, key)
+      const child_path = json_path.build_path(current_path, key)
       const in_old = key in old_obj
       const in_new = key in new_obj
       if (!in_old) {

--- a/tests/vitest/file-viewer/detect.test.ts
+++ b/tests/vitest/file-viewer/detect.test.ts
@@ -449,6 +449,25 @@ describe(`scan_renderable_paths`, () => {
     },
   )
 
+  test.each([
+    { label: `bracket`, key: `a[b]` },
+    { label: `dot`, key: `dot.key` },
+    { label: `quote`, key: `say "hello"` },
+    { label: `backslash`, key: `slash\\key` },
+    { label: `mixed punctuation`, key: `mix.["quoted"]\\tail` },
+    { label: `empty`, key: `` },
+    { label: `numeric-looking`, key: `0` },
+  ])(`round-trips renderable object key: $label`, ({ key }) => {
+    const original = { sites: [{ species: [{ element: `Si` }], abc: [0, 0, 0] }] }
+    const data = { root: { [key]: original } }
+    const paths = scan_renderable_paths(data)
+    const path = [...paths.keys()][0]
+
+    expect(paths.size).toBe(1)
+    expect(path).toBe(`root[${JSON.stringify(key)}]`)
+    expect(resolve_path(data, path)).toBe(original)
+  })
+
   test(`all scanned paths resolve back to the original value`, () => {
     for (const [path] of fixture_paths) {
       const resolved = resolve_path(fixture, path)

--- a/tests/vitest/layout/json-tree.utils.test.ts
+++ b/tests/vitest/layout/json-tree.utils.test.ts
@@ -168,6 +168,14 @@ describe(`format_path`, () => {
       `key.with.dot`,
     ])
   })
+
+  it.each([`a[b]`, `dot.key`, `say "hello"`, `slash\\key`, `mix.["quoted"]\\tail`, ``, `0`])(
+    `round-trips arbitrary key %p`,
+    (key) => {
+      const segments = [`root`, key, 2, `leaf`]
+      expect(parse_path(format_path(segments))).toEqual(segments)
+    },
+  )
 })
 
 describe(`build_path`, () => {


### PR DESCRIPTION
Fixes #384

Shared `$lib/json-path` codec so file-viewer and JsonTree round-trip arbitrary object keys (brackets, dots, quotes, backslashes, empty, numeric-looking strings).

This PR currently targets `agent/docs-and-site-metadata` (#410). **GitHub only auto-closes issues when merging into the default branch**, so either:

1. Merge this PR into #410, add `Fixes #384` on #410, then merge #410 to `main`, or
2. Retarget this PR to `main` and merge it directly.