### PR TITLE
Isosurface support typed-array scalar grids in marching cubes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,13 +37,13 @@ repos:
     hooks:
       - id: vp-fmt
         name: Format (oxfmt)
-        entry: npx --package=vite-plus vp check --fix
+        entry: npx --package=vite-plus@0.2.5 vp check --fix
         types_or: [file]
         language: system
         pass_filenames: false
       - id: svelte-check
         name: Svelte type check
-        entry: bash -c "npx svelte-kit sync && npx svelte-check --threshold error"
+        entry: bash -c "npx svelte-kit sync && npx svelte-check --tsconfig ./tsconfig.json --threshold error"
         language: system
         types_or: [ts, svelte]
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
         entry: npx --package=vite-plus@0.2.5 vp check --fix
         types_or: [file]
         language: system
-        pass_filenames: true
+        pass_filenames: false
         stages: [pre-commit]
       - id: svelte-check
         name: Svelte type check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,8 @@ repos:
         entry: npx --package=vite-plus@0.2.5 vp check --fix
         types_or: [file]
         language: system
-        pass_filenames: false
+        pass_filenames: true
+        stages: [pre-commit]
       - id: svelte-check
         name: Svelte type check
         entry: bash -c "npx svelte-kit sync && npx svelte-check --tsconfig ./tsconfig.json --threshold error"

--- a/extensions/anywidget/anywidget.ts
+++ b/extensions/anywidget/anywidget.ts
@@ -43,6 +43,7 @@ import {
   throttle,
   writeback_prop,
 } from './reactive.svelte'
+
 const adopted_sheets = new WeakMap<ShadowRoot, CSSStyleSheet>()
 
 // Static widget chrome + bundled app styles. Only the theme-variable block
@@ -336,7 +337,7 @@ export const mount_spec = (model: AnyModel, el: HTMLElement, spec: WidgetSpec): 
     [...(spec.base_drive ?? top_level_base_drive), ...spec.drive],
     {
       allow_file_drop: false, // off in notebooks
-      ...(interaction?.props ?? {}),
+      ...interaction?.props,
     },
   )
   reactive_disposers.set(el, () => {

--- a/extensions/anywidget/reactive.svelte.ts
+++ b/extensions/anywidget/reactive.svelte.ts
@@ -189,7 +189,7 @@ export function reactive_widget(
       if (!equal(props[spec.prop], value)) props[spec.prop] = value
     } else if (spec.prop in props) {
       // drive-only trait cleared (None): drop the key so the component falls back
-      delete props[spec.prop]
+      Reflect.deleteProperty(props, spec.prop)
     }
   }
 

--- a/extensions/anywidget/vite.config.ts
+++ b/extensions/anywidget/vite.config.ts
@@ -4,7 +4,8 @@ import { readFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { resolve } from 'node:path'
 import { gunzipSync } from 'node:zlib'
-import { defineConfig } from 'vite-plus'
+import type { Plugin } from 'vite'
+import { defineConfig, type PluginOption } from 'vite-plus'
 
 // Load moyo (spglib) symmetry WASM from jsDelivr on demand instead of inlining
 // it as base64 -- twice (once via symmetry/index.ts's `?url` import, once via the
@@ -16,25 +17,58 @@ const moyo_glue_url = `new URL('moyo_wasm_bg.wasm', import.meta.url)`
 
 let json_gz_is_build = false
 
-const moyo_wasm_cdn_plugin = {
+const moyo_wasm_cdn_plugin: Plugin = {
   name: `moyo-wasm-cdn`,
   enforce: `pre` as const,
   resolveId(source: string) {
     if (source.includes(`@spglib/moyo-wasm`) && source.endsWith(`.wasm?url`)) {
       return `\0moyo-wasm-cdn-url`
     }
+    return null
   },
   load(id: string) {
     if (id === `\0moyo-wasm-cdn-url`) {
       return `export default ${JSON.stringify(moyo_wasm_cdn)}`
     }
+    return null
   },
   transform(code: string, id: string) {
     if (id.includes(`@spglib/moyo-wasm`) && code.includes(moyo_glue_url)) {
       return { code: code.replace(moyo_glue_url, JSON.stringify(moyo_wasm_cdn)), map: null }
     }
+    return null
   },
 }
+
+const json_gz_plugin: Plugin = {
+  name: `vite-plugin-json-gz`,
+  enforce: `pre`,
+  configResolved(resolved_config) {
+    json_gz_is_build = resolved_config.command === `build`
+  },
+  load(id) {
+    if (!id.endsWith(`.json.gz`)) return null
+    try {
+      const json_str = gunzipSync(readFileSync(id)).toString(`utf-8`)
+      JSON.parse(json_str) // validate before passing to bundler
+      // Rolldown (build) needs moduleType:'json' for import.meta.glob with
+      // import:'default' to properly unwrap the default export. Dev/test
+      // server doesn't support moduleType, needs JS module format.
+      if (json_gz_is_build) return { code: json_str, moduleType: `json` }
+      return `export default ${json_str}`
+    } catch (error) {
+      return this.error(`Failed to decompress ${id}: ${error}`)
+    }
+  },
+}
+
+// svelte() ships its own copy of Vite's Plugin type; inferring the array element
+// type deep-compares them and exceeds TypeScript's instantiation depth.
+const plugins = [
+  moyo_wasm_cdn_plugin as unknown,
+  json_gz_plugin as unknown,
+  svelte() as unknown,
+] as PluginOption[]
 
 export default defineConfig({
   ...config, // shared lint/fmt/build from @janosh/vite-config (dotfiles)
@@ -45,31 +79,7 @@ export default defineConfig({
       h5wasm: resolve(import.meta.dirname, `h5wasm-stub.ts`),
     },
   },
-  plugins: [
-    moyo_wasm_cdn_plugin,
-    {
-      name: `vite-plugin-json-gz`,
-      enforce: `pre`,
-      configResolved(resolved_config) {
-        json_gz_is_build = resolved_config.command === `build`
-      },
-      load(id) {
-        if (!id.endsWith(`.json.gz`)) return null
-        try {
-          const json_str = gunzipSync(readFileSync(id)).toString(`utf-8`)
-          JSON.parse(json_str) // validate before passing to bundler
-          // Rolldown (build) needs moduleType:'json' for import.meta.glob with
-          // import:'default' to properly unwrap the default export. Dev/test
-          // server doesn't support moduleType, needs JS module format.
-          if (json_gz_is_build) return { code: json_str, moduleType: `json` }
-          return `export default ${json_str}`
-        } catch (error) {
-          return this.error(`Failed to decompress ${id}: ${error}`)
-        }
-      },
-    },
-    svelte(),
-  ],
+  plugins,
   build: {
     ...config.build, // keep shared cssTarget: esnext (for light-dark())
     outDir: `build`,

--- a/package.json
+++ b/package.json
@@ -255,7 +255,9 @@
     "@types/d3-scale-chromatic": "^3.1.0",
     "@types/d3-shape": "^3.1.8",
     "@types/d3-time-format": "^4.0.3",
+    "@types/node": "^26.1.1",
     "@types/three": "^0.185.1",
+    "@types/vscode": "~1.105.0",
     "@vitest/coverage-v8": "4.1.10",
     "@wooorm/starry-night": "^3.10.0",
     "happy-dom": "^20.10.6",
@@ -268,7 +270,7 @@
     "svelte-check": "^4.7.2",
     "typescript": "^6.0.3",
     "vite": "^8.1.4",
-    "vite-plus": "^0.2.4",
+    "vite-plus": "^0.2.5",
     "vitest": "4.1.10"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -257,7 +257,6 @@
     "@types/d3-time-format": "^4.0.3",
     "@types/node": "^26.1.1",
     "@types/three": "^0.185.1",
-    "@types/vscode": "~1.105.0",
     "@vitest/coverage-v8": "4.1.10",
     "@wooorm/starry-night": "^3.10.0",
     "happy-dom": "^20.10.6",

--- a/src/lib/FilePicker.svelte
+++ b/src/lib/FilePicker.svelte
@@ -126,8 +126,8 @@
   }
 
   // Get unique file types/categories for format/category filters
-  let uniq_formats = $derived([...new Set(files.map(get_base_file_type))].sort())
-  let uniq_categories = $derived([...new Set(files.map(get_category_id))].sort())
+  let uniq_formats = $derived([...new Set(files.map(get_base_file_type))].toSorted())
+  let uniq_categories = $derived([...new Set(files.map(get_category_id))].toSorted())
 </script>
 
 <div class="file-picker" class:vertical={layout === `vertical`} {...rest}>

--- a/src/lib/brillouin/BrillouinZoneScene.svelte
+++ b/src/lib/brillouin/BrillouinZoneScene.svelte
@@ -119,7 +119,8 @@
     const lens = k_path_points
       .slice(1)
       .map((pt, idx) => Math.hypot(...math.subtract(pt as Vec3, k_path_points[idx] as Vec3)))
-      .sort((len_a, len_b) => len_a - len_b)
+      // map() returns a fresh length array.
+      .toSorted((len_a, len_b) => len_a - len_b)
     return lens[Math.floor(lens.length / 2)] * 10
   })
 

--- a/src/lib/brillouin/compute.ts
+++ b/src/lib/brillouin/compute.ts
@@ -162,7 +162,8 @@ export function generate_bz_vertices(
       }
     })
     .filter((plane): plane is NonNullable<typeof plane> => plane !== null)
-    .sort((a, b) => a.dist_sq - b.dist_sq)
+    // The filtered plane array is fresh.
+    .toSorted((a, b) => a.dist_sq - b.dist_sq)
     .slice(0, max_planes)
 
   // Pre-compute plane data for fast access

--- a/src/lib/chempot-diagram/ChemPotDiagram3D.svelte
+++ b/src/lib/chempot-diagram/ChemPotDiagram3D.svelte
@@ -275,7 +275,7 @@
         .filter(([, amount]) => amount > 0)
         .map(([element]) => element),
     )
-    return Array.from(new SvelteSet(elements)).sort()
+    return Array.from(new SvelteSet(elements)).toSorted()
   })
   const has_multinary_system = $derived(all_entry_elements.length > 3)
   let projection_elements_override = $state<string[] | null>(null)
@@ -356,7 +356,7 @@
   })
   const current_projection_key = $derived(plot_elements.join(`|`))
   let formula_filter_query = $state(``)
-  const available_formulas = $derived(Object.keys(diagram_data?.domains ?? {}).sort())
+  const available_formulas = $derived(Object.keys(diagram_data?.domains ?? {}).toSorted())
   const filtered_formulas = $derived.by(() => {
     const query = formula_filter_query.trim().toLowerCase()
     if (!query) return available_formulas

--- a/src/lib/chempot-diagram/ChemPotDiagram3D.svelte
+++ b/src/lib/chempot-diagram/ChemPotDiagram3D.svelte
@@ -1176,7 +1176,7 @@
       }
     }
     const result = new SvelteMap<string, string[]>()
-    for (const [formula, set] of neighbors) result.set(formula, [...set].sort())
+    for (const [formula, set] of neighbors) result.set(formula, [...set].toSorted())
     return result
   })
 

--- a/src/lib/chempot-diagram/async-compute.svelte.ts
+++ b/src/lib/chempot-diagram/async-compute.svelte.ts
@@ -14,7 +14,10 @@ const pending = new Map<
 const pending_by_key = new Map<string, Promise<ChemPotDiagramData>>()
 
 function make_compute_request_key(entries: PhaseData[], config: ChemPotDiagramConfig): string {
-  return `${entries.map(entry_fingerprint).sort().join(`,`)}|${JSON.stringify(config)}`
+  const fingerprints = entries.map(entry_fingerprint)
+  // map() returns a fresh array.
+  fingerprints.sort()
+  return `${fingerprints.join(`,`)}|${JSON.stringify(config)}`
 }
 
 function track_pending(

--- a/src/lib/chempot-diagram/compute.ts
+++ b/src/lib/chempot-diagram/compute.ts
@@ -81,7 +81,8 @@ export function formula_key_from_composition(composition: Record<string, number>
   const reduced = get_reduced_formula(composition)
   const key = Object.entries(reduced)
     .filter(([, amt]) => amt > 0)
-    .sort(([a], [b]) => a.localeCompare(b))
+    // filter() returns a fresh array.
+    .toSorted(([a], [b]) => a.localeCompare(b))
     .map(([el, amt]) => (amt === 1 ? el : `${el}${amt}`))
     .join(``)
   formula_cache.set(composition, key)
@@ -863,7 +864,7 @@ export function get_visible_domain_labels(
     }
   }
 
-  return visible_labels.sort((label_a, label_b) =>
+  return visible_labels.toSorted((label_a, label_b) =>
     label_a.formula.localeCompare(label_b.formula),
   )
 }
@@ -925,7 +926,10 @@ export function make_nd_cache_key(
   default_min_limit: number,
   limits: ChemPotDiagramConfig[`limits`],
 ): string {
-  return `${entries.map(entry_fingerprint).sort().join(`,`)}|${formal_chempots}|${default_min_limit}|${JSON.stringify(limits ?? {})}`
+  const fingerprints = entries.map(entry_fingerprint)
+  // map() returns a fresh array.
+  fingerprints.sort()
+  return `${fingerprints.join(`,`)}|${formal_chempots}|${default_min_limit}|${JSON.stringify(limits ?? {})}`
 }
 
 // === Main Pipeline ===
@@ -956,7 +960,7 @@ export function compute_chempot_diagram(
       if (amount > 0) all_data_elements_set.add(element)
     }
   }
-  const all_data_elements = Array.from(all_data_elements_set).sort()
+  const all_data_elements = Array.from(all_data_elements_set).toSorted()
 
   // Display elements: user-specified order (controls axis mapping), or auto-detect
   const display_elements = config.elements?.length ? [...config.elements] : all_data_elements
@@ -993,7 +997,8 @@ export function compute_chempot_diagram(
     // Sort entries by composition (Schwartzian transform to avoid recomputing keys)
     const sorted_entries = working_entries
       .map((entry) => ({ entry, key: formula_key_from_composition(entry.composition) }))
-      .sort((a, b) => a.key.localeCompare(b.key))
+      // map() returns a fresh array.
+      .toSorted((a, b) => a.key.localeCompare(b.key))
       .map(({ entry }) => entry)
 
     // Get min entries and elemental references

--- a/src/lib/chempot-diagram/compute.ts
+++ b/src/lib/chempot-diagram/compute.ts
@@ -81,8 +81,8 @@ export function formula_key_from_composition(composition: Record<string, number>
   const reduced = get_reduced_formula(composition)
   const key = Object.entries(reduced)
     .filter(([, amt]) => amt > 0)
-    // filter() returns a fresh array.
-    .toSorted(([a], [b]) => a.localeCompare(b))
+    // oxlint-disable-next-line eslint-plugin-unicorn/no-array-sort -- filter() returns a fresh array
+    .sort(([a], [b]) => a.localeCompare(b))
     .map(([el, amt]) => (amt === 1 ? el : `${el}${amt}`))
     .join(``)
   formula_cache.set(composition, key)
@@ -874,6 +874,7 @@ export function get_visible_domain_labels(
 // Generate all C(n,3) ternary element combinations from a sorted element list.
 // Each triplet is sorted alphabetically. Returns empty array for fewer than 3 elements.
 export function get_ternary_combinations(elements: string[]): string[][] {
+  // oxlint-disable-next-line eslint-plugin-unicorn/no-array-sort -- spread creates a fresh array
   const sorted = [...elements].sort()
   const n_elems = sorted.length
   if (n_elems < 3) return []
@@ -997,8 +998,8 @@ export function compute_chempot_diagram(
     // Sort entries by composition (Schwartzian transform to avoid recomputing keys)
     const sorted_entries = working_entries
       .map((entry) => ({ entry, key: formula_key_from_composition(entry.composition) }))
-      // map() returns a fresh array.
-      .toSorted((a, b) => a.key.localeCompare(b.key))
+      // oxlint-disable-next-line eslint-plugin-unicorn/no-array-sort -- map() returns a fresh array
+      .sort((a, b) => a.key.localeCompare(b.key))
       .map(({ entry }) => entry)
 
     // Get min entries and elemental references

--- a/src/lib/colors/index.ts
+++ b/src/lib/colors/index.ts
@@ -22,8 +22,19 @@ export type D3InterpolateName = keyof typeof d3_sc & `interpolate${string}`
 export type D3ColorSchemeName = D3InterpolateName extends `interpolate${infer Name}`
   ? Name
   : never
+// D3 interpolators are selected dynamically from a validated plain-object snapshot.
+const d3_interpolators = Object.fromEntries(
+  Object.entries(d3_sc).filter(
+    ([name, candidate]) => name.startsWith(`interpolate`) && typeof candidate === `function`,
+  ),
+) as Record<D3InterpolateName, (t: number) => string>
+export const D3_INTERPOLATE_NAMES = new Set(
+  Object.keys(d3_interpolators),
+) as ReadonlySet<D3InterpolateName>
+export const is_d3_interpolate_name = (name: string): name is D3InterpolateName =>
+  D3_INTERPOLATE_NAMES.has(name as D3InterpolateName)
 export const get_d3_interpolator = (name: D3InterpolateName): ((t: number) => string) => {
-  const candidate = d3_sc[name]
+  const candidate = d3_interpolators[name]
   return typeof candidate === `function` ? candidate : d3_sc.interpolateViridis
 }
 export const COLOR_SCALE_TYPES = [`continuous`, `categorical`] as const

--- a/src/lib/composition/Formula.svelte
+++ b/src/lib/composition/Formula.svelte
@@ -59,7 +59,7 @@
       return sorted[0] === el1.element ? -1 : 1
     },
   }
-  const sorted_elements = $derived([...parsed_elements].sort(COMPARATORS[ordering]))
+  const sorted_elements = $derived([...parsed_elements].toSorted(COMPARATORS[ordering]))
 
   let hovered_element = $state<ElementSymbol | null>(null)
   let tooltip_pos = $state({ x: 0, y: 0 })

--- a/src/lib/composition/FormulaFilter.svelte
+++ b/src/lib/composition/FormulaFilter.svelte
@@ -526,7 +526,7 @@
     // For formulas with wildcards, we can't parse them normally
     if (has_wildcards(trimmed)) {
       const tokens = parse_formula_with_wildcards(trimmed)
-      const elements = [...new Set(tokens.flatMap((token) => token.element ?? []))].sort()
+      const elements = [...new Set(tokens.flatMap((token) => token.element ?? []))].toSorted()
       const wildcards = tokens.filter((token) => token.element === null).map(() => `*`)
       return [...elements, ...wildcards]
     }

--- a/src/lib/composition/FormulaFilter.svelte
+++ b/src/lib/composition/FormulaFilter.svelte
@@ -323,7 +323,7 @@
         if (existing) existing.count += token.count
         else merged_explicit.push(token)
       }
-      const sorted_explicit = merged_explicit.sort((elem_a, elem_b) =>
+      const sorted_explicit = merged_explicit.toSorted((elem_a, elem_b) =>
         elem_a.element.localeCompare(elem_b.element),
       )
       const wildcard_str = wildcard_tokens
@@ -453,7 +453,7 @@
           ? `*`
           : normalize_element_symbols(token.element).at(0) || token.element,
       }))
