### PR TITLE
Fix VS Code editor lifecycle edge cases

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -79,7 +79,7 @@
             "filenamePattern": "*{poscar,xdatcar,contcar,outcar}"
           },
           {
-            "filenamePattern": "*{trajectory,traj,relax,npt,nvt,nve,qha,dynamics,simulation}*"
+            "filenamePattern": "*{trajectory,traj,relax,npt,nvt,nve,qha,md_*,dynamics,simulation}*"
           },
           {
             "filenamePattern": "*.{bxsf,frmsf}"

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -80,7 +80,7 @@
             "filenamePattern": "*{poscar,xdatcar,contcar,outcar}"
           },
           {
-            "filenamePattern": "*{trajectory,traj,relax,npt,nvt,nve,qha,md,dynamics,simulation}*"
+            "filenamePattern": "*{trajectory,traj,relax,npt,nvt,nve,qha,dynamics,simulation}*"
           },
           {
             "filenamePattern": "*.{bxsf,frmsf}"

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -54,8 +54,7 @@
     "menus": {
       "explorer/context": [
         {
-          "command": "matterviz.open",
-          "when": "matterviz.supported_resource"
+          "command": "matterviz.open"
         }
       ]
     },

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -60,6 +60,11 @@ type WatcherMeta = { request_id?: string; filename?: string; frame_index?: numbe
 
 // Track active file watchers by file path
 export const active_watchers = new Map<string, vscode.FileSystemWatcher>()
+// Track webviews subscribed to each watched file path
+export const active_watcher_subscribers = new Map<
+  string,
+  Map<WebviewLike, WatcherMeta | undefined>
+>()
 // Track active frame loaders by file path
 export const active_frame_loaders = new Map<string, FrameLoaderData>()
 // Track auto-render timers to clear them on deactivate
@@ -465,7 +470,7 @@ export const handle_msg = async (msg: MessageData, webview?: WebviewLike): Promi
     })
   } else if (msg.command === `stopWatching` && msg.file_path) {
     // Handle request to stop watching a file
-    stop_watching_file(msg.file_path)
+    stop_watching_file(msg.file_path, webview)
   }
 }
 
