### PR TITLE
Preserve CIF occupancy and EXTXYZ periodicity

### DIFF
--- a/src/lib/structure/parse.ts
+++ b/src/lib/structure/parse.ts
@@ -819,7 +819,7 @@ const parse_cif_atom_data = (
       ? parse_cif_uncertain_number(raw_data[occupancy])
       : null
   // Missing or unknown occupancy defaults to fully occupied; explicit numeric zero is meaningful.
-  const occu = raw_occu == null ? 1.0 : raw_occu
+  const occu = raw_occu ?? 1.0
 
   const from_symbol =
     symbol >= 0 ? /^(?<element>[A-Z][a-z]*)/.exec(raw_data[symbol])?.[1] : undefined

--- a/src/lib/structure/parse.ts
+++ b/src/lib/structure/parse.ts
@@ -818,8 +818,8 @@ const parse_cif_atom_data = (
     occupancy >= 0 && raw_data[occupancy]
       ? parse_cif_uncertain_number(raw_data[occupancy])
       : null
-  // invalid or zero occupancy defaults to fully occupied
-  const occu = raw_occu == null || raw_occu === 0 ? 1.0 : raw_occu
+  // Missing or unknown occupancy defaults to fully occupied; explicit numeric zero is meaningful.
+  const occu = raw_occu == null ? 1.0 : raw_occu
 
   const from_symbol =
     symbol >= 0 ? /^(?<element>[A-Z][a-z]*)/.exec(raw_data[symbol])?.[1] : undefined

--- a/src/lib/trajectory/parse/xyz.ts
+++ b/src/lib/trajectory/parse/xyz.ts
@@ -54,10 +54,13 @@ const EXTXYZ_BOOL = new Map<string, boolean>([
 
 // Parse pbc="T F T" / pbc=T F T boolean triples from an extxyz comment line
 export function parse_extxyz_pbc(comment: string): Pbc | undefined {
-  const match = /\bpbc\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s]+\s+[^\s]+\s+[^\s]+))/iu.exec(
-    comment,
-  )
-  const tokens = (match?.[1] ?? match?.[2] ?? match?.[3])?.trim().split(/\s+/u)
+  const match =
+    /\bpbc\s*=\s*(?:"(?<double>[^"]*)"|'(?<single>[^']*)'|(?<bare>[^\s]+\s+[^\s]+\s+[^\s]+))/iu.exec(
+      comment,
+    )
+  const tokens = (match?.groups?.double ?? match?.groups?.single ?? match?.groups?.bare)
+    ?.trim()
+    .split(/\s+/u)
   if (tokens?.length !== 3) return undefined
   const first = EXTXYZ_BOOL.get(tokens[0].toLowerCase())
   const second = EXTXYZ_BOOL.get(tokens[1].toLowerCase())

--- a/src/lib/trajectory/parse/xyz.ts
+++ b/src/lib/trajectory/parse/xyz.ts
@@ -2,6 +2,7 @@
 import type { ElementSymbol } from '$lib/element/types'
 import * as math from '$lib/math'
 import { coerce_elem_symbol } from '$lib/element/helpers'
+import type { Pbc } from '$lib/structure/pbc'
 import {
   calc_force_stats,
   create_trajectory_frame,
@@ -42,6 +43,27 @@ function parse_extxyz_lattice(comment: string): math.Matrix3x3 | undefined {
     .map(Number)
   if (vals?.length !== 9 || !vals.every(Number.isFinite)) return undefined
   return [vals.slice(0, 3), vals.slice(3, 6), vals.slice(6, 9)] as math.Matrix3x3
+}
+
+const EXTXYZ_BOOL = new Map<string, boolean>([
+  [`t`, true],
+  [`true`, true],
+  [`f`, false],
+  [`false`, false],
+])
+
+// Parse pbc="T F T" / pbc=T F T boolean triples from an extxyz comment line
+export function parse_extxyz_pbc(comment: string): Pbc | undefined {
+  const match = /\bpbc\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s]+\s+[^\s]+\s+[^\s]+))/iu.exec(
+    comment,
+  )
+  const tokens = (match?.[1] ?? match?.[2] ?? match?.[3])?.trim().split(/\s+/u)
+  if (tokens?.length !== 3) return undefined
+  const first = EXTXYZ_BOOL.get(tokens[0].toLowerCase())
+  const second = EXTXYZ_BOOL.get(tokens[1].toLowerCase())
+  const third = EXTXYZ_BOOL.get(tokens[2].toLowerCase())
+  if (first === undefined || second === undefined || third === undefined) return undefined
+  return [first, second, third]
 }
 
 // Keys anchored at ^|\s and followed by [=:] so single-letter keys (E/V/P/T) don't match mid-word
