### PR TITLE
Fix binned scatter automatic ranges

### DIFF
--- a/src/lib/plot/scatter/BinnedScatterPlot.svelte
+++ b/src/lib/plot/scatter/BinnedScatterPlot.svelte
@@ -266,14 +266,16 @@
   const needs_data_range = (range: AxisConfig[`range`] | undefined): boolean =>
     range?.[0] == null || range?.[1] == null
 
+  let x_scale_type = $derived(x_axis.scale_type ?? `linear`)
+  let y_scale_type = $derived(y_axis.scale_type ?? `linear`)
   let needs_auto_range = $derived(
     needs_data_range(x_axis.range) || needs_data_range(y_axis.range),
   )
   let auto_ranges = $derived(
-    needs_auto_range ? series_extents(series) : { x: [0, 1] as Vec2, y: [0, 1] as Vec2 },
+    needs_auto_range
+      ? series_extents(series, x_scale_type, y_scale_type)
+      : { x: [0, 1] as Vec2, y: [0, 1] as Vec2 },
   )
-  let x_scale_type = $derived(x_axis.scale_type ?? `linear`)
-  let y_scale_type = $derived(y_axis.scale_type ?? `linear`)
   let has_plot_size = $derived(width > 0 && height > 0)
 
   const axis_range = (axis: AxisConfig, fallback: Vec2): Vec2 => [

--- a/src/lib/plot/scatter/adaptive-density.ts
+++ b/src/lib/plot/scatter/adaptive-density.ts
@@ -127,36 +127,51 @@ const value_bin = (value: number, min: number, span: number, bins: number): numb
 const series_length = (srs: Pick<DensePointSeries, `x` | `y`>): number =>
   Math.min(srs.x.length, srs.y.length)
 
-const padded_extent = (min: number, max: number): Vec2 => {
+const padded_extent = (min: number, max: number, scale_type?: ScaleType): Vec2 => {
   if (!Number.isFinite(min) || !Number.isFinite(max)) return [0, 1]
+  if (get_scale_type_name(scale_type) === `log`) {
+    if (min === max) return [min / Math.sqrt(10), max * Math.sqrt(10)]
+    const transform = scale_bin_transform(scale_type)
+    const t_min = transform.forward(min)
+    const t_max = transform.forward(max)
+    const padding = (t_max - t_min) * 0.05
+    return [transform.inverse(t_min - padding), transform.inverse(t_max + padding)]
+  }
   if (min === max) return [min - 0.5, max + 0.5]
   const padding = (max - min) * 0.05
   return [min - padding, max + padding]
 }
 
-export function series_extents(series: readonly DensePointSeries[]): { x: Vec2; y: Vec2 } {
+export function series_extents(
+  series: readonly DensePointSeries[],
+  x_scale_type?: ScaleType,
+  y_scale_type?: ScaleType,
+): { x: Vec2; y: Vec2 } {
   let x_min = Infinity
   let x_max = -Infinity
   let y_min = Infinity
   let y_max = -Infinity
+  const log_x = get_scale_type_name(x_scale_type) === `log`
+  const log_y = get_scale_type_name(y_scale_type) === `log`
 
   for (const srs of series) {
     const n_points = series_length(srs)
     for (let idx = 0; idx < n_points; idx++) {
       const x = srs.x[idx]
       const y = srs.y[idx]
-      if (Number.isFinite(x)) {
-        if (x < x_min) x_min = x
-        if (x > x_max) x_max = x
-      }
-      if (Number.isFinite(y)) {
-        if (y < y_min) y_min = y
-        if (y > y_max) y_max = y
-      }
+      if (!Number.isFinite(x) || !Number.isFinite(y)) continue
+      if ((log_x && x <= 0) || (log_y && y <= 0)) continue
+      if (x < x_min) x_min = x
+      if (x > x_max) x_max = x
+      if (y < y_min) y_min = y
+      if (y > y_max) y_max = y
     }
   }
 
-  return { x: padded_extent(x_min, x_max), y: padded_extent(y_min, y_max) }
+  return {
+    x: padded_extent(x_min, x_max, x_scale_type),
+    y: padded_extent(y_min, y_max, y_scale_type),
+  }
 }
 
 export function bin_points(

--- a/tests/vitest/plot/BinnedScatterPlot.test.svelte.ts
+++ b/tests/vitest/plot/BinnedScatterPlot.test.svelte.ts
@@ -160,6 +160,47 @@ describe(`BinnedScatterPlot`, () => {
     expect(errors.map(String).join(`\n`)).toBe(``)
   })
 
+  test(`auto-ranges finite pairs on logarithmic axes`, async () => {
+    const plotted_x: number[] = []
+    const arc = vi.fn((x: number, y: number) => {
+      expect(Number.isFinite(x)).toBe(true)
+      expect(Number.isFinite(y)).toBe(true)
+      plotted_x.push(x)
+    })
+    mock_canvas_context({ arc })
+
+    mount_plot({
+      series: [{ x: [1, 100, 1e9], y: [1, 10, Number.NaN] }],
+      x_axis: { scale_type: `log` },
+      density: point_mode(),
+      style: `width: 800px; height: 600px`,
+    })
+    await settle()
+
+    expect(arc).toHaveBeenCalledTimes(2)
+    expect(Math.max(...plotted_x) - Math.min(...plotted_x)).toBeGreaterThan(500)
+  })
+
+  test(`keeps explicit partial and reversed ranges authoritative`, async () => {
+    for (const range of [
+      [5, null],
+      [100, 1],
+    ] as [number, number | null][]) {
+      mount_plot({
+        series: [{ x: [1, 10], y: [1, 10] }],
+        x_axis: { range, ticks: [range[0]] },
+        density: point_mode(),
+        style: `width: 800px; height: 600px`,
+      })
+      await settle()
+      const labels = [...document.querySelectorAll(`.x-axis .tick text`)].map((node) =>
+        Number(node.textContent?.replaceAll(`,`, ``)),
+      )
+      expect(labels.some((value) => value === range[0])).toBe(true)
+      document.body.replaceChildren()
+    }
+  })
+
   test(`can hide the fullscreen toggle`, async () => {
     mount_plot({
       series: [{ x: [0, 1], y: [0, 1] }],

--- a/tests/vitest/plot/adaptive-density.test.ts
+++ b/tests/vitest/plot/adaptive-density.test.ts
@@ -131,6 +131,28 @@ describe(`adaptive density utilities`, () => {
     })
   })
 
+  it(`computes both extents from the same finite point pairs`, () => {
+    expect(series_extents([{ x: [1, 1e9], y: [1, Number.NaN] }])).toEqual({
+      x: [0.5, 1.5],
+      y: [0.5, 1.5],
+    })
+  })
+
+  it(`pads log extents in transformed space`, () => {
+    const extents = series_extents([{ x: [1, 100], y: [2, 20] }], `log`, `linear`)
+
+    expect(extents.x[0]).toBeCloseTo(10 ** -0.1)
+    expect(extents.x[1]).toBeCloseTo(10 ** 2.1)
+    expect(extents.y).toEqual([1.1, 20.9])
+  })
+
+  it(`drops pairs that cannot render on a log axis`, () => {
+    expect(series_extents([{ x: [-10, 10], y: [1, 2] }], `log`, `linear`)).toEqual({
+      x: [10 / Math.sqrt(10), 10 * Math.sqrt(10)],
+      y: [1.5, 2.5],
+    })
+  })
+
   it(`does not pick outside visible ranges or radius`, () => {
     const hidden = pick_from_index(
       build_pick_index(series, { ...pick_options, radius_px: 30 }),


### PR DESCRIPTION
## Summary

Fixes #385.

This draft PR is part of the Codex global code scan described in #401. The issue was reproduced before implementation with real `series_extents()`, `create_scale()`, and `bin_points()` calls.

- Compute automatic binned-scatter extents from finite renderable point pairs, not independently from all finite x and y coordinates.
- Drop point pairs that cannot render on log axes before they influence automatic domains.
- Pad log domains in transformed/log space, while keeping the existing linear padding behavior.
- Pass `x_axis.scale_type` and `y_axis.scale_type` into `BinnedScatterPlot` automatic range calculation without changing explicit range precedence.

## Root Cause

`series_extents()` filtered x and y independently, so a point with one invalid coordinate could still expand the other axis domain. It also always used additive linear padding before log scale creation. For positive log-scale data such as `x=[1, 100]`, the additive padding made the lower bound negative; the rendered log scale then clamped the domain floor near `LOG_EPS`, compressing valid data into a small part of the plot.

## Reproduction

The pre-fix reproduction observed:

- `x=[1,100]` on a log axis produced an auto extent of `[-3.95, 104.95]`, which was clamped by the rendered log scale and left the valid two-decade data using only about `18.15%` of the x pixel range.
- `x=[1,1e9]`, `y=[1,NaN]` produced an x auto extent around `[-49999998.95, 1049999999.95]`, even though only the first coordinate pair could render.

## Review Notes

This PR intentionally does not include local scan plans or reproduction notes. Those files are ignored locally and are not part of the Git-tracked changes.