@@ -476,8 +481,18 @@ function start_watching_file(
   meta?: WatcherMeta,
 ): void {
   try {
-    // Stop existing watcher for this file if any
-    stop_watching_file(file_path)
+    const existing_watcher = active_watchers.get(file_path)
+    if (existing_watcher) {
+      const subscribers =
+        active_watcher_subscribers.get(file_path) ??
+        new Map<WebviewLike, WatcherMeta | undefined>()
+      subscribers.set(webview, meta)
+      active_watcher_subscribers.set(file_path, subscribers)
+      return
+    }
+
+    const subscribers = new Map<WebviewLike, WatcherMeta | undefined>([[webview, meta]])
+    active_watcher_subscribers.set(file_path, subscribers)
 
     // Create a new file system watcher for this specific file
     const file_dir = vscode.Uri.file(path.dirname(file_path))
@@ -487,17 +502,26 @@ function start_watching_file(
 
     // Listen for file changes
     watcher.onDidChange(() => {
-      void handle_file_change(`change`, file_path, webview, meta)
+      for (const [subscriber_webview, subscriber_meta] of active_watcher_subscribers.get(
+        file_path,
+      ) ?? []) {
+        void handle_file_change(`change`, file_path, subscriber_webview, subscriber_meta)
+      }
     })
 
     // Listen for file deletion
     watcher.onDidDelete(() => {
-      void handle_file_change(`delete`, file_path, webview, meta)
+      for (const [subscriber_webview, subscriber_meta] of active_watcher_subscribers.get(
+        file_path,
+      ) ?? []) {
+        void handle_file_change(`delete`, file_path, subscriber_webview, subscriber_meta)
+      }
       stop_watching_file(file_path) // Clean up watcher
     })
 
     active_watchers.set(file_path, watcher)
   } catch (error) {
+    active_watcher_subscribers.delete(file_path)
     console.error(`Failed to start watching file ${file_path}:`, error)
     webview.postMessage({
       command: `error`,
@@ -551,7 +575,15 @@ async function handle_file_change(
 }
 
 // Stop watching a file and dispose the watcher
-function stop_watching_file(file_path: string): void {
+function stop_watching_file(file_path: string, webview?: WebviewLike): void {
+  const subscribers = active_watcher_subscribers.get(file_path)
+  if (webview && subscribers) {
+    subscribers.delete(webview)
+    if (subscribers.size > 0) return
+  }
+
+  active_watcher_subscribers.delete(file_path)
+
   const watcher = active_watchers.get(file_path)
   if (watcher) {
     watcher.dispose()
@@ -626,7 +658,7 @@ function create_webview_panel(
   panel.onDidDispose(() => {
     theme_listener.dispose()
     config_listener.dispose()
-    if (file_path) stop_watching_file(file_path)
+    if (file_path) stop_watching_file(file_path, panel.webview)
   })
 
   return panel
@@ -734,7 +766,7 @@ class Provider implements vscode.CustomReadonlyEditorProvider {
         theme_change_listener.dispose()
         config_change_listener.dispose()
 
-        stop_watching_file(file_path) // Clean up file watcher
+        stop_watching_file(file_path, webview_panel.webview) // Clean up file watcher
       })
       // Note: webview_panel disposal is managed by VSCode for custom editors
     } catch (error: unknown) {
@@ -946,6 +978,7 @@ export const deactivate = (): void => {
   auto_render_timers.clear()
   active_watchers.forEach((watcher) => watcher.dispose())
   active_watchers.clear()
+  active_watcher_subscribers.clear()
   active_frame_loaders.clear()
   active_auto_render_panels.clear()
 }

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -648,6 +648,23 @@ export const render = async (
   }
 }
 
+const open_resource = async (
+  context: vscode.ExtensionContext,
+  uri?: vscode.Uri,
+): Promise<void> => {
+  if (uri) {
+    const filename = path.basename(uri.fsPath)
+    if (!should_auto_render(filename)) {
+      vscode.window.showErrorMessage(
+        `MatterViz cannot open ${filename} because it is not a supported structure or trajectory file.`,
+      )
+      return
+    }
+  }
+
+  await render(context, uri)
+}
+
 // Custom editor provider for MatterViz files
 class Provider implements vscode.CustomReadonlyEditorProvider {
   constructor(private readonly context: vscode.ExtensionContext) {}
@@ -736,7 +753,7 @@ export const activate = (context: vscode.ExtensionContext) => {
 
   context.subscriptions.push(
     vscode.commands.registerCommand(`matterviz.open`, (uri?: vscode.Uri) =>
-      render(context, uri),
+      open_resource(context, uri),
     ),
     vscode.commands.registerCommand(`matterviz.report_bug`, report_bug),
     vscode.window.registerCustomEditorProvider(`matterviz.viewer`, new Provider(context), {

--- a/extensions/vscode/tests/extension.test.ts
+++ b/extensions/vscode/tests/extension.test.ts
@@ -144,6 +144,7 @@ describe(`MatterViz Extension`, () => {
     // Import extension module and clear all watchers
     const ext = await import(`../src/extension`)
     ext.active_watchers.clear()
+    ext.active_watcher_subscribers.clear()
     ext.active_frame_loaders.clear()
     ext.auto_render_timers.clear()
     ext.active_auto_render_panels.clear()
@@ -1592,6 +1593,68 @@ describe(`MatterViz Extension`, () => {
           `matterviz.open`,
           expect.any(Function),
         )
+      })
+
+      test(`shares one file watcher across same-file panels until the final panel closes`, async () => {
+        const shared_watcher = {
+          onDidChange: vi.fn(),
+          onDidDelete: vi.fn(),
+          dispose: vi.fn(),
+        }
+        const webview1 = {
+          ...mock_webview,
+          postMessage: vi.fn(),
+          onDidReceiveMessage: vi.fn(),
+          html: ``,
+        }
+        const webview2 = {
+          ...mock_webview,
+          postMessage: vi.fn(),
+          onDidReceiveMessage: vi.fn(),
+          html: ``,
+        }
+        const panel1 = { webview: webview1, onDidDispose: vi.fn(), visible: true }
+        const panel2 = { webview: webview2, onDidDispose: vi.fn(), visible: true }
+
+        mock_vscode.workspace.createFileSystemWatcher.mockReturnValue(shared_watcher)
+        mock_vscode.window.createWebviewPanel
+          .mockReturnValueOnce(panel1)
+          .mockReturnValueOnce(panel2)
+        mock_vscode.window.activeTextEditor = {
+          document: { fileName: `/test/file.cif`, getText: () => `content` },
+        } as TextEditor
+
+        await render(mock_context)
+        await render(mock_context)
+
+        expect(mock_vscode.workspace.createFileSystemWatcher).toHaveBeenCalledTimes(1)
+
+        const change_handler = shared_watcher.onDidChange.mock.calls[0]?.[0] as
+          | (() => Promise<void> | void)
+          | undefined
+        expect(change_handler).toBeDefined()
+        await change_handler?.()
+
+        await vi.waitFor(() => {
+          expect(webview1.postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+              command: `fileUpdated`,
+              file_path: `/test/file.cif`,
+            }),
+          )
+          expect(webview2.postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+              command: `fileUpdated`,
+              file_path: `/test/file.cif`,
+            }),
+          )
+        })
+
+        panel1.onDidDispose.mock.calls[0]?.[0]()
+        expect(shared_watcher.dispose).not.toHaveBeenCalled()
+
+        panel2.onDidDispose.mock.calls[0]?.[0]()
+        expect(shared_watcher.dispose).toHaveBeenCalledTimes(1)
       })
     })
   })

--- a/extensions/vscode/tests/extension.test.ts
+++ b/extensions/vscode/tests/extension.test.ts
@@ -251,6 +251,21 @@ describe(`MatterViz Extension`, () => {
     ])(`pattern does not match unsupported near miss "%s"`, (filename) => {
       expect(matches_any_pattern(filename)).toBe(false)
     })
+
+    test(`trajectory keyword selector does not include a bare md token`, () => {
+      const trajectory_keyword_pattern = patterns.find(
+        (pattern) => pattern.includes(`trajectory`) && pattern.includes(`simulation`),
+      )
+
+      expect(trajectory_keyword_pattern).toBeDefined()
+      expect(trajectory_keyword_pattern?.match(/\{(?<keywords>[^}]+)\}/)?.groups?.keywords)
+        .toBeDefined()
+      expect(
+        trajectory_keyword_pattern
+          ?.match(/\{(?<keywords>[^}]+)\}/)
+          ?.groups?.keywords.split(`,`),
+      ).not.toContain(`md`)
+    })
   })
 
   // Test data consolidation

--- a/extensions/vscode/tests/extension.test.ts
+++ b/extensions/vscode/tests/extension.test.ts
@@ -735,6 +735,82 @@ describe(`MatterViz Extension`, () => {
     )
   })
 