@@ -128,6 +150,7 @@ export function build_xyz_frame(
   const { start, num_atoms, comment } = frame
   const { step, properties } = parse_xyz_comment_metadata(comment)
   const lattice_matrix = parse_extxyz_lattice(comment)
+  const pbc = parse_extxyz_pbc(comment) ?? ([true, true, true] satisfies Pbc)
   const { elements, positions, force_stats } = parse_xyz_atom_lines(
     lines,
     start + 2,
@@ -141,7 +164,7 @@ export function build_xyz_frame(
     positions,
     elements,
     lattice_matrix,
-    lattice_matrix ? [true, true, true] : undefined,
+    lattice_matrix ? pbc : undefined,
     step ?? opts.default_step,
     metadata,
   )

--- a/tests/vitest/structure/parse.test.ts
+++ b/tests/vitest/structure/parse.test.ts
@@ -1126,6 +1126,49 @@ H1   H   0.500  0.500  0.500  1.000  1.000`
       expect(result.sites[0].species[0].occu).toBe(1.0)
     })
 
+    test.each([
+      [`0`, 0],
+      [`0.25`, 0.25],
+      [`.`, 1],
+      [`?`, 1],
+    ])(`preserves occupancy token %p as %p`, (token, expected) => {
+      const cif = `data_occupancy
+_cell_length_a 5
+_cell_length_b 5
+_cell_length_c 5
+_cell_angle_alpha 90
+_cell_angle_beta 90
+_cell_angle_gamma 90
+loop_
+_atom_site_label
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+H1 0 0 0 ${token}`
+
+      const parsed = parse_cif(cif)
+      expect(parsed?.sites[0]?.species[0]?.occu).toBe(expected)
+    })
+
+    test(`defaults omitted CIF occupancy to one`, () => {
+      const cif = `data_occupancy
+_cell_length_a 5
+_cell_length_b 5
+_cell_length_c 5
+_cell_angle_alpha 90
+_cell_angle_beta 90
+_cell_angle_gamma 90
+loop_
+_atom_site_label
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+H1 0 0 0`
+
+      expect(parse_cif(cif)?.sites[0]?.species[0]?.occu).toBe(1)
+    })
+
     it(`should handle comments and syntax errors`, () => {
       const cif_with_comments = `data_test
 # Comment

--- a/tests/vitest/trajectory/parse.test.ts
+++ b/tests/vitest/trajectory/parse.test.ts
@@ -1037,6 +1037,27 @@ describe(`XYZ Trajectory Format`, () => {
     ])
   })
 
+  const extxyz_pbc_frame = (pbc_field = ``): string => `1
+Lattice="10 0 0 0 10 0 0 0 10" Properties=species:S:1:pos:R:3${pbc_field}
+Si 0 0 0
+`
+
+  it.each<[string, readonly [boolean, boolean, boolean]]>([
+    [` pbc="F F F"`, [false, false, false]],
+    [` pbc="T F T"`, [true, false, true]],
+    [` pbc=T F T`, [true, false, true]],
+    [` pbc="true FALSE t"`, [true, false, true]],
+    [``, [true, true, true]],
+  ])(`should parse EXTXYZ PBC field %p`, async (field, expected) => {
+    const trajectory = await parse_trajectory_data(
+      `${extxyz_pbc_frame(field)}${extxyz_pbc_frame(field)}`,
+      `pbc.extxyz`,
+    )
+
+    const structure = trajectory.frames[0].structure
+    expect(structure && `lattice` in structure && structure.lattice.pbc).toEqual(expected)
+  })
+
   it.each<[string, string, number[][]]>([
     // forces directly after pos, after momenta, and after a scalar column
     [

--- a/tests/vitest/trajectory/streaming.test.ts
+++ b/tests/vitest/trajectory/streaming.test.ts
@@ -223,6 +223,24 @@ describe(`Trajectory Streaming`, () => {
       expect(loaded?.metadata?.energy).toBe(-1.5)
       expect(loaded?.metadata?.volume).toBe(216) // derived from lattice (6^3), parity with eager parser
     })
+
+    it(`should preserve EXTXYZ PBC in indexed loads`, async () => {
+      const frame = (pbc_field: string): string => `1
+Lattice="10 0 0 0 10 0 0 0 10" Properties=species:S:1:pos:R:3${pbc_field}
+Si 0 0 0`
+      const source = `${frame(` pbc="F F F"`)}\n${frame(` pbc="T F T"`)}`
+
+      const loader = new TrajFrameReader(`pbc.extxyz`)
+      const frame_0 = await loader.load_frame(source, 0)
+      const frame_1 = await loader.load_frame(source, 1)
+
+      expect(
+        frame_0?.structure && `lattice` in frame_0.structure && frame_0.structure.lattice.pbc,
+      ).toEqual([false, false, false])
+      expect(
+        frame_1?.structure && `lattice` in frame_1.structure && frame_1.structure.lattice.pbc,
+      ).toEqual([true, false, true])
+    })
   })
 
   describe(`Plot Metadata Extraction`, () => {


### PR DESCRIPTION
Fixes #386
Fixes #387

This draft PR is follow-up work from the Codex global scan summarized in #401. I reproduced both parser metadata issues before implementing the fixes.

## Reproduction

- CIF occupancy: a CIF site with `_atom_site_occupancy` set to `0` was parsed as fully occupied (`1`) because numeric zero was treated like a missing value.
- EXTXYZ PBC: frames with `pbc="F F F"` or `pbc="T F T"` were parsed with lattice PBC `[true, true, true]` in both eager trajectory parsing and indexed frame loading.

## Changes

- Preserve explicit numeric CIF occupancy values, including `0`, while keeping missing, `.` and `?` occupancy values defaulting to `1`.
- Parse EXTXYZ `pbc` boolean triples (`T/F` and `true/false`, quoted or unquoted) and pass them through the shared XYZ frame builder.
- Keep the existing compatibility default of `[true, true, true]` for lattice-bearing EXTXYZ frames without a `pbc` header.
- Add eager parser coverage and indexed `TrajFrameReader.load_frame()` coverage for the EXTXYZ PBC path.