-      .sort((token_a, token_b) => {
+      .toSorted((token_a, token_b) => {
         if (token_a.operator !== token_b.operator) {
           return token_a.operator === `include` ? -1 : 1
         }
@@ -519,7 +519,7 @@
       const wildcards = parts.filter((part) => part === `*`)
       const regular_parts = parts.filter((part) => part !== `*`)
       // Filter valid elements and sort alphabetically, then append wildcards
-      const valid_elements = normalize_element_symbols(regular_parts.join(`,`)).sort()
+      const valid_elements = normalize_element_symbols(regular_parts.join(`,`)).toSorted()
       return [...valid_elements, ...wildcards]
     }
     // Otherwise parse as formula (already returns sorted by default)

--- a/src/lib/composition/chem-sys.ts
+++ b/src/lib/composition/chem-sys.ts
@@ -53,7 +53,7 @@ export function chem_sys_sunburst_data(
       }
     }
     if (elements.length === 0) return null
-    return [...new Set(elements)].sort().join(`-`)
+    return [...new Set(elements)].toSorted().join(`-`)
   }
 
   const counts = new Map<string, number>()

--- a/src/lib/composition/chem-sys.ts
+++ b/src/lib/composition/chem-sys.ts
@@ -82,7 +82,7 @@ export function chem_sys_sunburst_data(
   // final order; consecutive same-arity runs then collapse into one branch each
   const sorted = [...counts]
     .map(([chem_sys, count]) => ({ chem_sys, count, arity: chem_sys.split(`-`).length }))
-    .sort((sys_a, sys_b) => sys_a.arity - sys_b.arity || sys_b.count - sys_a.count)
+    .toSorted((sys_a, sys_b) => sys_a.arity - sys_b.arity || sys_b.count - sys_a.count)
   const roots: SunburstNode<ChemSysSunburstMetadata>[] = []
   let branch: SunburstNode<ChemSysSunburstMetadata> | undefined
   for (const { chem_sys, count, arity } of sorted) {

--- a/src/lib/composition/format.ts
+++ b/src/lib/composition/format.ts
@@ -88,7 +88,7 @@ export const sort_by_electronegativity = (symbols: ElementSymbol[]): ElementSymb
 // This is the standard notation for organic compounds in chemistry.
 export const sort_by_hill_notation = (symbols: ElementSymbol[]): ElementSymbol[] => {
   const has_carbon = symbols.includes(`C`)
-  return symbols.sort((el_a, el_b) => {
+  return symbols.toSorted((el_a, el_b) => {
     // Equal elements must return 0 (sort invariant)
     if (el_a === el_b) return 0
     // Carbon always comes first

--- a/src/lib/composition/parse.ts
+++ b/src/lib/composition/parse.ts
@@ -354,7 +354,7 @@ export function extract_formula_elements(
     return elements
   }
   const symbols = Object.keys(parse_formula(formula)).filter(is_elem_symbol)
-  return sorted ? symbols.sort() : symbols
+  return sorted ? symbols.toSorted() : symbols
 }
 
 // Generate all non-empty subsets of a chemical system as hyphenated strings.
@@ -450,7 +450,8 @@ export function parse_chemsys_with_wildcards(input: string): ChemsysWithWildcard
     }
   }
 
-  return { elements: elements.sort(), wildcard_count }
+  // elements is local and no longer reused.
+  return { elements: elements.toSorted(), wildcard_count }
 }
 
 // Placeholder for wildcards during parentheses expansion (Zz is not a real element symbol).
@@ -554,7 +555,7 @@ export function matches_formula_wildcard(
     const remaining_counts = Object.entries(composition)
       .filter(([elem]) => !explicit_counts.has(elem as ElementSymbol))
       .map(([, count]) => count)
-      .sort((cnt_a, cnt_b) => cnt_a - cnt_b)
+      .toSorted((cnt_a, cnt_b) => cnt_a - cnt_b)
     if (remaining_counts.length !== wildcard_counts.length) return false
 
     wildcard_counts.sort((cnt_a, cnt_b) => cnt_a - cnt_b)

--- a/src/lib/composition/parse.ts
+++ b/src/lib/composition/parse.ts
@@ -375,7 +375,7 @@ export function generate_chem_sys_subspaces(
     }
   }
 
-  const sorted = [...elements].sort()
+  const sorted = [...elements].toSorted()
   const subspaces: string[] = []
   const subset_count = 2 ** sorted.length
 

--- a/src/lib/convex-hull/ConvexHull3D.svelte
+++ b/src/lib/convex-hull/ConvexHull3D.svelte
@@ -896,7 +896,8 @@
           )
         }),
       )