+  describe(`Explorer open command`, () => {
+    const activate_with_open_command = (): ((uri?: Uri) => Promise<void> | void) => {
+      const command_registry = new Map<string, (uri?: Uri) => Promise<void> | void>()
+      mock_vscode.commands.registerCommand = vi.fn(
+        (command_name: string, callback: (uri?: Uri) => Promise<void> | void) => {
+          command_registry.set(command_name, callback)
+          return { dispose: vi.fn() }
+        },
+      )
+
+      activate(mock_context)
+      const open_command = command_registry.get(`matterviz.open`)
+      expect(open_command).toBeDefined()
+      return open_command as (uri?: Uri) => Promise<void> | void
+    }
+
+    const create_mock_panel = () => ({
+      webview: { ...mock_webview, postMessage: vi.fn(), onDidReceiveMessage: vi.fn() },
+      onDidDispose: vi.fn(),
+      visible: true,
+    })
+
+    test(`explorer menu command is not gated by active-editor support context`, () => {
+      const explorer_menu = pkg_json.contributes.menus[`explorer/context`]
+      const open_menu_item = explorer_menu.find((item) => item.command === `matterviz.open`)
+
+      expect(open_menu_item).toBeDefined()
+      expect(open_menu_item).not.toEqual(
+        expect.objectContaining({
+          when: expect.stringContaining(`matterviz.supported_resource`),
+        }),
+      )
+    })
+
+    test(`rejects unsupported clicked URIs without rendering the active editor`, async () => {
+      mock_vscode.window.activeTextEditor = {
+        document: {
+          fileName: `/test/active.cif`,
+          uri: { fsPath: `/test/active.cif` },
+          getText: () => `active content`,
+        },
+      } as TextEditor
+      mock_vscode.window.createWebviewPanel.mockReturnValue(create_mock_panel())
+
+      const open_command = activate_with_open_command()
+      await open_command({ fsPath: `/test/README.md` } as Uri)
+
+      expect(mock_vscode.window.createWebviewPanel).not.toHaveBeenCalled()
+      expect(mock_vscode.window.showErrorMessage).toHaveBeenCalledWith(
+        `MatterViz cannot open README.md because it is not a supported structure or trajectory file.`,
+      )
+    })
+
+    test(`renders supported clicked URIs even when the active editor is unsupported`, async () => {
+      mock_vscode.window.activeTextEditor = {
+        document: {
+          fileName: `/test/README.md`,
+          uri: { fsPath: `/test/README.md` },
+          getText: () => `notes`,
+        },
+      } as TextEditor
+      mock_vscode.window.createWebviewPanel.mockReturnValue(create_mock_panel())
+
+      const open_command = activate_with_open_command()
+      await open_command({ fsPath: `/test/structure.cif` } as Uri)
+
+      expect(mock_vscode.window.createWebviewPanel).toHaveBeenCalledWith(
+        `matterviz`,
+        `MatterViz - structure.cif`,
+        mock_vscode.ViewColumn.Active,
+        expect.any(Object),
+      )
+      expect(mock_vscode.window.showErrorMessage).not.toHaveBeenCalled()
+    })
+  })
+
   describe(`Bug Reporting`, () => {
     let mock_opened_document: { content: string; language: string } | null = null
     let report_bug_command: (() => Promise<void>) | null = null


### PR DESCRIPTION
This draft PR is part of the Codex global scan follow-up described in #401. It fixes VS Code extension editor registration, explorer command handling, and same-file watcher lifecycle issues that were reproduced before implementation:

- Fixes #390 by removing the bare `md` trajectory keyword from the custom editor filename selector.
- Fixes #391 by letting the explorer context menu invoke the command for clicked resources while validating the clicked URI before rendering.
- Fixes #392 by sharing one file watcher across multiple panels for the same file and disposing it only after the final subscriber closes.