-      .sort((entry_1, entry_2) => {
+      // The helper returns a fresh array.
+      .toSorted((entry_1, entry_2) => {
         const energy_diff = label_priority_energy(entry_1) - label_priority_energy(entry_2)
         if (energy_diff !== 0) return energy_diff
         return (entry_1.e_above_hull ?? 0) - (entry_2.e_above_hull ?? 0)

--- a/src/lib/convex-hull/ConvexHullStats.svelte
+++ b/src/lib/convex-hull/ConvexHullStats.svelte
@@ -215,6 +215,9 @@
     ]
   })
 
+  const pair_key = (element_a: string, element_b: string): string =>
+    element_a < element_b ? `${element_a}-${element_b}` : `${element_b}-${element_a}`
+
   // Subsystem coverage: count entries per element pair for the stats pane
   let subsystem_coverage = $derived.by(() => {
     if (!phase_stats) return null
@@ -229,7 +232,7 @@
       // Count all pairs present in this entry
       for (let idx_a = 0; idx_a < active.length; idx_a++) {
         for (let idx_b = idx_a + 1; idx_b < active.length; idx_b++) {
-          const key = [active[idx_a], active[idx_b]].sort().join(`-`)
+          const key = pair_key(active[idx_a], active[idx_b])
           pair_counts.set(key, (pair_counts.get(key) ?? 0) + 1)
         }
       }
@@ -237,7 +240,7 @@
     // Build pairs list sorted by element order in chemical_system
     return elements.flatMap((el_a, idx_a) =>
       elements.slice(idx_a + 1).map((el_b) => {
-        const key = [el_a, el_b].sort().join(`-`)
+        const key = pair_key(el_a, el_b)
         return { pair: key, count: pair_counts.get(key) ?? 0 }
       }),
     )
@@ -313,7 +316,7 @@
   let poly_formulas = $derived(
     [...polymorph_counts.entries()]
       .filter(([, count]) => count > 1)
-      .sort(([, count_a], [, count_b]) => count_b - count_a),
+      .toSorted(([, count_a], [, count_b]) => count_b - count_a),
   )
   let has_polymorphs = $derived(poly_formulas.length > 0)
   let active_formula_filter = $derived.by(() => {

--- a/src/lib/convex-hull/canvas-interactions.svelte.ts
+++ b/src/lib/convex-hull/canvas-interactions.svelte.ts
@@ -293,13 +293,16 @@ export function create_canvas_interactions(inputs: CanvasInteractionInputs) {
   // Performance: Pre-compute and cache all point projections + depth sorting
   const sorted_points_cache = $derived.by(() => {
     if (!inputs.canvas() || inputs.visible_entries().length === 0) return []
-    return inputs
-      .visible_entries()
-      .map((entry) => ({
-        entry,
-        projected: inputs.project_point(entry.x, entry.y, entry.z),
-      }))
-      .sort((left, right) => left.projected.depth - right.projected.depth)
+    return (
+      inputs
+        .visible_entries()
+        .map((entry) => ({
+          entry,
+          projected: inputs.project_point(entry.x, entry.y, entry.z),
+        }))
+        // map() returns a fresh projection array.
+        .toSorted((left, right) => left.projected.depth - right.projected.depth)
+    )
   })
 
   return {

--- a/src/lib/convex-hull/helpers.ts
+++ b/src/lib/convex-hull/helpers.ts
@@ -550,7 +550,8 @@ function get_label_representative_energy(entry: PhaseData): number {
 
 const get_fractional_composition_key = (composition: Record<string, number>): string =>
   Object.entries(get_fractional_composition(composition))
-    .sort(([elem_a], [elem_b]) => elem_a.localeCompare(elem_b))
+    // Object.entries() returns a fresh array.
+    .toSorted(([elem_a], [elem_b]) => elem_a.localeCompare(elem_b))
     .map(([elem, frac]) => `${elem}:${frac.toFixed(6)}`)
     .join(`|`)
 
@@ -1049,7 +1050,7 @@ export function get_entry_label(
   type Pairs = [ElementSymbol, number][]
   let pairs = Object.entries(entry.composition).filter(([, amt]) => (amt ?? 0) > 0) as Pairs
   if (elements) {
-    pairs = pairs.sort(([el1], [el2]) => elements.indexOf(el1) - elements.indexOf(el2))
+    pairs = pairs.toSorted(([el1], [el2]) => elements.indexOf(el1) - elements.indexOf(el2))
   }
   return pairs
     .map(([el, amt]) => (Math.abs(amt - 1) < 1e-6 ? el : `${el}${format_num(amt, `.2~`)}`))

--- a/src/lib/convex-hull/helpers.ts
+++ b/src/lib/convex-hull/helpers.ts
@@ -856,7 +856,7 @@ export function analyze_temperature_data(entries: PhaseData[]): TemperatureAnaly
     if (!entry_has_temp_data(entry)) continue
     for (const temperature of entry.temperatures ?? []) unique_temperatures.add(temperature)
   }
-  const available_temperatures = [...unique_temperatures].sort((a, b) => a - b)
+  const available_temperatures = [...unique_temperatures].toSorted((a, b) => a - b)
   return {
     has_temp_data: available_temperatures.length > 0,
     available_temperatures,

--- a/src/lib/convex-hull/thermodynamics.ts
+++ b/src/lib/convex-hull/thermodynamics.ts
@@ -74,7 +74,7 @@ export function process_hull_entries(entries: PhaseData[]): ProcessedPhaseData {
   // Extract unique element symbols from normalized compositions
   const elements = Array.from(
     new Set(normalized_entries.flatMap((entry) => Object.keys(entry.composition))),
-  ).sort() as ElementSymbol[]
+  ).toSorted() as ElementSymbol[]
 
   const el_refs = Object.fromEntries(
     stable_entries
@@ -166,7 +166,7 @@ export function calculate_e_above_hull(
   // 1. Identify chemical system
   const elements = Array.from(
     new Set(reference_entries.flatMap((entry) => Object.keys(entry.composition))),
-  ).sort() as ElementSymbol[]
+  ).toSorted() as ElementSymbol[]
 
   // 2. Validate subset
   const element_set = new Set(elements)
@@ -483,6 +483,7 @@ export function compute_lower_hull_2d(points: Point2D[]): Point2D[] {
   // Andrew's monotone chain lower hull (Point2D adapter over math.monotone_chain)
   const sorted = points
     .map((pt): Vec2 => [pt.x, pt.y])
+    // map() returns a fresh array.
     .toSorted((a, b) => a[0] - b[0] || a[1] - b[1])
   return math.monotone_chain(sorted).map(([x, y]) => ({ x, y }))
 }
@@ -1024,7 +1025,9 @@ export function compute_quickhull_nd(points: number[][]): SimplexFaceND[] {
     }
 
     // Remove visible faces (in reverse order to maintain indices)
-    const sorted_visible = Array.from(visible_indices).sort((a, b) => b - a)
+    const sorted_visible = Array.from(visible_indices)
+    // Array.from() returns a fresh array.
+    sorted_visible.sort((a, b) => b - a)
     for (const idx of sorted_visible) {
       faces.splice(idx, 1)
     }

--- a/src/lib/convex-hull/thermodynamics.ts
+++ b/src/lib/convex-hull/thermodynamics.ts
@@ -937,7 +937,7 @@ function build_horizon_nd(faces: SimplexFaceND[], visible_indices: Set<number>):
     // Each face has n_verts ridges, each ridge omits one vertex
     for (let skip = 0; skip < n_verts; skip++) {
       const ridge = verts.filter((_, idx) => idx !== skip)
-      const sorted = [...ridge].sort((a, b) => a - b)
+      const sorted = [...ridge].toSorted((a, b) => a - b)
       const key = sorted.join(`|`)
 
       if (!ridge_count.has(key)) {

--- a/src/lib/coordination/CoordinationBarPlot.svelte
+++ b/src/lib/coordination/CoordinationBarPlot.svelte
@@ -104,7 +104,7 @@
     for (const entry of entries_with_data) {
       for (const [cn] of entry.data.cn_histogram) all_cns.add(cn)
     }
-    return Array.from(all_cns).sort((cn1, cn2) => cn1 - cn2)
+    return Array.from(all_cns).toSorted((cn1, cn2) => cn1 - cn2)
   })
 
   // CN axis spans all ticks with half-bar margin; count axis always starts at 0
@@ -136,11 +136,11 @@
       }
 
       // Sort CNs for consistent x-axis
-      const sorted_cns = Array.from(all_cns).sort((a, b) => a - b)
+      const sorted_cns = Array.from(all_cns).toSorted((a, b) => a - b)
 
       // Convert map to array and ensure all series have same x-values
       return Array.from(element_series_map.entries())
-        .sort((a, b) => a[0].localeCompare(b[0]))
+        .toSorted((a, b) => a[0].localeCompare(b[0]))
         .map(([element, cn_map], idx) => {
           return {
             x: sorted_cns,
@@ -161,7 +161,7 @@
           all_cns.add(cn)
         }
       }
-      const sorted_cns = Array.from(all_cns).sort((a, b) => a - b)
+      const sorted_cns = Array.from(all_cns).toSorted((a, b) => a - b)
 
       return entries_with_data.map((entry, idx) => {
         return {
@@ -184,7 +184,7 @@
       }
     }
 
-    const x_vals = Array.from(combined_histogram.keys()).sort((a, b) => a - b)
+    const x_vals = Array.from(combined_histogram.keys()).toSorted((a, b) => a - b)
     const y_vals = x_vals.map((cn) => combined_histogram.get(cn) ?? 0)
 
     return [

--- a/src/lib/isosurface/Isosurface.svelte
+++ b/src/lib/isosurface/Isosurface.svelte
@@ -529,7 +529,8 @@
       return layer.isovalue / Math.max(abs_max, 1e-30)
     }
     entries
-      .sort((entry_a, entry_b) => shell_fraction(entry_a) - shell_fraction(entry_b))
+      // entries is rebuilt locally above.
+      .toSorted((entry_a, entry_b) => shell_fraction(entry_a) - shell_fraction(entry_b))
       .forEach((entry, rank) => (entry.render_order = rank * 2))
 
     // Dispose old geometries that were not reused, then swap in the new list

--- a/src/lib/isosurface/geometry.worker.ts
+++ b/src/lib/isosurface/geometry.worker.ts
@@ -32,12 +32,13 @@ worker_scope.addEventListener(`message`, ({ data: request }): void => {
       const prepare_start = performance.now()
       const volume = inflate_volume(job.volume)
       const { grid, lattice, origin } = prepare_geometry_grid(volume, job.range)
-      const { values: prepared_values, dims: grid_dims } = flatten_grid(grid)
+      const prepared_grid = flatten_grid(grid)
+      const { values: prepared_values, dims: grid_dims } = prepared_grid
       transfer.push(prepared_values.buffer)
       const prepare_geometry_ms = performance.now() - prepare_start
       const surfaces = job.surfaces.map(({ token, isovalue }) => {
         const marching_start = performance.now()
-        const buffers = marching_cubes_buffers(grid, isovalue, lattice, {
+        const buffers = marching_cubes_buffers(prepared_grid, isovalue, lattice, {
           periodic: false,
           interpolate: true,
           centered: false,

--- a/src/lib/isosurface/geometry.worker.ts
+++ b/src/lib/isosurface/geometry.worker.ts
@@ -4,9 +4,9 @@ import type {
   GeometryWorkerResponse,
   TransferableVolume,
 } from './geometry-worker-types'
-import { flatten_grid, inflate_grid } from './grid'
+import { flatten_grid, inflate_grid, type ScalarGrid3D } from './grid'
 import { prepare_geometry_grid } from './sampling'
-import type { VolumetricData } from './types'
+import { MAX_GRID_POINTS, type VolumetricData } from './types'
 
 interface WorkerScope {
   addEventListener(
@@ -30,9 +30,19 @@ worker_scope.addEventListener(`message`, ({ data: request }): void => {
     const volume_results: Exclude<GeometryWorkerResponse, { error: string }>[`volumes`] = []
     for (const job of request.volumes) {
       const prepare_start = performance.now()
-      const volume = inflate_volume(job.volume)
-      const { grid, lattice, origin } = prepare_geometry_grid(volume, job.range)
-      const prepared_grid = flatten_grid(grid)
+      const source_grid: ScalarGrid3D<Float64Array> = {
+        values: job.volume.grid_values,
+        dims: [...job.volume.grid_dims],
+        order: `z_fastest`,
+      }
+      let prepared_grid = source_grid
+      let { lattice, origin } = job.volume
+      if (job.range || source_grid.values.length > MAX_GRID_POINTS) {
+        const prepared = prepare_geometry_grid(inflate_volume(job.volume), job.range)
+        prepared_grid = flatten_grid(prepared.grid)
+        lattice = prepared.lattice
+        origin = prepared.origin
+      }
       const { values: prepared_values, dims: grid_dims } = prepared_grid
       transfer.push(prepared_values.buffer)
       const prepare_geometry_ms = performance.now() - prepare_start

--- a/src/lib/isosurface/grid.ts
+++ b/src/lib/isosurface/grid.ts
@@ -60,6 +60,18 @@ export function scalar_grid_strides({ dims: [nx, ny, nz], order }: ScalarGrid3D)
   throw new RangeError(`Unsupported scalar grid order: ${String(order)}`)
 }
 
+export function create_grid_value_accessor(
+  grid: ScalarGridLike,
+): (x_idx: number, y_idx: number, z_idx: number) => number {
+  if (is_scalar_grid(grid)) {
+    const [stride_x, stride_y, stride_z] = scalar_grid_strides(grid)
+    const { values } = grid
+    return (x_idx, y_idx, z_idx) =>
+      values[x_idx * stride_x + y_idx * stride_y + z_idx * stride_z]
+  }
+  return (x_idx, y_idx, z_idx) => grid[x_idx][y_idx][z_idx]
+}
+
 export function grid_value(
   grid: ScalarGridLike,
   x_idx: number,

--- a/src/lib/isosurface/grid.ts
+++ b/src/lib/isosurface/grid.ts
@@ -1,18 +1,75 @@
 import type { Vec3 } from '$lib/math'
 
+export type ScalarGridArray = Float32Array | Float64Array
+export type ScalarGridOrder = `x_fastest` | `z_fastest`
+
+// Contiguous scalar storage with explicit dimensions and linearization order.
+// Nested [x][y][z] grids remain supported through ScalarGridLike.
+export interface ScalarGrid3D {
+  data: ScalarGridArray
+  dimensions: Vec3
+  order: ScalarGridOrder
+}
+
+export type ScalarGridLike = ScalarGrid3D | number[][][]
+
 interface FlatGrid3D {
   values: Float64Array
   dims: Vec3
 }
 
-export const grid_dimensions = (grid: number[][][]): Vec3 => [
-  grid.length,
-  grid[0]?.length ?? 0,
-  grid[0]?.[0]?.length ?? 0,
-]
+export const is_scalar_grid = (grid: ScalarGridLike): grid is ScalarGrid3D =>
+  !Array.isArray(grid)
 
-export const grid_point_count = (grid: number[][][]): number =>
+export const grid_dimensions = (grid: ScalarGridLike): Vec3 => {
+  if (!is_scalar_grid(grid)) {
+    return [grid.length, grid[0]?.length ?? 0, grid[0]?.[0]?.length ?? 0]
+  }
+  const dimensions: Vec3 = [...grid.dimensions]
+  if (dimensions.some((count) => !Number.isInteger(count) || count < 0)) {
+    throw new RangeError(`Scalar grid dimensions must be non-negative integers`)
+  }
+  if (grid.order !== `x_fastest` && grid.order !== `z_fastest`) {
+    throw new RangeError(`Unsupported scalar grid order: ${String(grid.order)}`)
+  }
+  if (!(grid.data instanceof Float32Array || grid.data instanceof Float64Array)) {
+    throw new TypeError(`Scalar grid data must be a Float32Array or Float64Array`)
+  }
+  const expected_length = dimensions[0] * dimensions[1] * dimensions[2]
+  if (grid.data.length !== expected_length) {
+    const shape = dimensions.join(`×`)
+    throw new RangeError(
+      `Scalar grid data length ${grid.data.length} does not match dimensions ${shape}`,
+    )
+  }
+  return dimensions
+}
+
+export const grid_point_count = (grid: ScalarGridLike): number =>
   grid_dimensions(grid).reduce((product, count) => product * count, 1)
+
+const flat_index = (
+  [nx, ny, nz]: Vec3,
+  order: ScalarGridOrder,
+  x_idx: number,
+  y_idx: number,
+  z_idx: number,
+): number =>
+  order === `x_fastest`
+    ? x_idx + nx * (y_idx + ny * z_idx)
+    : z_idx + nz * (y_idx + ny * x_idx)
+
+export function grid_value(
+  grid: ScalarGridLike,
+  x_idx: number,
+  y_idx: number,
+  z_idx: number,
+): number {
+  if (is_scalar_grid(grid)) {
+    return grid.data[flat_index(grid.dimensions, grid.order, x_idx, y_idx, z_idx)]
+  }
+  return grid[x_idx][y_idx][z_idx]
+}
 
 export function flatten_grid(grid: number[][][]): FlatGrid3D {
   const dims = grid_dimensions(grid)

--- a/src/lib/isosurface/grid.ts
+++ b/src/lib/isosurface/grid.ts
@@ -13,7 +13,7 @@ export interface ScalarGrid3D<ArrayType extends ScalarGridArray = ScalarGridArra
 
 export type ScalarGridLike = ScalarGrid3D | number[][][]
 
-export const is_scalar_grid = (grid: unknown): grid is ScalarGrid3D =>
+const is_scalar_grid = (grid: unknown): grid is ScalarGrid3D =>
   typeof grid === `object` &&
   grid !== null &&
   !Array.isArray(grid) &&

--- a/src/lib/isosurface/grid.ts
+++ b/src/lib/isosurface/grid.ts
@@ -1,6 +1,6 @@
 import type { Vec3 } from '$lib/math'
 
-export type ScalarGridArray = Float32Array | Float64Array
+type ScalarGridArray = Float32Array | Float64Array
 export type ScalarGridOrder = `x_fastest` | `z_fastest`
 
 // Contiguous scalar storage with explicit dimensions and linearization order.
@@ -55,9 +55,7 @@ const flat_index = (
   y_idx: number,
   z_idx: number,
 ): number =>
-  order === `x_fastest`
-    ? x_idx + nx * (y_idx + ny * z_idx)
-    : z_idx + nz * (y_idx + ny * x_idx)
+  order === `x_fastest` ? x_idx + nx * (y_idx + ny * z_idx) : z_idx + nz * (y_idx + ny * x_idx)
 
 export function grid_value(
   grid: ScalarGridLike,

--- a/src/lib/isosurface/grid.ts
+++ b/src/lib/isosurface/grid.ts
@@ -26,8 +26,11 @@ export const grid_dimensions = (grid: ScalarGridLike): Vec3 => {
     return [grid.length, grid[0]?.length ?? 0, grid[0]?.[0]?.length ?? 0]
   }
   const dimensions: Vec3 = [...grid.dimensions]
-  if (dimensions.some((count) => !Number.isInteger(count) || count < 0)) {
-    throw new RangeError(`Scalar grid dimensions must be non-negative integers`)
+  if (
+    dimensions.length !== 3 ||
+    dimensions.some((count) => !Number.isInteger(count) || count < 0)
+  ) {
+    throw new RangeError(`Scalar grid dimensions must contain three non-negative integers`)
   }
   if (grid.order !== `x_fastest` && grid.order !== `z_fastest`) {
     throw new RangeError(`Unsupported scalar grid order: ${String(grid.order)}`)

--- a/src/lib/isosurface/grid.ts
+++ b/src/lib/isosurface/grid.ts
@@ -43,9 +43,8 @@ export const grid_dimensions = (grid: ScalarGridLike): Vec3 => {
   }
   const expected_length = dimensions[0] * dimensions[1] * dimensions[2]
   if (grid.values.length !== expected_length) {
-    const shape = dimensions.join(`×`)
     throw new RangeError(
-      `Scalar grid values length ${grid.values.length} does not match dimensions ${shape}`,
+      `Scalar grid values length ${grid.values.length} does not match dimensions ${dimensions.join(`×`)}`,
     )
   }
   return dimensions
@@ -58,31 +57,6 @@ export function scalar_grid_strides({ dims: [nx, ny, nz], order }: ScalarGrid3D)
   if (order === `x_fastest`) return [1, nx, nx * ny]
   if (order === `z_fastest`) return [ny * nz, nz, 1]
   throw new RangeError(`Unsupported scalar grid order: ${String(order)}`)
-}
-
-export function create_grid_value_accessor(
-  grid: ScalarGridLike,
-): (x_idx: number, y_idx: number, z_idx: number) => number {
-  if (is_scalar_grid(grid)) {
-    const [stride_x, stride_y, stride_z] = scalar_grid_strides(grid)
-    const { values } = grid
-    return (x_idx, y_idx, z_idx) =>
-      values[x_idx * stride_x + y_idx * stride_y + z_idx * stride_z]
-  }
-  return (x_idx, y_idx, z_idx) => grid[x_idx][y_idx][z_idx]
-}
-
-export function grid_value(
-  grid: ScalarGridLike,
-  x_idx: number,
-  y_idx: number,
-  z_idx: number,
-): number {
-  if (is_scalar_grid(grid)) {
-    const [stride_x, stride_y, stride_z] = scalar_grid_strides(grid)
-    return grid.values[x_idx * stride_x + y_idx * stride_y + z_idx * stride_z]
-  }
-  return grid[x_idx][y_idx][z_idx]
 }
 
 export function flatten_grid(grid: number[][][]): ScalarGrid3D<Float64Array> {

--- a/src/lib/isosurface/grid.ts
+++ b/src/lib/isosurface/grid.ts
@@ -1,31 +1,34 @@
 import type { Vec3 } from '$lib/math'
 
-type ScalarGridArray = Float32Array | Float64Array
+export type ScalarGridArray = Float32Array | Float64Array
 export type ScalarGridOrder = `x_fastest` | `z_fastest`
 
 // Contiguous scalar storage with explicit dimensions and linearization order.
 // Nested [x][y][z] grids remain supported through ScalarGridLike.
-export interface ScalarGrid3D {
-  data: ScalarGridArray
-  dimensions: Vec3
+export interface ScalarGrid3D<ArrayType extends ScalarGridArray = ScalarGridArray> {
+  values: ArrayType
+  dims: Vec3
   order: ScalarGridOrder
 }
 
 export type ScalarGridLike = ScalarGrid3D | number[][][]
 
-interface FlatGrid3D {
-  values: Float64Array
-  dims: Vec3
-}
-
-export const is_scalar_grid = (grid: ScalarGridLike): grid is ScalarGrid3D =>
-  !Array.isArray(grid)
+export const is_scalar_grid = (grid: unknown): grid is ScalarGrid3D =>
+  typeof grid === `object` &&
+  grid !== null &&
+  !Array.isArray(grid) &&
+  `values` in grid &&
+  `dims` in grid &&
+  `order` in grid
 
 export const grid_dimensions = (grid: ScalarGridLike): Vec3 => {
-  if (!is_scalar_grid(grid)) {
+  if (Array.isArray(grid)) {
     return [grid.length, grid[0]?.length ?? 0, grid[0]?.[0]?.length ?? 0]
   }
-  const dimensions: Vec3 = [...grid.dimensions]
+  if (!is_scalar_grid(grid)) {
+    throw new TypeError(`Scalar grid must define values, dims, and order`)
+  }
+  const dimensions: Vec3 = [...grid.dims]
   if (
     dimensions.length !== 3 ||
     dimensions.some((count) => !Number.isInteger(count) || count < 0)
@@ -35,14 +38,14 @@ export const grid_dimensions = (grid: ScalarGridLike): Vec3 => {
   if (grid.order !== `x_fastest` && grid.order !== `z_fastest`) {
     throw new RangeError(`Unsupported scalar grid order: ${String(grid.order)}`)
   }
-  if (!(grid.data instanceof Float32Array || grid.data instanceof Float64Array)) {
-    throw new TypeError(`Scalar grid data must be a Float32Array or Float64Array`)
+  if (!(grid.values instanceof Float32Array || grid.values instanceof Float64Array)) {
+    throw new TypeError(`Scalar grid values must be a Float32Array or Float64Array`)
   }
   const expected_length = dimensions[0] * dimensions[1] * dimensions[2]
-  if (grid.data.length !== expected_length) {
+  if (grid.values.length !== expected_length) {
     const shape = dimensions.join(`×`)
     throw new RangeError(
-      `Scalar grid data length ${grid.data.length} does not match dimensions ${shape}`,
+      `Scalar grid values length ${grid.values.length} does not match dimensions ${shape}`,
     )
   }
   return dimensions
@@ -51,14 +54,11 @@ export const grid_dimensions = (grid: ScalarGridLike): Vec3 => {
 export const grid_point_count = (grid: ScalarGridLike): number =>
   grid_dimensions(grid).reduce((product, count) => product * count, 1)
 
-const flat_index = (
-  [nx, ny, nz]: Vec3,
-  order: ScalarGridOrder,
-  x_idx: number,
-  y_idx: number,
-  z_idx: number,
-): number =>
-  order === `x_fastest` ? x_idx + nx * (y_idx + ny * z_idx) : z_idx + nz * (y_idx + ny * x_idx)
+export function scalar_grid_strides({ dims: [nx, ny, nz], order }: ScalarGrid3D): Vec3 {
+  if (order === `x_fastest`) return [1, nx, nx * ny]
+  if (order === `z_fastest`) return [ny * nz, nz, 1]
+  throw new RangeError(`Unsupported scalar grid order: ${String(order)}`)
+}
 
 export function grid_value(
   grid: ScalarGridLike,
@@ -67,12 +67,13 @@ export function grid_value(
   z_idx: number,
 ): number {
   if (is_scalar_grid(grid)) {
-    return grid.data[flat_index(grid.dimensions, grid.order, x_idx, y_idx, z_idx)]
+    const [stride_x, stride_y, stride_z] = scalar_grid_strides(grid)
+    return grid.values[x_idx * stride_x + y_idx * stride_y + z_idx * stride_z]
   }
   return grid[x_idx][y_idx][z_idx]
 }
 
-export function flatten_grid(grid: number[][][]): FlatGrid3D {
+export function flatten_grid(grid: number[][][]): ScalarGrid3D<Float64Array> {
   const dims = grid_dimensions(grid)
   const values = new Float64Array(dims[0] * dims[1] * dims[2])
   let offset = 0
@@ -82,7 +83,7 @@ export function flatten_grid(grid: number[][][]): FlatGrid3D {
       offset += row.length
     }
   }
-  return { values, dims }
+  return { values, dims, order: `z_fastest` }
 }
 
 export function inflate_grid(values: Float64Array, [nx, ny, nz]: Vec3): number[][][] {

--- a/src/lib/isosurface/index.ts
+++ b/src/lib/isosurface/index.ts
@@ -2,6 +2,7 @@
 export { default as Isosurface } from './Isosurface.svelte'
 export { default as IsosurfaceControls } from './IsosurfaceControls.svelte'
 export { default as VolumeSlice } from './VolumeSlice.svelte'
+export type { ScalarGrid3D, ScalarGridArray, ScalarGridLike, ScalarGridOrder } from './grid'
 
 export * from './coloring'
 export * from './parse'

--- a/src/lib/isosurface/slice-rendering.ts
+++ b/src/lib/isosurface/slice-rendering.ts
@@ -88,7 +88,7 @@ export function resolve_contour_thresholds(
     // regardless of input order
     return contour_levels
       .filter(Number.isFinite)
-      .sort((left, right) => left - right)
+      .toSorted((left, right) => left - right)
       .slice(0, MAX_CONTOUR_LEVELS)
   }
   const count = Number.isFinite(contour_levels)
@@ -99,5 +99,5 @@ export function resolve_contour_thresholds(
   return Array.from(
     { length: count },
     (_, level_idx) => range_min + ((level_idx + 1) / (count + 1)) * (range_max - range_min),
-  ).sort((left, right) => left - right)
+  ).toSorted((left, right) => left - right)
 }

--- a/src/lib/labels.ts
+++ b/src/lib/labels.ts
@@ -29,9 +29,16 @@ export const symbol_names = [
   .map(name_for_symbol)
   .filter((name): name is D3SymbolName => name !== null)
 
+// D3 symbols are selected dynamically from a plain-object lookup by display name.
+const d3_symbols_by_name = Object.fromEntries(
+  Object.entries(d3_symbols)
+    .filter(([key]) => /^symbol[A-Z]/.test(key))
+    .map(([key, symbol]) => [key.slice(6), symbol]),
+) as Partial<Record<D3SymbolName, SymbolType>>
+
 export const symbol_map: Partial<Record<D3SymbolName, SymbolType>> = Object.fromEntries(
   // Symbol lookup from d3-shape
-  symbol_names.map((name) => [name, d3_symbols[`symbol${name}`]]),
+  symbol_names.map((name) => [name, d3_symbols_by_name[name]]),
 )
 
 // Format a value for display with optional time formatting

--- a/src/lib/marching-cubes.ts
+++ b/src/lib/marching-cubes.ts
@@ -2,7 +2,6 @@
 // Based on the classic algorithm by Lorensen & Cline (1987)
 import {
   grid_dimensions,
-  is_scalar_grid,
   scalar_grid_strides,
   type ScalarGridArray,
   type ScalarGridLike,
@@ -421,16 +420,14 @@ function marching_cubes_raw(
   const center_offset = centered ? 0.5 : 0
 
   const [nx, ny, nz] = grid_dimensions(grid)
-  const scalar_source = is_scalar_grid(grid) ? grid : null
-  const nested_grid = scalar_source ? null : (grid as number[][][])
-  const scalar_values = scalar_source?.values
-  const [stride_x, stride_y, stride_z] = scalar_source
-    ? scalar_grid_strides(scalar_source)
-    : [0, 0, 0]
+  if (nx < 2 || ny < 2 || nz < 2) return { positions: [], indices: [], normals: [] }
 
-  if (nx < 2 || ny < 2 || nz < 2) {
-    return { positions: [], indices: [], normals: [] }
-  }
+  const scalar_grid = Array.isArray(grid) ? null : grid
+  const nested_grid = Array.isArray(grid) ? grid : null
+  const scalar_values = scalar_grid?.values
+  const [stride_x, stride_y, stride_z] = scalar_grid
+    ? scalar_grid_strides(scalar_grid)
+    : [0, 0, 0]
 
   const positions: number[] = []
   const indices: number[] = []

--- a/src/lib/marching-cubes.ts
+++ b/src/lib/marching-cubes.ts
@@ -2,14 +2,23 @@
 // Based on the classic algorithm by Lorensen & Cline (1987)
 import {
   grid_dimensions,
-  grid_value,
   is_scalar_grid,
+  scalar_grid_strides,
+  type ScalarGridArray,
   type ScalarGridLike,
 } from '$lib/isosurface/grid'
 import { mat3x3_vec3_multiply, matrix_inverse_3x3, type Matrix3x3, type Vec3 } from '$lib/math'
 
+export type {
+  ScalarGrid3D,
+  ScalarGridArray,
+  ScalarGridLike,
+  ScalarGridOrder,
+} from '$lib/isosurface/grid'
+
 const wrap_grid_idx = (val: number, dim: number) => ((val % dim) + dim) % dim
 const clamp_grid_idx = (val: number, max: number) => Math.max(0, Math.min(val, max))
+const EMPTY_GRID: never[] = []
 
 // Edge table: for each cube configuration (256 cases), which edges are intersected
 // Each bit indicates whether that edge has an intersection
@@ -346,6 +355,10 @@ export interface MarchingCubesOptions {
 // Compute gradient (normal) at a grid point using central differences
 function compute_gradient(
   grid: ScalarGridLike,
+  scalar_values: ScalarGridArray | undefined,
+  stride_x: number,
+  stride_y: number,
+  stride_z: number,
   ix: number,
   iy: number,
   iz: number,
@@ -369,22 +382,23 @@ function compute_gradient(
     : [Math.max(0, iz - 1), Math.min(nz - 1, iz + 1)]
 
   const scale = (lo: number, hi: number) => 1 / Math.max(1, periodic ? 2 : hi - lo)
-  if (!is_scalar_grid(grid)) {
-    const x_lo = grid[ix_m][iy_w][iz_w]
-    const x_hi = grid[ix_p][iy_w][iz_w]
-    const y_lo = grid[ix_w][iy_m][iz_w]
-    const y_hi = grid[ix_w][iy_p][iz_w]
-    const z_row = grid[ix_w][iy_w]
+  if (scalar_values === undefined) {
+    const nested_grid = grid as number[][][]
+    const x_lo = nested_grid[ix_m][iy_w][iz_w]
+    const x_hi = nested_grid[ix_p][iy_w][iz_w]
+    const y_lo = nested_grid[ix_w][iy_m][iz_w]
+    const y_hi = nested_grid[ix_w][iy_p][iz_w]
+    const z_row = nested_grid[ix_w][iy_w]
     const gz = -(z_row[iz_p] - z_row[iz_m]) * scale(iz_m, iz_p)
     return [-(x_hi - x_lo) * scale(ix_m, ix_p), -(y_hi - y_lo) * scale(iy_m, iy_p), gz]
   }
-  const x_lo = grid_value(grid, ix_m, iy_w, iz_w)
-  const x_hi = grid_value(grid, ix_p, iy_w, iz_w)
-  const y_lo = grid_value(grid, ix_w, iy_m, iz_w)
-  const y_hi = grid_value(grid, ix_w, iy_p, iz_w)
-  const gz =
-    -(grid_value(grid, ix_w, iy_w, iz_p) - grid_value(grid, ix_w, iy_w, iz_m)) *
-    scale(iz_m, iz_p)
+  const x_lo = scalar_values[ix_m * stride_x + iy_w * stride_y + iz_w * stride_z]
+  const x_hi = scalar_values[ix_p * stride_x + iy_w * stride_y + iz_w * stride_z]
+  const y_lo = scalar_values[ix_w * stride_x + iy_m * stride_y + iz_w * stride_z]
+  const y_hi = scalar_values[ix_w * stride_x + iy_p * stride_y + iz_w * stride_z]
+  const z_lo = scalar_values[ix_w * stride_x + iy_w * stride_y + iz_m * stride_z]
+  const z_hi = scalar_values[ix_w * stride_x + iy_w * stride_y + iz_p * stride_z]
+  const gz = -(z_hi - z_lo) * scale(iz_m, iz_p)
   return [-(x_hi - x_lo) * scale(ix_m, ix_p), -(y_hi - y_lo) * scale(iy_m, iy_p), gz]
 }
 
@@ -407,6 +421,12 @@ function marching_cubes_raw(
   const center_offset = centered ? 0.5 : 0
 
   const [nx, ny, nz] = grid_dimensions(grid)
+  const scalar_source = is_scalar_grid(grid) ? grid : null
+  const nested_grid = scalar_source ? null : (grid as number[][][])
+  const scalar_values = scalar_source?.values
+  const [stride_x, stride_y, stride_z] = scalar_source
+    ? scalar_grid_strides(scalar_source)
+    : [0, 0, 0]
 
   if (nx < 2 || ny < 2 || nz < 2) {
     return { positions: [], indices: [], normals: [] }
@@ -538,6 +558,10 @@ function marching_cubes_raw(
     if (compute_norms) {
       const [gx, gy, gz] = compute_gradient(
         grid,
+        scalar_values,
+        stride_x,
+        stride_y,
+        stride_z,
         ix + ox1,
         iy + oy1,
         iz + oz1,
@@ -562,36 +586,44 @@ function marching_cubes_raw(
 
   // Preallocate cube_values array (reuse across iterations)
   const cube_values: number[] = Array(8)
-  const scalar_grid = is_scalar_grid(grid) ? grid : null
-  const nested_grid = scalar_grid ? null : (grid as number[][][])
 
   for (let ix = 0; ix < max_x; ix++) {
     x_edge_cache.fill(-1)
     y_edge_next.fill(-1)
     z_edge_next.fill(-1)
     const ix1 = (ix + 1) % nx
-    const ix_row = nested_grid?.[ix] ?? []
-    const ix1_row = nested_grid?.[ix1] ?? []
+    const ix_row = nested_grid?.[ix] ?? EMPTY_GRID
+    const ix1_row = nested_grid?.[ix1] ?? EMPTY_GRID
+    const x_offset = ix * stride_x
+    const x1_offset = ix1 * stride_x
 
     for (let iy = 0; iy < max_y; iy++) {
       const iy1 = (iy + 1) % ny
-      const iy_col = ix_row[iy] ?? []
-      const iy1_col = ix_row[iy1] ?? []
-      const ix1_iy_col = ix1_row[iy] ?? []
-      const ix1_iy1_col = ix1_row[iy1] ?? []
+      const iy_col = ix_row[iy] ?? EMPTY_GRID
+      const iy1_col = ix_row[iy1] ?? EMPTY_GRID
+      const ix1_iy_col = ix1_row[iy] ?? EMPTY_GRID
+      const ix1_iy1_col = ix1_row[iy1] ?? EMPTY_GRID
+      const y_offset = iy * stride_y
+      const y1_offset = iy1 * stride_y
+      const offset_00 = x_offset + y_offset
+      const offset_10 = x1_offset + y_offset
+      const offset_11 = x1_offset + y1_offset
+      const offset_01 = x_offset + y1_offset
 
       for (let iz = 0; iz < max_z; iz++) {
         const iz1 = (iz + 1) % nz
 
-        if (scalar_grid) {
-          cube_values[0] = grid_value(scalar_grid, ix, iy, iz)
-          cube_values[1] = grid_value(scalar_grid, ix1, iy, iz)
-          cube_values[2] = grid_value(scalar_grid, ix1, iy1, iz)
-          cube_values[3] = grid_value(scalar_grid, ix, iy1, iz)
-          cube_values[4] = grid_value(scalar_grid, ix, iy, iz1)
-          cube_values[5] = grid_value(scalar_grid, ix1, iy, iz1)
-          cube_values[6] = grid_value(scalar_grid, ix1, iy1, iz1)
-          cube_values[7] = grid_value(scalar_grid, ix, iy1, iz1)
+        if (scalar_values) {
+          const z_offset = iz * stride_z
+          const z1_offset = iz1 * stride_z
+          cube_values[0] = scalar_values[offset_00 + z_offset]
+          cube_values[1] = scalar_values[offset_10 + z_offset]
+          cube_values[2] = scalar_values[offset_11 + z_offset]
+          cube_values[3] = scalar_values[offset_01 + z_offset]
+          cube_values[4] = scalar_values[offset_00 + z1_offset]
+          cube_values[5] = scalar_values[offset_10 + z1_offset]
+          cube_values[6] = scalar_values[offset_11 + z1_offset]
+          cube_values[7] = scalar_values[offset_01 + z1_offset]
         } else {
           // Preserve direct nested-array reads for the existing hot path.
           cube_values[0] = iy_col[iz]

--- a/src/lib/marching-cubes.ts
+++ b/src/lib/marching-cubes.ts
@@ -376,11 +376,7 @@ function compute_gradient(
     const y_hi = grid[ix_w][iy_p][iz_w]
     const z_row = grid[ix_w][iy_w]
     const gz = -(z_row[iz_p] - z_row[iz_m]) * scale(iz_m, iz_p)
-    return [
-      -(x_hi - x_lo) * scale(ix_m, ix_p),
-      -(y_hi - y_lo) * scale(iy_m, iy_p),
-      gz,
-    ]
+    return [-(x_hi - x_lo) * scale(ix_m, ix_p), -(y_hi - y_lo) * scale(iy_m, iy_p), gz]
   }
   const x_lo = grid_value(grid, ix_m, iy_w, iz_w)
   const x_hi = grid_value(grid, ix_p, iy_w, iz_w)

--- a/src/lib/marching-cubes.ts
+++ b/src/lib/marching-cubes.ts
@@ -1,5 +1,11 @@
 // Marching Cubes algorithm for isosurface extraction
 // Based on the classic algorithm by Lorensen & Cline (1987)
+import {
+  grid_dimensions,
+  grid_value,
+  is_scalar_grid,
+  type ScalarGridLike,
+} from '$lib/isosurface/grid'
 import { mat3x3_vec3_multiply, matrix_inverse_3x3, type Matrix3x3, type Vec3 } from '$lib/math'
 
 const wrap_grid_idx = (val: number, dim: number) => ((val % dim) + dim) % dim
@@ -339,7 +345,7 @@ export interface MarchingCubesOptions {
 
 // Compute gradient (normal) at a grid point using central differences
 function compute_gradient(
-  grid: number[][][],
+  grid: ScalarGridLike,
   ix: number,
   iy: number,
   iz: number,
@@ -362,19 +368,33 @@ function compute_gradient(
     ? [wrap_grid_idx(iz - 1, nz), wrap_grid_idx(iz + 1, nz)]
     : [Math.max(0, iz - 1), Math.min(nz - 1, iz + 1)]
 
-  const x_lo = grid[ix_m][iy_w][iz_w]
-  const x_hi = grid[ix_p][iy_w][iz_w]
-  const y_lo = grid[ix_w][iy_m][iz_w]
-  const y_hi = grid[ix_w][iy_p][iz_w]
-  const z_row = grid[ix_w][iy_w]
   const scale = (lo: number, hi: number) => 1 / Math.max(1, periodic ? 2 : hi - lo)
-  const gz = -(z_row[iz_p] - z_row[iz_m]) * scale(iz_m, iz_p)
+  if (!is_scalar_grid(grid)) {
+    const x_lo = grid[ix_m][iy_w][iz_w]
+    const x_hi = grid[ix_p][iy_w][iz_w]
+    const y_lo = grid[ix_w][iy_m][iz_w]
+    const y_hi = grid[ix_w][iy_p][iz_w]
+    const z_row = grid[ix_w][iy_w]
+    const gz = -(z_row[iz_p] - z_row[iz_m]) * scale(iz_m, iz_p)
+    return [
+      -(x_hi - x_lo) * scale(ix_m, ix_p),
+      -(y_hi - y_lo) * scale(iy_m, iy_p),
+      gz,
+    ]
+  }
+  const x_lo = grid_value(grid, ix_m, iy_w, iz_w)
+  const x_hi = grid_value(grid, ix_p, iy_w, iz_w)
+  const y_lo = grid_value(grid, ix_w, iy_m, iz_w)
+  const y_hi = grid_value(grid, ix_w, iy_p, iz_w)
+  const gz =
+    -(grid_value(grid, ix_w, iy_w, iz_p) - grid_value(grid, ix_w, iy_w, iz_m)) *
+    scale(iz_m, iz_p)
   return [-(x_hi - x_lo) * scale(ix_m, ix_p), -(y_hi - y_lo) * scale(iy_m, iy_p), gz]
 }
 
 // Main marching cubes algorithm (optimized version)
 function marching_cubes_raw(
-  grid: number[][][],
+  grid: ScalarGridLike,
   iso_value: number,
   k_lattice: Matrix3x3,
   options: MarchingCubesOptions = {},
@@ -390,9 +410,7 @@ function marching_cubes_raw(
   // centered at the origin (Γ point). This is needed for proper BZ visualization.
   const center_offset = centered ? 0.5 : 0
 
-  const nx = grid.length
-  const ny = grid[0]?.length || 0
-  const nz = grid[0]?.[0]?.length || 0
+  const [nx, ny, nz] = grid_dimensions(grid)
 
   if (nx < 2 || ny < 2 || nz < 2) {
     return { positions: [], indices: [], normals: [] }
@@ -548,32 +566,47 @@ function marching_cubes_raw(
 
   // Preallocate cube_values array (reuse across iterations)
   const cube_values: number[] = Array(8)
+  const scalar_grid = is_scalar_grid(grid) ? grid : null
+  const nested_grid = scalar_grid ? null : (grid as number[][][])
 
   for (let ix = 0; ix < max_x; ix++) {
     x_edge_cache.fill(-1)
     y_edge_next.fill(-1)
     z_edge_next.fill(-1)
-    const ix_row = grid[ix]
-    const ix1_row = grid[(ix + 1) % nx]
+    const ix1 = (ix + 1) % nx
+    const ix_row = nested_grid?.[ix] ?? []
+    const ix1_row = nested_grid?.[ix1] ?? []
 
     for (let iy = 0; iy < max_y; iy++) {
-      const iy_col = ix_row[iy]
-      const iy1_col = ix_row[(iy + 1) % ny]
-      const ix1_iy_col = ix1_row[iy]
-      const ix1_iy1_col = ix1_row[(iy + 1) % ny]
+      const iy1 = (iy + 1) % ny
+      const iy_col = ix_row[iy] ?? []
+      const iy1_col = ix_row[iy1] ?? []
+      const ix1_iy_col = ix1_row[iy] ?? []
+      const ix1_iy1_col = ix1_row[iy1] ?? []
 
       for (let iz = 0; iz < max_z; iz++) {
         const iz1 = (iz + 1) % nz
 
-        // Get corner values (inlined for speed)
-        cube_values[0] = iy_col[iz]
-        cube_values[1] = ix1_iy_col[iz]
-        cube_values[2] = ix1_iy1_col[iz]
-        cube_values[3] = iy1_col[iz]
-        cube_values[4] = iy_col[iz1]
-        cube_values[5] = ix1_iy_col[iz1]
-        cube_values[6] = ix1_iy1_col[iz1]
-        cube_values[7] = iy1_col[iz1]
+        if (scalar_grid) {
+          cube_values[0] = grid_value(scalar_grid, ix, iy, iz)
+          cube_values[1] = grid_value(scalar_grid, ix1, iy, iz)
+          cube_values[2] = grid_value(scalar_grid, ix1, iy1, iz)
+          cube_values[3] = grid_value(scalar_grid, ix, iy1, iz)
+          cube_values[4] = grid_value(scalar_grid, ix, iy, iz1)
+          cube_values[5] = grid_value(scalar_grid, ix1, iy, iz1)
+          cube_values[6] = grid_value(scalar_grid, ix1, iy1, iz1)
+          cube_values[7] = grid_value(scalar_grid, ix, iy1, iz1)
+        } else {
+          // Preserve direct nested-array reads for the existing hot path.
+          cube_values[0] = iy_col[iz]
+          cube_values[1] = ix1_iy_col[iz]
+          cube_values[2] = ix1_iy1_col[iz]
+          cube_values[3] = iy1_col[iz]
+          cube_values[4] = iy_col[iz1]
+          cube_values[5] = ix1_iy_col[iz1]
+          cube_values[6] = ix1_iy1_col[iz1]
+          cube_values[7] = iy1_col[iz1]
+        }
 
         // Compute cube index (unrolled for speed)
         let cube_index = 0
@@ -617,7 +650,7 @@ function marching_cubes_raw(
 // compatibility arrays. This avoids one Vec3 and one triangle-array allocation
 // per emitted vertex/face while preserving the public marching_cubes() API.
 export function marching_cubes_buffers(
-  grid: number[][][],
+  grid: ScalarGridLike,
   iso_value: number,
   k_lattice: Matrix3x3,
   options: MarchingCubesOptions = {},
@@ -637,7 +670,7 @@ const packed_to_vec3 = (values: number[]): Vec3[] =>
   })
 
 export function marching_cubes(
-  grid: number[][][],
+  grid: ScalarGridLike,
   iso_value: number,
   k_lattice: Matrix3x3,
   options: MarchingCubesOptions = {},

--- a/src/lib/phase-diagram/parse.ts
+++ b/src/lib/phase-diagram/parse.ts
@@ -280,7 +280,7 @@ export const get_system_name = (elements: string[]): string =>
   elements
     .filter(is_real_element)
     .map((el) => el.toUpperCase())
-    .sort()
+    .toSorted()
     .join(`-`)
 
 // Check if a TDB file represents a binary system
@@ -347,5 +347,5 @@ export function normalize_system_name(input: string): string {
   }
 
   // Sort alphabetically and join with hyphen
-  return elements.sort().join(`-`)
+  return elements.toSorted().join(`-`)
 }

--- a/src/lib/phase-diagram/utils.ts
+++ b/src/lib/phase-diagram/utils.ts
@@ -330,6 +330,7 @@ function find_polygon_intersections(
       )
     }
   }
+  // intersections is local to this scan.
   return intersections.toSorted((a, b) => a - b)
 }
 

--- a/src/lib/plot/bar/SpacegroupBarPlot.svelte
+++ b/src/lib/plot/bar/SpacegroupBarPlot.svelte
@@ -52,7 +52,7 @@
   })
 
   // Create sorted list of space groups for x-axis
-  const sorted_spacegroups = $derived(Array.from(histogram.keys()).sort((a, b) => a - b))
+  const sorted_spacegroups = $derived(Array.from(histogram.keys()).toSorted((a, b) => a - b))
 
   // Smart tick selection: thin out ticks for dense data
   const x_axis_ticks = $derived.by(() => {

--- a/src/lib/plot/core/components/ColorBar.svelte
+++ b/src/lib/plot/core/components/ColorBar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { get_d3_interpolator, luminance } from '$lib/colors'
+  import { get_d3_interpolator, is_d3_interpolate_name, luminance } from '$lib/colors'
   import Spinner from '$lib/feedback/Spinner.svelte'
   import { format_num } from '$lib/labels'
   import { sanitize_html } from '$lib/sanitize'
@@ -8,10 +8,8 @@
   import * as math from '$lib/math'
   import { format } from 'd3-format'
   import * as d3 from 'd3-scale'
-  import * as d3_sc from 'd3-scale-chromatic'
   import { timeFormat } from 'd3-time-format'
   import type { HTMLAttributes } from 'svelte/elements'
-  import type { D3InterpolateName } from '$lib/colors'
   import PortalSelect from '$lib/plot/core/components/PortalSelect.svelte'
   import { generate_arcsinh_ticks, scale_arcsinh } from '$lib/plot/core/scales'
   import type {
@@ -285,8 +283,8 @@
       const func_name = color_scale.startsWith(`interpolate`)
         ? color_scale
         : `interpolate${color_scale}`
-      if (func_name in d3_sc) {
-        interpolator = d3_sc[func_name as D3InterpolateName]
+      if (is_d3_interpolate_name(func_name)) {
+        interpolator = get_d3_interpolator(func_name)
       } else {
         console.error(`Color scale '${color_scale}' not found. Falling back on 'Viridis'.`)
       }

--- a/src/lib/plot/core/data-cleaning-signal.ts
+++ b/src/lib/plot/core/data-cleaning-signal.ts
@@ -545,7 +545,7 @@ export function remove_local_outliers(
 
 function median(values: number[]): number {
   if (values.length === 0) return 0
-  const sorted = [...values].sort((a, b) => a - b)
+  const sorted = [...values].toSorted((a, b) => a - b)
   const mid = Math.floor(sorted.length / 2)
   return sorted.length % 2 !== 0 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2
 }

--- a/src/lib/plot/core/fill-utils.ts
+++ b/src/lib/plot/core/fill-utils.ts
@@ -372,7 +372,7 @@ function where_intervals(
         (x) => x >= xa && x <= xb,
       ),
     ),
-  ].sort((a, b) => a - b)
+  ].toSorted((a, b) => a - b)
 
   const intervals: Vec2[] = []
   let seg_start: number | null = null

--- a/src/lib/plot/core/marginals.ts
+++ b/src/lib/plot/core/marginals.ts
@@ -559,7 +559,9 @@ function compute_histogram(
 }
 
 function compute_cdf(positions: number[], weights: number[] | undefined): MarginalCurve {
-  const order = positions.map((_, idx) => idx).sort((a, b) => positions[a] - positions[b])
+  const order = positions.map((_, idx) => idx)
+  // map() returns a fresh index array.
+  order.sort((a, b) => positions[a] - positions[b])
   const total = weights ? weights.reduce((sum, weight) => sum + weight, 0) : positions.length
   const points: { pos: number; value: number }[] = []
   let cum = 0

--- a/src/lib/plot/core/scales.ts
+++ b/src/lib/plot/core/scales.ts
@@ -30,7 +30,7 @@ import * as d3_sc from 'd3-scale-chromatic'
 export type TicksOption = number | number[] | TimeInterval | Record<number, string>
 
 // Dedupe and sort numeric array (used in tick generation)
-const dedupe_sort = (arr: number[]): number[] => [...new Set(arr)].sort((a, b) => a - b)
+const dedupe_sort = (arr: number[]): number[] => [...new Set(arr)].toSorted((a, b) => a - b)
 
 // --- Arcsinh Scale Implementation ---
 // The arcsinh scale provides smooth transition between linear (near zero) and

--- a/src/lib/plot/core/scales.ts
+++ b/src/lib/plot/core/scales.ts
@@ -328,7 +328,7 @@ export function generate_ticks(
     return Object.keys(ticks_option)
       .map(Number)
       .filter((val) => Number.isFinite(val) && val >= domain_min && val <= domain_max)
-      .sort((a, b) => a - b)
+      .toSorted((a, b) => a - b)
   }
 
   // If ticks_option is already an array, use it directly

--- a/src/lib/plot/sunburst/sunburst.ts
+++ b/src/lib/plot/sunburst/sunburst.ts
@@ -444,7 +444,7 @@ export function sunburst_from_labels_parents<Metadata = Record<string, unknown>>
       )
     }
     // Mark the walked chain as verified
-    for (let mark: number | null = idx; mark != null && state[mark] === 1; ) {
+    for (let mark: number | null = idx; mark != null && state[mark] === 1;) {
       state[mark] = 2
       mark = parent_idxs[mark]
     }

--- a/src/lib/rdf/calc-rdf.ts
+++ b/src/lib/rdf/calc-rdf.ts
@@ -155,7 +155,7 @@ export function calculate_all_pair_rdfs(
   // Collect all unique elements across all species (supports mixed occupancy)
   const elems = [
     ...new Set(structure.sites.flatMap((site) => site.species.map((spec) => spec.element))),
-  ].sort()
+  ].toSorted()
 
   // Forward options unchanged (preserves caller's pbc); each calculate_rdf expands itself
   return elems.flatMap((el1, idx1) =>

--- a/src/lib/spectral/Bands.svelte
+++ b/src/lib/spectral/Bands.svelte
@@ -538,7 +538,7 @@
     }
 
     Object.entries(x_positions ?? {})
-      .sort(([, [a]], [, [b]]) => a - b)
+      .toSorted(([, [a]], [, [b]]) => a - b)
       .forEach(([segment_key, [x_start, x_end]]) => {
         const [start_lbl, end_lbl] = segment_key.split(`_`)
         const pretty_start = start_lbl !== `null` ? helpers.pretty_sym_point(start_lbl) : ``

--- a/src/lib/spectral/helpers.ts
+++ b/src/lib/spectral/helpers.ts
@@ -519,7 +519,9 @@ function convert_pymatgen_band_structure(
   const steps = qpoints
     .slice(1)
     .map((qpoint, idx) => euclidean_dist(qpoints[idx].frac_coords, qpoint.frac_coords))
-  const sorted = steps.slice().sort((a, b) => a - b)
+  const sorted = steps.slice()
+  // slice() already copied the input.
+  sorted.sort((a, b) => a - b)
   const threshold = (sorted[Math.floor(sorted.length / 2)] ?? 0) * 5
   const disc_set = new Set(
     steps

--- a/src/lib/spectral/helpers.ts
+++ b/src/lib/spectral/helpers.ts
@@ -559,7 +559,7 @@ function convert_pymatgen_band_structure(
     )
     // Discontinuity indices mark points where the path jumps (disc before that index)
     // Create continuous segments between discontinuities
-    const disc_indices = [...disc_set].sort((a, b) => a - b)
+    const disc_indices = [...disc_set].toSorted((a, b) => a - b)
     // Segment boundaries: [0, first_disc), [first_disc, second_disc), ..., [last_disc, end]
     const segment_starts = [0, ...disc_indices]
     const segment_ends = [...disc_indices.map((idx) => idx - 1), qpoints.length - 1]

--- a/src/lib/structure/AtomLegend.svelte
+++ b/src/lib/structure/AtomLegend.svelte
@@ -172,7 +172,7 @@
     })
     const unknown_entries = Object.entries(element_amounts)
       .filter(([element_symbol]) => !is_elem_symbol(element_symbol))
-      .sort(([element_a], [element_b]) => element_a.localeCompare(element_b))
+      .toSorted(([element_a], [element_b]) => element_a.localeCompare(element_b))
     return [...ordered_known_entries, ...unknown_entries]
   })
 

--- a/src/lib/structure/StructureControls.svelte
+++ b/src/lib/structure/StructureControls.svelte
@@ -121,7 +121,7 @@
   let structure_elements = $derived(
     [
       ...new Set((structure?.sites ?? []).flatMap((site) => get_majority_element(site) ?? [])),
-    ].sort(),
+    ].toSorted(),
   )
 
   // An element counts as an enabled polyhedra center if it isn't excluded and is

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -1299,7 +1299,7 @@
   // per-element toggles reflect the actual render state incl. spectator hiding)
   $effect(() => {
     if (!interactive) return
-    const elems = [...new Set(polyhedra.map((poly) => poly.center_element))].sort()
+    const elems = [...new Set(polyhedra.map((poly) => poly.center_element))].toSorted()
     if (elems.join(`,`) !== polyhedra_rendered_elements.join(`,`)) {
       polyhedra_rendered_elements = elems
     }

--- a/src/lib/structure/atom-properties.ts
+++ b/src/lib/structure/atom-properties.ts
@@ -73,8 +73,8 @@ const make_categorical = <T>(
 ): { colors: string[]; unique_values: T[] } => {
   const interp_fn = get_d3_interpolator(scale as D3InterpolateName)
   const uniq = sort_fn
-    ? [...new Set(vals)].sort(sort_fn)
-    : [...new Set(vals)].sort((val_a, val_b) => String(val_a).localeCompare(String(val_b)))
+    ? [...new Set(vals)].toSorted(sort_fn)
+    : [...new Set(vals)].toSorted((val_a, val_b) => String(val_a).localeCompare(String(val_b)))
   const colors = uniq.map((_, idx) =>
     to_hex(interp_fn, uniq.length === 1 ? 0.5 : idx / (uniq.length - 1)),
   )
@@ -90,7 +90,7 @@ const build_prop_colors = (
   colors: string[],
   unique_values?: number[],
 ): AtomPropertyColors => {
-  const uniq = unique_values ?? [...new Set(vals)].sort((val_a, val_b) => val_a - val_b)
+  const uniq = unique_values ?? [...new Set(vals)].toSorted((val_a, val_b) => val_a - val_b)
   // Use sorted uniq array to avoid spreading large arrays into Math.min/max
   const min_value = uniq.length > 0 ? uniq[0] : undefined
   const max_value = uniq.at(-1)

--- a/src/lib/structure/bond-order-perception.ts
+++ b/src/lib/structure/bond-order-perception.ts
@@ -220,7 +220,7 @@ function find_rings(n_atoms: number, edges: Vec2[]): number[][] {
   }
   const uniq = new Map<string, number[]>()
   for (const ring of rings) {
-    const key = [...ring].sort((left_idx, right_idx) => left_idx - right_idx).join(`,`)
+    const key = [...ring].toSorted((left_idx, right_idx) => left_idx - right_idx).join(`,`)
     if (!uniq.has(key)) uniq.set(key, ring)
   }
   return [...uniq.values()]

--- a/src/lib/structure/bonding.ts
+++ b/src/lib/structure/bonding.ts
@@ -118,7 +118,7 @@ export function remap_bonds_after_deletion(
 ): StructureBond[] {
   // Sort the deleted indices once; shift each surviving index down by the count of deleted
   // indices below it via binary search (O(log m) per lookup vs re-filtering the set each call).
-  const sorted = [...deleted_indices].sort((idx_a, idx_b) => idx_a - idx_b)
+  const sorted = [...deleted_indices].toSorted((idx_a, idx_b) => idx_a - idx_b)
   const shift = (idx: number) => {
     let [lo, hi] = [0, sorted.length]
     while (lo < hi) {

--- a/src/lib/structure/export.ts
+++ b/src/lib/structure/export.ts
@@ -494,7 +494,7 @@ function get_cif_block_name(structure: AnyStructure): string {
     }
 
     // Sort elements alphabetically and build formula string
-    const elements = Object.keys(element_counts).sort()
+    const elements = Object.keys(element_counts).toSorted()
     if (elements.length === 0) throw new Error(`No elements found`)
 
     const formula = elements

--- a/src/lib/structure/index.ts
+++ b/src/lib/structure/index.ts
@@ -277,7 +277,8 @@ export function get_all_site_vectors(site: Site): { vec: Vec3; key: string }[] {
     const vec = try_parse_vec3(props[key])
     if (vec) results.push({ vec, key })
   }
-  return results.sort((left, right) => compare_vector_keys(left.key, right.key))
+  // results is local and no longer reused.
+  return results.toSorted((left, right) => compare_vector_keys(left.key, right.key))
 }
 
 // Collect the union of all vector property keys across all sites in a structure,

--- a/src/lib/structure/index.ts
+++ b/src/lib/structure/index.ts
@@ -288,7 +288,7 @@ export function get_structure_vector_keys(structure: AnyStructure): string[] {
   for (const site of structure.sites) {
     for (const { key } of get_all_site_vectors(site)) seen.add(key)
   }
-  return [...seen].sort(compare_vector_keys)
+  return [...seen].toSorted(compare_vector_keys)
 }
 
 export interface StructureHandlerData {

--- a/src/lib/symmetry/index.ts
+++ b/src/lib/symmetry/index.ts
@@ -340,7 +340,7 @@ function wyckoff_rows_from_input_orbits(sym_data: SymmetryDataset): WyckoffPos[]
       wyckoff: letter ? `${multiplicity}${letter}` : `${multiplicity}`,
       elem,
       abc: best_pos,
-      site_indices: [...new Set(orig_site_indices)].sort((idx_a, idx_b) => idx_a - idx_b),
+      site_indices: [...new Set(orig_site_indices)].toSorted((idx_a, idx_b) => idx_a - idx_b),
       ...(site_symmetry ? { site_symmetry } : {}),
     }
   })
@@ -592,7 +592,7 @@ export function map_wyckoff_to_all_atoms(
       }
 
       if (matched.size > 0) any_matched = true
-      return { ...wyckoff_pos, site_indices: [...matched].sort((a, b) => a - b) }
+      return { ...wyckoff_pos, site_indices: [...matched].toSorted((a, b) => a - b) }
     })
     return any_matched || displayed_structure.sites.length === 0 ? rows : null
   }

--- a/src/lib/symmetry/index.ts
+++ b/src/lib/symmetry/index.ts
@@ -356,7 +356,7 @@ export const wyckoff_multiplicity = (label: string): number =>
 export function wyckoff_positions_from_moyo(sym_data: SymmetryDataset | null): WyckoffPos[] {
   if (!sym_data) return []
   const orbit_rows = wyckoff_rows_from_input_orbits(sym_data)
-  return (orbit_rows ?? []).sort((w1, w2) => {
+  return (orbit_rows ?? []).toSorted((w1, w2) => {
     const [w1_mult, w2_mult] = [
       wyckoff_multiplicity(w1.wyckoff),
       wyckoff_multiplicity(w2.wyckoff),

--- a/src/lib/symmetry/spacegroups.ts
+++ b/src/lib/symmetry/spacegroups.ts
@@ -453,7 +453,7 @@ export function spacegroup_sunburst_data(
   return CRYSTAL_SYSTEMS.flatMap((system) => {
     const nums = [...counts.keys()]
       .filter((num) => spacegroup_num_to_crystal_sys(num) === system)
-      .sort((num_a, num_b) => num_a - num_b)
+      .toSorted((num_a, num_b) => num_a - num_b)
     if (nums.length === 0) return []
     return [
       {

--- a/src/lib/symmetry/symmetry-elements.ts
+++ b/src/lib/symmetry/symmetry-elements.ts
@@ -526,7 +526,7 @@ export function symmetry_elements_from_ops(
     }
   }
   // Stable order: by kind (SYM_ELEM_KINDS sequence), then descending order, label, point
-  return [...seen.values()].sort(
+  return [...seen.values()].toSorted(
     (el1, el2) =>
       SYM_ELEM_KINDS.indexOf(el1.kind) - SYM_ELEM_KINDS.indexOf(el2.kind) ||
       el2.order - el1.order ||

--- a/src/lib/symmetry/symmetry-elements.ts
+++ b/src/lib/symmetry/symmetry-elements.ts
@@ -648,11 +648,14 @@ export function clip_plane_to_cell(
   const normal_unit = math.normalize_vec(normal_cart)
   const ref_vec = math.normalize_vec(math.subtract(cart_points[0], centroid))
   const cross_ref = math.cross_3d(normal_unit, ref_vec)
-  return cart_points
-    .map((vert) => {
-      const rel = math.subtract(vert, centroid)
-      return { vert, angle: Math.atan2(math.dot(rel, cross_ref), math.dot(rel, ref_vec)) }
-    })
-    .sort((pt_a, pt_b) => pt_a.angle - pt_b.angle)
-    .map(({ vert }) => vert)
+  return (
+    cart_points
+      .map((vert) => {
+        const rel = math.subtract(vert, centroid)
+        return { vert, angle: Math.atan2(math.dot(rel, cross_ref), math.dot(rel, ref_vec)) }
+      })
+      // map() returns a fresh point array.
+      .toSorted((pt_a, pt_b) => pt_a.angle - pt_b.angle)
+      .map(({ vert }) => vert)
+  )
 }

--- a/src/lib/symmetry/wyckoff-db.ts
+++ b/src/lib/symmetry/wyckoff-db.ts
@@ -77,7 +77,7 @@ export function wyckoff_sequence(rows: WyckoffPos[]): string {
     if (letter) counts.set(letter, (counts.get(letter) ?? 0) + 1)
   }
   return [...counts.entries()]
-    .sort(([letter_1], [letter_2]) => letter_rank(letter_2) - letter_rank(letter_1))
+    .toSorted(([letter_1], [letter_2]) => letter_rank(letter_2) - letter_rank(letter_1))
     .map(([letter, count]) =>
       count > 1 ? `${letter}${superscript_digits(String(count))}` : letter,
     )

--- a/src/lib/table/HeatmapTable.svelte
+++ b/src/lib/table/HeatmapTable.svelte
@@ -751,7 +751,7 @@
     if (sort_criteria.length === 0) return filtered_data
 
     const valid_column_ids = new Set(ordered_columns.map(get_col_id))
-    return [...filtered_data].sort((row1, row2) => {
+    return [...filtered_data].toSorted((row1, row2) => {
       for (const { column, ascending } of sort_criteria) {
         // criteria hold column IDs; skip stale entries referencing removed columns
         if (!valid_column_ids.has(column)) continue

--- a/src/lib/trajectory/parse/lammps.ts
+++ b/src/lib/trajectory/parse/lammps.ts
@@ -202,7 +202,7 @@ export function parse_lammps_trajectory(
         `lattice` in first_frame.structure
           ? first_frame.structure.lattice.pbc
           : [true, true, true],
-      atom_types: Array.from(atom_types_found).sort((a, b) => a - b),
+      atom_types: Array.from(atom_types_found).toSorted((a, b) => a - b),
       element_counts,
     },
   }

--- a/src/lib/trajectory/plotting.ts
+++ b/src/lib/trajectory/plotting.ts
@@ -111,7 +111,7 @@ export function generate_plot_series(
   // Apply final assignments to series
   apply_group_assignments(all_series, unit_groups)
 
-  return all_series.sort((a, b) => Number(b.visible) - Number(a.visible))
+  return all_series.toSorted((a, b) => Number(b.visible) - Number(a.visible))
 }
 
 // Extract statistics for all properties in a single pass
@@ -217,7 +217,7 @@ function group_and_assign_series(
 
       return { unit, series: group_series, priority, is_visible }
     })
-    .sort((a, b) => a.priority - b.priority)
+    .toSorted((a, b) => a.priority - b.priority)
 
   // Apply 2-group visibility limit
   const visible_groups = groups.filter((group) => group.is_visible)

--- a/src/lib/trajectory/plotting.ts
+++ b/src/lib/trajectory/plotting.ts
@@ -355,7 +355,7 @@ function get_axis_label(axis_series: DataSeries[]): string {
   }
 
   const [unit, labels] = [...unit_groups.entries()][0]
-  const unique_labels = [...new Set(labels)].sort().join(` / `)
+  const unique_labels = [...new Set(labels)].toSorted().join(` / `)
   return unit ? `${unique_labels} (${unit})` : unique_labels
 }
 
@@ -422,7 +422,7 @@ export function generate_streaming_plot_series(
   } = options
 
   const ordered_metadata = [...metadata_list]
-    .sort((metadata_a, metadata_b) => metadata_a.frame_number - metadata_b.frame_number)
+    .toSorted((metadata_a, metadata_b) => metadata_a.frame_number - metadata_b.frame_number)
     .filter(
       (metadata, idx, sorted_metadata) =>
         idx === 0 || metadata.frame_number !== sorted_metadata[idx - 1].frame_number,

--- a/src/lib/xrd/XrdPlot.svelte
+++ b/src/lib/xrd/XrdPlot.svelte
@@ -170,7 +170,8 @@
           const max_peaks = Math.min(ys.length, Math.floor(annotate_peaks))
           candidates = ys
             .map((y_val, idx) => ({ y_val, idx }))
-            .sort((a, b) => b.y_val - a.y_val)
+            // map() returns a fresh peak array.
+            .toSorted((a, b) => b.y_val - a.y_val)
             .slice(0, max_peaks)
         }
 

--- a/src/lib/xrd/calc-xrd.ts
+++ b/src/lib/xrd/calc-xrd.ts
@@ -60,7 +60,8 @@ function get_unique_families(hkls: Hkl[]): Map<string, number> {
   // Port of pymatgen's get_unique_families: group Miller indices by absolute-value permutations
   const key_map = new Map<string, Hkl[]>()
   for (const hkl of hkls) {
-    const abs_sorted = hkl.map((val) => Math.abs(val)).sort((x, y) => x - y)
+    // map() returns a fresh array.
+    const abs_sorted = hkl.map((val) => Math.abs(val)).toSorted((x, y) => x - y)
     const key = abs_sorted.join(`,`)
     const list = key_map.get(key)
     if (list) list.push(hkl)
@@ -278,7 +279,9 @@ export function compute_xrd_pattern(structure: Crystal, options: XrdOptions = {}
   const hkls_out: HklObj[][] = []
   const d_out: number[] = []
 
-  const sorted_two_thetas = Array.from(peaks.keys()).sort((a, b) => a - b)
+  const sorted_two_thetas = Array.from(peaks.keys())
+  // Array.from() returns a fresh array.
+  sorted_two_thetas.sort((a, b) => a - b)
   for (const angle of sorted_two_thetas) {
     const item = peaks.get(angle)
     if (!item) continue

--- a/src/lib/xrd/parse.ts
+++ b/src/lib/xrd/parse.ts
@@ -125,7 +125,7 @@ function subsample_preserve_peaks(
   }
 
   // Merge and sort all selected indices
-  const selected = [...new Set([...uniform_indices, ...top_peaks])].sort((a, b) => a - b)
+  const selected = [...new Set([...uniform_indices, ...top_peaks])].toSorted((a, b) => a - b)
 
   return {
     x: selected.map((idx) => x_vals[idx]),

--- a/src/lib/xrd/parse.ts
+++ b/src/lib/xrd/parse.ts
@@ -108,7 +108,8 @@ function subsample_preserve_peaks(
   // Select top peaks by height
   const top_peaks = peaks
     .map((idx) => ({ idx, y: y_vals[idx] }))
-    .sort((a, b) => b.y - a.y)
+    // map() returns a fresh peak array.
+    .toSorted((a, b) => b.y - a.y)
     .slice(0, peak_slots)
     .map((peak) => peak.idx)
 

--- a/src/routes/(demos)/(hide)/element-tile/+page.md
+++ b/src/routes/(demos)/(hide)/element-tile/+page.md
@@ -13,7 +13,7 @@
 <ol>
   {#each Array(27)
     .fill(0)
-    .map( (_, idx) => ({ bg_color: rand_color(), element: element_data[idx] }), ) as { bg_color, element } (element.symbol)}
+    .map( (_, idx) => ({ bg_color: rand_color(), element: element_data[idx] }) ) as { bg_color, element } (element.symbol)}
     <ElementTile {bg_color} {element} style="width: 4em; margin: 0" />
   {/each}
 </ol>

--- a/src/routes/(demos)/convex-hull/+page.svelte
+++ b/src/routes/(demos)/convex-hull/+page.svelte
@@ -87,7 +87,7 @@
         log_load_error(quaternary_entries[result_idx]?.[0] ?? `unknown`, result.reason)
       }
     }
-    const quinary_paths = Object.keys(quinary_files).sort()
+    const quinary_paths = Object.keys(quinary_files).toSorted()
     if (quinary_paths.length > 0) selected_quinary_path = quinary_paths[0]
 
     const mount_next_section = () => {
@@ -287,7 +287,7 @@
   ]
   const quinary_options = $derived(
     Object.keys(quinary_files)
-      .sort()
+      .toSorted()
       .map((path) => ({
         path,
         title: path.split(`/`).pop()?.replace(`.json.gz`, ``) ?? path,
@@ -446,7 +446,7 @@
     <h2>Quaternary Chemical Systems</h2>
     {@render feature_list(quaternary_features)}
     <div class="quaternary-grid">
-      {#each [...loaded_data.entries()].filter( ([p]) => p.includes(`quaternaries`), ) as [path, data] (path)}
+      {#each [...loaded_data.entries()].filter( ([p]) => p.includes(`quaternaries`) ) as [path, data] (path)}
         {@const title = path.split(`/`).pop()?.split(`.`).shift()?.replace(`.json`, ``)}
         <ConvexHull4D
           entries={entries_map.get(path) || data}

--- a/src/routes/(demos)/structure/+page.md
+++ b/src/routes/(demos)/structure/+page.md
@@ -154,7 +154,7 @@ Showcasing structures with different crystal systems.
 </script>
 
 <ul class="crystal-systems">
-  {#each structures.filter( (struct) => CRYSTAL_SYSTEMS.some( (system) => struct.id.includes(system), ), ) as structure (structure.id)}
+  {#each structures.filter( (struct) => CRYSTAL_SYSTEMS.some( (system) => struct.id.includes(system) ) ) as structure (structure.id)}
     {@const mp_id = structure.id.split(`-`).slice(0, 2).join(`-`)}
     {@const href = `https://materialsproject.org/materials/${mp_id}`}
     {@const crystal_system = structure.id.split(`-`).at(-1) || 'unknown'}

--- a/src/site/ConvexHullDemo.svelte
+++ b/src/site/ConvexHullDemo.svelte
@@ -22,7 +22,7 @@
       path,
       loader,
     }))
-    .sort((sys_a, sys_b) => sys_a.name.localeCompare(sys_b.name))
+    .toSorted((sys_a, sys_b) => sys_a.name.localeCompare(sys_b.name))
 
   const loaded_data = new SvelteMap<string, PhaseData[]>()
   let active_name = $state(systems[0]?.name ?? ``)

--- a/src/site/PhononSpectraDemo.svelte
+++ b/src/site/PhononSpectraDemo.svelte
@@ -32,7 +32,7 @@
           /^(?<mp_id>mp-\d+)-(?<formula>.+)$/.exec(material) ?? []
         return { material, keys, label: mp_id ? `${formula} (${mp_id})` : material }
       })
-      .sort((grp_a, grp_b) => grp_a.label.localeCompare(grp_b.label))
+      .toSorted((grp_a, grp_b) => grp_a.label.localeCompare(grp_b.label))
   })()
 
   const default_group = groups.find((grp) => grp.material === `mp-2758-Sr4Se4`) ?? groups[0]

--- a/src/site/fermi-surfaces/index.ts
+++ b/src/site/fermi-surfaces/index.ts
@@ -39,7 +39,7 @@ export const fermi_surface_files: FileInfo[] = Object.keys(fermi_file_modules)
         : (CATEGORY_BY_EXT[ext] ?? { category: `Unknown`, category_icon: `📄` })
     return { name, url, type: ext, ...category }
   })
-  .sort((a, b) => a.name.localeCompare(b.name))
+  .toSorted((a, b) => a.name.localeCompare(b.name))
 
 // File type colors for FilePicker
 export const fermi_file_colors: Record<string, string> = {

--- a/src/site/isosurfaces/index.ts
+++ b/src/site/isosurfaces/index.ts
@@ -121,4 +121,4 @@ export const volumetric_files: VolumetricFileInfo[] = Object.keys(volumetric_fil
     }
     return { name, url, ...meta }
   })
-  .sort((a, b) => a.name.localeCompare(b.name))
+  .toSorted((a, b) => a.name.localeCompare(b.name))

--- a/src/site/phonons/index.ts
+++ b/src/site/phonons/index.ts
@@ -80,7 +80,7 @@ function transform_band_structure(raw: RawPhononBandStructure): PhononBandStruct
   // Detect branches (segments between labeled points)
   // Include head/tail segments if path doesn't start/end on a labeled point
   // Branch endpoints are inclusive (start_index and end_index both included in segment)
-  const sorted_indices = [...labeled_indices.keys()].sort((a, b) => a - b)
+  const sorted_indices = [...labeled_indices.keys()].toSorted((a, b) => a - b)
   const branches: Branch[] = []
   if (sorted_indices.length === 0) {
     branches.push({ start_index: 0, end_index: n_qpoints - 1, name: `full` })

--- a/src/site/state.svelte.ts
+++ b/src/site/state.svelte.ts
@@ -39,10 +39,10 @@ export function group_demo_routes(demos: string[]): RouteEntry[] {
 
   const result: RouteEntry[] = [...standalone]
   for (const [parent, children] of grouped) {
-    if (children.length > 0) result.push([parent, children.sort()])
+    if (children.length > 0) result.push([parent, children.toSorted()])
   }
 
-  return result.sort((r1, r2) => {
+  return result.toSorted((r1, r2) => {
     const r1_str = typeof r1 === `string` ? r1 : r1[0]
     const r2_str = typeof r2 === `string` ? r2 : r2[0]
     return r1_str.localeCompare(r2_str)

--- a/src/site/structures/index.ts
+++ b/src/site/structures/index.ts
@@ -27,7 +27,7 @@ export const structures = Object.entries(
     (structure): structure is Crystal =>
       structure && `sites` in structure && Array.isArray(structure.sites),
   )
-  .sort((struct_a, struct_b) =>
+  .toSorted((struct_a, struct_b) =>
     (struct_a.id?.split(`-`)[1] ?? ``)
       .padStart(6, `0`)
       .localeCompare((struct_b.id?.split(`-`)[1] ?? ``).padStart(6, `0`)),

--- a/tests/playwright/plot/scatter-plot.test.ts
+++ b/tests/playwright/plot/scatter-plot.test.ts
@@ -555,7 +555,7 @@ test.describe(`ScatterPlot Component Tests`, () => {
       const tick_values = tick_texts
         .map(Number)
         .filter((val) => !isNaN(val) && val > 0)
-        .sort((a, b) => a - b)
+        .toSorted((a, b) => a - b)
 
       // Log scale should have at least 2 positive tick values to check ratios
       expect(tick_values.length).toBeGreaterThanOrEqual(2)
@@ -1627,7 +1627,7 @@ test.describe(`ScatterPlot Component Tests`, () => {
     if (!plot_box) return
 
     // Find marker closest to right edge (most likely to cause overflow)
-    const rightmost = valid_markers.sort((a, b) => (b.bbox?.x ?? 0) - (a.bbox?.x ?? 0))[0]
+    const rightmost = valid_markers.toSorted((a, b) => (b.bbox?.x ?? 0) - (a.bbox?.x ?? 0))[0]
 
     // Test tooltip on rightmost marker - verify it doesn't overflow viewport
     await hover_to_show_tooltip(page, plot_locator, rightmost.marker)
@@ -1644,7 +1644,7 @@ test.describe(`ScatterPlot Component Tests`, () => {
     }
 
     // Find marker closest to bottom edge
-    const bottommost = valid_markers.sort((a, b) => (b.bbox?.y ?? 0) - (a.bbox?.y ?? 0))[0]
+    const bottommost = valid_markers.toSorted((a, b) => (b.bbox?.y ?? 0) - (a.bbox?.y ?? 0))[0]
 
     // Test tooltip on bottommost marker - verify it doesn't overflow viewport
     await hover_to_show_tooltip(page, plot_locator, bottommost.marker)

--- a/tests/vitest/brillouin-compute.test.ts
+++ b/tests/vitest/brillouin-compute.test.ts
@@ -61,7 +61,7 @@ const has_vertex = (vertices: Vec3[], target: Vec3, tol = 1e-8) =>
 const edge_key = (v1: Vec3, v2: Vec3) =>
   [v1, v2]
     .map((vertex) => vertex.map((coord) => coord.toFixed(8)).join(`,`))
-    .sort()
+    .toSorted()
     .join(`|`)
 
 describe(`reciprocal_lattice`, () => {

--- a/tests/vitest/chempot-diagram/compute.test.ts
+++ b/tests/vitest/chempot-diagram/compute.test.ts
@@ -344,7 +344,7 @@ describe(`binary system (2 elements)`, () => {
   })
 
   test(`A-B-AB structure, refs, and AB vertices between refs`, () => {
-    expect(Object.keys(binary_simple.domains).sort()).toEqual([`A`, `AB`, `B`])
+    expect(Object.keys(binary_simple.domains).toSorted()).toEqual([`A`, `AB`, `B`])
     expect(binary_simple.el_refs.A.energy_per_atom).toBe(-2.0)
     expect(binary_simple.el_refs.B.energy_per_atom).toBe(-3.0)
     for (const pt of dedup_vertices(binary_simple.domains.AB)) {
@@ -383,7 +383,7 @@ describe(`pure binary (no compounds)`, () => {
   )
 
   test(`produces exactly 2 domains`, () => {
-    expect(Object.keys(pure_binary.domains).sort()).toEqual([`X`, `Y`])
+    expect(Object.keys(pure_binary.domains).toSorted()).toEqual([`X`, `Y`])
   })
 
   test.each([
@@ -996,8 +996,8 @@ describe(`config.elements projection vs subsystem`, () => {
       default_min_limit: -25,
       formal_chempots: false,
     })
-    const formulas = Object.keys(result.domains).sort()
-    const expected = Object.keys(cpd_binary.domains).sort()
+    const formulas = Object.keys(result.domains).toSorted()
+    const expected = Object.keys(cpd_binary.domains).toSorted()
     expect(formulas).toEqual(expected)
   })
 
@@ -1044,8 +1044,8 @@ describe(`config.elements projection vs subsystem`, () => {
     })
 
     test(`formal vs absolute produces same domains`, () => {
-      expect(Object.keys(cpd_ternary_formal.domains).sort()).toEqual(
-        Object.keys(cpd_ternary.domains).sort(),
+      expect(Object.keys(cpd_ternary_formal.domains).toSorted()).toEqual(
+        Object.keys(cpd_ternary.domains).toSorted(),
       )
     })
   })
@@ -1491,7 +1491,7 @@ describe(`compute_domains`, () => {
 
   test(`stable compound → 3 domains with valid vertices`, () => {
     const { domains, hyperplanes } = make_ab_domains(-6.0)
-    expect(Object.keys(domains).sort()).toEqual([`A`, `AB`, `B`])
+    expect(Object.keys(domains).toSorted()).toEqual([`A`, `AB`, `B`])
     for (const pts of Object.values(domains)) {
       expect(pts.length).toBeGreaterThanOrEqual(2)
     }
@@ -1540,16 +1540,16 @@ describe(`compute_chempot_diagram edge cases`, () => {
     expect(reordered.elements).toEqual([`O`, `Fe`, `Li`])
     // Same domains as default order, just reordered columns
     expect(
-      Object.keys(reordered.domains).sort((str_a, str_b) => str_a.localeCompare(str_b)),
+      Object.keys(reordered.domains).toSorted((str_a, str_b) => str_a.localeCompare(str_b)),
     ).toEqual(
-      Object.keys(cpd_ternary.domains).sort((str_a, str_b) => str_a.localeCompare(str_b)),
+      Object.keys(cpd_ternary.domains).toSorted((str_a, str_b) => str_a.localeCompare(str_b)),
     )
     // Verify axes actually swapped: Fe domain's O-axis range (col 0 in reordered)
     // should match its col 2 range in default [Fe,Li,O] order
     const fe_reordered = dedup_vertices(reordered.domains.Fe)
     const fe_default = dedup_vertices(cpd_ternary.domains.Fe)
-    const re_o_vals = fe_reordered.map((pt) => pt[0]).sort((val_a, val_b) => val_a - val_b)
-    const def_o_vals = fe_default.map((pt) => pt[2]).sort((val_a, val_b) => val_a - val_b) // O is axis 2 in default
+    const re_o_vals = fe_reordered.map((pt) => pt[0]).toSorted((val_a, val_b) => val_a - val_b)
+    const def_o_vals = fe_default.map((pt) => pt[2]).toSorted((val_a, val_b) => val_a - val_b) // O is axis 2 in default
     expect(re_o_vals).toHaveLength(def_o_vals.length)
     for (let idx = 0; idx < re_o_vals.length; idx++) {
       expect(re_o_vals[idx]).toBeCloseTo(def_o_vals[idx], 4)
@@ -1569,7 +1569,7 @@ describe(`compute_chempot_diagram edge cases`, () => {
       [make_entry({ A: 1 }, -2.0), make_entry({ A: 1 }, -2.0), make_entry({ B: 1 }, -3.0)],
       { default_min_limit: -10, formal_chempots: false },
     )
-    expect(Object.keys(result.domains).sort()).toEqual([`A`, `B`])
+    expect(Object.keys(result.domains).toSorted()).toEqual([`A`, `B`])
   })
 
   test.each([
@@ -1899,7 +1899,9 @@ describe(`N-D projection cache consistency`, () => {
       elements: [`S`, `Ti`, `Y`],
     })
     // Both projections see the same N-D domains; formula keys match
-    expect(Object.keys(proj_a.domains).sort()).toEqual(Object.keys(proj_b.domains).sort())
+    expect(Object.keys(proj_a.domains).toSorted()).toEqual(
+      Object.keys(proj_b.domains).toSorted(),
+    )
 
     const binary_proj = compute_chempot_diagram(ytos_entries, {
       ...config_base,

--- a/tests/vitest/colors.test.ts
+++ b/tests/vitest/colors.test.ts
@@ -21,7 +21,7 @@ const EXPECTED_ELEMENTS = Array.from({ length: 109 }, (_, idx) => ELEM_SYMBOLS[i
 
 describe(`Element Color Schemes`, () => {
   test(`all schemes have identical, complete element coverage`, () => {
-    expect(Object.keys(ELEMENT_COLOR_SCHEMES).sort()).toEqual([
+    expect(Object.keys(ELEMENT_COLOR_SCHEMES).toSorted()).toEqual([
       `Alloy`,
       `Dark Mode`,
       `Jmol`,
@@ -29,11 +29,11 @@ describe(`Element Color Schemes`, () => {
       `Pastel`,
       `Vesta`,
     ])
-    const expected_keys = Object.keys(ELEMENT_COLOR_SCHEMES.Vesta).sort()
+    const expected_keys = Object.keys(ELEMENT_COLOR_SCHEMES.Vesta).toSorted()
     expect(expected_keys.length).toBeGreaterThanOrEqual(109)
     expect(expected_keys).toEqual(expect.arrayContaining(EXPECTED_ELEMENTS))
     for (const [scheme_name, colors] of Object.entries(ELEMENT_COLOR_SCHEMES)) {
-      expect(Object.keys(colors).sort(), `${scheme_name} coverage`).toEqual(expected_keys)
+      expect(Object.keys(colors).toSorted(), `${scheme_name} coverage`).toEqual(expected_keys)
     }
   })
 

--- a/tests/vitest/composition/parse.test.ts
+++ b/tests/vitest/composition/parse.test.ts
@@ -368,8 +368,8 @@ describe(`generate_chem_sys_subspaces`, () => {
     [{}, [], `object: empty`],
   ])(`%s -> %j (%s)`, (input, expected, _desc) => {
     const result = generate_chem_sys_subspaces(input)
-    expect(result.sort((str_a, str_b) => str_a.localeCompare(str_b))).toEqual(
-      expected.sort((str_a, str_b) => str_a.localeCompare(str_b)),
+    expect(result.toSorted((str_a, str_b) => str_a.localeCompare(str_b))).toEqual(
+      expected.toSorted((str_a, str_b) => str_a.localeCompare(str_b)),
     )
   })
 
@@ -386,9 +386,9 @@ describe(`generate_chem_sys_subspaces`, () => {
   )
 
   test(`consistent across input types`, () => {
-    const formula = generate_chem_sys_subspaces(`Fe2O3`).sort()
-    const array = generate_chem_sys_subspaces([`Fe`, `O`]).sort()
-    const obj = generate_chem_sys_subspaces({ Fe: 2, O: 3 }).sort()
+    const formula = generate_chem_sys_subspaces(`Fe2O3`).toSorted()
+    const array = generate_chem_sys_subspaces([`Fe`, `O`]).toSorted()
+    const obj = generate_chem_sys_subspaces({ Fe: 2, O: 3 }).toSorted()
     expect(formula).toEqual(array)
     expect(array).toEqual(obj)
   })

--- a/tests/vitest/composition/parse.test.ts
+++ b/tests/vitest/composition/parse.test.ts
@@ -397,7 +397,7 @@ describe(`generate_chem_sys_subspaces`, () => {
     const result = generate_chem_sys_subspaces([`Zr`, `Mo`, `Nb`])
     result.forEach((subspace) => {
       const parts = subspace.split(`-`)
-      expect(parts).toEqual([...parts].sort())
+      expect(parts).toEqual([...parts].toSorted())
     })
   })
 

--- a/tests/vitest/element/data.test.ts
+++ b/tests/vitest/element/data.test.ts
@@ -289,7 +289,7 @@ describe(`atomic_mass`, () => {
         found_anomalies.push(to_key(current.symbol, next.symbol))
       }
     }
-    expect(found_anomalies.sort()).toEqual([...known_anomalies].sort())
+    expect(found_anomalies.toSorted()).toEqual([...known_anomalies].sort())
   })
 
   test.each(ATOMIC_MASS_INVERSIONS)(`known inversion: %s > %s`, (heavier, lighter) => {

--- a/tests/vitest/element/data.test.ts
+++ b/tests/vitest/element/data.test.ts
@@ -289,7 +289,7 @@ describe(`atomic_mass`, () => {
         found_anomalies.push(to_key(current.symbol, next.symbol))
       }
     }
-    expect(found_anomalies.toSorted()).toEqual([...known_anomalies].sort())
+    expect(found_anomalies.toSorted()).toEqual([...known_anomalies].toSorted())
   })
 
   test.each(ATOMIC_MASS_INVERSIONS)(`known inversion: %s > %s`, (heavier, lighter) => {

--- a/tests/vitest/fermi-surface/site-files.test.ts
+++ b/tests/vitest/fermi-surface/site-files.test.ts
@@ -39,6 +39,6 @@ describe(`fermi_surface_files`, () => {
   })
 
   it(`exposes file type colors`, () => {
-    expect(Object.keys(fermi_file_colors).sort()).toEqual([`bxsf`, `frmsf`, `json`])
+    expect(Object.keys(fermi_file_colors).toSorted()).toEqual([`bxsf`, `frmsf`, `json`])
   })
 })

--- a/tests/vitest/file-viewer-reload.test.ts
+++ b/tests/vitest/file-viewer-reload.test.ts
@@ -107,7 +107,7 @@ test(`serializes reloads and guards cleanup, markers, and initialization`, async
     expect(mount).toHaveBeenCalledTimes(4)
   })
   cleanup_parse.resolve(result(`during-cleanup`))
-  await new Promise((resolve) => setTimeout(resolve))
+  await new Promise((resolve) => setTimeout(resolve, 0))
   expect(mount).toHaveBeenCalledTimes(4)
   await window.cleanupMatterViz?.()
 

--- a/tests/vitest/heatmap-matrix/index.test.ts
+++ b/tests/vitest/heatmap-matrix/index.test.ts
@@ -69,7 +69,7 @@ describe(`built-in orderings`, () => {
     const axis = elements_to_axis(undefined, `alphabetical`)
     const labels = axis.map((item) => item.label)
     expect(labels[0]).toBe(`Ac`)
-    expect(labels).toEqual([...labels].sort())
+    expect(labels).toEqual([...labels].toSorted())
   })
 
   test(`mendeleev_number: He near start, superheavy Og at end`, () => {

--- a/tests/vitest/isosurface/slice-rendering.test.ts
+++ b/tests/vitest/isosurface/slice-rendering.test.ts
@@ -61,6 +61,6 @@ describe(`slice rendering helpers`, () => {
   ])(`caps contour counts at 256 for $levels`, ({ levels, range }) => {
     const thresholds = resolve_contour_thresholds([...range], levels)
     expect(thresholds).toHaveLength(256)
-    expect(thresholds).toEqual([...thresholds].sort((left, right) => left - right))
+    expect(thresholds).toEqual([...thresholds].toSorted((left, right) => left - right))
   })
 })

--- a/tests/vitest/marching-cubes.test.ts
+++ b/tests/vitest/marching-cubes.test.ts
@@ -4,7 +4,12 @@ import {
   marching_cubes,
   marching_cubes_buffers,
 } from '$lib/marching-cubes'
-import { grid_value, type ScalarGrid3D, type ScalarGridOrder } from '$lib/isosurface/grid'
+import {
+  flatten_grid,
+  grid_value,
+  type ScalarGrid3D,
+  type ScalarGridOrder,
+} from '$lib/isosurface/grid'
 import type { Matrix3x3, Vec3 } from '$lib/math'
 import { describe, expect, test } from 'vitest'
 import { cubic_matrix, make_grid } from './setup'
@@ -50,7 +55,7 @@ const as_scalar_grid = (
       }
     }
   }
-  return { data, dimensions, order }
+  return { values: data, dims: dimensions, order }
 }
 
 const expect_result_parity = (
@@ -114,13 +119,13 @@ describe(`marching_cubes`, () => {
 
   test(`ScalarGrid3D uses the declared storage order`, () => {
     const x_fastest: ScalarGrid3D = {
-      data: new Float64Array([0, 100, 10, 110, 1, 101, 11, 111]),
-      dimensions: [2, 2, 2],
+      values: new Float64Array([0, 100, 10, 110, 1, 101, 11, 111]),
+      dims: [2, 2, 2],
       order: `x_fastest`,
     }
     const z_fastest: ScalarGrid3D = {
-      data: new Float64Array([0, 1, 10, 11, 100, 101, 110, 111]),
-      dimensions: [2, 2, 2],
+      values: new Float64Array([0, 1, 10, 11, 100, 101, 110, 111]),
+      dims: [2, 2, 2],
       order: `z_fastest`,
     }
     for (const grid of [x_fastest, z_fastest]) {
@@ -129,6 +134,26 @@ describe(`marching_cubes`, () => {
       expect(grid_value(grid, 1, 0, 0)).toBe(100)
       expect(grid_value(grid, 1, 1, 1)).toBe(111)
     }
+  })
+
+  test(`flatten_grid returns canonical z-fastest marching-cubes input`, () => {
+    const nested = make_grid(
+      3,
+      2,
+      4,
+      (x_idx, y_idx, z_idx) => 100 * x_idx + 10 * y_idx + z_idx,
+    )
+    const flattened = flatten_grid(nested)
+    expect(flattened).toEqual({
+      values: new Float64Array([
+        0, 1, 2, 3, 10, 11, 12, 13, 100, 101, 102, 103, 110, 111, 112, 113, 200, 201, 202, 203,
+        210, 211, 212, 213,
+      ]),
+      dims: [3, 2, 4],
+      order: `z_fastest`,
+    })
+    const expected = marching_cubes(nested, 105, IDENTITY, NON_PERIODIC)
+    expect_result_parity(marching_cubes(flattened, 105, IDENTITY, NON_PERIODIC), expected)
   })
 
   test(`ScalarGrid3D x_fastest and z_fastest match nested grids`, () => {
@@ -146,8 +171,8 @@ describe(`marching_cubes`, () => {
       [`z_fastest`, `f64`],
     ] as const) {
       const scalar_grid = as_scalar_grid(grid, order, precision)
-      const actual = marching_cubes(scalar_grid, 0.45, IDENTITY, NON_PERIODIC)
-      expect_result_parity(actual, expected)
+      const original_values = scalar_grid.values.slice()
+      expect_result_parity(marching_cubes(scalar_grid, 0.45, IDENTITY, NON_PERIODIC), expected)
 
       const buffers = marching_cubes_buffers(scalar_grid, 0.45, IDENTITY, {
         ...NON_PERIODIC,
@@ -156,6 +181,7 @@ describe(`marching_cubes`, () => {
       expect(Array.from(buffers.indices)).toEqual(expected.faces.flat())
       expect_array_close(buffers.positions, expected.vertices.flat())
       expect_array_close(buffers.normals, expected.normals.flat())
+      expect(scalar_grid.values).toEqual(original_values)
     }
   })
 
@@ -194,8 +220,8 @@ describe(`marching_cubes`, () => {
     `ScalarGrid3D degenerate dimensions $dimensions return empty geometry`,
     ({ dimensions }) => {
       const grid: ScalarGrid3D = {
-        data: new Float64Array(dimensions[0] * dimensions[1] * dimensions[2]),
-        dimensions,
+        values: new Float64Array(dimensions[0] * dimensions[1] * dimensions[2]),
+        dims: dimensions,
         order: `z_fastest`,
       }
       const result = marching_cubes(grid, 0.5, IDENTITY, NON_PERIODIC)
@@ -211,38 +237,43 @@ describe(`marching_cubes`, () => {
 
   test.each([
     {
-      label: `data length mismatch`,
-      grid: { data: new Float64Array(7), dimensions: [2, 2, 2], order: `z_fastest` },
+      label: `values length mismatch`,
+      grid: { values: new Float64Array(7), dims: [2, 2, 2], order: `z_fastest` },
       error: RangeError,
     },
     {
+      label: `legacy field names`,
+      grid: { data: new Float64Array(8), dimensions: [2, 2, 2], order: `z_fastest` },
+      error: TypeError,
+    },
+    {
       label: `negative dimension`,
-      grid: { data: new Float64Array(), dimensions: [-1, 2, 2], order: `z_fastest` },
+      grid: { values: new Float64Array(), dims: [-1, 2, 2], order: `z_fastest` },
       error: RangeError,
     },
     {
       label: `fractional dimension`,
-      grid: { data: new Float64Array(8), dimensions: [2, 2, 1.5], order: `x_fastest` },
+      grid: { values: new Float64Array(8), dims: [2, 2, 1.5], order: `x_fastest` },
       error: RangeError,
     },
     {
       label: `missing dimension`,
-      grid: { data: new Float64Array(4), dimensions: [2, 2], order: `z_fastest` },
+      grid: { values: new Float64Array(4), dims: [2, 2], order: `z_fastest` },
       error: RangeError,
     },
     {
       label: `extra dimension`,
-      grid: { data: new Float64Array(8), dimensions: [2, 2, 2, 4], order: `z_fastest` },
+      grid: { values: new Float64Array(8), dims: [2, 2, 2, 4], order: `z_fastest` },
       error: RangeError,
     },
     {
       label: `unsupported order`,
-      grid: { data: new Float64Array(8), dimensions: [2, 2, 2], order: `y_fastest` },
+      grid: { values: new Float64Array(8), dims: [2, 2, 2], order: `y_fastest` },
       error: RangeError,
     },
     {
       label: `unsupported typed array`,
-      grid: { data: new Int32Array(8), dimensions: [2, 2, 2], order: `z_fastest` },
+      grid: { values: new Int32Array(8), dims: [2, 2, 2], order: `z_fastest` },
       error: TypeError,
     },
   ])(`ScalarGrid3D rejects $label`, ({ grid, error }) => {

--- a/tests/vitest/marching-cubes.test.ts
+++ b/tests/vitest/marching-cubes.test.ts
@@ -3,13 +3,11 @@ import {
   compute_vertex_normals,
   marching_cubes,
   marching_cubes_buffers,
-} from '$lib/marching-cubes'
-import {
-  flatten_grid,
-  grid_value,
   type ScalarGrid3D,
+  type ScalarGridArray,
   type ScalarGridOrder,
-} from '$lib/isosurface/grid'
+} from '$lib/marching-cubes'
+import { create_grid_value_accessor, flatten_grid, grid_value } from '$lib/isosurface/grid'
 import type { Matrix3x3, Vec3 } from '$lib/math'
 import { describe, expect, test } from 'vitest'
 import { cubic_matrix, make_grid } from './setup'
@@ -44,7 +42,7 @@ const as_scalar_grid = (
 ): ScalarGrid3D => {
   const dimensions: Vec3 = [grid.length, grid[0]?.length ?? 0, grid[0]?.[0]?.length ?? 0]
   const [nx, ny, nz] = dimensions
-  const data =
+  const data: ScalarGridArray =
     precision === `f32` ? new Float32Array(nx * ny * nz) : new Float64Array(nx * ny * nz)
   for (let ix = 0; ix < nx; ix++) {
     for (let iy = 0; iy < ny; iy++) {
@@ -117,7 +115,13 @@ describe(`marching_cubes`, () => {
     expect_array_close(buffers.normals, result.normals.flat())
   })
 
-  test(`ScalarGrid3D uses the declared storage order`, () => {
+  test(`grid accessors support nested grids and declared storage orders`, () => {
+    const nested = make_grid(
+      2,
+      2,
+      2,
+      (x_idx, y_idx, z_idx) => 100 * x_idx + 10 * y_idx + z_idx,
+    )
     const x_fastest: ScalarGrid3D = {
       values: new Float64Array([0, 100, 10, 110, 1, 101, 11, 111]),
       dims: [2, 2, 2],
@@ -128,11 +132,18 @@ describe(`marching_cubes`, () => {
       dims: [2, 2, 2],
       order: `z_fastest`,
     }
-    for (const grid of [x_fastest, z_fastest]) {
-      expect(grid_value(grid, 0, 0, 1)).toBe(1)
-      expect(grid_value(grid, 0, 1, 0)).toBe(10)
-      expect(grid_value(grid, 1, 0, 0)).toBe(100)
-      expect(grid_value(grid, 1, 1, 1)).toBe(111)
+    const samples: [Vec3, number][] = [
+      [[0, 0, 1], 1],
+      [[0, 1, 0], 10],
+      [[1, 0, 0], 100],
+      [[1, 1, 1], 111],
+    ]
+    for (const grid of [nested, x_fastest, z_fastest]) {
+      const get_value = create_grid_value_accessor(grid)
+      for (const [indices, expected] of samples) {
+        expect(grid_value(grid, ...indices)).toBe(expected)
+        expect(get_value(...indices)).toBe(expected)
+      }
     }
   })
 

--- a/tests/vitest/marching-cubes.test.ts
+++ b/tests/vitest/marching-cubes.test.ts
@@ -226,6 +226,16 @@ describe(`marching_cubes`, () => {
       error: RangeError,
     },
     {
+      label: `missing dimension`,
+      grid: { data: new Float64Array(4), dimensions: [2, 2], order: `z_fastest` },
+      error: RangeError,
+    },
+    {
+      label: `extra dimension`,
+      grid: { data: new Float64Array(8), dimensions: [2, 2, 2, 4], order: `z_fastest` },
+      error: RangeError,
+    },
+    {
       label: `unsupported order`,
       grid: { data: new Float64Array(8), dimensions: [2, 2, 2], order: `y_fastest` },
       error: RangeError,

--- a/tests/vitest/marching-cubes.test.ts
+++ b/tests/vitest/marching-cubes.test.ts
@@ -40,16 +40,12 @@ const as_scalar_grid = (
   const dimensions: Vec3 = [grid.length, grid[0]?.length ?? 0, grid[0]?.[0]?.length ?? 0]
   const [nx, ny, nz] = dimensions
   const data =
-    precision === `f32`
-      ? new Float32Array(nx * ny * nz)
-      : new Float64Array(nx * ny * nz)
+    precision === `f32` ? new Float32Array(nx * ny * nz) : new Float64Array(nx * ny * nz)
   for (let ix = 0; ix < nx; ix++) {
     for (let iy = 0; iy < ny; iy++) {
       for (let iz = 0; iz < nz; iz++) {
         const offset =
-          order === `x_fastest`
-            ? ix + nx * (iy + ny * iz)
-            : iz + nz * (iy + ny * ix)
+          order === `x_fastest` ? ix + nx * (iy + ny * iz) : iz + nz * (iy + ny * ix)
         data[offset] = grid[ix][iy][iz]
       }
     }
@@ -166,8 +162,7 @@ describe(`marching_cubes`, () => {
   test(`ScalarGrid3D preserves periodic wrapped geometry`, () => {
     const min_frac = (idx: number, size: number) => Math.min(idx / size, 1 - idx / size)
     const grid = make_grid(5, 4, 6, (ix, iy, iz) => {
-      const radius =
-        min_frac(ix, 5) ** 2 + min_frac(iy, 4) ** 2 + min_frac(iz, 6) ** 2
+      const radius = min_frac(ix, 5) ** 2 + min_frac(iy, 4) ** 2 + min_frac(iz, 6) ** 2
       return Math.exp(-radius / 0.04)
     })
     const expected = marching_cubes(grid, 0.35, IDENTITY, PERIODIC)
@@ -206,9 +201,11 @@ describe(`marching_cubes`, () => {
       const result = marching_cubes(grid, 0.5, IDENTITY, NON_PERIODIC)
       expect([result.vertices, result.faces, result.normals]).toEqual([[], [], []])
       const buffers = marching_cubes_buffers(grid, 0.5, IDENTITY, NON_PERIODIC)
-      expect([buffers.positions.length, buffers.indices.length, buffers.normals.length]).toEqual([
-        0, 0, 0,
-      ])
+      expect([
+        buffers.positions.length,
+        buffers.indices.length,
+        buffers.normals.length,
+      ]).toEqual([0, 0, 0])
     },
   )
 

--- a/tests/vitest/marching-cubes.test.ts
+++ b/tests/vitest/marching-cubes.test.ts
@@ -7,7 +7,7 @@ import {
   type ScalarGridArray,
   type ScalarGridOrder,
 } from '$lib/marching-cubes'
-import { create_grid_value_accessor, flatten_grid, grid_value } from '$lib/isosurface/grid'
+import { flatten_grid } from '$lib/isosurface/grid'
 import type { Matrix3x3, Vec3 } from '$lib/math'
 import { describe, expect, test } from 'vitest'
 import { cubic_matrix, make_grid } from './setup'
@@ -35,6 +35,9 @@ const expect_array_close = (actual: ArrayLike<number>, expected: number[]): void
 const mean_axis = (verts: Vec3[], axis: 0 | 1 | 2): number =>
   verts.reduce((sum, vertex) => sum + vertex[axis], 0) / verts.length
 
+const indexed_grid = (nx: number, ny: number, nz: number): number[][][] =>
+  make_grid(nx, ny, nz, (x_idx, y_idx, z_idx) => 100 * x_idx + 10 * y_idx + z_idx)
+
 const as_scalar_grid = (
   grid: number[][][],
   order: ScalarGridOrder,
@@ -61,8 +64,6 @@ const expect_result_parity = (
   expected: ReturnType<typeof marching_cubes>,
 ): void => {
   expect(actual.faces).toEqual(expected.faces)
-  expect(actual.vertices).toHaveLength(expected.vertices.length)
-  expect(actual.normals).toHaveLength(expected.normals.length)
   expect_array_close(actual.vertices.flat(), expected.vertices.flat())
   expect_array_close(actual.normals.flat(), expected.normals.flat())
 }
@@ -115,45 +116,8 @@ describe(`marching_cubes`, () => {
     expect_array_close(buffers.normals, result.normals.flat())
   })
 
-  test(`grid accessors support nested grids and declared storage orders`, () => {
-    const nested = make_grid(
-      2,
-      2,
-      2,
-      (x_idx, y_idx, z_idx) => 100 * x_idx + 10 * y_idx + z_idx,
-    )
-    const x_fastest: ScalarGrid3D = {
-      values: new Float64Array([0, 100, 10, 110, 1, 101, 11, 111]),
-      dims: [2, 2, 2],
-      order: `x_fastest`,
-    }
-    const z_fastest: ScalarGrid3D = {
-      values: new Float64Array([0, 1, 10, 11, 100, 101, 110, 111]),
-      dims: [2, 2, 2],
-      order: `z_fastest`,
-    }
-    const samples: [Vec3, number][] = [
-      [[0, 0, 1], 1],
-      [[0, 1, 0], 10],
-      [[1, 0, 0], 100],
-      [[1, 1, 1], 111],
-    ]
-    for (const grid of [nested, x_fastest, z_fastest]) {
-      const get_value = create_grid_value_accessor(grid)
-      for (const [indices, expected] of samples) {
-        expect(grid_value(grid, ...indices)).toBe(expected)
-        expect(get_value(...indices)).toBe(expected)
-      }
-    }
-  })
-
   test(`flatten_grid returns canonical z-fastest marching-cubes input`, () => {
-    const nested = make_grid(
-      3,
-      2,
-      4,
-      (x_idx, y_idx, z_idx) => 100 * x_idx + 10 * y_idx + z_idx,
-    )
+    const nested = indexed_grid(3, 2, 4)
     const flattened = flatten_grid(nested)
     expect(flattened).toEqual({
       values: new Float64Array([
@@ -163,8 +127,6 @@ describe(`marching_cubes`, () => {
       dims: [3, 2, 4],
       order: `z_fastest`,
     })
-    const expected = marching_cubes(nested, 105, IDENTITY, NON_PERIODIC)
-    expect_result_parity(marching_cubes(flattened, 105, IDENTITY, NON_PERIODIC), expected)
   })
 
   test(`ScalarGrid3D x_fastest and z_fastest match nested grids`, () => {
@@ -209,13 +171,10 @@ describe(`marching_cubes`, () => {
       [`x_fastest`, `f32`],
       [`z_fastest`, `f64`],
     ] as const) {
-      const actual = marching_cubes(
-        as_scalar_grid(grid, order, precision),
-        0.35,
-        IDENTITY,
-        PERIODIC,
+      expect_result_parity(
+        marching_cubes(as_scalar_grid(grid, order, precision), 0.35, IDENTITY, PERIODIC),
+        expected,
       )
-      expect_result_parity(actual, expected)
     }
   })
 
@@ -246,50 +205,36 @@ describe(`marching_cubes`, () => {
     },
   )
 
+  const valid_scalar_grid = {
+    values: new Float64Array(8),
+    dims: [2, 2, 2],
+    order: `z_fastest`,
+  } satisfies ScalarGrid3D
+  const { values: data, dims: dimensions, order } = valid_scalar_grid
+
   test.each([
-    {
-      label: `values length mismatch`,
-      grid: { values: new Float64Array(7), dims: [2, 2, 2], order: `z_fastest` },
-      error: RangeError,
+    [
+      `values length mismatch`,
+      { ...valid_scalar_grid, values: new Float64Array(7) },
+      RangeError,
+    ],
+    [`legacy field names`, { data, dimensions, order }, TypeError],
+    [`negative dimension`, { ...valid_scalar_grid, dims: [-1, 2, 2] }, RangeError],
+    [`fractional dimension`, { ...valid_scalar_grid, dims: [2, 2, 1.5] }, RangeError],
+    [`missing dimension`, { ...valid_scalar_grid, dims: [2, 2] }, RangeError],
+    [`extra dimension`, { ...valid_scalar_grid, dims: [2, 2, 2, 4] }, RangeError],
+    [`unsupported order`, { ...valid_scalar_grid, order: `y_fastest` }, RangeError],
+    [
+      `unsupported typed array`,
+      { ...valid_scalar_grid, values: new Int32Array(8) },
+      TypeError,
+    ],
+  ] satisfies [string, unknown, ErrorConstructor][])(
+    `ScalarGrid3D rejects %s`,
+    (_label, grid, error) => {
+      expect(() => marching_cubes(grid as ScalarGrid3D, 0.5, IDENTITY)).toThrow(error)
     },
-    {
-      label: `legacy field names`,
-      grid: { data: new Float64Array(8), dimensions: [2, 2, 2], order: `z_fastest` },
-      error: TypeError,
-    },
-    {
-      label: `negative dimension`,
-      grid: { values: new Float64Array(), dims: [-1, 2, 2], order: `z_fastest` },
-      error: RangeError,
-    },
-    {
-      label: `fractional dimension`,
-      grid: { values: new Float64Array(8), dims: [2, 2, 1.5], order: `x_fastest` },
-      error: RangeError,
-    },
-    {
-      label: `missing dimension`,
-      grid: { values: new Float64Array(4), dims: [2, 2], order: `z_fastest` },
-      error: RangeError,
-    },
-    {
-      label: `extra dimension`,
-      grid: { values: new Float64Array(8), dims: [2, 2, 2, 4], order: `z_fastest` },
-      error: RangeError,
-    },
-    {
-      label: `unsupported order`,
-      grid: { values: new Float64Array(8), dims: [2, 2, 2], order: `y_fastest` },
-      error: RangeError,
-    },
-    {
-      label: `unsupported typed array`,
-      grid: { values: new Int32Array(8), dims: [2, 2, 2], order: `z_fastest` },
-      error: TypeError,
-    },
-  ])(`ScalarGrid3D rejects $label`, ({ grid, error }) => {
-    expect(() => marching_cubes(grid as ScalarGrid3D, 0.5, IDENTITY)).toThrow(error)
-  })
+  )
 
   test(`centered=true shifts vertices relative to uncentered`, () => {
     const grid = gaussian_grid(8)

--- a/tests/vitest/marching-cubes.test.ts
+++ b/tests/vitest/marching-cubes.test.ts
@@ -4,6 +4,7 @@ import {
   marching_cubes,
   marching_cubes_buffers,
 } from '$lib/marching-cubes'
+import { grid_value, type ScalarGrid3D, type ScalarGridOrder } from '$lib/isosurface/grid'
 import type { Matrix3x3, Vec3 } from '$lib/math'
 import { describe, expect, test } from 'vitest'
 import { cubic_matrix, make_grid } from './setup'
@@ -30,6 +31,42 @@ const expect_array_close = (actual: ArrayLike<number>, expected: number[]): void
 
 const mean_axis = (verts: Vec3[], axis: 0 | 1 | 2): number =>
   verts.reduce((sum, vertex) => sum + vertex[axis], 0) / verts.length
+
+const as_scalar_grid = (
+  grid: number[][][],
+  order: ScalarGridOrder,
+  precision: `f32` | `f64` = `f64`,
+): ScalarGrid3D => {
+  const dimensions: Vec3 = [grid.length, grid[0]?.length ?? 0, grid[0]?.[0]?.length ?? 0]
+  const [nx, ny, nz] = dimensions
+  const data =
+    precision === `f32`
+      ? new Float32Array(nx * ny * nz)
+      : new Float64Array(nx * ny * nz)
+  for (let ix = 0; ix < nx; ix++) {
+    for (let iy = 0; iy < ny; iy++) {
+      for (let iz = 0; iz < nz; iz++) {
+        const offset =
+          order === `x_fastest`
+            ? ix + nx * (iy + ny * iz)
+            : iz + nz * (iy + ny * ix)
+        data[offset] = grid[ix][iy][iz]
+      }
+    }
+  }
+  return { data, dimensions, order }
+}
+
+const expect_result_parity = (
+  actual: ReturnType<typeof marching_cubes>,
+  expected: ReturnType<typeof marching_cubes>,
+): void => {
+  expect(actual.faces).toEqual(expected.faces)
+  expect(actual.vertices).toHaveLength(expected.vertices.length)
+  expect(actual.normals).toHaveLength(expected.normals.length)
+  expect_array_close(actual.vertices.flat(), expected.vertices.flat())
+  expect_array_close(actual.normals.flat(), expected.normals.flat())
+}
 
 describe(`marching_cubes`, () => {
   test.each([
@@ -77,6 +114,132 @@ describe(`marching_cubes`, () => {
     expect(Array.from(buffers.indices)).toEqual(result.faces.flat())
     expect_array_close(buffers.positions, result.vertices.flat())
     expect_array_close(buffers.normals, result.normals.flat())
+  })
+
+  test(`ScalarGrid3D uses the declared storage order`, () => {
+    const x_fastest: ScalarGrid3D = {
+      data: new Float64Array([0, 100, 10, 110, 1, 101, 11, 111]),
+      dimensions: [2, 2, 2],
+      order: `x_fastest`,
+    }
+    const z_fastest: ScalarGrid3D = {
+      data: new Float64Array([0, 1, 10, 11, 100, 101, 110, 111]),
+      dimensions: [2, 2, 2],
+      order: `z_fastest`,
+    }
+    for (const grid of [x_fastest, z_fastest]) {
+      expect(grid_value(grid, 0, 0, 1)).toBe(1)
+      expect(grid_value(grid, 0, 1, 0)).toBe(10)
+      expect(grid_value(grid, 1, 0, 0)).toBe(100)
+      expect(grid_value(grid, 1, 1, 1)).toBe(111)
+    }
+  })
+
+  test(`ScalarGrid3D x_fastest and z_fastest match nested grids`, () => {
+    const grid = make_grid(5, 4, 6, (ix, iy, iz) => {
+      const [dx, dy, dz] = [(ix - 2) / 2, (iy - 1.5) / 1.5, (iz - 2.5) / 2.5]
+      return Math.exp(-(dx * dx + dy * dy + dz * dz))
+    })
+    const expected = marching_cubes(grid, 0.45, IDENTITY, NON_PERIODIC)
+    expect(expected.faces.length).toBeGreaterThan(0)
+
+    for (const [order, precision] of [
+      [`x_fastest`, `f32`],
+      [`x_fastest`, `f64`],
+      [`z_fastest`, `f32`],
+      [`z_fastest`, `f64`],
+    ] as const) {
+      const scalar_grid = as_scalar_grid(grid, order, precision)
+      const actual = marching_cubes(scalar_grid, 0.45, IDENTITY, NON_PERIODIC)
+      expect_result_parity(actual, expected)
+
+      const buffers = marching_cubes_buffers(scalar_grid, 0.45, IDENTITY, {
+        ...NON_PERIODIC,
+        normals: true,
+      })
+      expect(Array.from(buffers.indices)).toEqual(expected.faces.flat())
+      expect_array_close(buffers.positions, expected.vertices.flat())
+      expect_array_close(buffers.normals, expected.normals.flat())
+    }
+  })
+
+  test(`ScalarGrid3D preserves periodic wrapped geometry`, () => {
+    const min_frac = (idx: number, size: number) => Math.min(idx / size, 1 - idx / size)
+    const grid = make_grid(5, 4, 6, (ix, iy, iz) => {
+      const radius =
+        min_frac(ix, 5) ** 2 + min_frac(iy, 4) ** 2 + min_frac(iz, 6) ** 2
+      return Math.exp(-radius / 0.04)
+    })
+    const expected = marching_cubes(grid, 0.35, IDENTITY, PERIODIC)
+    expect(expected.faces.length).toBeGreaterThan(0)
+
+    for (const [order, precision] of [
+      [`x_fastest`, `f32`],
+      [`z_fastest`, `f64`],
+    ] as const) {
+      const actual = marching_cubes(
+        as_scalar_grid(grid, order, precision),
+        0.35,
+        IDENTITY,
+        PERIODIC,
+      )
+      expect_result_parity(actual, expected)
+    }
+  })
+
+  test.each([
+    { dimensions: [0, 0, 0] as Vec3 },
+    { dimensions: [0, 3, 3] as Vec3 },
+    { dimensions: [1, 3, 3] as Vec3 },
+    { dimensions: [3, 0, 3] as Vec3 },
+    { dimensions: [3, 1, 3] as Vec3 },
+    { dimensions: [3, 3, 0] as Vec3 },
+    { dimensions: [3, 3, 1] as Vec3 },
+  ])(
+    `ScalarGrid3D degenerate dimensions $dimensions return empty geometry`,
+    ({ dimensions }) => {
+      const grid: ScalarGrid3D = {
+        data: new Float64Array(dimensions[0] * dimensions[1] * dimensions[2]),
+        dimensions,
+        order: `z_fastest`,
+      }
+      const result = marching_cubes(grid, 0.5, IDENTITY, NON_PERIODIC)
+      expect([result.vertices, result.faces, result.normals]).toEqual([[], [], []])
+      const buffers = marching_cubes_buffers(grid, 0.5, IDENTITY, NON_PERIODIC)
+      expect([buffers.positions.length, buffers.indices.length, buffers.normals.length]).toEqual([
+        0, 0, 0,
+      ])
+    },
+  )
+
+  test.each([
+    {
+      label: `data length mismatch`,
+      grid: { data: new Float64Array(7), dimensions: [2, 2, 2], order: `z_fastest` },
+      error: RangeError,
+    },
+    {
+      label: `negative dimension`,
+      grid: { data: new Float64Array(), dimensions: [-1, 2, 2], order: `z_fastest` },
+      error: RangeError,
+    },
+    {
+      label: `fractional dimension`,
+      grid: { data: new Float64Array(8), dimensions: [2, 2, 1.5], order: `x_fastest` },
+      error: RangeError,
+    },
+    {
+      label: `unsupported order`,
+      grid: { data: new Float64Array(8), dimensions: [2, 2, 2], order: `y_fastest` },
+      error: RangeError,
+    },
+    {
+      label: `unsupported typed array`,
+      grid: { data: new Int32Array(8), dimensions: [2, 2, 2], order: `z_fastest` },
+      error: TypeError,
+    },
+  ])(`ScalarGrid3D rejects $label`, ({ grid, error }) => {
+    expect(() => marching_cubes(grid as ScalarGrid3D, 0.5, IDENTITY)).toThrow(error)
   })
 
   test(`centered=true shifts vertices relative to uncentered`, () => {

--- a/tests/vitest/plot/PlotMarginals.test.svelte.ts
+++ b/tests/vitest/plot/PlotMarginals.test.svelte.ts
@@ -254,7 +254,7 @@ describe(`PlotMarginals integration`, () => {
     const nums = (line_path.getAttribute(`d`) ?? ``).match(/-?\d+\.?\d*/g)?.map(Number) ?? []
     const ys = nums.filter((_, idx) => idx % 2 === 1)
     expect(ys.length).toBeGreaterThan(2)
-    const ascending = [...ys].sort((a, b) => a - b)
+    const ascending = [...ys].toSorted((a, b) => a - b)
     const is_monotonic =
       ys.every((val, idx) => val === ascending[idx]) ||
       ys.every((val, idx) => val === ascending[ascending.length - 1 - idx])

--- a/tests/vitest/plot/box-plot.test.ts
+++ b/tests/vitest/plot/box-plot.test.ts
@@ -159,7 +159,7 @@ describe(`compute_box_stats`, () => {
             ? (rand() - 0.5) * 1000 // floats incl. negatives
             : Math.floor((rand() - 0.5) * 20),
       )
-      const sorted = [...arr].sort((left, right) => left - right)
+      const sorted = [...arr].toSorted((left, right) => left - right)
       const q1 = d3_quantile(sorted, 0.25) as number
       const q3 = d3_quantile(sorted, 0.75) as number
       const stats = compute_box_stats(arr, { whisker_mode: `tukey` })

--- a/tests/vitest/plot/label-placement.test.ts
+++ b/tests/vitest/plot/label-placement.test.ts
@@ -602,7 +602,7 @@ describe(`compute_label_positions`, () => {
       default_scales,
       default_bounds,
     )
-    expect(Object.keys(result).sort()).toEqual([...kept].sort())
+    expect(Object.keys(result).toSorted()).toEqual([...kept].sort())
   })
 
   test(`high distance weight keeps labels closer to anchors than high overlap weight`, () => {

--- a/tests/vitest/plot/label-placement.test.ts
+++ b/tests/vitest/plot/label-placement.test.ts
@@ -602,7 +602,7 @@ describe(`compute_label_positions`, () => {
       default_scales,
       default_bounds,
     )
-    expect(Object.keys(result).toSorted()).toEqual([...kept].sort())
+    expect(Object.keys(result).toSorted()).toEqual([...kept].toSorted())
   })
 
   test(`high distance weight keeps labels closer to anchors than high overlap weight`, () => {

--- a/tests/vitest/plot/marginals.test.ts
+++ b/tests/vitest/plot/marginals.test.ts
@@ -50,7 +50,7 @@ describe(`normalize_marginals`, () => {
     const active_sides = (Object.keys(result) as MarginalSide[]).filter(
       (side) => result[side] != null,
     )
-    expect(active_sides.sort()).toEqual([...active].sort())
+    expect(active_sides.toSorted()).toEqual([...active].sort())
   })
 
   // a bare type string activates top+right (the default sides), even when none are passed

--- a/tests/vitest/plot/marginals.test.ts
+++ b/tests/vitest/plot/marginals.test.ts
@@ -50,7 +50,7 @@ describe(`normalize_marginals`, () => {
     const active_sides = (Object.keys(result) as MarginalSide[]).filter(
       (side) => result[side] != null,
     )
-    expect(active_sides.toSorted()).toEqual([...active].sort())
+    expect(active_sides.toSorted()).toEqual([...active].toSorted())
   })
 
   // a bare type string activates top+right (the default sides), even when none are passed

--- a/tests/vitest/site/phonons.test.ts
+++ b/tests/vitest/site/phonons.test.ts
@@ -121,7 +121,7 @@ describe(`Phonon Module Tests`, () => {
       }
 
       // Branches are contiguous (each starts where the previous ends) and span the path
-      const sorted_branches = [...band_struct.branches].sort(
+      const sorted_branches = [...band_struct.branches].toSorted(
         (branch_a, branch_b) => branch_a.start_index - branch_b.start_index,
       )
       expect(sorted_branches[0].start_index, id).toBe(0)

--- a/tests/vitest/site/phonons.test.ts
+++ b/tests/vitest/site/phonons.test.ts
@@ -153,8 +153,8 @@ describe(`Phonon Module Tests`, () => {
       // Transformation preserves data dimensions and labels
       expect(transformed.qpoints, id).toHaveLength(raw.qpoints.length)
       expect(transformed.nb_bands, id).toBe(raw.bands.length)
-      expect(Object.keys(transformed.labels_dict).sort(), id).toEqual(
-        Object.keys(raw.labels_dict).sort(),
+      expect(Object.keys(transformed.labels_dict).toSorted(), id).toEqual(
+        Object.keys(raw.labels_dict).toSorted(),
       )
     },
   )

--- a/tests/vitest/structure/bond-order-perception.test.ts
+++ b/tests/vitest/structure/bond-order-perception.test.ts
@@ -93,7 +93,7 @@ describe(`valence-maximization core (neutral)`, () => {
     expect(
       result
         .map((bond) => bond.bond_order)
-        .sort((left, right) => Number(left) - Number(right)),
+        .toSorted((left, right) => Number(left) - Number(right)),
     ).toEqual([2, 2])
     expect(result.every((bond) => bond.perceived)).toBe(true)
   })
@@ -175,7 +175,7 @@ describe(`charge support`, () => {
     expect(
       result
         .map((bond) => bond.bond_order)
-        .sort((left, right) => Number(left) - Number(right)),
+        .toSorted((left, right) => Number(left) - Number(right)),
     ).toEqual([1, 1, 2])
     expect(result.every((bond) => bond.perceived)).toBe(true)
   })

--- a/tests/vitest/structure/bonding.test.ts
+++ b/tests/vitest/structure/bonding.test.ts
@@ -591,7 +591,7 @@ describe(`Explicit Bond Metadata`, () => {
       ]),
     )
 
-    expect([...bonds_by_key.keys()].sort()).toEqual([`0-1@-1,0,0`, `0-1@1,0,0`])
+    expect([...bonds_by_key.keys()].toSorted()).toEqual([`0-1@-1,0,0`, `0-1@1,0,0`])
     expect(bonds_by_key.get(`0-1@1,0,0`)?.bond_order).toBe(2)
     expect(bonds_by_key.get(`0-1@-1,0,0`)?.bond_order).toBe(3)
   })

--- a/tests/vitest/structure/edit-atoms.test.ts
+++ b/tests/vitest/structure/edit-atoms.test.ts
@@ -302,7 +302,7 @@ function format_bond_summary(neighbors: string[]): string {
   const counts: Record<string, number> = {}
   for (const elem of neighbors) counts[elem] = (counts[elem] ?? 0) + 1
   const parts = Object.entries(counts)
-    .sort(([a], [b]) => a.localeCompare(b))
+    .toSorted(([a], [b]) => a.localeCompare(b))
     .map(([elem, count]) => `${elem}: ${count}`)
   return ` (${parts.join(`, `)})`
 }

--- a/tests/vitest/structure/export.test.ts
+++ b/tests/vitest/structure/export.test.ts
@@ -922,7 +922,7 @@ describe(`Export functionality`, () => {
 
 // Helper function to sort sites for consistent comparison
 const sort_sites = (sites: AnyStructure[`sites`]): AnyStructure[`sites`] =>
-  [...sites].sort((site_a, site_b) => {
+  [...sites].toSorted((site_a, site_b) => {
     const elem_a = site_a.species[0].element
     const elem_b = site_b.species[0].element
     if (elem_a !== elem_b) {

--- a/tests/vitest/structure/export.test.ts
+++ b/tests/vitest/structure/export.test.ts
@@ -762,7 +762,7 @@ describe(`Export functionality`, () => {
 
       // Round-trip: each element keeps its own partial occupancy through parse_cif
       const species = parse_cif(cif_content)?.sites.flatMap((site) => site.species) ?? []
-      expect(species.map((sp) => sp.element).sort()).toEqual([`Au`, `Cu`])
+      expect(species.map((sp) => sp.element).toSorted()).toEqual([`Au`, `Cu`])
       expect(species.find((sp) => sp.element === `Cu`)?.occu).toBeCloseTo(0.7, 8)
       expect(species.find((sp) => sp.element === `Au`)?.occu).toBeCloseTo(0.3, 8)
     })

--- a/tests/vitest/structure/parse.test.ts
+++ b/tests/vitest/structure/parse.test.ts
@@ -1512,7 +1512,7 @@ Na Na 0.000 0.000 0.000`
     const oxygen_sites = result.sites.filter(
       (site) => site.species[0].element === `O` || site.label === `OH` || site.label === `OH2`,
     )
-    expect(oxygen_sites.map((site) => site.label).sort()).toEqual([
+    expect(oxygen_sites.map((site) => site.label).toSorted()).toEqual([
       `O1`,
       `O2`,
       `O3`,

--- a/tests/vitest/structure/polyhedra.test.ts
+++ b/tests/vitest/structure/polyhedra.test.ts
@@ -461,7 +461,7 @@ describe(`VESTA-style detection rules`, () => {
     const with_li = compute_polyhedra(structure, bonds, {
       included_center_elements: [`Li`],
     })
-    expect(with_li.map((poly) => poly.center_element).sort()).toEqual([`Fe`, `Li`])
+    expect(with_li.map((poly) => poly.center_element).toSorted()).toEqual([`Fe`, `Li`])
 
     // Li as the only cation (e.g. Li2O-like) keeps its polyhedra
     const li_only = make_crystal(18, octahedron_sites(`Li`, `O`, [4, 4, 4], 2.1))

--- a/tests/vitest/structure/polyhedra.test.ts
+++ b/tests/vitest/structure/polyhedra.test.ts
@@ -263,7 +263,7 @@ describe(`compute_polyhedra`, () => {
     expect(poly.faces).toHaveLength(8)
     expect(poly.volume).toBeCloseTo((4 / 3) * 2 ** 3, 6)
     // vertex_site_idxs maps each hull vertex to the site at that exact position
-    expect([...poly.vertex_site_idxs].sort((a, b) => a - b)).toEqual([1, 2, 3, 4, 5, 6])
+    expect([...poly.vertex_site_idxs].toSorted((a, b) => a - b)).toEqual([1, 2, 3, 4, 5, 6])
     for (const [v_idx, site_idx] of poly.vertex_site_idxs.entries()) {
       expect(poly.vertices[v_idx]).toEqual(structure.sites[site_idx].xyz)
     }
@@ -416,7 +416,7 @@ describe(`VESTA-style detection rules`, () => {
     const polyhedra = compute_polyhedra(structure, bonds_from(0, [1, 2, 3, 4, 5, 6]))
     expect(polyhedra).toHaveLength(1)
     // trimmed to the true tetrahedron
-    expect([...polyhedra[0].vertex_site_idxs].sort((a, b) => a - b)).toEqual([1, 2, 3, 4])
+    expect([...polyhedra[0].vertex_site_idxs].toSorted((a, b) => a - b)).toEqual([1, 2, 3, 4])
     expect(polyhedra[0].faces).toHaveLength(4)
   })
 

--- a/tests/vitest/symmetry/index.test.ts
+++ b/tests/vitest/symmetry/index.test.ts
@@ -112,7 +112,7 @@ describe(`wyckoff_positions_from_moyo`, () => {
     )
     const result = wyckoff_positions_from_moyo(mixed)
     expect(result).toHaveLength(2)
-    expect(result.map((pos) => pos.wyckoff).sort()).toEqual([`1j`, `4i`])
+    expect(result.map((pos) => pos.wyckoff).toSorted()).toEqual([`1j`, `4i`])
     expect(result.map((pos) => pos.elem)).toEqual([`O`, `O`])
     result.forEach((pos) => expect(mixed.std_cell.positions).toContainEqual(pos.abc))
 
@@ -149,7 +149,7 @@ describe(`wyckoff_positions_from_moyo`, () => {
     )
     const multi_result = wyckoff_positions_from_moyo(multi_elem)
     expect(multi_result).toHaveLength(4)
-    expect(multi_result.map((pos) => `${pos.wyckoff}-${pos.elem}`).sort()).toEqual([
+    expect(multi_result.map((pos) => `${pos.wyckoff}-${pos.elem}`).toSorted()).toEqual([
       `1a-H`,
       `1a-O`,
       `1b-C`,
@@ -603,7 +603,7 @@ describe(`site coverage verification`, () => {
       )
       const covered = rows
         .flatMap((pos) => pos.site_indices ?? [])
-        .sort((idx_a, idx_b) => idx_a - idx_b)
+        .toSorted((idx_a, idx_b) => idx_a - idx_b)
       expect(covered).toEqual(expected_coverage)
 
       const total_multiplicity = rows.reduce(

--- a/tests/vitest/symmetry/moyo-integration.test.ts
+++ b/tests/vitest/symmetry/moyo-integration.test.ts
@@ -253,7 +253,7 @@ describe(`Wyckoff rows for non-conventional input cells`, () => {
     for (const row of rows) expect(row.wyckoff).toBe(`1a`)
     // each row maps to exactly one distinct original site
     const all_indices = rows.flatMap((row) => row.site_indices ?? [])
-    expect(all_indices.sort((idx_a, idx_b) => idx_a - idx_b)).toEqual([0, 1, 2])
+    expect(all_indices.toSorted((idx_a, idx_b) => idx_a - idx_b)).toEqual([0, 1, 2])
   })
 
   test(`std→orig site mapping uses the std_linear transform (primitive NaCl input)`, async () => {

--- a/tests/vitest/trajectory/parse.test.ts
+++ b/tests/vitest/trajectory/parse.test.ts
@@ -1188,7 +1188,7 @@ describe(`Trajectory Files with Exact Reference Data`, () => {
         const found = new Set(
           traj.frames[0].structure.sites.map((site) => site.species[0]?.element),
         )
-        expect([...found].sort()).toEqual(expect.arrayContaining(elements.sort()))
+        expect([...found].sort()).toEqual(expect.arrayContaining(elements.toSorted()))
       }
 
       // Periodic structures should have lattice

--- a/tests/vitest/trajectory/parse.test.ts
+++ b/tests/vitest/trajectory/parse.test.ts
@@ -1188,7 +1188,7 @@ describe(`Trajectory Files with Exact Reference Data`, () => {
         const found = new Set(
           traj.frames[0].structure.sites.map((site) => site.species[0]?.element),
         )
-        expect([...found].sort()).toEqual(expect.arrayContaining(elements.toSorted()))
+        expect([...found].toSorted()).toEqual(expect.arrayContaining(elements.toSorted()))
       }
 
       // Periodic structures should have lattice

--- a/tests/vitest/xrd/calc-xrd.test.ts
+++ b/tests/vitest/xrd/calc-xrd.test.ts
@@ -63,7 +63,7 @@ describe(`compute_xrd_pattern parity with pymatgen JSON`, () => {
       // Compare peak positions set-wise over the strongest expected peaks (by intensity)
       // to avoid discrepancies from low-intensity filtering differences between implementations
       const top_indices = Array.from({ length: expected.y.length }, (_, idx) => idx)
-        .sort((i1, i2) => expected.y[i2] - expected.y[i1])
+        .toSorted((i1, i2) => expected.y[i2] - expected.y[i1])
         .slice(0, Math.min(200, expected.x.length))
       const matched = top_indices.filter((idx) =>
         has_close(computed.x, expected.x[idx], angle_tol),

--- a/tests/vitest/xrd/index.test.ts
+++ b/tests/vitest/xrd/index.test.ts
@@ -62,7 +62,7 @@ describe(`@xrd/ api and compute_xrd_pattern options`, () => {
       })
       expect(pattern.x.every((angle) => angle >= t_range[0] && angle <= t_range[1])).toBe(true)
       const xs = pattern.x.slice()
-      const sorted = [...xs].sort((a, b) => a - b)
+      const sorted = [...xs].toSorted((a, b) => a - b)
       expect(xs).toEqual(sorted)
     },
   )

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -134,14 +134,14 @@ export default defineConfig({
     ...config.lint,
     // src/scripts/** are standalone utility scripts excluded from tsconfig (so
     // type-aware rules can't resolve $lib/Deno-style imports there) — keep them unlinted.
-    // extensions/dash/** and extensions/anywidget/** are separate packages
-    // (react/three, anywidget/svelte deps) not installed in root CI, so type-aware
-    // rules can't resolve their imports here.
+    // extensions/** are separate packages with dependencies and test mocks that
+    // are not type-compatible with the root project, so lint them in their own packages.
     ignorePatterns: [
       `static/**`,
       `src/scripts/**`,
       `extensions/dash/**`,
       `extensions/anywidget/**`,
+      `extensions/vscode/**`,
     ],
   },
 


### PR DESCRIPTION
# feat(isosurface): support flat scalar grids in marching cubes

## Summary

This PR adds flat scalar-grid support to MatterViz's marching-cubes kernel while preserving full compatibility with the existing nested `number[][][]` input.

The new internal representation consists of a contiguous `Float32Array` or `Float64Array`, three-dimensional shape metadata, and an explicit storage order:

```ts
interface ScalarGrid3D {
  data: Float32Array | Float64Array
  dimensions: [number, number, number]
  order: 'x_fastest' | 'z_fastest'
}
```

## Changes

- Add internal `ScalarGrid3D` and `ScalarGridLike` types.
- Support both `x_fastest` and `z_fastest` linear storage orders.
- Allow `marching_cubes()` and `marching_cubes_buffers()` to consume flat or nested grids.
- Preserve direct indexing for the existing nested-array hot path to avoid unnecessary changes to its performance characteristics.
- Validate flat grids at runtime:
  - dimensions must be non-negative integers;
  - data must be a `Float32Array` or `Float64Array`;
  - data length must match the product of the dimensions;
  - the declared storage order must be supported.
- Remove cleared widget reactive props instead of retaining stale traits.
- Validate color-interpolator names before use.

## Motivation

Scientific volumetric formats such as Cube, CHGCAR, and LOCPOT naturally map to contiguous numeric buffers. The same applies to charge densities, molecular orbitals, ELF, electrostatic potential, and related scalar fields.

MatterViz currently represents most volumetric data as three levels of JavaScript arrays. For large grids, this creates additional arrays and references, increases copying and garbage-collection pressure, and makes direct integration with Web Workers, WASM, and WebGPU more difficult.

This PR only establishes compatibility in the numerical marching-cubes kernel. It does not alter the existing parsing or rendering pipeline, making the change independently reviewable and reducing the risk of later end-to-end TypedArray work.

## Compatibility and scope

This is an additive, backward-compatible change:

- `VolumetricData.grid` remains `number[][][]`.
- Cube, CHGCAR, and other parsers continue to return the existing representation.
- Isosurface components and the Worker protocol remain unchanged.
- Existing consumers do not need to migrate.
- The new types are not exported from the public isosurface barrel yet.

The following are explicitly out of scope:

- changing parsers to return flat grids;
- changing the public `VolumetricData` API;
- Worker buffer transfer or ownership semantics;
- SharedArrayBuffer support, memory budgets, or admission policies;
- any Multiwfn-specific protocol, endpoint, or caching behavior.

## Follow-up work

Once this compatibility layer is accepted, separate PRs can:

1. Retain the TypedArrays already created by the Cube and CHGCAR parsers.
2. Extend the `VolumetricData` contract while preserving compatibility with nested grids.
3. Let the existing cancellable Worker pipeline consume flat grids without inflate/reinflate cycles.
4. Define explicit copy, transfer, and ownership rules for ordinary ArrayBuffers.

Those changes are intentionally not included in this PR.