### PR TITLE
Overhaul searchable settings controls and viewer preferences

### DIFF
--- a/extensions/dash/vite.config.ts
+++ b/extensions/dash/vite.config.ts
@@ -23,10 +23,9 @@ const inline_moyo_wasm_plugin = (): Plugin => ({
   transform(code: string, id: string) {
     if (!id.includes(`@spglib/moyo-wasm`) || !code.includes(moyo_glue_url)) return null
     return {
-      code: `import __matterviz_moyo_wasm_url from '@spglib/moyo-wasm/moyo_wasm_bg.wasm?url';\n${code.replace(
-        moyo_glue_url,
-        `__matterviz_moyo_wasm_url`,
-      )}`,
+      code:
+        `import __matterviz_moyo_wasm_url from '@spglib/moyo-wasm/moyo_wasm_bg.wasm?url';\n` +
+        code.replace(moyo_glue_url, `__matterviz_moyo_wasm_url`),
       map: null,
     }
   },

--- a/extensions/dash/vite.config.ts
+++ b/extensions/dash/vite.config.ts
@@ -23,9 +23,10 @@ const inline_moyo_wasm_plugin = (): Plugin => ({
   transform(code: string, id: string) {
     if (!id.includes(`@spglib/moyo-wasm`) || !code.includes(moyo_glue_url)) return null
     return {
-      code:
-        `import __matterviz_moyo_wasm_url from '@spglib/moyo-wasm/moyo_wasm_bg.wasm?url';\n` +
-        code.replace(moyo_glue_url, `__matterviz_moyo_wasm_url`),
+      code: `import __matterviz_moyo_wasm_url from '@spglib/moyo-wasm/moyo_wasm_bg.wasm?url';\n${code.replace(
+        moyo_glue_url,
+        `__matterviz_moyo_wasm_url`,
+      )}`,
       map: null,
     }
   },

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -219,7 +219,7 @@
           "default": 0.07,
           "description": "Thickness of bonds relative to atom radius",
           "minimum": 0.01,
-          "maximum": 1
+          "maximum": 0.5
         },
         "matterviz.structure.auto_bond_order": {
           "type": "boolean",
@@ -408,14 +408,14 @@
         },
         "matterviz.structure.rotation_damping": {
           "type": "number",
-          "default": 0.1,
-          "description": "Camera rotation damping factor (0 = no damping, 1 = heavy damping)",
+          "default": 0.2,
+          "description": "Camera rotation damping factor (0 disables damping; higher values stop rotation sooner)",
           "minimum": 0,
-          "maximum": 1
+          "maximum": 0.3
         },
         "matterviz.structure.rotate_speed": {
           "type": "number",
-          "default": 1,
+          "default": 0.6,
           "description": "Mouse rotation sensitivity (set to 0 to disable rotation)",
           "minimum": 0,
           "maximum": 2
@@ -425,13 +425,13 @@
           "default": 0.5,
           "description": "Mouse wheel zoom sensitivity",
           "minimum": 0.1,
-          "maximum": 2
+          "maximum": 0.8
         },
         "matterviz.structure.pan_speed": {
           "type": "number",
           "default": 0.5,
-          "description": "Mouse pan sensitivity",
-          "minimum": 0.1,
+          "description": "Mouse pan sensitivity (set to 0 to disable panning)",
+          "minimum": 0,
           "maximum": 2
         },
         "matterviz.structure.zoom_to_cursor": {
@@ -454,7 +454,7 @@
           "default": 0,
           "description": "Automatic rotation speed (0 = disabled, positive = clockwise)",
           "minimum": 0,
-          "maximum": 10
+          "maximum": 2
         },
         "matterviz.structure.rotation": {
           "type": "array",
@@ -485,7 +485,7 @@
           "default": 1,
           "description": "Font size for atom labels",
           "minimum": 0.5,
-          "maximum": 5
+          "maximum": 2
         },
         "matterviz.structure.site_label_color": {
           "type": "string",
@@ -502,7 +502,7 @@
           "default": 2,
           "description": "Padding around atom labels in pixels",
           "minimum": 0,
-          "maximum": 20
+          "maximum": 10
         },
         "matterviz.structure.site_label_offset": {
           "type": "array",
@@ -541,7 +541,7 @@
           "type": "number",
           "default": 0.75,
           "description": "Scale factor for site vector arrows",
-          "minimum": 0.1,
+          "minimum": 0.001,
           "maximum": 10
         },
         "matterviz.structure.vector_color": {

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -254,11 +254,10 @@ const read_explicit_overrides = (
       inspected?.globalValue,
     ].find((candidate) => candidate !== undefined)
     const configured_value = value
-    if (typeof value === `number` && typeof setting.minimum === `number`) {
-      value = Math.max(setting.minimum, value)
-    }
-    if (typeof value === `number` && typeof setting.maximum === `number`) {
-      value = Math.min(setting.maximum, value)
+    if (typeof value === `number`) {
+      const minimum = typeof setting.minimum === `number` ? setting.minimum : -Infinity
+      const maximum = typeof setting.maximum === `number` ? setting.maximum : Infinity
+      value = Math.min(maximum, Math.max(minimum, value))
     }
     if (!Object.is(value, configured_value)) {
       console.warn(

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -14,7 +14,7 @@ import type {
 } from '$lib/file-viewer/host-protocol'
 import { is_plain_object, to_error } from '$lib/utils'
 import { format_bytes } from '$lib/labels'
-import { DEFAULTS, type DefaultSettings, merge } from '$lib/settings'
+import { DEFAULTS, type DefaultSettings, merge, SETTINGS_CONFIG } from '$lib/settings'
 import { AUTO_THEME, COLOR_THEMES, is_valid_theme_mode, type ThemeName } from '$lib/theme'
 import type { FrameLoader } from '$lib/trajectory'
 import { LARGE_FILE_THRESHOLD, parse_trajectory_async } from '$lib/trajectory/parse'
@@ -233,24 +233,38 @@ const get_system_theme = (): ThemeName => {
 // Collect user/workspace overrides via config.inspect() (ignores package defaults)
 const read_explicit_overrides = (
   config: vscode.WorkspaceConfiguration,
-  defaults: Record<string, unknown>,
+  schema: unknown,
   prefix = ``,
 ): Record<string, unknown> => {
+  if (!is_plain_object(schema)) return {}
   const overrides: Record<string, unknown> = {}
-  for (const [key, default_value] of Object.entries(defaults)) {
+  for (const [key, setting] of Object.entries(schema)) {
+    if (!is_plain_object(setting)) continue
     const full_key = prefix ? `${prefix}.${key}` : key
-    if (is_plain_object(default_value) && Object.keys(default_value).length > 0) {
-      const nested = read_explicit_overrides(config, default_value, full_key)
+    if (!(`value` in setting)) {
+      const nested = read_explicit_overrides(config, setting, full_key)
       if (Object.keys(nested).length > 0) overrides[key] = nested
       continue
     }
     const inspected = config.inspect(full_key)
     // Prefer more specific scope: folder > workspace > global
-    const value = [
+    let value = [
       inspected?.workspaceFolderValue,
       inspected?.workspaceValue,
       inspected?.globalValue,
     ].find((candidate) => candidate !== undefined)
+    const configured_value = value
+    if (typeof value === `number` && typeof setting.minimum === `number`) {
+      value = Math.max(setting.minimum, value)
+    }
+    if (typeof value === `number` && typeof setting.maximum === `number`) {
+      value = Math.min(setting.maximum, value)
+    }
+    if (!Object.is(value, configured_value)) {
+      console.warn(
+        `Clamped matterviz.${full_key} from ${String(configured_value)} to ${value}`,
+      )
+    }
     if (value !== undefined) overrides[key] = value
   }
   return overrides
@@ -260,7 +274,7 @@ const read_explicit_overrides = (
 export const get_defaults = (): DefaultSettings => {
   try {
     const config = vscode.workspace.getConfiguration(`matterviz`)
-    return merge(read_explicit_overrides(config, DEFAULTS))
+    return merge(read_explicit_overrides(config, SETTINGS_CONFIG))
   } catch (error) {
     console.error(`Failed to get defaults:`, error)
     return DEFAULTS

--- a/extensions/vscode/tests/extension.test.ts
+++ b/extensions/vscode/tests/extension.test.ts
@@ -1478,6 +1478,17 @@ describe(`MatterViz Extension`, () => {
     })
 
     test.each([
+      [`bond_thickness`, 0.2, 0.2],
+      [`site_label_padding`, -1, 0],
+      [`rotation_damping`, 1, 0.3],
+    ] as const)(`bounds structure.%s override %s to %s`, (key, value, expected) => {
+      const warn = vi.spyOn(console, `warn`).mockImplementation(() => {})
+      apply_overrides({ [`structure.${key}`]: value })
+      expect(get_defaults().structure[key]).toBe(expected)
+      expect(warn).toHaveBeenCalledTimes(value === expected ? 0 : 1)
+    })
+
+    test.each([
       [`missing inspect`, () => ({ get: vi.fn(), inspect: vi.fn(() => undefined) })],
       [
         `invalid structure values`,

--- a/package.json
+++ b/package.json
@@ -358,7 +358,7 @@
     "vitest": "4.1.10"
   },
   "peerDependencies": {
-    "svelte": "^5.0.0"
+    "svelte": "^5.48.0"
   },
   "engines": {
     "node": ">=24"

--- a/src/lib/app.css
+++ b/src/lib/app.css
@@ -98,8 +98,10 @@ body.fullscreen .draggable-pane {
   margin: var(--pane-hr-margin, 4pt 0);
   height: 1px;
 }
-.draggable-pane section > div {
-  text-align: right; /* right align long line-breaking trajectory file names */
+/* right align long line-breaking trajectory file names. Excludes grid sections, whose rows
+   are div-wrapped on purpose and must read left-aligned like every other label. */
+.draggable-pane section:not(.grid) > div {
+  text-align: right;
 }
 .draggable-pane :where(label) {
   display: inline-flex;
@@ -271,13 +273,6 @@ body.fullscreen .draggable-pane {
     width: min(1400px, calc(100vw - 2 * var(--margin))) !important;
     margin-left: calc(-50vw + 50% + max(var(--margin), (100vw - 1400px) / 2));
     max-width: none !important;
-  }
-  .copy-btn {
-    position: absolute;
-    top: 9pt;
-    right: 9pt;
-    background: var(--btn-bg);
-    color: var(--btn-color);
   }
 }
 

--- a/src/lib/app.css
+++ b/src/lib/app.css
@@ -98,8 +98,7 @@ body.fullscreen .draggable-pane {
   margin: var(--pane-hr-margin, 4pt 0);
   height: 1px;
 }
-/* right align long line-breaking trajectory file names. Excludes grid sections, whose rows
-   are div-wrapped on purpose and must read left-aligned like every other label. */
+/* Right-align long trajectory filenames without affecting div-wrapped grid rows. */
 .draggable-pane section:not(.grid) > div {
   text-align: right;
 }

--- a/src/lib/brillouin/BrillouinZoneControls.svelte
+++ b/src/lib/brillouin/BrillouinZoneControls.svelte
@@ -1,22 +1,35 @@
 <script lang="ts">
   import { Cross, Settings } from 'svelte-widgets/icons'
-  import SettingsSection from '$lib/layout/SettingsSection.svelte'
+  import { SettingsGroup, SettingsSection } from '$lib/layout'
   import { DraggablePane } from '$lib/overlays'
   import type { CameraProjection } from '$lib/settings'
 
+  const defaults = {
+    bz_order: 1,
+    surface_color: `#4488ff`,
+    surface_opacity: 0.3,
+    edge_color: `#000000`,
+    edge_width: 0.002,
+    show_vectors: true,
+    camera_projection: `perspective` as CameraProjection,
+    show_ibz: false,
+    ibz_color: `#ff8844`,
+    ibz_opacity: 0.5,
+  }
+
   let {
     controls_open = $bindable(false),
-    bz_order = $bindable(1),
-    surface_color = $bindable(`#4488ff`),
-    surface_opacity = $bindable(0.3),
-    edge_color = $bindable(`#000000`),
-    edge_width = $bindable(0.002),
-    show_vectors = $bindable(true),
-    camera_projection = $bindable(`perspective`),
+    bz_order = $bindable(defaults.bz_order),
+    surface_color = $bindable(defaults.surface_color),
+    surface_opacity = $bindable(defaults.surface_opacity),
+    edge_color = $bindable(defaults.edge_color),
+    edge_width = $bindable(defaults.edge_width),
+    show_vectors = $bindable(defaults.show_vectors),
+    camera_projection = $bindable(defaults.camera_projection),
     // Irreducible BZ options
-    show_ibz = $bindable(false),
-    ibz_color = $bindable(`#ff8844`),
-    ibz_opacity = $bindable(0.5),
+    show_ibz = $bindable(defaults.show_ibz),
+    ibz_color = $bindable(defaults.ibz_color),
+    ibz_opacity = $bindable(defaults.ibz_opacity),
   }: {
     controls_open?: boolean
     bz_order?: number
@@ -35,108 +48,105 @@
 
 <DraggablePane
   bind:open={controls_open}
-  pane_props={{ class: `bz-controls` }}
+  pane_props={{
+    class: `bz-controls`,
+    style: `--ctrl-label-w: 7.5em; --ctrl-value-w: 3.5em;`,
+  }}
   toggle_props={{ class: `controls-toggle`, title: `Brillouin zone controls` }}
   open_icon={Cross}
   closed_icon={Settings}
 >
-  <SettingsSection
-    title="Brillouin Zone Controls"
-    current_values={{ bz_order, show_vectors }}
-    on_reset={() => {
-      bz_order = 1
-      show_vectors = true
-    }}
-    style="display: flex; gap: 2ex; flex-wrap: wrap"
-  >
-    <label>
-      <span>Order:</span>
-      <select bind:value={bz_order}>
-        <option value={1}>1st BZ</option>
-        <option value={2}>2nd BZ</option>
-        <option value={3}>3rd BZ</option>
-      </select>
-    </label>
-    <label>
-      <span>Show Vectors:</span>
-      <input type="checkbox" bind:checked={show_vectors} />
-    </label>
-  </SettingsSection>
+  <SettingsGroup title="Geometry" open>
+    <SettingsSection
+      title="Brillouin zone controls"
+      current_values={{ bz_order, show_vectors }}
+      on_reset={() => ({ bz_order, show_vectors } = defaults)}
+      layout="grid"
+    >
+      <label>
+        <span>Order</span>
+        <select bind:value={bz_order}>
+          <option value={1}>1st BZ</option>
+          <option value={2}>2nd BZ</option>
+          <option value={3}>3rd BZ</option>
+        </select>
+      </label>
+      <label>
+        <span>Show vectors</span>
+        <input type="checkbox" bind:checked={show_vectors} />
+      </label>
+    </SettingsSection>
 
-  <SettingsSection
-    title="Surface"
-    current_values={{ surface_color, surface_opacity }}
-    on_reset={() => {
-      surface_color = `#4488ff`
-      surface_opacity = 0.3
-    }}
-  >
-    <label>
-      <span>Color:</span>
-      <input type="color" bind:value={surface_color} />
-    </label>
-    <label>
-      <span>Opacity:</span>
-      <input type="range" min="0" max="1" step="0.01" bind:value={surface_opacity} />
-      <span>{surface_opacity.toFixed(2)}</span>
-    </label>
-  </SettingsSection>
+    <SettingsSection
+      title="Surface"
+      current_values={{ surface_color, surface_opacity }}
+      on_reset={() => ({ surface_color, surface_opacity } = defaults)}
+      layout="grid"
+    >
+      <label>
+        <span>Color</span>
+        <input type="color" bind:value={surface_color} />
+      </label>
+      <label>
+        <span>Opacity</span>
+        <span>{surface_opacity.toFixed(2)}</span>
+        <input type="range" min="0" max="1" step="0.01" bind:value={surface_opacity} />
+      </label>
+    </SettingsSection>
 
-  <SettingsSection
-    title="Edges"
-    current_values={{ edge_color, edge_width }}
-    on_reset={() => ([edge_color, edge_width] = [`#000000`, 0.002])}
-  >
-    <label>
-      <span>Color:</span>
-      <input type="color" bind:value={edge_color} />
-    </label>
-    <label>
-      <span>Width:</span>
-      <input type="range" min="0.002" max="0.02" step="0.001" bind:value={edge_width} />
-      <span>{edge_width.toFixed(2)}</span>
-    </label>
-  </SettingsSection>
+    <SettingsSection
+      title="Edges"
+      current_values={{ edge_color, edge_width }}
+      on_reset={() => ({ edge_color, edge_width } = defaults)}
+      layout="grid"
+    >
+      <label>
+        <span>Color</span>
+        <input type="color" bind:value={edge_color} />
+      </label>
+      <label>
+        <span>Width</span>
+        <span>{edge_width.toFixed(2)}</span>
+        <input type="range" min="0.002" max="0.02" step="0.001" bind:value={edge_width} />
+      </label>
+    </SettingsSection>
+
+    <SettingsSection
+      title="Irreducible BZ"
+      current_values={{ show_ibz, ibz_color, ibz_opacity }}
+      on_reset={() => ({ show_ibz, ibz_color, ibz_opacity } = defaults)}
+      layout="grid"
+    >
+      <label>
+        <span>Show IBZ</span>
+        <input type="checkbox" bind:checked={show_ibz} />
+      </label>
+      {#if show_ibz}
+        <label>
+          <span>Color</span>
+          <input type="color" bind:value={ibz_color} />
+        </label>
+        <label>
+          <span>Opacity</span>
+          <span>{ibz_opacity.toFixed(2)}</span>
+          <input type="range" min="0" max="1" step="0.01" bind:value={ibz_opacity} />
+        </label>
+      {/if}
+    </SettingsSection>
+  </SettingsGroup>
 
   <SettingsSection
     title="Camera"
     current_values={{ camera_projection }}
-    on_reset={() => {
-      camera_projection = `perspective`
-    }}
+    on_reset={() => ({ camera_projection } = defaults)}
+    layout="grid"
   >
     <label>
-      <span>Projection:</span>
+      <span>Projection</span>
       <select bind:value={camera_projection}>
         <option value="perspective">Perspective</option>
         <option value="orthographic">Orthographic</option>
       </select>
     </label>
-  </SettingsSection>
-
-  <SettingsSection
-    title="Irreducible BZ"
-    current_values={{ show_ibz, ibz_color, ibz_opacity }}
-    on_reset={() => {
-      show_ibz = false
-      ibz_color = `#ff8844`
-      ibz_opacity = 0.5
-    }}
-  >
-    <label>
-      <span>Show IBZ:</span>
-      <input type="checkbox" bind:checked={show_ibz} />
-    </label>
-    {#if show_ibz}
-      <label>
-        <span>Color:</span>
-        <input type="color" bind:value={ibz_color} />
-      </label>
-      <label>
-        <span>Opacity:</span>
-        <input type="range" min="0" max="1" step="0.01" bind:value={ibz_opacity} />
-        <span>{ibz_opacity.toFixed(2)}</span>
-      </label>
-    {/if}
   </SettingsSection>
 </DraggablePane>

--- a/src/lib/brillouin/BrillouinZoneControls.svelte
+++ b/src/lib/brillouin/BrillouinZoneControls.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { Cross, Settings } from 'svelte-widgets/icons'
   import { SettingsGroup, SettingsSection } from '$lib/layout'
+  import { format_num } from '$lib/labels'
   import { DraggablePane } from '$lib/overlays'
   import type { CameraProjection } from '$lib/settings'
 
@@ -106,7 +107,7 @@
       </label>
       <label>
         <span>Width</span>
-        <span>{edge_width.toFixed(2)}</span>
+        <span>{format_num(edge_width, `.3f`)}</span>
         <input type="range" min="0.002" max="0.02" step="0.001" bind:value={edge_width} />
       </label>
     </SettingsSection>

--- a/src/lib/brillouin/BrillouinZoneControls.svelte
+++ b/src/lib/brillouin/BrillouinZoneControls.svelte
@@ -90,7 +90,7 @@
       </label>
       <label>
         <span>Opacity</span>
-        <span>{surface_opacity.toFixed(2)}</span>
+        <span>{format_num(surface_opacity, `.2f`)}</span>
         <input type="range" min="0" max="1" step="0.01" bind:value={surface_opacity} />
       </label>
     </SettingsSection>
@@ -129,7 +129,7 @@
         </label>
         <label>
           <span>Opacity</span>
-          <span>{ibz_opacity.toFixed(2)}</span>
+          <span>{format_num(ibz_opacity, `.2f`)}</span>
           <input type="range" min="0" max="1" step="0.01" bind:value={ibz_opacity} />
         </label>
       {/if}

--- a/src/lib/brillouin/geometry.ts
+++ b/src/lib/brillouin/geometry.ts
@@ -74,10 +74,10 @@ export const k_space_size = (k_lattice: Matrix3x3 | undefined): number =>
 export const default_camera_position = (size: number): Vec3 =>
   [10, 3, 8].map((coord) => coord * Math.max(1, size)) as Vec3
 
-// Occupy at most 85% of the shorter viewport edge, matching structure_fit_frame's
+// Occupy at most 92% of the shorter viewport edge, matching structure_fit_frame's
 // DEFAULT_FIT_PADDING (asserted equal in brillouin-compute.test.ts rather than imported, which
 // would pull the element data tables into every consumer of this module).
-const FIT_PADDING = 1 / 0.85
+const FIT_PADDING = 1 / 0.92
 
 // Padded diameter of the sphere enclosing the centered parallelepiped k_latticeᵀ·[-0.5, 0.5]³,
 // whose half-extent along Cartesian axis j is 0.5·Σᵢ|k_lattice[i][j]|. Marching cubes leaves
@@ -98,7 +98,7 @@ export const k_cell_fit_extent = (
 
 // Padded diameter of the sphere enclosing the zone, in the same "fit to the shorter viewport
 // edge" currency as structure_fit_frame, so ortho_zoom_for_extent can frame it. Falls back to
-// the cell the zone is inscribed in, which for a cubic lattice is the same 85% framing the
+// the cell the zone is inscribed in, which for a cubic lattice is the same 92% framing the
 // vertices give — so the zoom does not jump the moment the computed vertices arrive.
 export const bz_fit_extent = (
   vertices: Vec3[] | undefined,

--- a/src/lib/convex-hull/ConvexHullControls.svelte
+++ b/src/lib/convex-hull/ConvexHullControls.svelte
@@ -175,6 +175,26 @@
           [`rotation_y`, `θ`, `Horizontal rotation (left/right)`, 0.1, 2],
         ],
   )
+  let point_toggles = $derived([
+    {
+      active: show_stable,
+      marker: `stable`,
+      label: `Stable${merged_controls.show_counts ? ` (${stable_entries.length})` : ``}`,
+      tip: `Toggle visibility of stable points`,
+      toggle: () => (show_stable = !show_stable),
+    },
+    {
+      active: show_unstable,
+      marker: `unstable`,
+      label: `Above hull${
+        merged_controls.show_counts
+          ? ` (${show_unstable ? unstable_entries.length : 0}/${unstable_entries.length})`
+          : ``
+      }`,
+      tip: `Toggle visibility of above-hull points`,
+      toggle: () => (show_unstable = !show_unstable),
+    },
+  ])
 
   // One mutually exclusive toggle button per option
   type ToggleOption = readonly [text: string, tip: string, active: boolean, select: () => void]
@@ -280,36 +300,20 @@
       <div class="setting">
         <span class="control-label">Points</span>
         <div class="legend-items-container">
-          <div
-            class="legend-item {show_stable ? `active` : `inactive`}"
-            onclick={() => (show_stable = !show_stable)}
-            onkeydown={legend_keydown(() => (show_stable = !show_stable))}
-            role="button"
-            tabindex="0"
-            aria-pressed={show_stable}
-            {@attach tooltip({ content: `Toggle visibility of stable points` })}
-          >
-            <div class="marker stable"></div>
-            <span
-              >Stable{merged_controls.show_counts ? ` (${stable_entries.length})` : ``}</span
+          {#each point_toggles as { active, marker, label, tip, toggle } (marker)}
+            <div
+              class="legend-item {active ? `active` : `inactive`}"
+              onclick={toggle}
+              onkeydown={legend_keydown(toggle)}
+              role="button"
+              tabindex="0"
+              aria-pressed={active}
+              {@attach tooltip({ content: tip })}
             >
-          </div>
-          <div
-            class="legend-item {show_unstable ? `active` : `inactive`}"
-            onclick={() => (show_unstable = !show_unstable)}
-            onkeydown={legend_keydown(() => (show_unstable = !show_unstable))}
-            role="button"
-            tabindex="0"
-            aria-pressed={show_unstable}
-            {@attach tooltip({ content: `Toggle visibility of above-hull points` })}
-          >
-            <div class="marker unstable"></div>
-            <span
-              >Above hull{merged_controls.show_counts
-                ? ` (${show_unstable ? unstable_entries.length : 0}/${unstable_entries.length})`
-                : ``}</span
-            >
-          </div>
+              <div class="marker {marker}"></div>
+              <span>{label}</span>
+            </div>
+          {/each}
         </div>
       </div>
     {:else}
@@ -378,19 +382,11 @@
         <span class="control-label">Labels</span>
         <div style="display: flex; gap: 12px; flex: 1">
           <label {@attach tooltip({ content: `Show labels for stable points` })}>
-            <input
-              type="checkbox"
-              checked={show_stable_labels}
-              oninput={(evt) => (show_stable_labels = evt.currentTarget.checked)}
-            />
+            <input type="checkbox" bind:checked={show_stable_labels} />
             <span>Stable</span>
           </label>
           <label {@attach tooltip({ content: `Show labels for unstable points` })}>
-            <input
-              type="checkbox"
-              checked={show_unstable_labels}
-              oninput={(evt) => (show_unstable_labels = evt.currentTarget.checked)}
-            />
+            <input type="checkbox" bind:checked={show_unstable_labels} />
             <span>Unstable</span>
           </label>
         </div>

--- a/src/lib/convex-hull/ConvexHullControls.svelte
+++ b/src/lib/convex-hull/ConvexHullControls.svelte
@@ -220,7 +220,7 @@
   pane_props={{
     ...pane_props,
     class: `convex-hull-controls-pane ${pane_props?.class ?? ``}`,
-    style: `${pane_props?.style ?? ``}`,
+    style: pane_props?.style ?? ``,
   }}
   toggle_props={{
     title: controls_open ? `` : `Convex hull controls`,

--- a/src/lib/convex-hull/ConvexHullControls.svelte
+++ b/src/lib/convex-hull/ConvexHullControls.svelte
@@ -3,9 +3,9 @@
   import { DraggablePane, type PaneProps, type PaneToggleProps } from '$lib/overlays'
   import type { D3InterpolateName } from '$lib/colors'
   import { format_num } from '$lib/labels'
+  import { SettingsSection } from '$lib/layout'
   import { sanitize_html } from '$lib/sanitize'
   import { ColorScaleSelect } from '$lib/plot'
-  import type { ComponentProps } from 'svelte'
   import { tooltip } from 'svelte-widgets/attachments'
   import type { HTMLAttributes } from 'svelte/elements'
   import { get_entry_category, marker_path_data } from './helpers'
@@ -147,7 +147,53 @@
     evt.preventDefault()
     action()
   }
+
+  // Camera rows by diagram dimensionality: ternary tilts by elevation/azimuth in degrees,
+  // quaternary by two rotation angles in radians
+  type CameraField = readonly [
+    key: keyof CameraState,
+    label: string,
+    tip: string,
+    step: number,
+    // digits, not a d3 format: format_num emits a unicode minus that <input type=number> rejects
+    digits: number,
+    suffix?: string,
+    min?: number,
+    max?: number,
+  ]
+  const ELEV_TIP = `Elevation angle (0° = look down z-axis, 90° = side view, 180° = look up z-axis)`
+  const TILT_TIP = `Vertical tilt (up/down rotation)`
+  const MAX_TILT = Math.PI / 3
+  let camera_fields = $derived<readonly CameraField[]>(
+    camera?.elevation !== undefined && camera.azimuth !== undefined
+      ? [
+          [`elevation`, `Elev`, ELEV_TIP, 5, 0, `°`],
+          [`azimuth`, `Azim`, `Azimuth rotation around z-axis`, 15, 0, `°`],
+        ]
+      : [
+          [`rotation_x`, `φ`, TILT_TIP, 0.1, 2, undefined, -MAX_TILT, MAX_TILT],
+          [`rotation_y`, `θ`, `Horizontal rotation (left/right)`, 0.1, 2],
+        ],
+  )
+
+  // One mutually exclusive toggle button per option
+  type ToggleOption = readonly [text: string, tip: string, active: boolean, select: () => void]
 </script>
+
+{#snippet toggle_row(label: string, options: readonly ToggleOption[])}
+  <div class="setting">
+    <span class="control-label">{label}</span>
+    {#each options as [text, tip, active, select] (text)}
+      <button
+        class="toggle-btn {active ? `active` : ``}"
+        onclick={select}
+        {@attach tooltip({ allow_html: true, content: tip })}
+      >
+        {text}
+      </button>
+    {/each}
+  </div>
+{/snippet}
 
 <DraggablePane
   bind:open={controls_open}
@@ -169,341 +215,289 @@
     {@html sanitize_html(merged_controls.title || `Convex Hull Controls`)}
   </h4>
 
-  <!-- Energy source selection (only if both options are available) -->
-  {#if has_precomputed_e_form && has_precomputed_hull && can_compute_e_form && can_compute_hull}
-    <div class="control-row">
-      <span class="control-label">Energy source</span>
-      <button
-        class="toggle-btn {energy_source_mode === `precomputed` ? `active` : ``}"
-        onclick={() => (energy_source_mode = `precomputed`)}
-        {@attach tooltip({
-          allow_html: true,
-          content: `Use precomputed formation energies (E<sub>form</sub>)`,
-        })}
-      >
-        Precomputed
-      </button>
-      <button
-        class="toggle-btn {energy_source_mode === `on-the-fly` ? `active` : ``}"
-        onclick={() => (energy_source_mode = `on-the-fly`)}
-        {@attach tooltip({
-          allow_html: true,
-          content: `Compute formation energies and hull distances on the fly. Note: Missing pure-element reference entries default to E<sub>form</sub> = 0 eV/atom if not provided explicitly.`,
-        })}
-      >
-        On the fly
-      </button>
-    </div>
-  {/if}
-
-  <!-- Color mode toggle -->
-  <div class="control-row">
-    <span class="control-label">Color mode</span>
-    <button
-      class="toggle-btn {color_mode === `stability` ? `active` : ``}"
-      onclick={() => (color_mode = `stability`)}
-      {@attach tooltip({ content: `Color points by stable/unstable` })}
-    >
-      Stability
-    </button>
-    <button
-      class="toggle-btn {color_mode === `energy` ? `active` : ``}"
-      onclick={() => (color_mode = `energy`)}
-      {@attach tooltip({ content: `Color points by energy above hull` })}
-    >
-      Energy
-    </button>
-  </div>
-
-  <!-- Energy threshold slider - shown in both color modes -->
-  <div
-    class="control-row"
-    {@attach tooltip({ content: `Max eV/atom above hull to display unstable points` })}
-  >
-    <span class="control-label">Points threshold</span>
-    <label style="display: flex; align-items: center; gap: 4px; flex: 1">
-      <input
-        type="number"
-        min="0"
-        max={max_hull_dist_in_data}
-        step="0.01"
-        bind:value={max_hull_dist_show_phases}
-        aria-label="Points threshold (eV/atom)"
-        style="border: 1px solid var(--border-color, rgba(0, 0, 0, 0.2))"
-      />
-      <span style="white-space: nowrap">eV/atom</span>
-      <input
-        type="range"
-        min="0"
-        max={max_hull_dist_in_data}
-        step="0.01"
-        bind:value={max_hull_dist_show_phases}
-      />
-    </label>
-  </div>
-
-  {#if color_mode === `stability`}
-    <div class="control-row">
-      <span class="control-label">Points</span>
-      <div class="legend-items-container">
-        <div
-          class="legend-item {show_stable ? `active` : `inactive`}"
-          onclick={() => (show_stable = !show_stable)}
-          onkeydown={legend_keydown(() => (show_stable = !show_stable))}
-          role="button"
-          tabindex="0"
-          aria-pressed={show_stable}
-          {@attach tooltip({ content: `Toggle visibility of stable points` })}
-        >
-          <div class="marker stable"></div>
-          <span>Stable{merged_controls.show_counts ? ` (${stable_entries.length})` : ``}</span>
-        </div>
-        <div
-          class="legend-item {show_unstable ? `active` : `inactive`}"
-          onclick={() => (show_unstable = !show_unstable)}
-          onkeydown={legend_keydown(() => (show_unstable = !show_unstable))}
-          role="button"
-          tabindex="0"
-          aria-pressed={show_unstable}
-          {@attach tooltip({ content: `Toggle visibility of above-hull points` })}
-        >
-          <div class="marker unstable"></div>
-          <span
-            >Above hull{merged_controls.show_counts
-              ? ` (${show_unstable ? unstable_entries.length : 0}/${unstable_entries.length})`
-              : ``}</span
-          >
-        </div>
-      </div>
-    </div>
-  {:else}
-    <!-- Color scale selector -->
-    <div class="color-scale-row">
-      <span
-        {@attach tooltip({ content: `Choose energy colormap` })}
-        onclick={focus_multiselect}
-        onkeydown={(evt) => {
-          if (evt.key === `Enter` || evt.key === ` `) focus_multiselect(evt)
-        }}
-        role="button"
-        tabindex="0"
-        style="cursor: pointer">Color scale</span
-      >
-      <ColorScaleSelect
-        bind:value={color_scale}
-        selected={[color_scale]}
-        placeholder="Select color scale"
-        {@attach tooltip({ content: `Set interpolator for energy colors` })}
-      />
-    </div>
-  {/if}
-
-  <!-- Category filters (only when entries carry recognized category data,
-    e.g. magnetic orderings with the default MAGNETIC_ORDERING_CATEGORY) -->
-  {#if entry_category && category_values_in_data.length > 0}
-    <div class="control-row">
-      <span class="control-label">{entry_category.label}</span>
-      <div class="legend-items-container category-filters">
-        {#each category_values_in_data as value (value)}
-          {@const hidden = hidden_categories.includes(value)}
-          {@const count = category_counts[value] ?? 0}
-          {@const long_name = entry_category.labels?.[value]}
-          <div
-            class="legend-item {hidden ? `inactive` : `active`}"
-            onclick={() => toggle_category(value)}
-            onkeydown={legend_keydown(() => toggle_category(value))}
-            role="button"
-            tabindex="0"
-            aria-pressed={!hidden}
-            {@attach tooltip({
-              content: `Toggle visibility of ${
-                long_name ? `${long_name.toLowerCase()} (${value})` : value
-              } entries`,
-            })}
-          >
-            <svg viewBox="-6 -6 12 12" width="12" height="12" aria-hidden="true">
-              <path d={marker_path_data(SWATCH_RADIUS, entry_category.markers[value]) ?? ``} />
-            </svg>
-            <span
-              >{value}{merged_controls.show_counts
-                ? ` (${hidden ? `0/${count}` : count})`
-                : ``}</span
-            >
-          </div>
-        {/each}
-      </div>
-    </div>
-  {/if}
-
-  {#if merged_controls.show_label_controls}
-    <div class="control-row">
-      <span class="control-label">Labels</span>
-      <div style="display: flex; gap: 12px; flex: 1">
-        <label {@attach tooltip({ content: `Show labels for stable points` })}>
-          <input
-            type="checkbox"
-            checked={show_stable_labels}
-            oninput={(evt) => (show_stable_labels = evt.currentTarget.checked)}
-          />
-          <span>Stable</span>
-        </label>
-        <label {@attach tooltip({ content: `Show labels for unstable points` })}>
-          <input
-            type="checkbox"
-            checked={show_unstable_labels}
-            oninput={(evt) => (show_unstable_labels = evt.currentTarget.checked)}
-          />
-          <span>Unstable</span>
-        </label>
-      </div>
-    </div>
-
-    {#if show_unstable_labels}
-      <div
-        class="control-row"
-        {@attach tooltip({ content: `Max eV/atom for labeling unstable points` })}
-      >
-        <span class="control-label">Label threshold</span>
-        <label style="display: flex; align-items: center; gap: 4px; flex: 1">
-          <span style="white-space: nowrap"
-            >{max_hull_dist_show_labels.toFixed(2)}
-            eV/atom</span
-          >
-          <input
-            type="range"
-            min="0"
-            max={max_hull_dist_in_data}
-            step="0.01"
-            bind:value={max_hull_dist_show_labels}
-          />
-        </label>
-      </div>
+  <SettingsSection title="Display" layout="grid">
+    <!-- Energy source selection (only if both options are available) -->
+    {#if has_precomputed_e_form && has_precomputed_hull && can_compute_e_form && can_compute_hull}
+      {@render toggle_row(`Energy source`, [
+        [
+          `Precomputed`,
+          `Use precomputed formation energies (E<sub>form</sub>)`,
+          energy_source_mode === `precomputed`,
+          () => (energy_source_mode = `precomputed`),
+        ],
+        [
+          `On the fly`,
+          `Compute formation energies and hull distances on the fly. Note: Missing pure-element reference entries default to E<sub>form</sub> = 0 eV/atom if not provided explicitly.`,
+          energy_source_mode === `on-the-fly`,
+          () => (energy_source_mode = `on-the-fly`),
+        ],
+      ])}
     {/if}
-  {/if}
 
-  <!-- Hull faces toggle (for 3D ternary and 4D quaternary diagrams) -->
-  {#if show_hull_faces !== undefined}
-    <div class="control-row">
-      <span class="control-label">Hull Faces</span>
-      <label {@attach tooltip({ content: `Toggle convex hull faces` })}>
+    {@render toggle_row(`Color mode`, [
+      [
+        `Stability`,
+        `Color points by stable/unstable`,
+        color_mode === `stability`,
+        () => (color_mode = `stability`),
+      ],
+      [
+        `Energy`,
+        `Color points by energy above hull`,
+        color_mode === `energy`,
+        () => (color_mode = `energy`),
+      ],
+    ])}
+
+    <!-- Energy threshold slider - shown in both color modes -->
+    <div
+      class="setting"
+      {@attach tooltip({ content: `Max eV/atom above hull to display unstable points` })}
+    >
+      <span class="control-label">Points threshold</span>
+      <label style="display: flex; align-items: center; gap: 4px; flex: 1">
         <input
-          type="checkbox"
-          checked={show_hull_faces}
-          oninput={(event) => on_hull_faces_change?.(event.currentTarget.checked)}
+          type="number"
+          min="0"
+          max={max_hull_dist_in_data}
+          step="0.01"
+          bind:value={max_hull_dist_show_phases}
+          aria-label="Points threshold (eV/atom)"
+          style="border: 1px solid var(--border-color, rgba(0, 0, 0, 0.2))"
         />
-        <span>Show</span>
-      </label>
-      <div style="display: flex; gap: 6px; align-items: center; flex: 1">
-        {#if hull_face_color_mode === `uniform`}
-          <input
-            type="color"
-            value={hull_face_color}
-            oninput={(event) => on_hull_face_color_change?.(event.currentTarget.value)}
-            {@attach tooltip({ content: `Set hull face color` })}
-            style="width: 40px; height: 20px"
-          />
-        {/if}
+        <span style="white-space: nowrap">eV/atom</span>
         <input
           type="range"
           min="0"
-          max="1"
+          max={max_hull_dist_in_data}
           step="0.01"
-          aria-label="Hull face opacity"
-          bind:value={hull_face_opacity}
-          oninput={() => on_hull_face_opacity_change?.(hull_face_opacity)}
-          {@attach tooltip({ content: `Hull face opacity (0 = transparent, 1 = opaque)` })}
-          style="flex: 1; min-width: 80px"
+          bind:value={max_hull_dist_show_phases}
         />
-        <span style="font-size: 0.9em; min-width: 2em; text-align: right"
-          >{format_num(hull_face_opacity, `.1%`)}</span
-        >
-      </div>
+      </label>
     </div>
 
-    <!-- Face color mode selector -->
-    <div class="control-row">
-      <span class="control-label">Face color</span>
-      <div class="face-color-mode-buttons">
-        {#each HULL_FACE_COLOR_MODES as mode (mode)}
-          <button
-            class="toggle-btn {hull_face_color_mode === mode ? `active` : ``}"
-            style="min-width: auto; flex: 0 1 auto"
-            onclick={() => on_hull_face_color_mode_change?.(mode)}
-            {@attach tooltip({ content: FACE_COLOR_MODES[mode].tip })}
+    {#if color_mode === `stability`}
+      <div class="setting">
+        <span class="control-label">Points</span>
+        <div class="legend-items-container">
+          <div
+            class="legend-item {show_stable ? `active` : `inactive`}"
+            onclick={() => (show_stable = !show_stable)}
+            onkeydown={legend_keydown(() => (show_stable = !show_stable))}
+            role="button"
+            tabindex="0"
+            aria-pressed={show_stable}
+            {@attach tooltip({ content: `Toggle visibility of stable points` })}
           >
-            {FACE_COLOR_MODES[mode].label}
-          </button>
+            <div class="marker stable"></div>
+            <span
+              >Stable{merged_controls.show_counts ? ` (${stable_entries.length})` : ``}</span
+            >
+          </div>
+          <div
+            class="legend-item {show_unstable ? `active` : `inactive`}"
+            onclick={() => (show_unstable = !show_unstable)}
+            onkeydown={legend_keydown(() => (show_unstable = !show_unstable))}
+            role="button"
+            tabindex="0"
+            aria-pressed={show_unstable}
+            {@attach tooltip({ content: `Toggle visibility of above-hull points` })}
+          >
+            <div class="marker unstable"></div>
+            <span
+              >Above hull{merged_controls.show_counts
+                ? ` (${show_unstable ? unstable_entries.length : 0}/${unstable_entries.length})`
+                : ``}</span
+            >
+          </div>
+        </div>
+      </div>
+    {:else}
+      <!-- Color scale selector -->
+      <div class="setting color-scale-row">
+        <span
+          {@attach tooltip({ content: `Choose energy colormap` })}
+          onclick={focus_multiselect}
+          onkeydown={(evt) => {
+            if (evt.key === `Enter` || evt.key === ` `) focus_multiselect(evt)
+          }}
+          role="button"
+          tabindex="0"
+          style="cursor: pointer">Color scale</span
+        >
+        <ColorScaleSelect
+          bind:value={color_scale}
+          selected={[color_scale]}
+          placeholder="Select color scale"
+          {@attach tooltip({ content: `Set interpolator for energy colors` })}
+        />
+      </div>
+    {/if}
+
+    <!-- Category filters (only when entries carry recognized category data,
+    e.g. magnetic orderings with the default MAGNETIC_ORDERING_CATEGORY) -->
+    {#if entry_category && category_values_in_data.length > 0}
+      <div class="setting">
+        <span class="control-label">{entry_category.label}</span>
+        <div class="legend-items-container category-filters">
+          {#each category_values_in_data as value (value)}
+            {@const hidden = hidden_categories.includes(value)}
+            {@const count = category_counts[value] ?? 0}
+            {@const long_name = entry_category.labels?.[value]}
+            <div
+              class="legend-item {hidden ? `inactive` : `active`}"
+              onclick={() => toggle_category(value)}
+              onkeydown={legend_keydown(() => toggle_category(value))}
+              role="button"
+              tabindex="0"
+              aria-pressed={!hidden}
+              {@attach tooltip({
+                content: `Toggle visibility of ${
+                  long_name ? `${long_name.toLowerCase()} (${value})` : value
+                } entries`,
+              })}
+            >
+              <svg viewBox="-6 -6 12 12" width="12" height="12" aria-hidden="true">
+                <path
+                  d={marker_path_data(SWATCH_RADIUS, entry_category.markers[value]) ?? ``}
+                />
+              </svg>
+              <span
+                >{value}{merged_controls.show_counts
+                  ? ` (${hidden ? `0/${count}` : count})`
+                  : ``}</span
+              >
+            </div>
+          {/each}
+        </div>
+      </div>
+    {/if}
+
+    {#if merged_controls.show_label_controls}
+      <div class="setting">
+        <span class="control-label">Labels</span>
+        <div style="display: flex; gap: 12px; flex: 1">
+          <label {@attach tooltip({ content: `Show labels for stable points` })}>
+            <input
+              type="checkbox"
+              checked={show_stable_labels}
+              oninput={(evt) => (show_stable_labels = evt.currentTarget.checked)}
+            />
+            <span>Stable</span>
+          </label>
+          <label {@attach tooltip({ content: `Show labels for unstable points` })}>
+            <input
+              type="checkbox"
+              checked={show_unstable_labels}
+              oninput={(evt) => (show_unstable_labels = evt.currentTarget.checked)}
+            />
+            <span>Unstable</span>
+          </label>
+        </div>
+      </div>
+
+      {#if show_unstable_labels}
+        <div
+          class="setting"
+          {@attach tooltip({ content: `Max eV/atom for labeling unstable points` })}
+        >
+          <span class="control-label">Label threshold</span>
+          <label style="display: flex; align-items: center; gap: 4px; flex: 1">
+            <span style="white-space: nowrap"
+              >{format_num(max_hull_dist_show_labels, `.2f`)} eV/atom</span
+            >
+            <input
+              type="range"
+              min="0"
+              max={max_hull_dist_in_data}
+              step="0.01"
+              bind:value={max_hull_dist_show_labels}
+            />
+          </label>
+        </div>
+      {/if}
+    {/if}
+
+    <!-- Hull faces toggle (for 3D ternary and 4D quaternary diagrams) -->
+    {#if show_hull_faces !== undefined}
+      <div class="setting">
+        <span class="control-label">Hull faces</span>
+        <label {@attach tooltip({ content: `Toggle convex hull faces` })}>
+          <input
+            type="checkbox"
+            checked={show_hull_faces}
+            oninput={(event) => on_hull_faces_change?.(event.currentTarget.checked)}
+          />
+          <span>Show</span>
+        </label>
+        <div style="display: flex; gap: 6px; align-items: center; flex: 1">
+          {#if hull_face_color_mode === `uniform`}
+            <input
+              type="color"
+              value={hull_face_color}
+              oninput={(event) => on_hull_face_color_change?.(event.currentTarget.value)}
+              {@attach tooltip({ content: `Set hull face color` })}
+              style="width: 40px; height: 20px"
+            />
+          {/if}
+          <input
+            type="range"
+            min="0"
+            max="1"
+            step="0.01"
+            aria-label="Hull face opacity"
+            bind:value={hull_face_opacity}
+            oninput={() => on_hull_face_opacity_change?.(hull_face_opacity)}
+            {@attach tooltip({ content: `Hull face opacity (0 = transparent, 1 = opaque)` })}
+            style="flex: 1; min-width: 80px"
+          />
+          <span style="font-size: 0.9em; min-width: 2em; text-align: right"
+            >{format_num(hull_face_opacity, `.1%`)}</span
+          >
+        </div>
+      </div>
+
+      <!-- Face color mode selector -->
+      <div class="setting">
+        <span class="control-label">Face color</span>
+        <div class="face-color-mode-buttons">
+          {#each HULL_FACE_COLOR_MODES as mode (mode)}
+            <button
+              class="toggle-btn {hull_face_color_mode === mode ? `active` : ``}"
+              style="min-width: auto; flex: 0 1 auto"
+              onclick={() => on_hull_face_color_mode_change?.(mode)}
+              {@attach tooltip({ content: FACE_COLOR_MODES[mode].tip })}
+            >
+              {FACE_COLOR_MODES[mode].label}
+            </button>
+          {/each}
+        </div>
+      </div>
+    {/if}
+
+    {#if camera}
+      <div class="setting">
+        <span class="control-label">Camera</span>
+        {#each camera_fields as [key, label, tip, step, digits, suffix, min, max] (key)}
+          <label {@attach tooltip({ content: tip })}>
+            <span>{label}</span>
+            <input
+              type="number"
+              value={(camera[key] ?? 0).toFixed(digits)}
+              {step}
+              {min}
+              {max}
+              oninput={(event) => {
+                if (camera) camera[key] = parseFloat(event.currentTarget.value)
+              }}
+              style="width: 3em"
+            />
+            {#if suffix}<span>{suffix}</span>{/if}
+          </label>
         {/each}
       </div>
-    </div>
-  {/if}
-
-  {#if camera}
-    <div class="camera-controls">
-      <span class="control-label">Camera</span>
-      {#if camera.elevation !== undefined && camera.azimuth !== undefined}
-        <!-- Ternary camera controls (elevation/azimuth) -->
-        <label
-          {@attach tooltip({
-            content: `Elevation angle (0° = look down z-axis, 90° = side view, 180° = look up z-axis)`,
-          })}
-        >
-          <span>Elev</span>
-          <input
-            type="number"
-            value={camera.elevation.toFixed(0)}
-            step="5"
-            oninput={(event) => {
-              camera.elevation = parseFloat(event.currentTarget.value)
-            }}
-            style="width: 3em"
-          />
-          <span>°</span>
-        </label>
-        <label {@attach tooltip({ content: `Azimuth rotation around z-axis` })}>
-          <span>Azim</span>
-          <input
-            type="number"
-            value={camera.azimuth.toFixed(0)}
-            step="15"
-            oninput={(event) => {
-              camera.azimuth = parseFloat(event.currentTarget.value)
-            }}
-            style="width: 3em"
-          />
-          <span>°</span>
-        </label>
-      {:else}
-        <!-- Quaternary camera controls (rotation_x/rotation_y) -->
-        <label {@attach tooltip({ content: `Vertical tilt (up/down rotation)` })}>
-          <span>φ</span>
-          <input
-            type="number"
-            value={(camera.rotation_x ?? 0).toFixed(2)}
-            step="0.1"
-            min={-Math.PI / 3}
-            max={Math.PI / 3}
-            oninput={(event) => {
-              camera.rotation_x = parseFloat(event.currentTarget.value)
-            }}
-            style="width: 3em"
-          />
-        </label>
-        <label {@attach tooltip({ content: `Horizontal rotation (left/right)` })}>
-          <span>θ</span>
-          <input
-            type="number"
-            value={(camera.rotation_y ?? 0).toFixed(2)}
-            step="0.1"
-            oninput={(event) => {
-              camera.rotation_y = parseFloat(event.currentTarget.value)
-            }}
-            style="width: 3em"
-          />
-        </label>
-      {/if}
-    </div>
-  {/if}
+    {/if}
+  </SettingsSection>
 </DraggablePane>
 
 <style>
@@ -511,18 +505,14 @@
     --pane-max-height: max(350px, calc(100cqh - 40px));
     --pane-padding: 1ex;
     --pane-gap: 0;
+    --ctrl-label-w: 8em;
+    --ctrl-value-w: 4em;
+    --settings-row-gap: 8pt;
     font-size: 0.85em;
     pointer-events: auto;
   }
-  .control-row {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    margin-top: 12px;
-  }
   .control-label {
     font-weight: 500;
-    min-width: 80px;
   }
   button {
     border: 1px solid var(--border-color, rgba(0, 0, 0, 0.2));
@@ -571,12 +561,6 @@
   .marker.unstable {
     background: var(--unstable-color, #e69f00);
   }
-  .camera-controls {
-    display: flex;
-    gap: 12px;
-    flex: 1;
-    margin-top: 12px;
-  }
   .face-color-mode-buttons {
     display: flex;
     gap: 4px;
@@ -584,13 +568,8 @@
     flex-wrap: wrap;
   }
   .color-scale-row {
-    display: grid;
-    gap: 8px;
-    grid-template-columns: auto 1fr;
-    align-items: center;
-    margin-top: 12px;
-  }
-  .color-scale-row :global(.multiselect) {
-    --sms-min-height: 24px;
+    :global(.multiselect) {
+      --sms-min-height: 24px;
+    }
   }
 </style>

--- a/src/lib/convex-hull/ConvexHullControls.svelte
+++ b/src/lib/convex-hull/ConvexHullControls.svelte
@@ -488,7 +488,8 @@
               {min}
               {max}
               oninput={(event) => {
-                if (camera) camera[key] = parseFloat(event.currentTarget.value)
+                const camera_value = event.currentTarget.valueAsNumber
+                if (camera && Number.isFinite(camera_value)) camera[key] = camera_value
               }}
               style="width: 3em"
             />

--- a/src/lib/effects.svelte.ts
+++ b/src/lib/effects.svelte.ts
@@ -7,6 +7,9 @@ type PulseAnimationOptions = {
 
 type PulseAnimation = { readonly time: number; readonly unit: number }
 
+export const pulsing_highlight_opacity = (pulse_unit: number): number =>
+  0.2 + 0.15 * pulse_unit
+
 export function create_pulse_animation(
   active: () => boolean,
   options: PulseAnimationOptions = {},

--- a/src/lib/fermi-surface/FermiSurfaceControls.svelte
+++ b/src/lib/fermi-surface/FermiSurfaceControls.svelte
@@ -140,14 +140,20 @@
       : [...bands, band_idx].toSorted((left, right) => left - right)
   }
 
+  const set_mu = (next_mu: number): void => {
+    mu = next_mu
+    on_mu_change?.(next_mu)
+  }
+  const set_interpolation_factor = (factor: number): void => {
+    interpolation_factor = factor
+    on_interpolation_change?.(factor)
+  }
+
   function handle_mu_change(event: Event & { currentTarget: HTMLInputElement }) {
     const parsed = parse_num_token(event.currentTarget.value)
     // Only update mu when input is valid; keep last valid value during transient
     // invalid states (e.g. empty string while user is typing a new value)
-    if (Number.isFinite(parsed)) {
-      mu = parsed
-      on_mu_change?.(parsed)
-    }
+    if (Number.isFinite(parsed)) set_mu(parsed)
   }
 </script>
 
@@ -165,10 +171,7 @@
     <SettingsSection
       title="Chemical potential"
       current_values={{ mu }}
-      on_reset={() => {
-        mu = defaults.mu
-        on_mu_change?.(defaults.mu)
-      }}
+      on_reset={() => set_mu(defaults.mu)}
       layout="grid"
     >
       <label>
@@ -198,9 +201,7 @@
       <SettingsSection
         title="Bands"
         current_values={{ selected_bands }}
-        on_reset={() => {
-          selected_bands = [...available_bands]
-        }}
+        on_reset={() => (selected_bands = [...available_bands])}
         layout="grid"
       >
         <div class="band-checkboxes">
@@ -331,10 +332,7 @@
       <SettingsSection
         title="Interpolation"
         current_values={{ interpolation_factor }}
-        on_reset={() => {
-          interpolation_factor = defaults.interpolation_factor
-          on_interpolation_change?.(defaults.interpolation_factor)
-        }}
+        on_reset={() => set_interpolation_factor(defaults.interpolation_factor)}
         layout="grid"
       >
         <label>
@@ -344,8 +342,7 @@
             onchange={(event) => {
               const val = parseFloat(event.currentTarget.value)
               if (!Number.isFinite(val)) return
-              interpolation_factor = val
-              on_interpolation_change?.(val)
+              set_interpolation_factor(val)
             }}
           >
             <option value={1}>1× (original)</option>

--- a/src/lib/fermi-surface/FermiSurfaceControls.svelte
+++ b/src/lib/fermi-surface/FermiSurfaceControls.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { Cross, Settings } from 'svelte-widgets/icons'
-  import SettingsSection from '$lib/layout/SettingsSection.svelte'
+  import { SettingsGroup, SettingsSection } from '$lib/layout'
   import { DraggablePane } from '$lib/overlays'
   import type { CameraProjection } from '$lib/settings'
   import { make_change_detector, parse_num_token } from '$lib/utils'
@@ -12,30 +12,48 @@
     RepresentationMode,
   } from './types'
 
+  const defaults = {
+    mu: 0,
+    color_property: `band` as ColorProperty,
+    color_scale: `interpolateViridis`,
+    representation: `solid` as RepresentationMode,
+    surface_opacity: 0.8,
+    show_bz: true,
+    bz_opacity: 0.1,
+    show_vectors: true,
+    tile_bz: false,
+    clip_enabled: false,
+    clip_axis: `z` as const,
+    clip_position: 0,
+    clip_flip: false,
+    interpolation_factor: 1,
+    camera_projection: `perspective` as CameraProjection,
+  }
+
   let {
     controls_open = $bindable(false),
     fermi_data,
     band_data,
-    mu = $bindable(0),
-    color_property = $bindable(`band`),
-    color_scale = $bindable(`interpolateViridis`),
+    mu = $bindable(defaults.mu),
+    color_property = $bindable(defaults.color_property),
+    color_scale = $bindable(defaults.color_scale),
     custom_property_label,
-    representation = $bindable(`solid`),
-    surface_opacity = $bindable(0.8),
+    representation = $bindable(defaults.representation),
+    surface_opacity = $bindable(defaults.surface_opacity),
     selected_bands = $bindable(),
-    show_bz = $bindable(true),
-    bz_opacity = $bindable(0.1),
-    show_vectors = $bindable(true),
-    tile_bz = $bindable(false),
+    show_bz = $bindable(defaults.show_bz),
+    bz_opacity = $bindable(defaults.bz_opacity),
+    show_vectors = $bindable(defaults.show_vectors),
+    tile_bz = $bindable(defaults.tile_bz),
     // Clipping plane
-    clip_enabled = $bindable(false),
-    clip_axis = $bindable(`z`),
-    clip_position = $bindable(0),
-    clip_flip = $bindable(false),
+    clip_enabled = $bindable(defaults.clip_enabled),
+    clip_axis = $bindable(defaults.clip_axis),
+    clip_position = $bindable(defaults.clip_position),
+    clip_flip = $bindable(defaults.clip_flip),
     // Interpolation
-    interpolation_factor = $bindable(1),
+    interpolation_factor = $bindable(defaults.interpolation_factor),
     // Camera
-    camera_projection = $bindable(`perspective`),
+    camera_projection = $bindable(defaults.camera_projection),
     on_mu_change,
     on_interpolation_change,
     on_export,
@@ -68,19 +86,25 @@
     children?: Snippet<[{ fermi_data?: FermiSurfaceData; band_data?: BandGridData }]>
   } = $props()
 
+  const export_formats = [
+    [`stl`, `3D printing`],
+    [`obj`, `Wavefront`],
+    [`gltf`, `web/AR`],
+  ] as const
+
   // Color scale options
   const color_scales = [
-    { value: `interpolateViridis`, label: `Viridis` },
-    { value: `interpolatePlasma`, label: `Plasma` },
-    { value: `interpolateInferno`, label: `Inferno` },
-    { value: `interpolateMagma`, label: `Magma` },
-    { value: `interpolateCool`, label: `Cool` },
-    { value: `interpolateWarm`, label: `Warm` },
-    { value: `interpolateRainbow`, label: `Rainbow` },
-    { value: `interpolateTurbo`, label: `Turbo` },
-    { value: `interpolateRdYlBu`, label: `RdYlBu` },
-    { value: `interpolateSpectral`, label: `Spectral` },
-  ]
+    `Viridis`,
+    `Plasma`,
+    `Inferno`,
+    `Magma`,
+    `Cool`,
+    `Warm`,
+    `Rainbow`,
+    `Turbo`,
+    `RdYlBu`,
+    `Spectral`,
+  ].map((label) => ({ value: `interpolate${label}`, label }))
 
   let has_custom_color = $derived(
     Boolean(custom_property_label) ||
@@ -99,7 +123,9 @@
   const available_bands_changed = make_change_detector()
 
   $effect(() => {
-    if (color_property === `custom` && !has_custom_color) color_property = `band`
+    if (color_property === `custom` && !has_custom_color) {
+      color_property = defaults.color_property
+    }
     const bands_changed = available_bands_changed(available_bands_key)
     if (available_bands.length > 0 && (selected_bands === undefined || bands_changed)) {
       selected_bands = [...available_bands]
@@ -132,231 +158,223 @@
 
 <DraggablePane
   bind:open={controls_open}
-  pane_props={{ class: `fermi-controls` }}
+  pane_props={{
+    class: `fermi-controls`,
+    style: `--ctrl-label-w: 8.5em; --ctrl-value-w: 4em;`,
+  }}
   toggle_props={{ class: `controls-toggle`, title: `Fermi surface controls` }}
   open_icon={Cross}
   closed_icon={Settings}
 >
-  <SettingsSection
-    title="Chemical Potential"
-    current_values={{ mu }}
-    on_reset={() => {
-      mu = 0
-      on_mu_change?.(0)
-    }}
-  >
-    <label>
-      <span>μ offset (eV):</span>
-      <input type="range" min="-1" max="1" step="0.01" value={mu} oninput={handle_mu_change} />
-      <input
-        type="number"
-        step="0.01"
-        value={mu}
-        oninput={handle_mu_change}
-        style="width: 4em"
-      />
-    </label>
-    {#if fermi_data}
-      <small>E_F = {fermi_data.fermi_energy.toFixed(3)} eV</small>
-    {/if}
-  </SettingsSection>
-
-  {#if available_bands.length > 0}
+  <SettingsGroup title="Surface" open>
     <SettingsSection
-      title="Bands"
-      current_values={{ selected_bands }}
+      title="Chemical potential"
+      current_values={{ mu }}
       on_reset={() => {
-        selected_bands = [...available_bands]
+        mu = defaults.mu
+        on_mu_change?.(defaults.mu)
       }}
+      layout="grid"
     >
-      <div class="band-checkboxes">
-        {#each available_bands as band_idx (band_idx)}
-          <label class="band-checkbox">
-            <input
-              type="checkbox"
-              checked={selected_bands?.includes(band_idx)}
-              onchange={() => toggle_band(band_idx)}
-            />
-            <span>Band {band_idx}</span>
-          </label>
-        {/each}
-      </div>
-      <div class="band-actions">
-        <button type="button" onclick={() => (selected_bands = [...available_bands])}>
-          All
-        </button>
-        <button type="button" onclick={() => (selected_bands = [])}>None</button>
-      </div>
-    </SettingsSection>
-  {/if}
-
-  <SettingsSection
-    title="Appearance"
-    current_values={{ color_property, representation, surface_opacity }}
-    on_reset={() => {
-      color_property = `band`
-      representation = `solid`
-      surface_opacity = 0.8
-    }}
-  >
-    <label>
-      <span>Color by:</span>
-      <select bind:value={color_property}>
-        <option value="band">Band</option>
-        <option value="velocity">Velocity</option>
-        <option value="spin">Spin</option>
-        {#if has_custom_color}
-          <option value="custom">{custom_property_label ?? `Custom`}</option>
-        {/if}
-      </select>
-    </label>
-    {#if color_property === `velocity` || color_property === `custom`}
       <label>
-        <span>Color scale:</span>
-        <select bind:value={color_scale}>
-          {#each color_scales as scale (scale.value)}
-            <option value={scale.value}>{scale.label}</option>
+        <span>μ offset (eV)</span>
+        <input
+          type="number"
+          step="0.01"
+          value={mu}
+          oninput={handle_mu_change}
+          style="width: 4em"
+        />
+        <input
+          type="range"
+          min="-1"
+          max="1"
+          step="0.01"
+          value={mu}
+          oninput={handle_mu_change}
+        />
+      </label>
+      {#if fermi_data}
+        <small>E_F = {fermi_data.fermi_energy.toFixed(3)} eV</small>
+      {/if}
+    </SettingsSection>
+
+    {#if available_bands.length > 0}
+      <SettingsSection
+        title="Bands"
+        current_values={{ selected_bands }}
+        on_reset={() => {
+          selected_bands = [...available_bands]
+        }}
+        layout="grid"
+      >
+        <div class="band-checkboxes">
+          {#each available_bands as band_idx (band_idx)}
+            <label class="band-checkbox">
+              <input
+                type="checkbox"
+                checked={selected_bands?.includes(band_idx)}
+                onchange={() => toggle_band(band_idx)}
+              />
+              <span>Band {band_idx}</span>
+            </label>
           {/each}
-        </select>
-      </label>
+        </div>
+        <div class="band-actions">
+          <button type="button" onclick={() => (selected_bands = [...available_bands])}>
+            All
+          </button>
+          <button type="button" onclick={() => (selected_bands = [])}>None</button>
+        </div>
+      </SettingsSection>
     {/if}
-    <label>
-      <span>Style:</span>
-      <select bind:value={representation}>
-        <option value="solid">Solid</option>
-        <option value="wireframe">Wireframe</option>
-        <option value="transparent">Transparent</option>
-      </select>
-    </label>
-    <label>
-      <span>Opacity:</span>
-      <input type="range" min="0.1" max="1" step="0.05" bind:value={surface_opacity} />
-      <span class="value">{surface_opacity.toFixed(2)}</span>
-    </label>
-  </SettingsSection>
 
-  <SettingsSection
-    title="Brillouin Zone"
-    current_values={{ show_bz, bz_opacity, show_vectors, tile_bz }}
-    on_reset={() => {
-      show_bz = true
-      bz_opacity = 0.1
-      show_vectors = true
-      tile_bz = false
-    }}
-  >
-    <label>
-      <span>Show BZ:</span>
-      <input type="checkbox" bind:checked={show_bz} />
-    </label>
-    {#if show_bz}
-      <label>
-        <span>BZ Opacity:</span>
-        <input type="range" min="0" max="0.5" step="0.01" bind:value={bz_opacity} />
-        <span class="value">{bz_opacity.toFixed(2)}</span>
-      </label>
-    {/if}
-    <label>
-      <span>Show Vectors:</span>
-      <input type="checkbox" bind:checked={show_vectors} />
-    </label>
-    <label
-      title="Tile Fermi surface from irreducible part to fill full Brillouin zone using symmetry"
-    >
-      <span>Tile to full BZ:</span>
-      <input type="checkbox" bind:checked={tile_bz} />
-    </label>
-  </SettingsSection>
-
-  <SettingsSection
-    title="Clipping Plane"
-    current_values={{ clip_enabled, clip_axis, clip_position, clip_flip }}
-    on_reset={() => {
-      clip_enabled = false
-      clip_axis = `z`
-      clip_position = 0
-      clip_flip = false
-    }}
-  >
-    <label>
-      <span>Enable:</span>
-      <input type="checkbox" bind:checked={clip_enabled} />
-    </label>
-    {#if clip_enabled}
-      <label>
-        <span>Axis:</span>
-        <select bind:value={clip_axis}>
-          <option value="x">X</option>
-          <option value="y">Y</option>
-          <option value="z">Z</option>
-        </select>
-      </label>
-      <label>
-        <span>Position:</span>
-        <input type="range" min="-1" max="1" step="0.01" bind:value={clip_position} />
-        <span class="value">{clip_position.toFixed(2)}</span>
-      </label>
-      <label>
-        <span>Flip:</span>
-        <input type="checkbox" bind:checked={clip_flip} />
-      </label>
-    {/if}
-  </SettingsSection>
-
-  {#if band_data}
     <SettingsSection
-      title="Interpolation"
-      current_values={{ interpolation_factor }}
-      on_reset={() => {
-        interpolation_factor = 1
-        on_interpolation_change?.(1)
-      }}
+      title="Appearance"
+      current_values={{ color_property, representation, surface_opacity }}
+      on_reset={() => ({ color_property, representation, surface_opacity } = defaults)}
+      layout="grid"
     >
       <label>
-        <span>Grid density:</span>
-        <select
-          value={interpolation_factor}
-          onchange={(event) => {
-            const val = parseFloat(event.currentTarget.value)
-            if (!Number.isFinite(val)) return
-            interpolation_factor = val
-            on_interpolation_change?.(val)
-          }}
-        >
-          <option value={1}>1× (original)</option>
-          <option value={1.5}>1.5×</option>
-          <option value={2}>2×</option>
-          <option value={3}>3×</option>
-          <option value={4}>4×</option>
+        <span>Color by</span>
+        <select bind:value={color_property}>
+          <option value="band">Band</option>
+          <option value="velocity">Velocity</option>
+          <option value="spin">Spin</option>
+          {#if has_custom_color}
+            <option value="custom">{custom_property_label ?? `Custom`}</option>
+          {/if}
         </select>
       </label>
-      <small>Higher = smoother surface, slower</small>
+      {#if color_property === `velocity` || color_property === `custom`}
+        <label>
+          <span>Color scale</span>
+          <select bind:value={color_scale}>
+            {#each color_scales as scale (scale.value)}
+              <option value={scale.value}>{scale.label}</option>
+            {/each}
+          </select>
+        </label>
+      {/if}
+      <label>
+        <span>Style</span>
+        <select bind:value={representation}>
+          <option value="solid">Solid</option>
+          <option value="wireframe">Wireframe</option>
+          <option value="transparent">Transparent</option>
+        </select>
+      </label>
+      <label>
+        <span>Opacity</span>
+        <span class="value">{surface_opacity.toFixed(2)}</span>
+        <input type="range" min="0.1" max="1" step="0.05" bind:value={surface_opacity} />
+      </label>
     </SettingsSection>
-  {/if}
 
-  <SettingsSection title="Export" current_values={{}}>
+    <SettingsSection
+      title="Brillouin zone"
+      current_values={{ show_bz, bz_opacity, show_vectors, tile_bz }}
+      on_reset={() => ({ show_bz, bz_opacity, show_vectors, tile_bz } = defaults)}
+      layout="grid"
+    >
+      <label>
+        <span>Show BZ</span>
+        <input type="checkbox" bind:checked={show_bz} />
+      </label>
+      {#if show_bz}
+        <label>
+          <span>BZ opacity</span>
+          <span class="value">{bz_opacity.toFixed(2)}</span>
+          <input type="range" min="0" max="0.5" step="0.01" bind:value={bz_opacity} />
+        </label>
+      {/if}
+      <label>
+        <span>Show vectors</span>
+        <input type="checkbox" bind:checked={show_vectors} />
+      </label>
+      <label
+        title="Tile Fermi surface from irreducible part to fill full Brillouin zone using symmetry"
+      >
+        <span>Tile to full BZ</span>
+        <input type="checkbox" bind:checked={tile_bz} />
+      </label>
+    </SettingsSection>
+
+    <SettingsSection
+      title="Clipping plane"
+      current_values={{ clip_enabled, clip_axis, clip_position, clip_flip }}
+      on_reset={() => ({ clip_enabled, clip_axis, clip_position, clip_flip } = defaults)}
+      layout="grid"
+    >
+      <label>
+        <span>Enable</span>
+        <input type="checkbox" bind:checked={clip_enabled} />
+      </label>
+      {#if clip_enabled}
+        <label>
+          <span>Axis</span>
+          <select bind:value={clip_axis}>
+            <option value="x">X</option>
+            <option value="y">Y</option>
+            <option value="z">Z</option>
+          </select>
+        </label>
+        <label>
+          <span>Position</span>
+          <span class="value">{clip_position.toFixed(2)}</span>
+          <input type="range" min="-1" max="1" step="0.01" bind:value={clip_position} />
+        </label>
+        <label>
+          <span>Flip</span>
+          <input type="checkbox" bind:checked={clip_flip} />
+        </label>
+      {/if}
+    </SettingsSection>
+
+    {#if band_data}
+      <SettingsSection
+        title="Interpolation"
+        current_values={{ interpolation_factor }}
+        on_reset={() => {
+          interpolation_factor = defaults.interpolation_factor
+          on_interpolation_change?.(defaults.interpolation_factor)
+        }}
+        layout="grid"
+      >
+        <label>
+          <span>Grid density</span>
+          <select
+            value={interpolation_factor}
+            onchange={(event) => {
+              const val = parseFloat(event.currentTarget.value)
+              if (!Number.isFinite(val)) return
+              interpolation_factor = val
+              on_interpolation_change?.(val)
+            }}
+          >
+            <option value={1}>1× (original)</option>
+            <option value={1.5}>1.5×</option>
+            <option value={2}>2×</option>
+            <option value={3}>3×</option>
+            <option value={4}>4×</option>
+          </select>
+        </label>
+        <small>Higher = smoother surface, slower</small>
+      </SettingsSection>
+    {/if}
+  </SettingsGroup>
+
+  <SettingsSection title="Export" layout="grid">
     <div class="export-buttons">
-      <button
-        type="button"
-        onclick={() => on_export?.(`stl`)}
-        title="Export as STL (3D printing)"
-      >
-        STL
-      </button>
-      <button
-        type="button"
-        onclick={() => on_export?.(`obj`)}
-        title="Export as OBJ (Wavefront)"
-      >
-        OBJ
-      </button>
-      <button
-        type="button"
-        onclick={() => on_export?.(`gltf`)}
-        title="Export as GLTF (web/AR)"
-      >
-        GLTF
-      </button>
+      {#each export_formats as [format, blurb] (format)}
+        <button
+          type="button"
+          onclick={() => on_export?.(format)}
+          title="Export as {format.toUpperCase()} ({blurb})"
+        >
+          {format.toUpperCase()}
+        </button>
+      {/each}
     </div>
     <small>Export visible Fermi surfaces</small>
   </SettingsSection>
@@ -364,12 +382,11 @@
   <SettingsSection
     title="Camera"
     current_values={{ camera_projection }}
-    on_reset={() => {
-      camera_projection = `perspective`
-    }}
+    on_reset={() => ({ camera_projection } = defaults)}
+    layout="grid"
   >
     <label>
-      <span>Projection:</span>
+      <span>Projection</span>
       <select bind:value={camera_projection}>
         <option value="perspective">Perspective</option>
         <option value="orthographic">Orthographic</option>
@@ -381,6 +398,9 @@
 </DraggablePane>
 
 <style>
+  :is(.band-checkboxes, .band-actions, .export-buttons, small) {
+    grid-column: 1 / -1;
+  }
   .band-checkboxes {
     display: flex;
     flex-wrap: wrap;
@@ -404,12 +424,6 @@
   small {
     color: var(--text-color-muted, #888);
     font-size: 0.85em;
-  }
-  label {
-    display: flex;
-    align-items: center;
-    gap: 0.5em;
-    flex-wrap: wrap;
   }
   .value {
     min-width: 3em;

--- a/src/lib/fermi-surface/FermiSurfaceControls.svelte
+++ b/src/lib/fermi-surface/FermiSurfaceControls.svelte
@@ -134,17 +134,11 @@
   untrack(sync_bindable_defaults)
   $effect(() => sync_bindable_defaults(available_bands_changed(available_bands_key)))
 
-  function toggle_band(band_idx: number) {
-    if (!selected_bands) {
-      selected_bands = [band_idx]
-      return
-    }
-    const idx = selected_bands.indexOf(band_idx)
-    if (idx !== -1) {
-      selected_bands = selected_bands.filter((band) => band !== band_idx)
-    } else {
-      selected_bands = [...selected_bands, band_idx].toSorted((a, b) => a - b)
-    }
+  function toggle_band(band_idx: number): void {
+    const bands = selected_bands ?? []
+    selected_bands = bands.includes(band_idx)
+      ? bands.filter((band) => band !== band_idx)
+      : [...bands, band_idx].toSorted((left, right) => left - right)
   }
 
   function handle_mu_change(event: Event & { currentTarget: HTMLInputElement }) {

--- a/src/lib/fermi-surface/FermiSurfaceControls.svelte
+++ b/src/lib/fermi-surface/FermiSurfaceControls.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { Cross, Settings } from 'svelte-widgets/icons'
+  import { format_num } from '$lib/labels'
   import { SettingsGroup, SettingsSection } from '$lib/layout'
   import { DraggablePane } from '$lib/overlays'
   import type { CameraProjection } from '$lib/settings'
@@ -193,7 +194,7 @@
         />
       </label>
       {#if fermi_data}
-        <small>E_F = {fermi_data.fermi_energy.toFixed(3)} eV</small>
+        <small>E_F = {format_num(fermi_data.fermi_energy, `.3f`)} eV</small>
       {/if}
     </SettingsSection>
 
@@ -263,7 +264,7 @@
       </label>
       <label>
         <span>Opacity</span>
-        <span class="value">{surface_opacity.toFixed(2)}</span>
+        <span class="value">{format_num(surface_opacity, `.2f`)}</span>
         <input type="range" min="0.1" max="1" step="0.05" bind:value={surface_opacity} />
       </label>
     </SettingsSection>
@@ -281,7 +282,7 @@
       {#if show_bz}
         <label>
           <span>BZ opacity</span>
-          <span class="value">{bz_opacity.toFixed(2)}</span>
+          <span class="value">{format_num(bz_opacity, `.2f`)}</span>
           <input type="range" min="0" max="0.5" step="0.01" bind:value={bz_opacity} />
         </label>
       {/if}
@@ -318,7 +319,7 @@
         </label>
         <label>
           <span>Position</span>
-          <span class="value">{clip_position.toFixed(2)}</span>
+          <span class="value">{format_num(clip_position, `.2f`)}</span>
           <input type="range" min="-1" max="1" step="0.01" bind:value={clip_position} />
         </label>
         <label>
@@ -405,9 +406,11 @@
     gap: 0.3em;
     font-size: 0.9em;
   }
-  .band-actions {
+  :is(.band-actions, .export-buttons) {
     display: flex;
     gap: 0.5em;
+  }
+  .band-actions {
     margin-top: 0.5em;
   }
   .band-actions button {
@@ -422,10 +425,6 @@
     min-width: 3em;
     font-family: monospace;
     font-size: 0.9em;
-  }
-  .export-buttons {
-    display: flex;
-    gap: 0.5em;
   }
   .export-buttons button {
     padding: 0.3em 0.8em;

--- a/src/lib/fermi-surface/FermiSurfaceControls.svelte
+++ b/src/lib/fermi-surface/FermiSurfaceControls.svelte
@@ -120,7 +120,6 @@
         )
       : [],
   )
-  let available_bands_key = $derived(available_bands.join(`,`))
   const available_bands_changed = make_change_detector()
 
   const sync_bindable_defaults = (bands_changed = false): void => {
@@ -132,7 +131,7 @@
   }
 
   untrack(sync_bindable_defaults)
-  $effect(() => sync_bindable_defaults(available_bands_changed(available_bands_key)))
+  $effect(() => sync_bindable_defaults(available_bands_changed(available_bands.join(`,`))))
 
   function toggle_band(band_idx: number): void {
     const bands = selected_bands ?? []

--- a/src/lib/fermi-surface/FermiSurfaceControls.svelte
+++ b/src/lib/fermi-surface/FermiSurfaceControls.svelte
@@ -4,7 +4,8 @@
   import { DraggablePane } from '$lib/overlays'
   import type { CameraProjection } from '$lib/settings'
   import { make_change_detector, parse_num_token } from '$lib/utils'
-  import type { Snippet } from 'svelte'
+  import { untrack, type Snippet } from 'svelte'
+  import { SvelteSet } from 'svelte/reactivity'
   import type {
     BandGridData,
     ColorProperty,
@@ -114,7 +115,7 @@
   // Get unique band indices from Fermi surface data
   let available_bands = $derived(
     fermi_data
-      ? [...new Set(fermi_data.isosurfaces.map((iso) => iso.band_index))].toSorted(
+      ? [...new SvelteSet(fermi_data.isosurfaces.map((iso) => iso.band_index))].toSorted(
           (a, b) => a - b,
         )
       : [],
@@ -122,15 +123,16 @@
   let available_bands_key = $derived(available_bands.join(`,`))
   const available_bands_changed = make_change_detector()
 
-  $effect(() => {
-    if (color_property === `custom` && !has_custom_color) {
+  const sync_bindable_defaults = (bands_changed = false): void => {
+    if (color_property === `custom` && !has_custom_color)
       color_property = defaults.color_property
-    }
-    const bands_changed = available_bands_changed(available_bands_key)
     if (available_bands.length > 0 && (selected_bands === undefined || bands_changed)) {
       selected_bands = [...available_bands]
     }
-  })
+  }
+
+  untrack(sync_bindable_defaults)
+  $effect(() => sync_bindable_defaults(available_bands_changed(available_bands_key)))
 
   function toggle_band(band_idx: number) {
     if (!selected_bands) {
@@ -231,8 +233,9 @@
 
     <SettingsSection
       title="Appearance"
-      current_values={{ color_property, representation, surface_opacity }}
-      on_reset={() => ({ color_property, representation, surface_opacity } = defaults)}
+      current_values={{ color_property, color_scale, representation, surface_opacity }}
+      on_reset={() =>
+        ({ color_property, color_scale, representation, surface_opacity } = defaults)}
       layout="grid"
     >
       <label>

--- a/src/lib/file-viewer/main.ts
+++ b/src/lib/file-viewer/main.ts
@@ -261,6 +261,11 @@ export const create_display = (
     enable_tips: false,
     fullscreen_toggle: false,
   }
+  const embedded_structure_props = {
+    ...structure_props(defaults),
+    ...common_props,
+    persist_settings: false,
+  }
 
   let app: MatterVizApp
   let log_message: string
@@ -349,8 +354,7 @@ export const create_display = (
       props: {
         structure: vol_file.structure,
         volumetric_data: vol_file.volumes,
-        ...structure_props(defaults),
-        ...common_props,
+        ...embedded_structure_props,
       },
     })
     log_message = `Volumetric data rendered: ${filename}`
@@ -375,7 +379,7 @@ export const create_display = (
     const structure = result.data as AnyStructure
     app = mount(Structure, {
       target: container,
-      props: { structure, ...structure_props(defaults), ...common_props },
+      props: { structure, ...embedded_structure_props },
     })
     log_message = `Structure rendered: ${filename} (${structure.sites?.length ?? 0} sites)`
   }
@@ -398,7 +402,7 @@ const trajectory_props = (defaults: DefaultSettings) => {
   }
   return {
     ...trajectory,
-    structure_props: structure_props(defaults),
+    structure_props: { ...structure_props(defaults), persist_settings: false },
     loading_options: {
       bin_file_threshold: trajectory.bin_file_threshold,
       text_file_threshold: trajectory.text_file_threshold,

--- a/src/lib/heatmap-matrix/HeatmapMatrixControls.svelte
+++ b/src/lib/heatmap-matrix/HeatmapMatrixControls.svelte
@@ -57,10 +57,8 @@
     children?: Snippet<[{ controls_open: boolean }]>
   } = $props()
 
-  function merge_styles(base_style: string, override_style: unknown): string {
-    const override_style_str = typeof override_style === `string` ? override_style : ``
-    return override_style_str ? `${base_style}; ${override_style_str}` : base_style
-  }
+  const merge_styles = (base_style: string, override_style: unknown): string =>
+    `${base_style}${typeof override_style === `string` && override_style ? `; ${override_style}` : ``}`
 
   // Stash custom format string so toggling the checkbox preserves it
   let stashed_format = $state<string | null>(null)

--- a/src/lib/heatmap-matrix/HeatmapMatrixControls.svelte
+++ b/src/lib/heatmap-matrix/HeatmapMatrixControls.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { Cross, Settings } from 'svelte-widgets/icons'
+  import { SettingsSection } from '$lib/layout'
   import { DraggablePane, type PaneProps, type PaneToggleProps } from '$lib/overlays'
-  import type { ComponentProps, Snippet } from 'svelte'
+  import type { Snippet } from 'svelte'
   import { ELEMENT_ORDERINGS, ORDERING_LABELS } from './index'
   import type {
     ElementAxisOrderingKey,
@@ -79,6 +80,8 @@
   const default_pane_style = [
     `z-index: var(--heatmap-matrix-controls-pane-z-index, 25)`,
     `min-width: var(--heatmap-matrix-controls-pane-min-width, 220px)`,
+    `--ctrl-label-w: 6.5em`,
+    `--ctrl-value-w: 4em`,
   ].join(`; `)
 </script>
 
@@ -100,71 +103,66 @@
     open_icon={Cross}
     closed_icon={Settings}
   >
-    <label>
-      Ordering
-      <select bind:value={ordering}>
-        {#each orderings as ord (ord)}
-          <option value={ord}>{ORDERING_LABELS[ord]}</option>
-        {/each}
-      </select>
-    </label>
-    <label>
-      Search
-      <input bind:value={search_query} placeholder="Filter labels/keys" />
-    </label>
-    <div class="pane-row">
+    <SettingsSection title="Heatmap" layout="grid">
       <label>
-        Normalize
+        <span>Ordering</span>
+        <select bind:value={ordering}>
+          {#each orderings as ord (ord)}
+            <option value={ord}>{ORDERING_LABELS[ord]}</option>
+          {/each}
+        </select>
+      </label>
+      <label>
+        <span>Search</span>
+        <input bind:value={search_query} placeholder="Filter labels/keys" />
+      </label>
+      <label>
+        <span>Normalize</span>
         <select bind:value={normalize}>
-          <option value="linear">linear</option>
-          <option value="log">log</option>
+          <option value="linear">Linear</option>
+          <option value="log">Log</option>
         </select>
       </label>
       <label>
-        Domain
+        <span>Domain</span>
         <select bind:value={domain_mode}>
-          <option value="auto">auto</option>
-          <option value="robust">robust</option>
-          <option value="fixed">fixed</option>
+          <option value="auto">Auto</option>
+          <option value="robust">Robust</option>
+          <option value="fixed">Fixed</option>
         </select>
       </label>
-    </div>
-    <div class="pane-row">
       <label>
+        <span>Legend</span>
         <input type="checkbox" bind:checked={show_legend} />
-        Legend
       </label>
       {#if show_legend}
         <label>
-          Position
+          <span>Position</span>
           <select bind:value={legend_position}>
-            <option value="right">right</option>
-            <option value="bottom">bottom</option>
+            <option value="right">Right</option>
+            <option value="bottom">Bottom</option>
           </select>
         </label>
       {/if}
-    </div>
-    <div class="pane-row">
       <label>
-        Symmetric
+        <span>Symmetric</span>
         <select bind:value={symmetric}>
-          <option value={false}>off</option>
-          <option value="lower">lower</option>
-          <option value="upper">upper</option>
+          <option value={false}>Off</option>
+          <option value="lower">Lower</option>
+          <option value="upper">Upper</option>
         </select>
       </label>
       <label>
-        Theme
+        <span>Theme</span>
         <select bind:value={theme}>
-          <option value="default">default</option>
-          <option value="light">light</option>
-          <option value="dark">dark</option>
-          <option value="publication">publication</option>
+          <option value="default">Default</option>
+          <option value="light">Light</option>
+          <option value="dark">Dark</option>
+          <option value="publication">Publication</option>
         </select>
       </label>
-    </div>
-    <div class="pane-row">
       <label>
+        <span>Values</span>
         <input
           type="checkbox"
           checked={!!show_values}
@@ -177,24 +175,26 @@
             }
           }}
         />
-        Values
       </label>
       <label>
+        <span>Row sums</span>
         <input type="checkbox" bind:checked={show_row_summaries} />
-        Row sums
       </label>
       <label>
+        <span>Col sums</span>
         <input type="checkbox" bind:checked={show_col_summaries} />
-        Col sums
       </label>
-    </div>
-    <div class="pane-row">
-      {#each export_formats as export_format (export_format)}
-        <button type="button" onclick={() => onexport?.(export_format)}>
-          Export {export_format.toUpperCase()}
-        </button>
-      {/each}
-    </div>
+      <div class="setting">
+        <span>Export</span>
+        <div class="pane-row">
+          {#each export_formats as export_format (export_format)}
+            <button type="button" onclick={() => onexport?.(export_format)}>
+              Export {export_format.toUpperCase()}
+            </button>
+          {/each}
+        </div>
+      </div>
+    </SettingsSection>
     {@render children?.({ controls_open })}
   </DraggablePane>
 {/if}
@@ -208,11 +208,6 @@
     display: flex;
     gap: 10pt;
     flex-wrap: wrap;
-  }
-  label {
-    display: flex;
-    align-items: center;
-    gap: 6pt;
   }
   select,
   input:not([type]) {

--- a/src/lib/heatmap-matrix/HeatmapMatrixControls.svelte
+++ b/src/lib/heatmap-matrix/HeatmapMatrixControls.svelte
@@ -167,10 +167,10 @@
           onchange={(evt) => {
             if (evt.currentTarget.checked) {
               show_values = stashed_format || true
-            } else {
-              stashed_format = typeof show_values === `string` ? show_values : null
-              show_values = false
+              return
             }
+            stashed_format = typeof show_values === `string` ? show_values : null
+            show_values = false
           }}
         />
       </label>

--- a/src/lib/isosurface/IsosurfaceControls.svelte
+++ b/src/lib/isosurface/IsosurfaceControls.svelte
@@ -523,14 +523,14 @@
               type="number"
               step="0.05"
               placeholder="0"
-              value={settings.display_range ? settings.display_range[axis][0] : ``}
+              value={settings.display_range?.[axis][0] ?? ``}
               onchange={(event) => update_display_range(axis, 0, event.currentTarget.value)}
             />
             <input
               type="number"
               step="0.05"
               placeholder="1"
-              value={settings.display_range ? settings.display_range[axis][1] : ``}
+              value={settings.display_range?.[axis][1] ?? ``}
               onchange={(event) => update_display_range(axis, 1, event.currentTarget.value)}
             />
           </label>

--- a/src/lib/isosurface/IsosurfaceControls.svelte
+++ b/src/lib/isosurface/IsosurfaceControls.svelte
@@ -193,7 +193,7 @@
   tip: string,
 )}
   <label {@attach tooltip({ content: tip })}>
-    <span>Color by:</span>
+    <span>Color by</span>
     <select
       value={selected}
       onchange={(event) => {
@@ -240,70 +240,69 @@
   on_reset={() => {
     settings = { ...DEFAULT_ISOSURFACE_SETTINGS }
   }}
+  layout="grid"
+  class="isosurface-settings"
 >
-  <!-- Top row: volume selector (single-layer multi-volume) + layer count + toggles -->
-  <div class="pane-row compact-row">
-    {#if !is_multi_layer && volumes.length > 1}
-      <label
-        {@attach tooltip({
-          content: `Select which volume to display (e.g. charge vs magnetization)`,
-        })}
-      >
-        <span>Volume:</span>
-        <select bind:value={active_volume_idx}>
-          {#each volumes as _vol, idx (idx)}
-            <option value={idx}>{vol_label(idx)}</option>
-          {/each}
-        </select>
-      </label>
-    {/if}
-    {#if !is_multi_layer}
-      <label
-        {@attach tooltip({
-          content: `Number of isosurface shells at different density thresholds`,
-        })}
-      >
-        <span>Layers:</span>
-        <select
-          value={n_layers}
-          onchange={(event) => set_layer_count(Number(event.currentTarget.value))}
-        >
-          {#each [1, 2, 3, 4, 5] as count (count)}
-            <option value={count}>{count}</option>
-          {/each}
-        </select>
-      </label>
-    {/if}
-    <!-- Sync both settings.show_negative (single-layer fallback) and all layer entries
-    so the toggle works consistently regardless of which mode is active -->
+  {#if !is_multi_layer && volumes.length > 1}
     <label
       {@attach tooltip({
-        content: `Show negative lobe at −isovalue (for orbitals, ESP, magnetization)`,
+        content: `Select which volume to display (e.g. charge vs magnetization)`,
       })}
     >
-      <span>Neg. lobe</span>
-      <input
-        type="checkbox"
-        checked={is_multi_layer
-          ? (settings.layers?.some((layer) => layer.show_negative) ?? false)
-          : settings.show_negative}
-        onchange={(event) => {
-          const checked = event.currentTarget.checked
-          settings.show_negative = checked
-          if (settings.layers) {
-            settings.layers = settings.layers.map((layer) => ({
-              ...layer,
-              show_negative: checked,
-            }))
-          }
-        }}
-      />
+      <span>Volume</span>
+      <select bind:value={active_volume_idx}>
+        {#each volumes as _vol, idx (idx)}
+          <option value={idx}>{vol_label(idx)}</option>
+        {/each}
+      </select>
     </label>
-    <label {@attach tooltip({ content: `Render as wireframe mesh instead of solid surface` })}>
-      <span>Wireframe</span>
-      <input type="checkbox" bind:checked={settings.wireframe} />
+  {/if}
+  {#if !is_multi_layer}
+    <label
+      {@attach tooltip({
+        content: `Number of isosurface shells at different density thresholds`,
+      })}
+    >
+      <span>Layers</span>
+      <select
+        value={n_layers}
+        onchange={(event) => set_layer_count(Number(event.currentTarget.value))}
+      >
+        {#each [1, 2, 3, 4, 5] as count (count)}
+          <option value={count}>{count}</option>
+        {/each}
+      </select>
     </label>
-  </div>
+  {/if}
+  <!-- Sync both settings.show_negative (single-layer fallback) and all layer entries
+    so the toggle works consistently regardless of which mode is active -->
+  <label
+    {@attach tooltip({
+      content: `Show negative lobe at −isovalue (for orbitals, ESP, magnetization)`,
+    })}
+  >
+    <span>Neg. lobe</span>
+    <input
+      type="checkbox"
+      checked={is_multi_layer
+        ? (settings.layers?.some((layer) => layer.show_negative) ?? false)
+        : settings.show_negative}
+      onchange={(event) => {
+        const checked = event.currentTarget.checked
+        settings.show_negative = checked
+        if (settings.layers) {
+          settings.layers = settings.layers.map((layer) => ({
+            ...layer,
+            show_negative: checked,
+          }))
+        }
+      }}
+    />
+  </label>
+  <label {@attach tooltip({ content: `Render as wireframe mesh instead of solid surface` })}>
+    <span>Wireframe</span>
+    <input type="checkbox" bind:checked={settings.wireframe} />
+  </label>
 
   {#if is_multi_layer && settings.layers}
     <!-- Multi-layer mode: surfaces grouped under their geometry-source volume -->
@@ -432,7 +431,7 @@
                 {@attach tooltip({ content: `Colormap for sampled values` })}
               />
               <div class="color-range" aria-label="Colormap value range">
-                <span>Range:</span>
+                <span>Range</span>
                 {@render range_bound_input(layer_idx, 0, explicit_range)}
                 <span aria-hidden="true">&ndash;</span>
                 {@render range_bound_input(layer_idx, 1, explicit_range)}
@@ -469,47 +468,37 @@
         content: `Density threshold — surface is drawn where grid values equal this`,
       })}
     >
-      <span>Isovalue:</span>
-      <input type="range" min={step} max={slider_max} {step} bind:value={settings.isovalue} />
+      <span>Isovalue</span>
       <span>{format_num(settings.isovalue, `.3~g`)}</span>
+      <input type="range" min={step} max={slider_max} {step} bind:value={settings.isovalue} />
     </label>
 
-    <!-- Opacity + colors on one row -->
-    <div class="pane-row compact-row">
-      <label
-        {@attach tooltip({
-          content: `Surface transparency — lower values reveal inner structure`,
-        })}
-      >
-        <span>Opacity:</span>
-        <input
-          type="range"
-          min={0.1}
-          max={1}
-          step={0.05}
-          bind:value={settings.opacity}
-          style="width: 60px"
-        />
-        <span>{format_num(settings.opacity, `.2f`)}</span>
+    <label
+      {@attach tooltip({
+        content: `Surface transparency — lower values reveal inner structure`,
+      })}
+    >
+      <span>Opacity</span>
+      <span>{format_num(settings.opacity, `.2f`)}</span>
+      <input type="range" min={0.1} max={1} step={0.05} bind:value={settings.opacity} />
+    </label>
+    <label {@attach tooltip({ content: `Color for the positive isovalue surface` })}>
+      <span>+ color</span>
+      <input type="color" bind:value={settings.positive_color} />
+    </label>
+    {#if settings.show_negative}
+      <label {@attach tooltip({ content: `Color for the negative (−isovalue) surface` })}>
+        <span>&minus; color</span>
+        <input type="color" bind:value={settings.negative_color} />
       </label>
-      <label {@attach tooltip({ content: `Color for the positive isovalue surface` })}>
-        <span>+ Color</span>
-        <input type="color" bind:value={settings.positive_color} />
-      </label>
-      {#if settings.show_negative}
-        <label {@attach tooltip({ content: `Color for the negative (−isovalue) surface` })}>
-          <span>&minus; Color</span>
-          <input type="color" bind:value={settings.negative_color} />
-        </label>
-      {/if}
-      {#if volumes.length > 1}
-        {@render color_source_select(
-          -1,
-          set_single_color_source,
-          `Color this surface by another volume's values (e.g. density by ESP)`,
-        )}
-      {/if}
-    </div>
+    {/if}
+    {#if volumes.length > 1}
+      {@render color_source_select(
+        -1,
+        set_single_color_source,
+        `Color this surface by another volume's values (e.g. density by ESP)`,
+      )}
+    {/if}
   {/if}
 
   {#if any_periodic}
@@ -518,45 +507,48 @@
         content: `Extend isosurface beyond cell boundaries to close partial spheres (fraction of cell)`,
       })}
     >
-      Halo: {format_num(settings.halo, `.2f`)}
+      <span>Halo</span>
+      <span>{format_num(settings.halo, `.2f`)}</span>
       <input type="range" min={0} max={0.5} step={0.01} bind:value={settings.halo} />
     </label>
-    <div class="pane-row compact-row display-range">
+    <div class="setting display-range">
       <span
         {@attach tooltip({
           content: `Fractional display range per lattice vector (VESTA-style): repeats periodic surfaces and clips them exactly at these bounds, e.g. -0.15 to 2.15. Empty = follow the structure supercell.`,
-        })}>Range:</span
+        })}>Range</span
       >
-      {#each [`a`, `b`, `c`] as axis_label, axis (axis)}
-        <label class="range-axis">
-          {axis_label}
-          <input
-            type="number"
-            step="0.05"
-            placeholder="0"
-            value={settings.display_range ? settings.display_range[axis][0] : ``}
-            onchange={(event) => update_display_range(axis, 0, event.currentTarget.value)}
-          />
-          <input
-            type="number"
-            step="0.05"
-            placeholder="1"
-            value={settings.display_range ? settings.display_range[axis][1] : ``}
-            onchange={(event) => update_display_range(axis, 1, event.currentTarget.value)}
-          />
-        </label>
-      {/each}
-      {#if settings.display_range}
-        <button
-          type="button"
-          class="icon-btn"
-          onclick={() => (settings.display_range = undefined)}
-          aria-label="Reset display range"
-          {@attach tooltip({ content: `Follow the structure supercell again` })}
-        >
-          <Icon icon={Reset} aria-hidden="true" style="--icon-size: 12px" />
-        </button>
-      {/if}
+      <div class="range-axes">
+        {#each [`a`, `b`, `c`] as axis_label, axis (axis)}
+          <label class="range-axis">
+            <span>{axis_label}</span>
+            <input
+              type="number"
+              step="0.05"
+              placeholder="0"
+              value={settings.display_range ? settings.display_range[axis][0] : ``}
+              onchange={(event) => update_display_range(axis, 0, event.currentTarget.value)}
+            />
+            <input
+              type="number"
+              step="0.05"
+              placeholder="1"
+              value={settings.display_range ? settings.display_range[axis][1] : ``}
+              onchange={(event) => update_display_range(axis, 1, event.currentTarget.value)}
+            />
+          </label>
+        {/each}
+        {#if settings.display_range}
+          <button
+            type="button"
+            class="icon-btn"
+            onclick={() => (settings.display_range = undefined)}
+            aria-label="Reset display range"
+            {@attach tooltip({ content: `Follow the structure supercell again` })}
+          >
+            <Icon icon={Reset} aria-hidden="true" style="--icon-size: 12px" />
+          </button>
+        {/if}
+      </div>
     </div>
   {/if}
 
@@ -572,7 +564,7 @@
 
 <style>
   /* Shared chrome for native selects/number/color + ColorScaleSelect (--sms-*) */
-  :is(.compact-row, .volume-group, .display-range) {
+  :global(.isosurface-settings) {
     --iso-ctrl-h: 22px;
     --iso-ctrl-radius: 3px;
     --iso-ctrl-border: 1px solid var(--border-color, light-dark(#b8bec8, #555));
@@ -582,42 +574,36 @@
     --sms-border-radius: var(--iso-ctrl-radius);
     --sms-bg: var(--iso-ctrl-bg);
     font-size: 0.95em;
-
-    :is(select, input[type='number'], input[type='color']) {
-      box-sizing: border-box;
-      margin: 0; /* beat DraggablePane margins */
-      border: var(--iso-ctrl-border);
-      border-radius: var(--iso-ctrl-radius);
-    }
-    :is(select, input[type='number']) {
-      height: var(--iso-ctrl-h);
-      padding: 0 4px;
-      background: var(--iso-ctrl-bg);
-      color: inherit;
-      font: inherit;
-      line-height: 1.2;
-    }
-    input[type='color'] {
-      width: var(--iso-ctrl-h);
-      height: var(--iso-ctrl-h);
-      padding: 0;
-      cursor: pointer;
-      background: transparent;
-    }
   }
-  .compact-row {
-    flex-wrap: wrap;
-    gap: 4pt 14pt;
+  :global(.isosurface-settings) :is(select, input[type='number'], input[type='color']) {
+    box-sizing: border-box;
+    margin: 0; /* beat DraggablePane margins */
+    border: var(--iso-ctrl-border);
+    border-radius: var(--iso-ctrl-radius);
   }
-  label {
-    gap: 6pt;
+  :global(.isosurface-settings) :is(select, input[type='number']) {
+    height: var(--iso-ctrl-h);
+    padding: 0 4px;
+    background: var(--iso-ctrl-bg);
+    color: inherit;
+    font: inherit;
+    line-height: 1.2;
+  }
+  :global(.isosurface-settings) input[type='color'] {
+    width: var(--iso-ctrl-h);
+    height: var(--iso-ctrl-h);
+    padding: 0;
+    cursor: pointer;
+    background: transparent;
   }
   .grid-info {
+    grid-column: 1 / -1;
     font-size: 0.75em;
     opacity: 0.7;
     padding: 2px 0;
   }
   .volume-group {
+    grid-column: 1 / -1;
     display: flex;
     flex-direction: column;
     gap: 3px;
@@ -732,7 +718,13 @@
     gap: 3px;
   }
   .display-range {
-    gap: 4pt 8pt;
+    .range-axes {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 4pt 8pt;
+      min-width: 0;
+    }
     .range-axis {
       display: flex;
       align-items: center;

--- a/src/lib/isosurface/IsosurfaceControls.svelte
+++ b/src/lib/isosurface/IsosurfaceControls.svelte
@@ -237,9 +237,7 @@
     layers: n_layers,
     display_range: settings.display_range?.flat().join(`,`) ?? ``,
   }}
-  on_reset={() => {
-    settings = { ...DEFAULT_ISOSURFACE_SETTINGS }
-  }}
+  on_reset={() => (settings = { ...DEFAULT_ISOSURFACE_SETTINGS })}
   layout="grid"
   class="isosurface-settings"
 >

--- a/src/lib/isosurface/VolumeSliceControls.svelte
+++ b/src/lib/isosurface/VolumeSliceControls.svelte
@@ -10,11 +10,18 @@
   import type { VolumeSlicePlaneMode, VolumeSliceSettings } from './slice-settings'
   import type { VolumeSliceMode } from './slice-rendering'
 
+  type CartesianVectorKey = `cartesian_point` | `cartesian_normal` | `cartesian_up`
+
   const CARTESIAN_PLANE_PRESETS = [
     { label: `XY`, cartesian_normal: [0, 0, 1], cartesian_up: [1, 0, 0] },
     { label: `XZ`, cartesian_normal: [0, 1, 0], cartesian_up: [1, 0, 0] },
     { label: `YZ`, cartesian_normal: [1, 0, 0], cartesian_up: [0, 1, 0] },
   ] satisfies { label: string; cartesian_normal: Vec3; cartesian_up: Vec3 }[]
+  const CARTESIAN_VECTOR_CONTROLS = [
+    { label: `Point (Å)`, name: `point`, key: `cartesian_point` },
+    { label: `Normal`, name: `normal`, key: `cartesian_normal` },
+    { label: `Up`, name: `up`, key: `cartesian_up` },
+  ] satisfies { label: string; name: string; key: CartesianVectorKey }[]
 
   let {
     settings = $bindable(create_volume_slice_settings()),
@@ -45,11 +52,7 @@
     on_settings_change?.(next_settings)
   }
 
-  function update_vector(
-    key: `cartesian_point` | `cartesian_normal` | `cartesian_up`,
-    axis_idx: number,
-    value: number,
-  ): void {
+  function update_vector(key: CartesianVectorKey, axis_idx: number, value: number): void {
     if (!Number.isFinite(value)) return
     const source = key === `cartesian_point` ? cartesian_point : resolved_settings[key]
     const vector = [...source] as Vec3
@@ -90,154 +93,159 @@
     update_settings(create_volume_slice_settings())
   }}
   class="slice-settings"
+  layout="grid"
 >
-  <div class="control-row">
-    {#if volumes.length > 1}
-      <label>
-        <span>Volume</span>
-        <select bind:value={active_volume_idx} aria-label="Slice volume">
-          {#each volumes as volume, volume_idx (volume_idx)}
-            <option value={volume_idx}>
-              {volume.label ?? `Volume ${volume_idx + 1}`}
-            </option>
-          {/each}
-        </select>
-      </label>
-    {/if}
-
+  {#if volumes.length > 1}
     <label>
-      <span>Plane</span>
-      <select
-        aria-label="Slice plane mode"
-        bind:value={
-          () => resolved_settings.plane_mode,
-          (plane_mode) => update_settings({ plane_mode: plane_mode as VolumeSlicePlaneMode })
-        }
-      >
-        <option value="hkl">HKL</option>
-        <option value="cartesian">Cartesian</option>
+      <span>Volume</span>
+      <select bind:value={active_volume_idx} aria-label="Slice volume">
+        {#each volumes as volume, volume_idx (volume_idx)}
+          <option value={volume_idx}>
+            {volume.label ?? `Volume ${volume_idx + 1}`}
+          </option>
+        {/each}
       </select>
     </label>
+  {/if}
 
-    {#if resolved_settings.plane_mode === `hkl`}
+  <label>
+    <span>Plane</span>
+    <select
+      aria-label="Slice plane mode"
+      bind:value={
+        () => resolved_settings.plane_mode,
+        (plane_mode) => update_settings({ plane_mode: plane_mode as VolumeSlicePlaneMode })
+      }
+    >
+      <option value="hkl">HKL</option>
+      <option value="cartesian">Cartesian</option>
+    </select>
+  </label>
+
+  {#if resolved_settings.plane_mode === `hkl`}
+    <div class="setting">
+      <span>Indices</span>
       <MillerIndexInput
         bind:value={
           () => resolved_settings.miller_indices,
           (miller_indices) => update_settings({ miller_indices })
         }
       />
-      <label class="wide-control">
-        <span>d = {resolved_settings.position.toFixed(2)}</span>
-        <input
-          type="range"
-          min={0}
-          max={1}
-          step={0.01}
-          aria-label="Slice position"
-          bind:value={
-            () => resolved_settings.position, (position) => update_settings({ position })
-          }
-        />
-      </label>
-    {/if}
-  </div>
+    </div>
+    <label>
+      <span>Position</span>
+      <span>d = {resolved_settings.position.toFixed(2)}</span>
+      <input
+        type="range"
+        min={0}
+        max={1}
+        step={0.01}
+        aria-label="Slice position"
+        bind:value={
+          () => resolved_settings.position, (position) => update_settings({ position })
+        }
+      />
+    </label>
+  {/if}
 
   {#if resolved_settings.plane_mode === `cartesian`}
-    {#each [{ label: `Point (Å)`, name: `point`, key: `cartesian_point`, vector: cartesian_point }, { label: `Normal`, name: `normal`, key: `cartesian_normal`, vector: resolved_settings.cartesian_normal }, { label: `Up`, name: `up`, key: `cartesian_up`, vector: resolved_settings.cartesian_up }] as { label, name, key, vector } (name)}
+    {#each CARTESIAN_VECTOR_CONTROLS as { label, name, key } (name)}
+      {@const vector = key === `cartesian_point` ? cartesian_point : resolved_settings[key]}
       <label class="vector-control">
         <span>{label}</span>
-        {#each [`x`, `y`, `z`] as axis, axis_idx (axis)}
-          <input
-            aria-label="Cartesian {name} {axis}"
-            type="number"
-            step={0.1}
-            value={vector[axis_idx]}
-            oninput={(event) =>
-              update_vector(
-                key as `cartesian_point` | `cartesian_normal` | `cartesian_up`,
-                axis_idx,
-                event.currentTarget.valueAsNumber,
-              )}
-          />
-        {/each}
+        <span class="vector-inputs">
+          {#each [`x`, `y`, `z`] as axis, axis_idx (axis)}
+            <input
+              aria-label="Cartesian {name} {axis}"
+              type="number"
+              step={0.1}
+              value={vector[axis_idx]}
+              oninput={(event) =>
+                update_vector(key, axis_idx, event.currentTarget.valueAsNumber)}
+            />
+          {/each}
+        </span>
       </label>
     {/each}
-    <div class="plane-presets" aria-label="Cartesian plane presets">
-      {#each CARTESIAN_PLANE_PRESETS as { label, ...plane } (label)}
-        <button type="button" onclick={() => update_settings({ cartesian_point, ...plane })}>
-          {label}
+    <div class="setting">
+      <span>Plane presets</span>
+      <div class="plane-presets" aria-label="Cartesian plane presets">
+        {#each CARTESIAN_PLANE_PRESETS as { label, ...plane } (label)}
+          <button type="button" onclick={() => update_settings({ cartesian_point, ...plane })}>
+            {label}
+          </button>
+        {/each}
+        <button type="button" onclick={() => update_settings({ cartesian_point: undefined })}>
+          Center
         </button>
-      {/each}
-      <button type="button" onclick={() => update_settings({ cartesian_point: undefined })}>
-        Center
-      </button>
+      </div>
     </div>
   {/if}
 
-  <div class="control-row">
-    <label>
-      <span>Resolution (0 = native)</span>
-      <input
-        aria-label="Slice resolution"
-        type="number"
-        min={0}
-        step={1}
-        bind:value={
-          () => resolved_settings.resolution, (resolution) => update_settings({ resolution })
-        }
-      />
-    </label>
-    <label>
-      <span>View</span>
-      <select
-        aria-label="Slice rendering mode"
-        bind:value={
-          () => resolved_settings.render_mode,
-          (render_mode) => update_settings({ render_mode: render_mode as VolumeSliceMode })
-        }
-      >
-        <option value="both">Filled + contours</option>
-        <option value="filled">Filled</option>
-        <option value="contours">Contours</option>
-      </select>
-    </label>
-    <label>
-      <span>Colormap</span>
-      <select
-        aria-label="Slice colormap"
-        bind:value={
-          () => resolved_settings.colormap, (colormap) => update_settings({ colormap })
-        }
-      >
-        {#each ISO_COLORMAPS as colormap (colormap)}
-          <option value={colormap}>{colormap.replace(`interpolate`, ``)}</option>
-        {/each}
-      </select>
-    </label>
-    <label>
-      <span>Contours</span>
-      <input
-        aria-label="Slice contour levels"
-        type="number"
-        min={0}
-        max={50}
-        step={1}
-        bind:value={
-          () => resolved_settings.contour_levels,
-          (contour_levels) => update_settings({ contour_levels })
-        }
-      />
-    </label>
-  </div>
+  <label>
+    <span>Resolution (0 = native)</span>
+    <input
+      aria-label="Slice resolution"
+      type="number"
+      min={0}
+      step={1}
+      bind:value={
+        () => resolved_settings.resolution, (resolution) => update_settings({ resolution })
+      }
+    />
+  </label>
+  <label>
+    <span>View</span>
+    <select
+      aria-label="Slice rendering mode"
+      bind:value={
+        () => resolved_settings.render_mode,
+        (render_mode) => update_settings({ render_mode: render_mode as VolumeSliceMode })
+      }
+    >
+      <option value="both">Filled + contours</option>
+      <option value="filled">Filled</option>
+      <option value="contours">Contours</option>
+    </select>
+  </label>
+  <label>
+    <span>Colormap</span>
+    <select
+      aria-label="Slice colormap"
+      bind:value={
+        () => resolved_settings.colormap, (colormap) => update_settings({ colormap })
+      }
+    >
+      {#each ISO_COLORMAPS as colormap (colormap)}
+        <option value={colormap}>{colormap.replace(`interpolate`, ``)}</option>
+      {/each}
+    </select>
+  </label>
+  <label>
+    <span>Contours</span>
+    <input
+      aria-label="Slice contour levels"
+      type="number"
+      min={0}
+      max={50}
+      step={1}
+      bind:value={
+        () => resolved_settings.contour_levels,
+        (contour_levels) => update_settings({ contour_levels })
+      }
+    />
+  </label>
 
-  <label class="control-row range-control">
+  <label class="range-control">
     <span>Range</span>
-    {@render color_bound_input(0)}
-    <span>to</span>
-    {@render color_bound_input(1)}
-    <button type="button" onclick={() => update_settings({ color_range: undefined })}>
-      Auto
-    </button>
+    <span class="range-inputs">
+      {@render color_bound_input(0)}
+      <span>to</span>
+      {@render color_bound_input(1)}
+      <button type="button" onclick={() => update_settings({ color_range: undefined })}>
+        Auto
+      </button>
+    </span>
   </label>
 
   {#if active_volume}
@@ -251,34 +259,19 @@
 </SettingsSection>
 
 <style>
-  :global(.slice-settings) {
-    display: grid;
-    gap: 0.55em;
-  }
-  :is(.control-row, .plane-presets, .vector-control, label) {
+  :is(.plane-presets, .vector-inputs, .range-inputs) {
     display: flex;
     align-items: center;
     gap: 0.35em;
     flex-wrap: wrap;
   }
-  .control-row {
-    gap: 0.7em;
+  .vector-inputs {
+    input {
+      width: 5.5em;
+      min-width: 0;
+    }
   }
-  label > span:first-child {
-    font-size: 0.85em;
-    font-weight: 600;
-  }
-  .wide-control {
-    flex: 1;
-    min-width: 11em;
-  }
-  .wide-control input {
-    flex: 1;
-  }
-  :is(.vector-control > span, .vector-control input) {
-    width: 5.5em;
-  }
-  .range-control input {
+  .range-inputs input {
     width: 6.5em;
   }
   .plane-presets {
@@ -288,6 +281,7 @@
     padding: 0.15em 0.45em;
   }
   .grid-info {
+    grid-column: 1 / -1;
     opacity: 0.7;
     font-size: 0.8em;
   }

--- a/src/lib/isosurface/VolumeSliceControls.svelte
+++ b/src/lib/isosurface/VolumeSliceControls.svelte
@@ -134,7 +134,7 @@
     </div>
     <label>
       <span>Position</span>
-      <span>d = {resolved_settings.position.toFixed(2)}</span>
+      <span>d = {format_num(resolved_settings.position, `.2f`)}</span>
       <input
         type="range"
         min={0}

--- a/src/lib/layout/NumberRangeInput.svelte
+++ b/src/lib/layout/NumberRangeInput.svelte
@@ -7,12 +7,7 @@ svelte-widgets once a version above 1.4.0 is published. The upstream one additio
   import type { HTMLAttributes } from 'svelte/elements'
   import { tooltip } from 'svelte-widgets/attachments'
 
-  // Paired number + range input bound to the same value, wrapped in a flex <label>.
-  // The label text/markup is passed as children (supports inline units like <small>Å</small>).
-  // Pass a `title` to show a tooltip; the wrapping <label> only names the number input,
-  // so the range slider reuses that `title` as its accessible name.
-  // Children go in their own <span> so the label is exactly three elements (text, number,
-  // range), which lets a settings pane put every row on one shared column grid.
+  // Keep rows at exactly text/number/range; `title` also names the otherwise unlabelled slider.
   let {
     value = $bindable(),
     min,

--- a/src/lib/layout/NumberRangeInput.svelte
+++ b/src/lib/layout/NumberRangeInput.svelte
@@ -1,3 +1,7 @@
+<!-- NumberRangeInput now exists upstream. Delete this local copy and import it from
+svelte-widgets once a version above 1.4.0 is published. The upstream one additionally accepts
+`setting` + `schema` to resolve bounds itself; this pane resolves them at the call site via
+`setting_range()`, and upstream still honours plain min/max/step, so either style migrates. -->
 <script lang="ts">
   import type { Snippet } from 'svelte'
   import type { HTMLAttributes } from 'svelte/elements'
@@ -5,28 +9,32 @@
 
   // Paired number + range input bound to the same value, wrapped in a flex <label>.
   // The label text/markup is passed as children (supports inline units like <small>Å</small>).
-  // Pass a `title` (via rest) to show a tooltip; wrapping <label> only names the number input
-  // so range slider reuses that `title` as its accessible name.
+  // Pass a `title` to show a tooltip; the wrapping <label> only names the number input,
+  // so the range slider reuses that `title` as its accessible name.
+  // Children go in their own <span> so the label is exactly three elements (text, number,
+  // range), which lets a settings pane put every row on one shared column grid.
   let {
     value = $bindable(),
     min,
     max,
     step,
+    title,
     children,
     ...rest
-  }: {
+  }: Omit<HTMLAttributes<HTMLLabelElement>, `title`> & {
     value: number | undefined
-    min: number | string
-    max: number | string
-    step: number | string
+    min?: number | string
+    max?: number | string
+    step?: number | string
+    title?: string
     children?: Snippet
-  } & HTMLAttributes<HTMLLabelElement> = $props()
+  } = $props()
 </script>
 
-<label {@attach tooltip()} {...rest}>
-  {@render children?.()}
+<label {@attach tooltip()} {title} {...rest}>
+  <span class="label-text">{@render children?.()}</span>
   <input type="number" {min} {max} {step} bind:value />
-  <input type="range" {min} {max} {step} bind:value aria-label={rest.title} />
+  <input type="range" {min} {max} {step} bind:value aria-label={title} />
 </label>
 
 <style>
@@ -34,6 +42,10 @@
     display: flex;
     align-items: center;
     gap: 10pt;
+  }
+  /* no children means no label cell, so the flex gap shouldn't reserve one either */
+  .label-text:empty {
+    display: none;
   }
   input {
     font-size: inherit;

--- a/src/lib/layout/NumberRangeInput.svelte
+++ b/src/lib/layout/NumberRangeInput.svelte
@@ -29,12 +29,23 @@ svelte-widgets once a version above 1.4.0 is published. The upstream one additio
     title?: string
     children?: Snippet
   } = $props()
+
+  const update_value = (next_value: number | null | undefined): void => {
+    if (typeof next_value === `number` && Number.isFinite(next_value)) value = next_value
+  }
 </script>
 
 <label {@attach tooltip()} {title} {...rest}>
   <span class="label-text">{@render children?.()}</span>
-  <input type="number" {min} {max} {step} bind:value />
-  <input type="range" {min} {max} {step} bind:value aria-label={title} />
+  <input type="number" {min} {max} {step} bind:value={() => value, update_value} />
+  <input
+    type="range"
+    {min}
+    {max}
+    {step}
+    bind:value={() => value, update_value}
+    aria-label={title}
+  />
 </label>
 
 <style>

--- a/src/lib/layout/SettingsGroup.svelte
+++ b/src/lib/layout/SettingsGroup.svelte
@@ -1,0 +1,86 @@
+<!-- SettingsGroup now exists upstream. Delete this local copy and import it from
+svelte-widgets once a version above 1.4.0 is published; its API is unchanged. -->
+<script lang="ts">
+  // Collapsible grouping one level above SettingsSection.
+  import type { Snippet } from 'svelte'
+  import type { HTMLAttributes } from 'svelte/elements'
+  import { Icon } from 'svelte-widgets'
+  import { ChevronRight } from 'svelte-widgets/icons'
+
+  let {
+    title,
+    open = $bindable(false),
+    subtitle,
+    children,
+    ...rest
+  }: HTMLAttributes<HTMLDetailsElement> & {
+    title: string
+    open?: boolean
+    // Short right-aligned hint, e.g. a count or the active mode, readable while collapsed
+    subtitle?: string
+    children: Snippet
+  } = $props()
+</script>
+
+<details {...rest} class={[`settings-group`, rest.class]} bind:open>
+  <summary>
+    <Icon icon={ChevronRight} style="width: 0.85em; height: 0.85em" />
+    <span class="group-title">{title}</span>
+    {#if subtitle}<span class="group-subtitle">{subtitle}</span>{/if}
+  </summary>
+  <div class="group-body">{@render children()}</div>
+</details>
+
+<style>
+  .settings-group {
+    border-top: 1px solid
+      var(--settings-group-border, color-mix(in srgb, currentColor 12%, transparent));
+  }
+  .settings-group:first-of-type {
+    border-top: none;
+  }
+  summary {
+    display: flex;
+    align-items: center;
+    gap: 5pt;
+    padding: 5pt 2pt;
+    cursor: pointer;
+    user-select: none;
+    border-radius: var(--border-radius, 3pt);
+    list-style: none;
+    &::-webkit-details-marker {
+      display: none;
+    }
+    &:hover {
+      background: color-mix(in srgb, currentColor 7%, transparent);
+    }
+    /* the chevron is the only rotating part, so transition it rather than the whole row */
+    :global(svg) {
+      flex: none;
+      opacity: 0.6;
+      transition: transform 0.15s ease;
+    }
+  }
+  .settings-group[open] > summary :global(svg) {
+    transform: rotate(90deg);
+  }
+  .group-title {
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    font-size: 0.85em;
+  }
+  .group-subtitle {
+    margin-left: auto;
+    font-size: 0.8em;
+    opacity: 0.55;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .group-body {
+    display: grid;
+    gap: 3pt;
+    padding: 2pt 0 8pt 2pt;
+  }
+</style>

--- a/src/lib/layout/SettingsGroup.svelte
+++ b/src/lib/layout/SettingsGroup.svelte
@@ -34,9 +34,12 @@ svelte-widgets once a version above 1.4.0 is published; its API is unchanged. --
   .settings-group {
     border-top: 1px solid
       var(--settings-group-border, color-mix(in srgb, currentColor 12%, transparent));
-  }
-  .settings-group:first-of-type {
-    border-top: none;
+    &:first-of-type {
+      border-top: none;
+    }
+    &[open] > summary :global(svg) {
+      transform: rotate(90deg);
+    }
   }
   summary {
     display: flex;
@@ -58,9 +61,6 @@ svelte-widgets once a version above 1.4.0 is published; its API is unchanged. --
       opacity: 0.6;
       transition: transform 0.15s ease;
     }
-  }
-  .settings-group[open] > summary :global(svg) {
-    transform: rotate(90deg);
   }
   .group-title {
     font-weight: 600;

--- a/src/lib/layout/SettingsGroup.svelte
+++ b/src/lib/layout/SettingsGroup.svelte
@@ -1,7 +1,6 @@
 <!-- SettingsGroup now exists upstream. Delete this local copy and import it from
 svelte-widgets once a version above 1.4.0 is published; its API is unchanged. -->
 <script lang="ts">
-  // Collapsible grouping one level above SettingsSection.
   import type { Snippet } from 'svelte'
   import type { HTMLAttributes } from 'svelte/elements'
   import { Icon } from 'svelte-widgets'
@@ -54,7 +53,6 @@ svelte-widgets once a version above 1.4.0 is published; its API is unchanged. --
     &:hover {
       background: color-mix(in srgb, currentColor 7%, transparent);
     }
-    /* the chevron is the only rotating part, so transition it rather than the whole row */
     :global(svg) {
       flex: none;
       opacity: 0.6;

--- a/src/lib/layout/SettingsSearch.svelte
+++ b/src/lib/layout/SettingsSearch.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import type { Snippet } from 'svelte'
+  import { untrack, type Snippet } from 'svelte'
   import type { HTMLAttributes } from 'svelte/elements'
-  import { SvelteSet } from 'svelte/reactivity'
+  import { SvelteMap, SvelteSet } from 'svelte/reactivity'
 
   let {
     query = $bindable(``),
@@ -27,6 +27,7 @@
   // just because nothing resets it individually, so plain section rows count too.
   const row_selector = `[data-key], section.settings-section :is(label, .setting)`
   const search_hidden_attr = `data-search-hidden`
+  let refresh_rows = $state<(() => void) | undefined>()
 
   const filter_settings = (root: HTMLElement): (() => void) => {
     // Keep search visibility separate from caller-owned `hidden` state.
@@ -56,30 +57,71 @@
         return
       }
 
-      const matching_rows = new SvelteSet<HTMLElement>()
-      const rows = [...root.querySelectorAll<HTMLElement>(row_selector)].filter(
-        (row) =>
-          row.hasAttribute(`data-key`) ||
-          row.parentElement?.closest(`label, .setting`) === null,
-      )
-      for (const row of rows) {
+      const sections = [...root.querySelectorAll<HTMLElement>(`section.settings-section`)]
+      const groups = [...root.querySelectorAll<HTMLDetailsElement>(`details.settings-group`)]
+      // A row is reachable by its section/group title, but those headings also carry action
+      // buttons ("Explain", "Reset"). Their labels are chrome, not settings text, and would
+      // otherwise make a search for "reset" match every row in the section.
+      const container_titles = new SvelteMap<HTMLElement, string>()
+      const record_title = (container: HTMLElement, heading: Element | null): void => {
+        if (!(heading instanceof HTMLElement)) return
+        const copy = heading.cloneNode(true) as HTMLElement
+        for (const chrome of copy.querySelectorAll(`button`)) chrome.remove()
+        container_titles.set(container, copy.textContent ?? ``)
+      }
+      for (const section of sections) record_title(section, section.previousElementSibling)
+      for (const group of groups) {
+        record_title(group, group.querySelector(`:scope > summary`))
+      }
+      const row_contexts = [...root.querySelectorAll<HTMLElement>(row_selector)]
+        .filter(
+          (row) =>
+            row.hasAttribute(`data-key`) ||
+            row.parentElement?.closest(`label, .setting`) === null,
+        )
+        .map((row) => ({
+          row,
+          section: row.closest<HTMLElement>(`section.settings-section`),
+          group: row.closest<HTMLDetailsElement>(`details.settings-group`),
+        }))
+      const directly_matched_rows = new SvelteSet<HTMLElement>()
+      for (const { row, section, group } of row_contexts) {
         const searchable_text = [
           row.getAttribute(`data-label`),
           row.textContent,
           row.getAttribute(`data-description`),
+          section && container_titles.get(section),
+          group && container_titles.get(group),
         ]
           .filter((value): value is string => Boolean(value))
           .join(` `)
           .toLocaleLowerCase()
-        const matches = searchable_text.includes(normalized_query)
-        set_hidden(row, !matches)
-        // A row the caller hid stays hidden, so it must not count as a match either
-        if (matches && !row.hidden) matching_rows.add(row)
+        if (searchable_text.includes(normalized_query)) directly_matched_rows.add(row)
       }
-      const matches = [...matching_rows]
+      const matched_containers = new SvelteSet<HTMLElement>()
+      let matched_row_count = 0
+      for (const { row, section, group } of row_contexts) {
+        let ancestor = row.parentElement
+        let ancestor_matches = false
+        while (ancestor && ancestor !== root) {
+          if (directly_matched_rows.has(ancestor)) {
+            ancestor_matches = true
+            break
+          }
+          ancestor = ancestor.parentElement
+        }
+        const is_match = directly_matched_rows.has(row) || ancestor_matches
+        set_hidden(row, !is_match)
+        // A row the caller hid stays hidden, so it must not count as a match either
+        if (is_match && !row.hidden) {
+          matched_row_count += 1
+          if (section) matched_containers.add(section)
+          if (group) matched_containers.add(group)
+        }
+      }
 
-      for (const section of root.querySelectorAll<HTMLElement>(`section.settings-section`)) {
-        const section_matches = matches.some((row) => section.contains(row))
+      for (const section of sections) {
+        const section_matches = matched_containers.has(section)
         set_hidden(section, !section_matches)
         const heading = section.previousElementSibling
         if (heading instanceof HTMLElement && heading.matches(`h4`)) {
@@ -87,10 +129,8 @@
         }
       }
 
-      for (const group of root.querySelectorAll<HTMLDetailsElement>(
-        `details.settings-group`,
-      )) {
-        const group_matches = matches.some((row) => group.contains(row))
+      for (const group of groups) {
+        const group_matches = matched_containers.has(group)
         set_hidden(group, !group_matches)
         if (group_matches && !group.open) {
           group.open = true
@@ -98,7 +138,7 @@
         }
       }
 
-      match_count = matching_rows.size
+      match_count = matched_row_count
     }
 
     const schedule_refresh = (): void => {
@@ -117,15 +157,23 @@
       attributes: true,
       attributeFilter: [`data-description`, `data-label`, `data-key`],
     })
-    refresh()
+    refresh_rows = schedule_refresh
+    untrack(refresh)
 
     return () => {
       disposed = true
       observer.disconnect()
+      if (refresh_rows === schedule_refresh) refresh_rows = undefined
       restore_visibility()
       match_count = 0
     }
   }
+
+  $effect(() => {
+    // Track the query here so filtering does not recreate the observer on every keystroke.
+    void query
+    refresh_rows?.()
+  })
 
   const handle_keydown = (event: KeyboardEvent): void => {
     if (event.key !== `Escape` || !query) return

--- a/src/lib/layout/SettingsSearch.svelte
+++ b/src/lib/layout/SettingsSearch.svelte
@@ -36,7 +36,6 @@
     // Keep search visibility separate from caller-owned `hidden` state.
     const opened_by_search = new SvelteSet<HTMLDetailsElement>()
     let refresh_queued = false
-    let disposed = false
 
     const set_hidden = (element: HTMLElement, hide: boolean): void => {
       element.toggleAttribute(search_hidden_attr, hide)
@@ -52,7 +51,6 @@
     }
 
     const refresh = (): void => {
-      if (disposed) return
       const normalized_query = query.trim().toLocaleLowerCase()
       if (!normalized_query) {
         restore_visibility()
@@ -62,18 +60,20 @@
 
       const sections = [...root.querySelectorAll<HTMLElement>(`section.settings-section`)]
       const groups = [...root.querySelectorAll<HTMLDetailsElement>(`details.settings-group`)]
-      // A row is reachable by its section/group title, but those headings also carry action
-      // buttons ("Explain", "Reset"). Their labels are chrome, not settings text, and would
-      // otherwise make a search for "reset" match every row in the section.
       const container_titles = new SvelteMap<HTMLElement, string>()
-      const record_title = (container: HTMLElement, heading: Element | null): void => {
-        if (!(heading instanceof HTMLElement)) return
-        const copy = heading.cloneNode(true) as HTMLElement
-        for (const chrome of copy.querySelectorAll(`button`)) chrome.remove()
-        container_titles.set(container, copy.textContent ?? ``)
+      for (const section of sections) {
+        const heading = section.previousElementSibling
+        container_titles.set(
+          section,
+          heading?.querySelector(`.section-title`)?.textContent ?? ``,
+        )
       }
-      for (const section of sections) record_title(section, section.previousElementSibling)
-      for (const group of groups) record_title(group, group.querySelector(`:scope > summary`))
+      for (const group of groups) {
+        container_titles.set(
+          group,
+          group.querySelector(`:scope > summary .group-title`)?.textContent ?? ``,
+        )
+      }
       const row_contexts = [...root.querySelectorAll<HTMLElement>(row_selector)]
         .filter(
           (row) =>
@@ -94,7 +94,6 @@
           section && container_titles.get(section),
           group && container_titles.get(group),
         ]
-          .filter((value): value is string => Boolean(value))
           .join(` `)
           .toLocaleLowerCase()
         if (searchable_text.includes(normalized_query)) directly_matched_rows.push(row)
@@ -140,7 +139,7 @@
       refresh_queued = true
       queueMicrotask(() => {
         refresh_queued = false
-        refresh()
+        if (refresh_rows === schedule_refresh) refresh()
       })
     }
 
@@ -156,7 +155,6 @@
     untrack(refresh)
 
     return () => {
-      disposed = true
       observer.disconnect()
       if (refresh_rows === schedule_refresh) refresh_rows = undefined
       restore_visibility()
@@ -266,17 +264,19 @@
       }
     }
   }
-  .open-search {
+  :is(.open-search, .clear-search) {
     display: grid;
     place-items: center;
-    width: 1.8em;
-    height: 1.8em;
-    padding: 2pt;
     border: 0;
-    border-radius: var(--border-radius, 3pt);
     background: transparent;
     color: var(--text-color-muted, #6b7280);
     cursor: pointer;
+  }
+  .open-search {
+    inline-size: 1.8em;
+    block-size: 1.8em;
+    padding: 2pt;
+    border-radius: var(--border-radius, 3pt);
     &:hover {
       background: color-mix(in srgb, currentColor 8%, transparent);
       color: inherit;
@@ -290,16 +290,10 @@
     position: absolute;
     right: 3pt;
     bottom: 0;
-    display: grid;
-    place-items: center;
-    width: 18pt;
-    height: 1.8em;
+    inline-size: 18pt;
+    block-size: 1.8em;
     padding: 0;
-    border: 0;
-    background: transparent;
-    color: var(--text-color-muted, #6b7280);
     font: inherit;
-    cursor: pointer;
   }
   .no-matches {
     margin: 6pt 0;

--- a/src/lib/layout/SettingsSearch.svelte
+++ b/src/lib/layout/SettingsSearch.svelte
@@ -22,6 +22,7 @@
   const status_id = `settings-search-status-${search_id}`
   let search_open = $derived(Boolean(query))
   let search_input: HTMLInputElement | undefined = $state()
+  let search_trigger: HTMLButtonElement | undefined = $state()
   let match_count = $state(0)
   let no_matches = $derived(query.trim().length > 0 && match_count === 0)
 
@@ -40,6 +41,7 @@
     const set_hidden = (element: HTMLElement, hide: boolean): void => {
       element.toggleAttribute(search_hidden_attr, hide)
     }
+    const caller_visible = (row: HTMLElement): boolean => !row.closest(`[hidden]`)
 
     const restore_visibility = (): void => {
       for (const element of root.querySelectorAll(`[${search_hidden_attr}]`)) {
@@ -100,22 +102,26 @@
           .toLocaleLowerCase()
         if (searchable_text.includes(normalized_query)) directly_matched_rows.add(row)
       }
-      const matched_containers = new SvelteSet<HTMLElement>()
-      let matched_row_count = 0
-      for (const { row, section, group } of row_contexts) {
+      const matched_rows = new SvelteSet(directly_matched_rows)
+      const row_set = new SvelteSet(row_contexts.map(({ row }) => row))
+      // Preserve descendants of matched containers and ancestors of nested matches.
+      for (const { row } of row_contexts) {
         let ancestor = row.parentElement
-        let ancestor_matches = false
         while (ancestor && ancestor !== root) {
-          if (directly_matched_rows.has(ancestor)) {
-            ancestor_matches = true
-            break
+          if (directly_matched_rows.has(ancestor)) matched_rows.add(row)
+          if (directly_matched_rows.has(row) && row_set.has(ancestor)) {
+            matched_rows.add(ancestor)
           }
           ancestor = ancestor.parentElement
         }
-        const is_match = directly_matched_rows.has(row) || ancestor_matches
+      }
+      const matched_containers = new SvelteSet<HTMLElement>()
+      let matched_row_count = 0
+      for (const { row, section, group } of row_contexts) {
+        const is_match = matched_rows.has(row)
         set_hidden(row, !is_match)
-        // A row the caller hid stays hidden, so it must not count as a match either
-        if (is_match && !row.hidden) {
+        // Caller-hidden rows and descendants stay absent from the count and containers.
+        if (is_match && caller_visible(row)) {
           matched_row_count += 1
           if (section) matched_containers.add(section)
           if (group) matched_containers.add(group)
@@ -157,7 +163,8 @@
       childList: true,
       subtree: true,
       attributes: true,
-      attributeFilter: [`data-description`, `data-label`, `data-key`],
+      attributeFilter: [`data-description`, `data-label`, `data-key`, `hidden`],
+      characterData: true,
     })
     refresh_rows = schedule_refresh
     untrack(refresh)
@@ -183,12 +190,14 @@
     search_input?.focus()
   }
 
-  const handle_keydown = (event: KeyboardEvent): void => {
+  const handle_keydown = async (event: KeyboardEvent): Promise<void> => {
     if (event.key !== `Escape`) return
     event.preventDefault()
     event.stopPropagation()
     query = ``
     search_open = false
+    await tick()
+    search_trigger?.focus()
   }
 </script>
 
@@ -219,6 +228,7 @@
       {/if}
     {:else}
       <button
+        bind:this={search_trigger}
         type="button"
         class="open-search"
         aria-label={label}

--- a/src/lib/layout/SettingsSearch.svelte
+++ b/src/lib/layout/SettingsSearch.svelte
@@ -41,7 +41,6 @@
     const set_hidden = (element: HTMLElement, hide: boolean): void => {
       element.toggleAttribute(search_hidden_attr, hide)
     }
-    const caller_visible = (row: HTMLElement): boolean => !row.closest(`[hidden]`)
 
     const restore_visibility = (): void => {
       for (const element of root.querySelectorAll(`[${search_hidden_attr}]`)) {
@@ -74,9 +73,7 @@
         container_titles.set(container, copy.textContent ?? ``)
       }
       for (const section of sections) record_title(section, section.previousElementSibling)
-      for (const group of groups) {
-        record_title(group, group.querySelector(`:scope > summary`))
-      }
+      for (const group of groups) record_title(group, group.querySelector(`:scope > summary`))
       const row_contexts = [...root.querySelectorAll<HTMLElement>(row_selector)]
         .filter(
           (row) =>
@@ -88,7 +85,7 @@
           section: row.closest<HTMLElement>(`section.settings-section`),
           group: row.closest<HTMLDetailsElement>(`details.settings-group`),
         }))
-      const directly_matched_rows = new SvelteSet<HTMLElement>()
+      const directly_matched_rows: HTMLElement[] = []
       for (const { row, section, group } of row_contexts) {
         const searchable_text = [
           row.getAttribute(`data-label`),
@@ -100,28 +97,17 @@
           .filter((value): value is string => Boolean(value))
           .join(` `)
           .toLocaleLowerCase()
-        if (searchable_text.includes(normalized_query)) directly_matched_rows.add(row)
-      }
-      const matched_rows = new SvelteSet(directly_matched_rows)
-      const row_set = new SvelteSet(row_contexts.map(({ row }) => row))
-      // Preserve descendants of matched containers and ancestors of nested matches.
-      for (const { row } of row_contexts) {
-        let ancestor = row.parentElement
-        while (ancestor && ancestor !== root) {
-          if (directly_matched_rows.has(ancestor)) matched_rows.add(row)
-          if (directly_matched_rows.has(row) && row_set.has(ancestor)) {
-            matched_rows.add(ancestor)
-          }
-          ancestor = ancestor.parentElement
-        }
+        if (searchable_text.includes(normalized_query)) directly_matched_rows.push(row)
       }
       const matched_containers = new SvelteSet<HTMLElement>()
       let matched_row_count = 0
       for (const { row, section, group } of row_contexts) {
-        const is_match = matched_rows.has(row)
+        const is_match = directly_matched_rows.some(
+          (matched_row) => row.contains(matched_row) || matched_row.contains(row),
+        )
         set_hidden(row, !is_match)
         // Caller-hidden rows and descendants stay absent from the count and containers.
-        if (is_match && caller_visible(row)) {
+        if (is_match && !row.closest(`[hidden]`)) {
           matched_row_count += 1
           if (section) matched_containers.add(section)
           if (group) matched_containers.add(group)
@@ -221,9 +207,7 @@
           type="button"
           class="clear-search"
           aria-label="Clear settings search"
-          onclick={() => {
-            query = ``
-          }}>×</button
+          onclick={() => (query = ``)}>×</button
         >
       {/if}
     {:else}

--- a/src/lib/layout/SettingsSearch.svelte
+++ b/src/lib/layout/SettingsSearch.svelte
@@ -1,0 +1,218 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte'
+  import type { HTMLAttributes } from 'svelte/elements'
+  import { SvelteSet } from 'svelte/reactivity'
+
+  let {
+    query = $bindable(``),
+    label = `Search settings`,
+    placeholder = `Search settings`,
+    children,
+    ...rest
+  }: HTMLAttributes<HTMLDivElement> & {
+    query?: string
+    label?: string
+    placeholder?: string
+    children: Snippet
+  } = $props()
+
+  const search_id = $props.id()
+  const input_id = `settings-search-input-${search_id}`
+  const status_id = `settings-search-status-${search_id}`
+  let match_count = $state(0)
+  let filtering = $derived(query.trim().length > 0)
+  let no_matches = $derived(filtering && match_count === 0)
+
+  // Rows opt into per-row reset with `data-key`, but a setting must not be unreachable by search
+  // just because nothing resets it individually, so plain section rows count too.
+  const row_selector = `[data-key], section.settings-section :is(label, .setting)`
+  const search_hidden_attr = `data-search-hidden`
+
+  const filter_settings = (root: HTMLElement): (() => void) => {
+    // Keep search visibility separate from caller-owned `hidden` state.
+    const opened_by_search = new SvelteSet<HTMLDetailsElement>()
+    let refresh_queued = false
+    let disposed = false
+
+    const set_hidden = (element: HTMLElement, hide: boolean): void => {
+      element.toggleAttribute(search_hidden_attr, hide)
+    }
+
+    const restore_visibility = (): void => {
+      for (const element of root.querySelectorAll(`[${search_hidden_attr}]`)) {
+        element.removeAttribute(search_hidden_attr)
+      }
+      // Groups the user had open are never recorded, so their state survives untouched
+      for (const group of opened_by_search) group.open = false
+      opened_by_search.clear()
+    }
+
+    const refresh = (): void => {
+      if (disposed) return
+      const normalized_query = query.trim().toLocaleLowerCase()
+      if (!normalized_query) {
+        restore_visibility()
+        match_count = 0
+        return
+      }
+
+      const matching_rows = new SvelteSet<HTMLElement>()
+      const rows = [...root.querySelectorAll<HTMLElement>(row_selector)].filter(
+        (row) =>
+          row.hasAttribute(`data-key`) ||
+          row.parentElement?.closest(`label, .setting`) === null,
+      )
+      for (const row of rows) {
+        const searchable_text = [
+          row.getAttribute(`data-label`),
+          row.textContent,
+          row.getAttribute(`data-description`),
+        ]
+          .filter((value): value is string => Boolean(value))
+          .join(` `)
+          .toLocaleLowerCase()
+        const matches = searchable_text.includes(normalized_query)
+        set_hidden(row, !matches)
+        // A row the caller hid stays hidden, so it must not count as a match either
+        if (matches && !row.hidden) matching_rows.add(row)
+      }
+      const matches = [...matching_rows]
+
+      for (const section of root.querySelectorAll<HTMLElement>(`section.settings-section`)) {
+        const section_matches = matches.some((row) => section.contains(row))
+        set_hidden(section, !section_matches)
+        const heading = section.previousElementSibling
+        if (heading instanceof HTMLElement && heading.matches(`h4`)) {
+          set_hidden(heading, !section_matches)
+        }
+      }
+
+      for (const group of root.querySelectorAll<HTMLDetailsElement>(
+        `details.settings-group`,
+      )) {
+        const group_matches = matches.some((row) => group.contains(row))
+        set_hidden(group, !group_matches)
+        if (group_matches && !group.open) {
+          group.open = true
+          opened_by_search.add(group)
+        }
+      }
+
+      match_count = matching_rows.size
+    }
+
+    const schedule_refresh = (): void => {
+      if (refresh_queued) return
+      refresh_queued = true
+      queueMicrotask(() => {
+        refresh_queued = false
+        refresh()
+      })
+    }
+
+    const observer = new MutationObserver(schedule_refresh)
+    observer.observe(root, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: [`data-description`, `data-label`, `data-key`],
+    })
+    refresh()
+
+    return () => {
+      disposed = true
+      observer.disconnect()
+      restore_visibility()
+      match_count = 0
+    }
+  }
+
+  const handle_keydown = (event: KeyboardEvent): void => {
+    if (event.key !== `Escape` || !query) return
+    event.preventDefault()
+    event.stopPropagation()
+    query = ``
+  }
+</script>
+
+<div {...rest} class={[`settings-search`, rest.class]} {@attach filter_settings}>
+  <div class="search-field">
+    <label for={input_id}>{label}</label>
+    <input
+      id={input_id}
+      type="search"
+      bind:value={query}
+      {placeholder}
+      onkeydown={handle_keydown}
+      aria-describedby={no_matches ? status_id : undefined}
+    />
+    {#if query}
+      <button
+        type="button"
+        class="clear-search"
+        aria-label="Clear settings search"
+        onclick={() => {
+          query = ``
+        }}>×</button
+      >
+    {/if}
+  </div>
+  {@render children()}
+  {#if no_matches}
+    <p id={status_id} class="no-matches" role="status">No settings match “{query.trim()}”.</p>
+  {/if}
+</div>
+
+<style>
+  .settings-search {
+    display: contents;
+  }
+  .settings-search :global(:is([hidden], [data-search-hidden])) {
+    display: none !important;
+  }
+  .search-field {
+    position: relative;
+    display: grid;
+    gap: 2pt;
+    margin-block-end: 4pt;
+    label {
+      font-size: 0.78em;
+      font-weight: 600;
+      color: var(--text-color-muted, #6b7280);
+    }
+    input {
+      width: 100%;
+      box-sizing: border-box;
+      padding: 4pt 20pt 4pt 6pt;
+      border: 1px solid var(--border-color, #d1d5db);
+      border-radius: var(--border-radius, 3pt);
+      background: var(--input-bg, transparent);
+      color: inherit;
+      font: inherit;
+      &::-webkit-search-cancel-button {
+        appearance: none;
+      }
+    }
+  }
+  .clear-search {
+    position: absolute;
+    right: 3pt;
+    bottom: 3pt;
+    display: grid;
+    place-items: center;
+    width: 18pt;
+    height: 18pt;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: var(--text-color-muted, #6b7280);
+    font: inherit;
+    cursor: pointer;
+  }
+  .no-matches {
+    margin: 6pt 0;
+    color: var(--text-color-muted, #6b7280);
+    font-size: 0.85em;
+    text-align: center;
+  }
+</style>

--- a/src/lib/layout/SettingsSearch.svelte
+++ b/src/lib/layout/SettingsSearch.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
-  import { untrack, type Snippet } from 'svelte'
+  import { tick, untrack, type Snippet } from 'svelte'
   import type { HTMLAttributes } from 'svelte/elements'
   import { SvelteMap, SvelteSet } from 'svelte/reactivity'
+  import { Icon } from 'svelte-widgets'
+  import { Search } from 'svelte-widgets/icons'
 
   let {
     query = $bindable(``),
@@ -17,8 +19,9 @@
   } = $props()
 
   const search_id = $props.id()
-  const input_id = `settings-search-input-${search_id}`
   const status_id = `settings-search-status-${search_id}`
+  let search_open = $derived(Boolean(query))
+  let search_input: HTMLInputElement | undefined = $state()
   let match_count = $state(0)
   let no_matches = $derived(query.trim().length > 0 && match_count === 0)
 
@@ -174,34 +177,56 @@
     refresh_rows?.()
   })
 
+  const open_search = async (): Promise<void> => {
+    search_open = true
+    await tick()
+    search_input?.focus()
+  }
+
   const handle_keydown = (event: KeyboardEvent): void => {
-    if (event.key !== `Escape` || !query) return
+    if (event.key !== `Escape`) return
     event.preventDefault()
     event.stopPropagation()
     query = ``
+    search_open = false
   }
 </script>
 
 <div {...rest} class={[`settings-search`, rest.class]} {@attach filter_settings}>
-  <div class="search-field">
-    <label for={input_id}>{label}</label>
-    <input
-      id={input_id}
-      type="search"
-      bind:value={query}
-      {placeholder}
-      onkeydown={handle_keydown}
-      aria-describedby={no_matches ? status_id : undefined}
-    />
-    {#if query}
+  <div class:open={search_open} class="search-field">
+    {#if search_open}
+      <input
+        bind:this={search_input}
+        type="search"
+        bind:value={query}
+        {placeholder}
+        aria-label={label}
+        onkeydown={handle_keydown}
+        onblur={() => {
+          if (!query) search_open = false
+        }}
+        aria-describedby={no_matches ? status_id : undefined}
+      />
+      {#if query}
+        <button
+          type="button"
+          class="clear-search"
+          aria-label="Clear settings search"
+          onclick={() => {
+            query = ``
+          }}>×</button
+        >
+      {/if}
+    {:else}
       <button
         type="button"
-        class="clear-search"
-        aria-label="Clear settings search"
-        onclick={() => {
-          query = ``
-        }}>×</button
+        class="open-search"
+        aria-label={label}
+        title={label}
+        onclick={open_search}
       >
+        <Icon icon={Search} />
+      </button>
     {/if}
   </div>
   {@render children()}
@@ -212,25 +237,31 @@
 
 <style>
   .settings-search {
-    display: contents;
+    position: relative;
+    display: grid;
+    gap: var(--pane-gap, 4pt);
   }
   .settings-search :global(:is([hidden], [data-search-hidden])) {
     display: none !important;
   }
   .search-field {
-    position: relative;
-    display: grid;
-    gap: 2pt;
-    margin-block-end: 4pt;
-    label {
-      font-size: 0.78em;
-      font-weight: 600;
-      color: var(--text-color-muted, #6b7280);
+    position: absolute;
+    top: 0;
+    right: 0;
+    display: flex;
+    justify-content: flex-end;
+    z-index: 1;
+    &.open {
+      position: relative;
+      inset: auto;
+      width: 100%;
+      margin-block-end: 4pt;
     }
     input {
       width: 100%;
+      height: 1.8em;
       box-sizing: border-box;
-      padding: 4pt 20pt 4pt 6pt;
+      padding: 1pt 20pt 1pt 6pt;
       border: 1px solid var(--border-color, #d1d5db);
       border-radius: var(--border-radius, 3pt);
       background: var(--input-bg, transparent);
@@ -241,14 +272,34 @@
       }
     }
   }
+  .open-search {
+    display: grid;
+    place-items: center;
+    width: 1.8em;
+    height: 1.8em;
+    padding: 2pt;
+    border: 0;
+    border-radius: var(--border-radius, 3pt);
+    background: transparent;
+    color: var(--text-color-muted, #6b7280);
+    cursor: pointer;
+    &:hover {
+      background: color-mix(in srgb, currentColor 8%, transparent);
+      color: inherit;
+    }
+    :global(svg) {
+      width: 1em;
+      height: 1em;
+    }
+  }
   .clear-search {
     position: absolute;
     right: 3pt;
-    bottom: 3pt;
+    bottom: 0;
     display: grid;
     place-items: center;
     width: 18pt;
-    height: 18pt;
+    height: 1.8em;
     padding: 0;
     border: 0;
     background: transparent;

--- a/src/lib/layout/SettingsSearch.svelte
+++ b/src/lib/layout/SettingsSearch.svelte
@@ -20,8 +20,7 @@
   const input_id = `settings-search-input-${search_id}`
   const status_id = `settings-search-status-${search_id}`
   let match_count = $state(0)
-  let filtering = $derived(query.trim().length > 0)
-  let no_matches = $derived(filtering && match_count === 0)
+  let no_matches = $derived(query.trim().length > 0 && match_count === 0)
 
   // Rows opt into per-row reset with `data-key`, but a setting must not be unreachable by search
   // just because nothing resets it individually, so plain section rows count too.

--- a/src/lib/layout/SettingsSection.svelte
+++ b/src/lib/layout/SettingsSection.svelte
@@ -122,10 +122,10 @@ svelte-widgets once a version above 1.4.0 is published; its API is otherwise unc
   function handle_reset(event: MouseEvent) {
     event.stopPropagation()
     event.preventDefault()
-    if (on_reset) on_reset()
+    if (on_reset) return on_reset()
     // Iterating reads changed_keys once, which is what we want: the derived shrinks under us as
     // each reset_key hands the reference value back to the caller.
-    else for (const key of changed_keys) reset_key(key)
+    for (const key of changed_keys) reset_key(key)
   }
 
   function handle_descriptions_toggle(event: MouseEvent) {
@@ -252,8 +252,7 @@ svelte-widgets once a version above 1.4.0 is published; its API is otherwise unc
         enhancement.description_element = null
       }
 
-      const needs_reset = Boolean(on_reset_key) && changed_keys.includes(key)
-      if (!needs_reset) remove_reset_button(row, enhancement)
+      if (!on_reset_key || !changed_keys.includes(key)) remove_reset_button(row, enhancement)
       else {
         if (!enhancement.reset_button) {
           const reset_button = document.createElement(`button`)

--- a/src/lib/layout/SettingsSection.svelte
+++ b/src/lib/layout/SettingsSection.svelte
@@ -1,8 +1,7 @@
 <!-- SettingsSection now exists upstream. Delete this local copy and import it from
 svelte-widgets once a version above 1.4.0 is published; its API is otherwise unchanged. -->
 <script lang="ts">
-  import type { Snippet } from 'svelte'
-  import { untrack } from 'svelte'
+  import { untrack, type Snippet } from 'svelte'
   import type { HTMLAttributes } from 'svelte/elements'
   import { SvelteMap, SvelteSet } from 'svelte/reactivity'
   import { Icon } from 'svelte-widgets'
@@ -88,11 +87,7 @@ svelte-widgets once a version above 1.4.0 is published; its API is otherwise unc
       )
     }
     if (left instanceof RegExp || right instanceof RegExp) {
-      return (
-        left instanceof RegExp &&
-        right instanceof RegExp &&
-        left.toString() === right.toString()
-      )
+      return left instanceof RegExp && right instanceof RegExp && `${left}` === `${right}`
     }
     if (Array.isArray(left) || Array.isArray(right)) {
       if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) {
@@ -118,14 +113,8 @@ svelte-widgets once a version above 1.4.0 is published; its API is otherwise unc
         !setting_equal(reference_values[key], current_values[key]),
     ),
   )
-  let has_changes = $derived(changed_keys.length > 0)
   let has_descriptions = $state(false)
   let refresh_rows = $state<(() => void) | undefined>()
-
-  const description_for = (key: string): string | undefined => {
-    const metadata = setting_metadata?.[key]
-    return typeof metadata === `string` ? metadata : metadata?.description
-  }
 
   const reset_key = (key: string): void => {
     if (!on_reset_key || !changed_keys.includes(key)) return
@@ -242,7 +231,9 @@ svelte-widgets once a version above 1.4.0 is published; its API is otherwise unc
       }
       sync_labelled_controls(row)
 
-      const mapped_description = description_for(key)
+      const metadata = setting_metadata?.[key]
+      const mapped_description =
+        typeof metadata === `string` ? metadata : metadata?.description
       if (mapped_description) row.setAttribute(`data-description`, mapped_description)
       else if (enhancement.original_description === null)
         row.removeAttribute(`data-description`)
@@ -336,9 +327,7 @@ svelte-widgets once a version above 1.4.0 is published; its API is otherwise unc
 
   $effect(() => {
     // Track reactive inputs here so refreshing rows does not recreate the observer or its nodes.
-    void changed_keys
-    void descriptions_open
-    void setting_metadata
+    void [changed_keys, descriptions_open, setting_metadata]
     refresh_rows?.()
   })
 </script>
@@ -346,7 +335,7 @@ svelte-widgets once a version above 1.4.0 is published; its API is otherwise unc
 <h4 id={title_id}>
   {title}
 
-  {#if has_descriptions || has_changes}
+  {#if has_descriptions || changed_keys.length}
     <span class="heading-actions">
       {#if has_descriptions}
         <button
@@ -361,7 +350,7 @@ svelte-widgets once a version above 1.4.0 is published; its API is otherwise unc
           Explain
         </button>
       {/if}
-      {#if has_changes}
+      {#if changed_keys.length}
         <button
           type="button"
           class="reset-button"

--- a/src/lib/layout/SettingsSection.svelte
+++ b/src/lib/layout/SettingsSection.svelte
@@ -3,7 +3,7 @@ svelte-widgets once a version above 1.4.0 is published; its API is otherwise unc
 <script lang="ts">
   import { untrack, type Snippet } from 'svelte'
   import type { HTMLAttributes } from 'svelte/elements'
-  import { SvelteMap, SvelteSet } from 'svelte/reactivity'
+  import { SvelteMap } from 'svelte/reactivity'
   import { Icon } from 'svelte-widgets'
   import { Reset } from 'svelte-widgets/icons'
 
@@ -81,18 +81,15 @@ svelte-widgets once a version above 1.4.0 is published; its API is otherwise unc
     if (left === right || Object.is(left, right)) return true
     if (left == null || right == null) return false
     if (typeof left !== `object` || typeof right !== `object`) return false
-    if (left instanceof Date || right instanceof Date) {
+    if (left instanceof Date || right instanceof Date)
       return (
         left instanceof Date && right instanceof Date && left.getTime() === right.getTime()
       )
-    }
-    if (left instanceof RegExp || right instanceof RegExp) {
+    if (left instanceof RegExp || right instanceof RegExp)
       return left instanceof RegExp && right instanceof RegExp && `${left}` === `${right}`
-    }
     if (Array.isArray(left) || Array.isArray(right)) {
-      if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) {
+      if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length)
         return false
-      }
       return left.every((item, idx) => setting_equal(item, right[idx]))
     }
     const left_obj = left as Record<string, unknown>
@@ -138,7 +135,6 @@ svelte-widgets once a version above 1.4.0 is published; its API is otherwise unc
   }
 
   type EnhancedRow = {
-    row: HTMLElement
     original_description: string | null
     description_element: HTMLElement | null
     reset_button: HTMLButtonElement | null
@@ -164,22 +160,22 @@ svelte-widgets once a version above 1.4.0 is published; its API is otherwise unc
     let refresh_queued = false
     let disposed = false
 
-    const remove_reset_button = (enhancement: EnhancedRow): void => {
+    const remove_reset_button = (row: HTMLElement, enhancement: EnhancedRow): void => {
       enhancement.reset_button?.remove()
       enhancement.reset_button = null
-      enhancement.row.classList.remove(`has-setting-reset`)
+      row.classList.remove(`has-setting-reset`)
     }
 
-    const cleanup_enhancement = (enhancement: EnhancedRow): void => {
+    const cleanup_enhancement = (row: HTMLElement, enhancement: EnhancedRow): void => {
       enhancement.description_element?.remove()
-      remove_reset_button(enhancement)
-      for (const control of enhancement.row.querySelectorAll(`[${auto_label_attr}]`)) {
+      remove_reset_button(row, enhancement)
+      for (const control of row.querySelectorAll(`[${auto_label_attr}]`)) {
         release_auto_label(control)
       }
       if (enhancement.original_description === null) {
-        enhancement.row.removeAttribute(`data-description`)
+        row.removeAttribute(`data-description`)
       } else {
-        enhancement.row.setAttribute(`data-description`, enhancement.original_description)
+        row.setAttribute(`data-description`, enhancement.original_description)
       }
     }
 
@@ -216,13 +212,12 @@ svelte-widgets once a version above 1.4.0 is published; its API is otherwise unc
       }
     }
 
-    const enhance_row = (row: HTMLElement, changed_key_set: SvelteSet<string>): boolean => {
+    const enhance_row = (row: HTMLElement): boolean => {
       const key = row.dataset.key
       if (!key) return false
       let enhancement = enhanced_rows.get(row)
       if (!enhancement) {
         enhancement = {
-          row,
           original_description: row.getAttribute(`data-description`),
           description_element: null,
           reset_button: null,
@@ -257,8 +252,8 @@ svelte-widgets once a version above 1.4.0 is published; its API is otherwise unc
         enhancement.description_element = null
       }
 
-      const needs_reset = Boolean(on_reset_key) && changed_key_set.has(key)
-      if (!needs_reset) remove_reset_button(enhancement)
+      const needs_reset = Boolean(on_reset_key) && changed_keys.includes(key)
+      if (!needs_reset) remove_reset_button(row, enhancement)
       else {
         if (!enhancement.reset_button) {
           const reset_button = document.createElement(`button`)
@@ -284,14 +279,13 @@ svelte-widgets once a version above 1.4.0 is published; its API is otherwise unc
     const refresh = (): void => {
       if (disposed) return
       let found_description = false
-      const changed_key_set = new SvelteSet(changed_keys)
       for (const row of section.querySelectorAll<HTMLElement>(`[data-key]`)) {
-        found_description = enhance_row(row, changed_key_set) || found_description
+        found_description = enhance_row(row) || found_description
       }
       has_descriptions = found_description
       for (const [row, enhancement] of enhanced_rows) {
         if (!row.isConnected || !section.contains(row) || !row.dataset.key) {
-          cleanup_enhancement(enhancement)
+          cleanup_enhancement(row, enhancement)
           enhanced_rows.delete(row)
         }
       }
@@ -320,7 +314,7 @@ svelte-widgets once a version above 1.4.0 is published; its API is otherwise unc
       disposed = true
       observer.disconnect()
       if (refresh_rows === schedule_refresh) refresh_rows = undefined
-      for (const enhancement of enhanced_rows.values()) cleanup_enhancement(enhancement)
+      for (const [row, enhancement] of enhanced_rows) cleanup_enhancement(row, enhancement)
       has_descriptions = false
     }
   }

--- a/src/lib/layout/SettingsSection.svelte
+++ b/src/lib/layout/SettingsSection.svelte
@@ -1,32 +1,57 @@
+<!-- SettingsSection now exists upstream. Delete this local copy and import it from
+svelte-widgets once a version above 1.4.0 is published; its API is otherwise unchanged. -->
 <script lang="ts">
-  import { Icon } from 'svelte-widgets'
-  import { Reset } from 'svelte-widgets/icons'
   import type { Snippet } from 'svelte'
   import { untrack } from 'svelte'
   import type { HTMLAttributes } from 'svelte/elements'
+  import { SvelteMap, SvelteSet } from 'svelte/reactivity'
+  import { Icon } from 'svelte-widgets'
+  import { Reset } from 'svelte-widgets/icons'
 
-  type SettingsSectionContext = {
-    current_values: Record<string, unknown>
-    has_changes: boolean
-    reference_values: Record<string, unknown>
-  }
+  type SettingMetadata = Readonly<
+    Record<string, string | { readonly description: string } | undefined>
+  >
 
   let {
     title,
-    current_values,
+    current_values = {},
+    reset_values,
     children,
-    on_reset = () => {},
+    layout = `flow`,
+    on_reset,
+    on_reset_key,
+    setting_metadata,
+    descriptions_open = $bindable(false),
     ...rest
   }: HTMLAttributes<HTMLElementTagNameMap[`section`]> & {
     title: string
-    current_values: Record<string, unknown>
-    children: Snippet<[SettingsSectionContext]>
+    // Omit for a section that only holds actions (export buttons, say) and has nothing to diff.
+    current_values?: Record<string, unknown>
+    // Optional reset baseline. Only keys present in current_values are captured.
+    reset_values?: Record<string, unknown>
+    children: Snippet
+    // `grid` puts every direct label/.setting row on one shared [label][value][wide] column
+    // rhythm, so number inputs and sliders line up down the whole section instead of each
+    // row's controls starting wherever its label text happens to end. `flow` leaves layout
+    // to the caller (the historical behaviour).
+    layout?: `flow` | `grid`
+    // Omit to reset every changed key through `on_reset_key`. Pass one only for sections whose
+    // reset has to do more than restore values (clearing validation state, for instance).
     on_reset?: () => void
+    // Rows opt in with `data-key`. The callback receives the mounted reference value and
+    // whether that key originally existed, so callers can restore or delete it exactly.
+    on_reset_key?: (key: string, reference_value: unknown, reference_present: boolean) => void
+    // Accepts SETTINGS_CONFIG directly as well as a compact key-to-description map.
+    setting_metadata?: SettingMetadata
+    descriptions_open?: boolean
   } = $props()
 
   // Create a deep copy of current_values on mount to use as reference values
   function deep_copy(obj: unknown): unknown {
     if (obj === null || typeof obj !== `object`) return obj
+    if (obj instanceof Set || obj instanceof Map) {
+      throw new TypeError(`SettingsSection values must not contain Set or Map instances`)
+    }
     if (obj instanceof Date) return new Date(obj)
     if (obj instanceof RegExp) return new RegExp(obj)
     if (Array.isArray(obj)) return obj.map(deep_copy)
@@ -36,7 +61,14 @@
   }
 
   // Capture initial values once at mount - must NOT be $derived or it tracks changes
-  const reference_values = untrack(() => deep_copy(current_values) as Record<string, unknown>)
+  const reference_values = untrack(() => {
+    if (!reset_values) return deep_copy(current_values) as Record<string, unknown>
+    return Object.fromEntries(
+      Object.keys(current_values)
+        .filter((key) => Object.hasOwn(reset_values, key))
+        .map((key) => [key, deep_copy(reset_values[key])]),
+    )
+  })
 
   // unique per-instance id so aria-labelledby stays valid with multiple sections on a page
   const section_id = $props.id()
@@ -76,40 +108,282 @@
 
   // Key presence is independent of value: additions/removals count even when the
   // value is undefined. Only compare values when both sides own the key.
-  let has_changes = $derived(
-    [...new Set([...Object.keys(reference_values), ...Object.keys(current_values)])].some(
-      (key) => {
-        const in_reference = Object.hasOwn(reference_values, key)
-        const in_current = Object.hasOwn(current_values, key)
-        if (in_reference !== in_current) return true
-        return !setting_equal(reference_values[key], current_values[key])
-      },
-    ),
+  let changed_keys = $derived(
+    [
+      ...new SvelteSet([...Object.keys(reference_values), ...Object.keys(current_values)]),
+    ].filter((key) => {
+      const in_reference = Object.hasOwn(reference_values, key)
+      const in_current = Object.hasOwn(current_values, key)
+      return (
+        in_reference !== in_current ||
+        !setting_equal(reference_values[key], current_values[key])
+      )
+    }),
   )
+  let has_changes = $derived(changed_keys.length > 0)
+  let has_descriptions = $state(false)
+  let refresh_rows = $state<(() => void) | undefined>()
+
+  const description_for = (key: string): string | undefined => {
+    const metadata = setting_metadata?.[key]
+    return typeof metadata === `string` ? metadata : metadata?.description
+  }
+
+  const reset_key = (key: string): void => {
+    if (!on_reset_key || !changed_keys.includes(key)) return
+    const reference_present = Object.hasOwn(reference_values, key)
+    on_reset_key(key, deep_copy(reference_values[key]), reference_present)
+  }
+
   function handle_reset(event: MouseEvent) {
     event.stopPropagation()
     event.preventDefault()
-    on_reset()
+    if (on_reset) on_reset()
+    // Iterating reads changed_keys once, which is what we want: the derived shrinks under us as
+    // each reset_key hands the reference value back to the caller.
+    else for (const key of changed_keys) reset_key(key)
   }
+
+  function handle_descriptions_toggle(event: MouseEvent) {
+    event.stopPropagation()
+    event.preventDefault()
+    descriptions_open = !descriptions_open
+  }
+
+  type EnhancedRow = {
+    row: HTMLElement
+    original_description: string | null
+    description_element: HTMLElement | null
+    reset_button: HTMLButtonElement | null
+  }
+
+  // A <label> only names its first control, so the slider paired with a number input would go
+  // unnamed. Mark every control we name with the exact text used: that is enough to rename or
+  // revoke it on a later pass without keeping a registry of elements, and it works on rows
+  // Svelte has already detached.
+  const auto_label_attr = `data-auto-label`
+
+  const release_auto_label = (control: Element): void => {
+    if (control.getAttribute(`aria-label`) === control.getAttribute(auto_label_attr)) {
+      control.removeAttribute(`aria-label`)
+    }
+    control.removeAttribute(auto_label_attr)
+  }
+
+  // Enhance only explicitly keyed rows. Callers that omit both opt-in props never attach this
+  // behavior, preserving the historical DOM and event handling.
+  const enhance_rows = (section: HTMLElement): (() => void) => {
+    const enhanced_rows = new SvelteMap<HTMLElement, EnhancedRow>()
+    let refresh_queued = false
+    let disposed = false
+
+    const remove_reset_button = (enhancement: EnhancedRow): void => {
+      enhancement.reset_button?.remove()
+      enhancement.reset_button = null
+      enhancement.row.classList.remove(`has-setting-reset`)
+    }
+
+    const cleanup_enhancement = (enhancement: EnhancedRow): void => {
+      enhancement.description_element?.remove()
+      remove_reset_button(enhancement)
+      for (const control of enhancement.row.querySelectorAll(`[${auto_label_attr}]`)) {
+        release_auto_label(control)
+      }
+      if (enhancement.original_description === null) {
+        enhancement.row.removeAttribute(`data-description`)
+      } else {
+        enhancement.row.setAttribute(`data-description`, enhancement.original_description)
+      }
+    }
+
+    const label_text = (row: HTMLLabelElement): string => {
+      const label_copy = row.cloneNode(true) as HTMLElement
+      for (const control of label_copy.querySelectorAll(
+        `input, select, textarea, button, .settings-row-description`,
+      )) {
+        control.remove()
+      }
+      return (row.dataset.label ?? label_copy.textContent ?? ``)
+        .replaceAll(/\s+/gu, ` `)
+        .trim()
+    }
+
+    const sync_labelled_controls = (row: HTMLElement): void => {
+      const label = row instanceof HTMLLabelElement ? label_text(row) : ``
+      for (const control of row.querySelectorAll(`input, select, textarea`)) {
+        const marker = control.getAttribute(auto_label_attr)
+        const own_label = control.getAttribute(`aria-label`)
+        // An author-set name always wins, whether it was there first or replaced ours
+        if (
+          marker === null &&
+          (own_label !== null || control.hasAttribute(`aria-labelledby`))
+        ) {
+          continue
+        }
+        if (marker !== null && own_label !== marker) control.removeAttribute(auto_label_attr)
+        else if (!label) release_auto_label(control)
+        else if (marker !== label) {
+          control.setAttribute(`aria-label`, label)
+          control.setAttribute(auto_label_attr, label)
+        }
+      }
+    }
+
+    const enhance_row = (row: HTMLElement): boolean => {
+      const key = row.dataset.key
+      if (!key) return false
+      let enhancement = enhanced_rows.get(row)
+      if (!enhancement) {
+        enhancement = {
+          row,
+          original_description: row.getAttribute(`data-description`),
+          description_element: null,
+          reset_button: null,
+        }
+        enhanced_rows.set(row, enhancement)
+      }
+      sync_labelled_controls(row)
+
+      const mapped_description = description_for(key)
+      if (mapped_description) row.setAttribute(`data-description`, mapped_description)
+      else if (enhancement.original_description === null)
+        row.removeAttribute(`data-description`)
+      else row.setAttribute(`data-description`, enhancement.original_description)
+
+      const description = mapped_description ?? enhancement.original_description ?? undefined
+      if (descriptions_open && description) {
+        if (!enhancement.description_element) {
+          const description_element = document.createElement(`small`)
+          description_element.className = `settings-row-description`
+          enhancement.description_element = description_element
+          row.append(description_element)
+        }
+        // Avoid notifying our own subtree observer forever: assigning textContent replaces
+        // the text node even when the string is unchanged.
+        if (enhancement.description_element.textContent !== description) {
+          enhancement.description_element.textContent = description
+        }
+      } else {
+        enhancement.description_element?.remove()
+        enhancement.description_element = null
+      }
+
+      const needs_reset = Boolean(on_reset_key) && changed_keys.includes(key)
+      if (!needs_reset) remove_reset_button(enhancement)
+      else {
+        if (!enhancement.reset_button) {
+          const reset_button = document.createElement(`button`)
+          reset_button.type = `button`
+          reset_button.className = `setting-reset-button`
+          reset_button.textContent = `↶`
+          // Resolve the key at click time so a row that changes data-key needs no rewiring
+          reset_button.addEventListener(`click`, (event) => {
+            event.preventDefault()
+            event.stopPropagation()
+            if (row.dataset.key) reset_key(row.dataset.key)
+          })
+          enhancement.reset_button = reset_button
+          row.classList.add(`has-setting-reset`)
+          row.append(reset_button)
+        }
+        enhancement.reset_button.setAttribute(`aria-label`, `Reset ${key} to default`)
+        enhancement.reset_button.title = `Reset ${key} to default`
+      }
+      return Boolean(mapped_description)
+    }
+
+    const refresh = (): void => {
+      if (disposed) return
+      let found_description = false
+      for (const row of section.querySelectorAll<HTMLElement>(`[data-key]`)) {
+        found_description = enhance_row(row) || found_description
+      }
+      has_descriptions = found_description
+      for (const [row, enhancement] of enhanced_rows) {
+        if (!row.isConnected || !section.contains(row) || !row.dataset.key) {
+          cleanup_enhancement(enhancement)
+          enhanced_rows.delete(row)
+        }
+      }
+    }
+
+    const schedule_refresh = (): void => {
+      if (refresh_queued) return
+      refresh_queued = true
+      queueMicrotask(() => {
+        refresh_queued = false
+        refresh()
+      })
+    }
+
+    const observer = new MutationObserver(schedule_refresh)
+    observer.observe(section, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: [`data-key`, `data-label`],
+    })
+    refresh_rows = schedule_refresh
+    untrack(refresh)
+
+    return () => {
+      disposed = true
+      observer.disconnect()
+      if (refresh_rows === schedule_refresh) refresh_rows = undefined
+      for (const enhancement of enhanced_rows.values()) cleanup_enhancement(enhancement)
+      has_descriptions = false
+    }
+  }
+
+  $effect(() => {
+    // Track reactive inputs here so refreshing rows does not recreate the observer or its nodes.
+    void changed_keys
+    void descriptions_open
+    void setting_metadata
+    refresh_rows?.()
+  })
 </script>
 
 <h4 id={title_id}>
   {title}
 
-  {#if has_changes}
-    <button
-      class="reset-button"
-      onclick={handle_reset}
-      title="Reset {title.toLowerCase()} to defaults"
-      aria-label="Reset {title.toLowerCase()} to defaults"
-    >
-      <Icon icon={Reset} style="width: 0.9em; height: 0.9em" />
-      Reset
-    </button>
+  {#if has_descriptions || has_changes}
+    <span class="heading-actions">
+      {#if has_descriptions}
+        <button
+          type="button"
+          class="description-toggle"
+          onclick={handle_descriptions_toggle}
+          aria-expanded={descriptions_open}
+          aria-label="{descriptions_open
+            ? `Hide`
+            : `Show`} descriptions for {title.toLowerCase()}"
+        >
+          Explain
+        </button>
+      {/if}
+      {#if has_changes}
+        <button
+          type="button"
+          class="reset-button"
+          onclick={handle_reset}
+          title="Reset {title.toLowerCase()} to defaults"
+          aria-label="Reset {title.toLowerCase()} to defaults"
+        >
+          <Icon icon={Reset} style="width: 0.9em; height: 0.9em" />
+          Reset
+        </button>
+      {/if}
+    </span>
   {/if}
 </h4>
-<section {...rest} aria-labelledby={title_id}>
-  {@render children?.({ current_values, has_changes, reference_values })}
+<section
+  {...rest}
+  class={[`settings-section`, rest.class, layout]}
+  aria-labelledby={title_id}
+  {@attach on_reset_key || setting_metadata ? enhance_rows : null}
+>
+  {@render children()}
 </section>
 
 <style>
@@ -117,13 +391,7 @@
     margin: 0;
     position: relative;
   }
-  .reset-button {
-    position: absolute;
-    top: 0;
-    right: 0;
-    display: flex;
-    align-items: center;
-    gap: 2pt;
+  :is(.reset-button, .description-toggle) {
     padding: var(--reset-btn-padding, 1pt 4pt);
     font-size: 0.65em;
     border-radius: var(--reset-btn-border-radius, var(--border-radius, 3pt));
@@ -131,15 +399,117 @@
     color: var(--text-color-muted, #6b7280);
     border: 1px solid var(--border-color, #d1d5db);
     cursor: pointer;
-    z-index: 5;
-    transition: all 0.15s ease;
     box-shadow: none;
     opacity: 0.7;
   }
-  .reset-button:hover {
+  :is(
+    .reset-button:hover,
+    .description-toggle:hover,
+    .description-toggle[aria-expanded='true']
+  ) {
     background: var(--btn-bg-hover, rgba(0, 0, 0, 0.2));
     color: var(--text-color, #374151);
     opacity: 1;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  }
+  .reset-button {
+    display: flex;
+    align-items: center;
+    gap: 2pt;
+    transition: all 0.15s ease;
+    &:hover {
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+    }
+  }
+  .heading-actions {
+    position: absolute;
+    top: 0;
+    right: 0;
+    display: flex;
+    align-items: center;
+    gap: 3pt;
+    z-index: 5;
+  }
+  section :global([data-key].has-setting-reset) {
+    position: relative;
+    padding-inline-end: 1.6em;
+  }
+  section :global(.setting-reset-button) {
+    position: absolute;
+    top: 50%;
+    right: 1pt;
+    translate: 0 -50%;
+    display: grid;
+    place-items: center;
+    width: 1.35em;
+    height: 1.35em;
+    padding: 0;
+    border: 0;
+    border-radius: var(--border-radius, 3pt);
+    background: transparent;
+    color: var(--text-color-muted, #6b7280);
+    font: inherit;
+    line-height: 1;
+    cursor: pointer;
+    opacity: 0.65;
+    &:hover,
+    &:focus-visible {
+      background: var(--btn-bg-hover, rgba(0, 0, 0, 0.15));
+      color: var(--text-color, #374151);
+      opacity: 1;
+    }
+  }
+  section :global(.settings-row-description) {
+    grid-column: 1 / -1;
+    display: block;
+    margin: 1pt 0 2pt;
+    color: var(--text-color-muted, #6b7280);
+    font-size: 0.78em;
+    font-weight: 400;
+    line-height: 1.3;
+  }
+  section.grid {
+    display: grid;
+    gap: var(--settings-row-gap, 4pt) 0;
+    align-content: start;
+  }
+  /* Rows are [label] [value] [wide control]. A row holding a single control lets it span the
+     last two tracks, so selects, sliders and swatches all begin on the same vertical line.
+     --ctrl-cols is published so a pane can give the same rhythm to rows it nests one level
+     deeper (grouped axis rows, say) without restating the track list. */
+  section.grid > :global(:is(label, .setting)) {
+    display: grid;
+    grid-template-columns: var(
+      --ctrl-cols,
+      var(--ctrl-label-w, 8.5em) var(--ctrl-value-w, 4em) minmax(0, 1fr)
+    );
+    align-items: center;
+    column-gap: var(--ctrl-gap, 7pt);
+    min-height: 1.9em;
+    margin: 0;
+    /* the label cell truncates rather than wrapping the row onto a second line */
+    > :global(:first-child) {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    /* a row holding a single control lets it span the last two tracks */
+    > :global(
+      :nth-child(2):is(
+        :last-child,
+        :has(+ .settings-row-description),
+        :has(+ .setting-reset-button)
+      )
+    ) {
+      grid-column: 2 / -1;
+    }
+    /* fixed-size controls keep their size instead of stretching across their track */
+    > :global(:is(input[type='color'], input[type='checkbox'])) {
+      justify-self: start;
+    }
+    /* range inputs have an intrinsic width and will not stretch into their track on their own */
+    > :global(input[type='range']) {
+      width: 100%;
+      min-width: 40px;
+    }
   }
 </style>

--- a/src/lib/layout/SettingsSection.svelte
+++ b/src/lib/layout/SettingsSection.svelte
@@ -55,6 +55,9 @@ svelte-widgets once a version above 1.4.0 is published; its API is otherwise unc
     if (obj instanceof Date) return new Date(obj)
     if (obj instanceof RegExp) return new RegExp(obj)
     if (Array.isArray(obj)) return obj.map(deep_copy)
+    const prototype = Object.getPrototypeOf(obj)
+    if (prototype && prototype !== Object.prototype)
+      throw new TypeError(`SettingsSection values must be plain objects`)
     return Object.fromEntries(
       Object.entries(obj).map(([key, value]) => [key, deep_copy(value)]),
     )
@@ -76,7 +79,7 @@ svelte-widgets once a version above 1.4.0 is published; its API is otherwise unc
 
   // Order-independent deep equality for setting values
   const setting_equal = (left: unknown, right: unknown): boolean => {
-    if (Object.is(left, right)) return true
+    if (left === right || Object.is(left, right)) return true
     if (left == null || right == null) return false
     if (typeof left !== `object` || typeof right !== `object`) return false
     if (left instanceof Date || right instanceof Date) {
@@ -229,7 +232,7 @@ svelte-widgets once a version above 1.4.0 is published; its API is otherwise unc
       }
     }
 
-    const enhance_row = (row: HTMLElement): boolean => {
+    const enhance_row = (row: HTMLElement, changed_key_set: SvelteSet<string>): boolean => {
       const key = row.dataset.key
       if (!key) return false
       let enhancement = enhanced_rows.get(row)
@@ -268,7 +271,7 @@ svelte-widgets once a version above 1.4.0 is published; its API is otherwise unc
         enhancement.description_element = null
       }
 
-      const needs_reset = Boolean(on_reset_key) && changed_keys.includes(key)
+      const needs_reset = Boolean(on_reset_key) && changed_key_set.has(key)
       if (!needs_reset) remove_reset_button(enhancement)
       else {
         if (!enhancement.reset_button) {
@@ -289,14 +292,15 @@ svelte-widgets once a version above 1.4.0 is published; its API is otherwise unc
         enhancement.reset_button.setAttribute(`aria-label`, `Reset ${key} to default`)
         enhancement.reset_button.title = `Reset ${key} to default`
       }
-      return Boolean(mapped_description)
+      return Boolean(description)
     }
 
     const refresh = (): void => {
       if (disposed) return
       let found_description = false
+      const changed_key_set = new SvelteSet(changed_keys)
       for (const row of section.querySelectorAll<HTMLElement>(`[data-key]`)) {
-        found_description = enhance_row(row) || found_description
+        found_description = enhance_row(row, changed_key_set) || found_description
       }
       has_descriptions = found_description
       for (const [row, enhancement] of enhanced_rows) {

--- a/src/lib/layout/SettingsSection.svelte
+++ b/src/lib/layout/SettingsSection.svelte
@@ -112,16 +112,11 @@ svelte-widgets once a version above 1.4.0 is published; its API is otherwise unc
   // Key presence is independent of value: additions/removals count even when the
   // value is undefined. Only compare values when both sides own the key.
   let changed_keys = $derived(
-    [
-      ...new SvelteSet([...Object.keys(reference_values), ...Object.keys(current_values)]),
-    ].filter((key) => {
-      const in_reference = Object.hasOwn(reference_values, key)
-      const in_current = Object.hasOwn(current_values, key)
-      return (
-        in_reference !== in_current ||
-        !setting_equal(reference_values[key], current_values[key])
-      )
-    }),
+    Object.keys({ ...reference_values, ...current_values }).filter(
+      (key) =>
+        Object.hasOwn(reference_values, key) !== Object.hasOwn(current_values, key) ||
+        !setting_equal(reference_values[key], current_values[key]),
+    ),
   )
   let has_changes = $derived(changed_keys.length > 0)
   let has_descriptions = $state(false)

--- a/src/lib/layout/SettingsSection.svelte
+++ b/src/lib/layout/SettingsSection.svelte
@@ -147,9 +147,8 @@ svelte-widgets once a version above 1.4.0 is published; its API is otherwise unc
   const auto_label_attr = `data-auto-label`
 
   const release_auto_label = (control: Element): void => {
-    if (control.getAttribute(`aria-label`) === control.getAttribute(auto_label_attr)) {
+    if (control.getAttribute(`aria-label`) === control.getAttribute(auto_label_attr))
       control.removeAttribute(`aria-label`)
-    }
     control.removeAttribute(auto_label_attr)
   }
 
@@ -158,34 +157,29 @@ svelte-widgets once a version above 1.4.0 is published; its API is otherwise unc
   const enhance_rows = (section: HTMLElement): (() => void) => {
     const enhanced_rows = new SvelteMap<HTMLElement, EnhancedRow>()
     let refresh_queued = false
-    let disposed = false
 
     const remove_reset_button = (row: HTMLElement, enhancement: EnhancedRow): void => {
       enhancement.reset_button?.remove()
       enhancement.reset_button = null
       row.classList.remove(`has-setting-reset`)
     }
+    const set_row_description = (row: HTMLElement, description: string | null): void => {
+      if (description === null) row.removeAttribute(`data-description`)
+      else row.setAttribute(`data-description`, description)
+    }
 
     const cleanup_enhancement = (row: HTMLElement, enhancement: EnhancedRow): void => {
       enhancement.description_element?.remove()
       remove_reset_button(row, enhancement)
-      for (const control of row.querySelectorAll(`[${auto_label_attr}]`)) {
-        release_auto_label(control)
-      }
-      if (enhancement.original_description === null) {
-        row.removeAttribute(`data-description`)
-      } else {
-        row.setAttribute(`data-description`, enhancement.original_description)
-      }
+      row.querySelectorAll(`[${auto_label_attr}]`).forEach(release_auto_label)
+      set_row_description(row, enhancement.original_description)
     }
 
     const label_text = (row: HTMLLabelElement): string => {
       const label_copy = row.cloneNode(true) as HTMLElement
-      for (const control of label_copy.querySelectorAll(
-        `input, select, textarea, button, .settings-row-description`,
-      )) {
-        control.remove()
-      }
+      label_copy
+        .querySelectorAll(`input, select, textarea, button, .settings-row-description`)
+        .forEach((control) => control.remove())
       return (row.dataset.label ?? label_copy.textContent ?? ``)
         .replaceAll(/\s+/gu, ` `)
         .trim()
@@ -197,12 +191,8 @@ svelte-widgets once a version above 1.4.0 is published; its API is otherwise unc
         const marker = control.getAttribute(auto_label_attr)
         const own_label = control.getAttribute(`aria-label`)
         // An author-set name always wins, whether it was there first or replaced ours
-        if (
-          marker === null &&
-          (own_label !== null || control.hasAttribute(`aria-labelledby`))
-        ) {
-          continue
-        }
+        const author_named = own_label !== null || control.hasAttribute(`aria-labelledby`)
+        if (marker === null && author_named) continue
         if (marker !== null && own_label !== marker) control.removeAttribute(auto_label_attr)
         else if (!label) release_auto_label(control)
         else if (marker !== label) {
@@ -229,18 +219,14 @@ svelte-widgets once a version above 1.4.0 is published; its API is otherwise unc
       const metadata = setting_metadata?.[key]
       const mapped_description =
         typeof metadata === `string` ? metadata : metadata?.description
-      if (mapped_description) row.setAttribute(`data-description`, mapped_description)
-      else if (enhancement.original_description === null)
-        row.removeAttribute(`data-description`)
-      else row.setAttribute(`data-description`, enhancement.original_description)
+      set_row_description(row, mapped_description || enhancement.original_description)
 
       const description = mapped_description ?? enhancement.original_description ?? undefined
       if (descriptions_open && description) {
         if (!enhancement.description_element) {
-          const description_element = document.createElement(`small`)
-          description_element.className = `settings-row-description`
-          enhancement.description_element = description_element
-          row.append(description_element)
+          enhancement.description_element = document.createElement(`small`)
+          enhancement.description_element.className = `settings-row-description`
+          row.append(enhancement.description_element)
         }
         // Avoid notifying our own subtree observer forever: assigning textContent replaces
         // the text node even when the string is unchanged.
@@ -276,7 +262,6 @@ svelte-widgets once a version above 1.4.0 is published; its API is otherwise unc
     }
 
     const refresh = (): void => {
-      if (disposed) return
       let found_description = false
       for (const row of section.querySelectorAll<HTMLElement>(`[data-key]`)) {
         found_description = enhance_row(row) || found_description
@@ -295,7 +280,7 @@ svelte-widgets once a version above 1.4.0 is published; its API is otherwise unc
       refresh_queued = true
       queueMicrotask(() => {
         refresh_queued = false
-        refresh()
+        if (refresh_rows === schedule_refresh) refresh()
       })
     }
 
@@ -310,7 +295,6 @@ svelte-widgets once a version above 1.4.0 is published; its API is otherwise unc
     untrack(refresh)
 
     return () => {
-      disposed = true
       observer.disconnect()
       if (refresh_rows === schedule_refresh) refresh_rows = undefined
       for (const [row, enhancement] of enhanced_rows) cleanup_enhancement(row, enhancement)
@@ -326,7 +310,7 @@ svelte-widgets once a version above 1.4.0 is published; its API is otherwise unc
 </script>
 
 <h4 id={title_id}>
-  {title}
+  <span class="section-title">{title}</span>
 
   {#if has_descriptions || changed_keys.length}
     <span class="heading-actions">
@@ -382,15 +366,11 @@ svelte-widgets once a version above 1.4.0 is published; its API is otherwise unc
     cursor: pointer;
     box-shadow: none;
     opacity: 0.7;
-  }
-  :is(
-    .reset-button:hover,
-    .description-toggle:hover,
-    .description-toggle[aria-expanded='true']
-  ) {
-    background: var(--btn-bg-hover, rgba(0, 0, 0, 0.2));
-    color: var(--text-color, #374151);
-    opacity: 1;
+    &:is(:hover, [aria-expanded='true']) {
+      background: var(--btn-bg-hover, rgba(0, 0, 0, 0.2));
+      color: var(--text-color, #374151);
+      opacity: 1;
+    }
   }
   .reset-button {
     display: flex;

--- a/src/lib/layout/index.ts
+++ b/src/lib/layout/index.ts
@@ -1,3 +1,6 @@
+// SettingsSection, SettingsGroup, SettingsSearch, and NumberRangeInput now exist upstream.
+// After svelte-widgets >1.4.0 is published, replace these local exports with package imports;
+// NumberRangeInput setting-based calls additionally need the generic schema prop.
 export * from './fullscreen'
 export { sync_fullscreen } from 'svelte-widgets/fullscreen'
 export { FullscreenButton } from 'svelte-widgets'
@@ -7,6 +10,8 @@ export { default as InfoTag } from './InfoTag.svelte'
 export { default as NumberRangeInput } from './NumberRangeInput.svelte'
 export * from './json-tree'
 export { default as PropertyFilter } from './PropertyFilter.svelte'
+export { default as SettingsGroup } from './SettingsGroup.svelte'
+export { default as SettingsSearch } from './SettingsSearch.svelte'
 export { default as SettingsSection } from './SettingsSection.svelte'
 export { default as SubpageGrid } from './SubpageGrid.svelte'
 export { default as ViewerChrome } from './ViewerChrome.svelte'

--- a/src/lib/periodic-table/PeriodicTableControls.svelte
+++ b/src/lib/periodic-table/PeriodicTableControls.svelte
@@ -25,7 +25,8 @@
     tooltip_line_height: 1.2,
     tooltip_text_align: `center`,
   }
-  const range = (data_key: string, min: number, max: number, step: number) => ({
+  type ControlKey = keyof typeof defaults
+  const range = (data_key: ControlKey, min: number, max: number, step: number) => ({
     'data-key': data_key,
     min,
     max,
@@ -101,7 +102,6 @@
     }
   })
 
-  type ControlKey = keyof typeof defaults
   const control_setters = {
     tile_gap: (value) => (tile_gap = value),
     symbol_font_size: (value) => (symbol_font_size = value),
@@ -122,13 +122,16 @@
     tooltip_line_height: (value) => (tooltip_line_height = value),
     tooltip_text_align: (value) => (tooltip_text_align = value),
   } satisfies { [Key in ControlKey]: (value: (typeof defaults)[Key]) => void }
+  const is_control_key = (key: string): key is ControlKey =>
+    Object.hasOwn(control_setters, key)
   const reset_control = (
     key: string,
     reference_value: unknown,
     reference_present: boolean,
   ): void => {
+    if (!is_control_key(key)) throw new Error(`Unknown fixed control key ${key}`)
     if (!reference_present) throw new Error(`Missing reset value for fixed control ${key}`)
-    control_setters[key as ControlKey]?.(reference_value as never)
+    control_setters[key](reference_value as never)
   }
   const reset_category_color = (
     category: string,

--- a/src/lib/periodic-table/PeriodicTableControls.svelte
+++ b/src/lib/periodic-table/PeriodicTableControls.svelte
@@ -319,7 +319,7 @@
     padding: 2px 4px;
     border-radius: 3px;
   }
-  .settings-card :global(.settings-section > label input[type='text']) {
+  .settings-card :global(.settings-section > label :is(input[type='text'], select)) {
     box-sizing: border-box;
     width: 100%;
     padding: 4px 6px;
@@ -332,10 +332,6 @@
     border: 1px solid var(--border-color);
   }
   .settings-card :global(.settings-section > label select) {
-    box-sizing: border-box;
-    width: 100%;
-    padding: 4px 6px;
-    border-radius: 3px;
     cursor: pointer;
   }
   .category-colors :global(.settings-section) {

--- a/src/lib/periodic-table/PeriodicTableControls.svelte
+++ b/src/lib/periodic-table/PeriodicTableControls.svelte
@@ -1,30 +1,73 @@
 <script lang="ts">
   import type { ElementCategory } from '$lib/element'
   import { DEFAULT_CATEGORY_COLORS } from '$lib/colors'
+  import { NumberRangeInput, SettingsSection } from '$lib/layout'
   import { colors, selected } from '$lib/state.svelte'
   import type { HTMLAttributes } from 'svelte/elements'
 
+  const defaults = {
+    tile_gap: `0.3cqw`,
+    symbol_font_size: 40,
+    number_font_size: 22,
+    name_font_size: 12,
+    value_font_size: 18,
+    tooltip_font_size: 14,
+    tooltip_bg_color: `#000000`,
+    tile_border_radius: 1,
+    inner_transition_offset: 0.5,
+    tile_font_color: `#ffffff`,
+    tile_transition_duration: 0.4,
+    hover_border_width: 1,
+    symbol_font_weight: 400,
+    number_font_weight: 300,
+    tooltip_border_radius: 6,
+    tooltip_padding: `4px 6px`,
+    tooltip_line_height: 1.2,
+    tooltip_text_align: `center`,
+  }
+  const range = (data_key: string, min: number, max: number, step: number) => ({
+    'data-key': data_key,
+    min,
+    max,
+    step,
+  })
+  const range_props = {
+    tile_border_radius: range(`tile_border_radius`, 0, 10, 0.5),
+    inner_transition_offset: range(`inner_transition_offset`, 0.1, 2, 0.1),
+    tile_transition_duration: range(`tile_transition_duration`, 0.1, 2, 0.1),
+    hover_border_width: range(`hover_border_width`, 0, 5, 1),
+    symbol_font_size: range(`symbol_font_size`, 20, 80, 2),
+    number_font_size: range(`number_font_size`, 10, 40, 1),
+    name_font_size: range(`name_font_size`, 6, 24, 1),
+    value_font_size: range(`value_font_size`, 10, 30, 1),
+    symbol_font_weight: range(`symbol_font_weight`, 100, 900, 100),
+    number_font_weight: range(`number_font_weight`, 100, 900, 100),
+    tooltip_font_size: range(`tooltip_font_size`, 8, 24, 1),
+    tooltip_border_radius: range(`tooltip_border_radius`, 0, 20, 1),
+    tooltip_line_height: range(`tooltip_line_height`, 0.8, 2, 0.1),
+  }
+
   let {
-    tile_gap = $bindable(`0.3cqw`),
-    symbol_font_size = $bindable(40),
-    number_font_size = $bindable(22),
-    name_font_size = $bindable(12),
-    value_font_size = $bindable(18),
-    tooltip_font_size = $bindable(14),
-    tooltip_bg_color = $bindable(`#000000`),
-    tile_border_radius = $bindable(1),
-    inner_transition_offset = $bindable(0.5),
-    tile_font_color = $bindable(`#ffffff`),
+    tile_gap = $bindable(defaults.tile_gap),
+    symbol_font_size = $bindable(defaults.symbol_font_size),
+    number_font_size = $bindable(defaults.number_font_size),
+    name_font_size = $bindable(defaults.name_font_size),
+    value_font_size = $bindable(defaults.value_font_size),
+    tooltip_font_size = $bindable(defaults.tooltip_font_size),
+    tooltip_bg_color = $bindable(defaults.tooltip_bg_color),
+    tile_border_radius = $bindable(defaults.tile_border_radius),
+    inner_transition_offset = $bindable(defaults.inner_transition_offset),
+    tile_font_color = $bindable(defaults.tile_font_color),
     // Additional Element Tile controls
-    tile_transition_duration = $bindable(0.4),
-    hover_border_width = $bindable(1),
-    symbol_font_weight = $bindable(400),
-    number_font_weight = $bindable(300),
+    tile_transition_duration = $bindable(defaults.tile_transition_duration),
+    hover_border_width = $bindable(defaults.hover_border_width),
+    symbol_font_weight = $bindable(defaults.symbol_font_weight),
+    number_font_weight = $bindable(defaults.number_font_weight),
     // Additional Tooltip controls
-    tooltip_border_radius = $bindable(6),
-    tooltip_padding = $bindable(`4px 6px`),
-    tooltip_line_height = $bindable(1.2),
-    tooltip_text_align = $bindable(`center`),
+    tooltip_border_radius = $bindable(defaults.tooltip_border_radius),
+    tooltip_padding = $bindable(defaults.tooltip_padding),
+    tooltip_line_height = $bindable(defaults.tooltip_line_height),
+    tooltip_text_align = $bindable(defaults.tooltip_text_align),
     ...rest
   }: HTMLAttributes<HTMLDivElement> & {
     // Appearance control values
@@ -49,28 +92,6 @@
     tooltip_line_height?: number
     tooltip_text_align?: string
   } = $props()
-
-  // Default values for easy reset
-  const defaults = {
-    tile_gap: `0.3cqw`,
-    symbol_font_size: 40,
-    number_font_size: 22,
-    name_font_size: 12,
-    value_font_size: 18,
-    tooltip_font_size: 14,
-    tooltip_bg_color: `#000000`,
-    tile_border_radius: 1,
-    inner_transition_offset: 0.5,
-    tile_font_color: `#ffffff`,
-    tile_transition_duration: 0.4,
-    hover_border_width: 1,
-    symbol_font_weight: 400,
-    number_font_weight: 300,
-    tooltip_border_radius: 6,
-    tooltip_padding: `4px 6px`,
-    tooltip_line_height: 1.2,
-    tooltip_text_align: `center`,
-  }
 
   // Apply CSS custom properties to document root
   $effect(() => {
@@ -102,271 +123,183 @@
     }
   })
 
-  // Check if settings in each section have been modified from defaults
-  let category_colors_modified = $derived(
-    Object.keys(colors.category).some(
-      (key) => colors.category[key] !== DEFAULT_CATEGORY_COLORS[key],
-    ),
-  )
-
-  let tiles_modified = $derived(
-    tile_gap !== defaults.tile_gap ||
-      tile_border_radius !== defaults.tile_border_radius ||
-      inner_transition_offset !== defaults.inner_transition_offset ||
-      tile_transition_duration !== defaults.tile_transition_duration ||
-      hover_border_width !== defaults.hover_border_width ||
-      tile_font_color !== defaults.tile_font_color,
-  )
-
-  let fonts_modified = $derived(
-    symbol_font_size !== defaults.symbol_font_size ||
-      number_font_size !== defaults.number_font_size ||
-      name_font_size !== defaults.name_font_size ||
-      value_font_size !== defaults.value_font_size ||
-      symbol_font_weight !== defaults.symbol_font_weight ||
-      number_font_weight !== defaults.number_font_weight,
-  )
-
-  let tooltip_modified = $derived(
-    tooltip_font_size !== defaults.tooltip_font_size ||
-      tooltip_bg_color !== defaults.tooltip_bg_color ||
-      tooltip_border_radius !== defaults.tooltip_border_radius ||
-      tooltip_padding !== defaults.tooltip_padding ||
-      tooltip_line_height !== defaults.tooltip_line_height ||
-      tooltip_text_align !== defaults.tooltip_text_align,
-  )
-
-  // Reset functions for each section
-  function reset_category_colors(): void {
-    for (const key of Object.keys(colors.category)) {
-      colors.category[key] = DEFAULT_CATEGORY_COLORS[key]
-    }
+  type ControlKey = keyof typeof defaults
+  const control_setters = {
+    tile_gap: (value) => (tile_gap = value),
+    symbol_font_size: (value) => (symbol_font_size = value),
+    number_font_size: (value) => (number_font_size = value),
+    name_font_size: (value) => (name_font_size = value),
+    value_font_size: (value) => (value_font_size = value),
+    tooltip_font_size: (value) => (tooltip_font_size = value),
+    tooltip_bg_color: (value) => (tooltip_bg_color = value),
+    tile_border_radius: (value) => (tile_border_radius = value),
+    inner_transition_offset: (value) => (inner_transition_offset = value),
+    tile_font_color: (value) => (tile_font_color = value),
+    tile_transition_duration: (value) => (tile_transition_duration = value),
+    hover_border_width: (value) => (hover_border_width = value),
+    symbol_font_weight: (value) => (symbol_font_weight = value),
+    number_font_weight: (value) => (number_font_weight = value),
+    tooltip_border_radius: (value) => (tooltip_border_radius = value),
+    tooltip_padding: (value) => (tooltip_padding = value),
+    tooltip_line_height: (value) => (tooltip_line_height = value),
+    tooltip_text_align: (value) => (tooltip_text_align = value),
+  } satisfies { [Key in ControlKey]: (value: (typeof defaults)[Key]) => void }
+  const reset_control = (key: string, reference_value: unknown): void => {
+    control_setters[key as ControlKey]?.(reference_value as never)
   }
-
-  function reset_tiles(): void {
-    tile_gap = defaults.tile_gap
-    tile_border_radius = defaults.tile_border_radius
-    inner_transition_offset = defaults.inner_transition_offset
-    tile_transition_duration = defaults.tile_transition_duration
-    hover_border_width = defaults.hover_border_width
-    tile_font_color = defaults.tile_font_color
-  }
-
-  function reset_fonts(): void {
-    symbol_font_size = defaults.symbol_font_size
-    number_font_size = defaults.number_font_size
-    name_font_size = defaults.name_font_size
-    value_font_size = defaults.value_font_size
-    symbol_font_weight = defaults.symbol_font_weight
-    number_font_weight = defaults.number_font_weight
-  }
-
-  function reset_tooltip(): void {
-    tooltip_font_size = defaults.tooltip_font_size
-    tooltip_bg_color = defaults.tooltip_bg_color
-    tooltip_border_radius = defaults.tooltip_border_radius
-    tooltip_padding = defaults.tooltip_padding
-    tooltip_line_height = defaults.tooltip_line_height
-    tooltip_text_align = defaults.tooltip_text_align
+  const reset_category_color = (
+    category: string,
+    reference_value: unknown,
+    reference_present: boolean,
+  ): void => {
+    if (reference_present) colors.category[category] = reference_value as string
+    else Reflect.deleteProperty(colors.category, category)
   }
 </script>
 
 <div {...rest} class={[`controls-grid`, rest.class]}>
-  <section class="category-colors">
-    <h3 style="grid-column: span 2">
-      Element Category Colors
-      {#if category_colors_modified}
-        <button class="section-reset" onclick={reset_category_colors}>reset</button>
-      {/if}
-    </h3>
-    {#each Object.keys(colors.category) as category (category)}
-      <label
-        onmouseenter={() => (selected.category = category as ElementCategory)}
-        onfocus={() => (selected.category = category as ElementCategory)}
-        onmouseleave={() => (selected.category = null)}
-        onblur={() => (selected.category = null)}
-      >
-        <input type="color" bind:value={colors.category[category]} />
-        <span>{category}</span>
-        {#if colors.category[category] !== DEFAULT_CATEGORY_COLORS[category]}
-          <button
-            onclick={(event) => {
-              event.preventDefault()
-              colors.category[category] = DEFAULT_CATEGORY_COLORS[category]
-            }}
-          >
-            reset
-          </button>
-        {/if}
+  <div class="settings-card category-colors">
+    <SettingsSection
+      title="Element category colors"
+      current_values={{ ...colors.category }}
+      reset_values={DEFAULT_CATEGORY_COLORS}
+      on_reset_key={reset_category_color}
+      layout="grid"
+    >
+      {#each Object.keys(colors.category) as category (category)}
+        <label
+          data-key={category}
+          onmouseenter={() => (selected.category = category as ElementCategory)}
+          onfocusin={() => (selected.category = category as ElementCategory)}
+          onmouseleave={() => (selected.category = null)}
+          onfocusout={() => (selected.category = null)}
+        >
+          <span>{category}</span>
+          <input type="color" bind:value={colors.category[category]} />
+        </label>
+      {/each}
+    </SettingsSection>
+  </div>
+
+  <div class="settings-card">
+    <SettingsSection
+      title="Element tiles"
+      current_values={{
+        tile_gap,
+        tile_border_radius,
+        inner_transition_offset,
+        tile_transition_duration,
+        hover_border_width,
+        tile_font_color,
+      }}
+      reset_values={defaults}
+      on_reset_key={reset_control}
+      layout="grid"
+    >
+      <label data-key="tile_gap">
+        <span>Gap between tiles</span>
+        <input type="text" bind:value={tile_gap} placeholder="0.3cqw" />
       </label>
-    {/each}
-  </section>
-
-  <section>
-    <h3>
-      Element Tiles
-      {#if tiles_modified}
-        <button class="section-reset" onclick={reset_tiles}>reset</button>
-      {/if}
-    </h3>
-
-    <label>
-      <span>Gap between tiles</span>
-      <input type="text" bind:value={tile_gap} placeholder="0.3cqw" />
-      <button onclick={() => (tile_gap = defaults.tile_gap)}>reset</button>
-    </label>
-
-    <label>
-      <span>Border radius (pt)</span>
-      <input type="range" min="0" max="10" step="0.5" bind:value={tile_border_radius} />
-      <input type="number" min="0" max="10" step="0.5" bind:value={tile_border_radius} />
-      <button onclick={() => (tile_border_radius = defaults.tile_border_radius)}>reset</button>
-    </label>
-
-    <label>
-      <span>Inner transition offset</span>
-      <input type="range" min="0.1" max="2" step="0.1" bind:value={inner_transition_offset} />
-      <input type="number" min="0.1" max="2" step="0.1" bind:value={inner_transition_offset} />
-      <button onclick={() => (inner_transition_offset = defaults.inner_transition_offset)}
-        >reset</button
+      <NumberRangeInput {...range_props.tile_border_radius} bind:value={tile_border_radius}
+        >Border radius (pt)</NumberRangeInput
       >
-    </label>
-
-    <label>
-      <span>Transition duration (s)</span>
-      <input type="range" min="0.1" max="2" step="0.1" bind:value={tile_transition_duration} />
-      <input
-        type="number"
-        min="0.1"
-        max="2"
-        step="0.1"
-        bind:value={tile_transition_duration}
-      />
-      <button onclick={() => (tile_transition_duration = defaults.tile_transition_duration)}
-        >reset</button
+      <NumberRangeInput
+        {...range_props.inner_transition_offset}
+        bind:value={inner_transition_offset}>Inner transition offset</NumberRangeInput
       >
-    </label>
-
-    <label>
-      <span>Hover border width (px)</span>
-      <input type="range" min="0" max="5" step="1" bind:value={hover_border_width} />
-      <input type="number" min="0" max="5" step="1" bind:value={hover_border_width} />
-      <button onclick={() => (hover_border_width = defaults.hover_border_width)}>reset</button>
-    </label>
-
-    <label>
-      <span>Font color</span>
-      <input type="color" bind:value={tile_font_color} />
-      <button onclick={() => (tile_font_color = defaults.tile_font_color)}>reset</button>
-    </label>
-  </section>
-
-  <section>
-    <h3>
-      Font Sizes
-      {#if fonts_modified}
-        <button class="section-reset" onclick={reset_fonts}>reset</button>
-      {/if}
-    </h3>
-
-    <label>
-      <span>Symbol size</span>
-      <input type="range" min="20" max="80" step="2" bind:value={symbol_font_size} />
-      <input type="number" min="20" max="80" step="2" bind:value={symbol_font_size} />
-      <button onclick={() => (symbol_font_size = defaults.symbol_font_size)}>reset</button>
-    </label>
-
-    <label>
-      <span>Number size</span>
-      <input type="range" min="10" max="40" step="1" bind:value={number_font_size} />
-      <input type="number" min="10" max="40" step="1" bind:value={number_font_size} />
-      <button onclick={() => (number_font_size = defaults.number_font_size)}>reset</button>
-    </label>
-
-    <label>
-      <span>Name size</span>
-      <input type="range" min="6" max="24" step="1" bind:value={name_font_size} />
-      <input type="number" min="6" max="24" step="1" bind:value={name_font_size} />
-      <button onclick={() => (name_font_size = defaults.name_font_size)}>reset</button>
-    </label>
-
-    <label>
-      <span>Value size</span>
-      <input type="range" min="10" max="30" step="1" bind:value={value_font_size} />
-      <input type="number" min="10" max="30" step="1" bind:value={value_font_size} />
-      <button onclick={() => (value_font_size = defaults.value_font_size)}>reset</button>
-    </label>
-
-    <label>
-      <span>Symbol weight</span>
-      <input type="range" min="100" max="900" step="100" bind:value={symbol_font_weight} />
-      <input type="number" min="100" max="900" step="100" bind:value={symbol_font_weight} />
-      <button onclick={() => (symbol_font_weight = defaults.symbol_font_weight)}>reset</button>
-    </label>
-
-    <label>
-      <span>Number weight</span>
-      <input type="range" min="100" max="900" step="100" bind:value={number_font_weight} />
-      <input type="number" min="100" max="900" step="100" bind:value={number_font_weight} />
-      <button onclick={() => (number_font_weight = defaults.number_font_weight)}>reset</button>
-    </label>
-  </section>
-
-  <section>
-    <h3>
-      Tooltip
-      {#if tooltip_modified}
-        <button class="section-reset" onclick={reset_tooltip}>reset</button>
-      {/if}
-    </h3>
-
-    <label>
-      <span>Font size (px)</span>
-      <input type="range" min="8" max="24" step="1" bind:value={tooltip_font_size} />
-      <input type="number" min="8" max="24" step="1" bind:value={tooltip_font_size} />
-      <button onclick={() => (tooltip_font_size = defaults.tooltip_font_size)}>reset</button>
-    </label>
-
-    <label>
-      <span>Background color</span>
-      <input type="color" bind:value={tooltip_bg_color} />
-      <button onclick={() => (tooltip_bg_color = defaults.tooltip_bg_color)}>reset</button>
-    </label>
-
-    <label>
-      <span>Border radius (px)</span>
-      <input type="range" min="0" max="20" step="1" bind:value={tooltip_border_radius} />
-      <input type="number" min="0" max="20" step="1" bind:value={tooltip_border_radius} />
-      <button onclick={() => (tooltip_border_radius = defaults.tooltip_border_radius)}
-        >reset</button
+      <NumberRangeInput
+        {...range_props.tile_transition_duration}
+        bind:value={tile_transition_duration}>Transition duration (s)</NumberRangeInput
       >
-    </label>
-
-    <label>
-      <span>Padding</span>
-      <input type="text" bind:value={tooltip_padding} placeholder="4px 6px" />
-      <button onclick={() => (tooltip_padding = defaults.tooltip_padding)}>reset</button>
-    </label>
-
-    <label>
-      <span>Line height</span>
-      <input type="range" min="0.8" max="2" step="0.1" bind:value={tooltip_line_height} />
-      <input type="number" min="0.8" max="2" step="0.1" bind:value={tooltip_line_height} />
-      <button onclick={() => (tooltip_line_height = defaults.tooltip_line_height)}
-        >reset</button
+      <NumberRangeInput {...range_props.hover_border_width} bind:value={hover_border_width}
+        >Hover border width (px)</NumberRangeInput
       >
-    </label>
+      <label data-key="tile_font_color">
+        <span>Font color</span>
+        <input type="color" bind:value={tile_font_color} />
+      </label>
+    </SettingsSection>
+  </div>
 
-    <label>
-      <span>Text align</span>
-      <select bind:value={tooltip_text_align}>
-        <option value="left">Left</option>
-        <option value="center">Center</option>
-        <option value="right">Right</option>
-      </select>
-      <button onclick={() => (tooltip_text_align = defaults.tooltip_text_align)}>reset</button>
-    </label>
-  </section>
+  <div class="settings-card">
+    <SettingsSection
+      title="Font sizes"
+      current_values={{
+        symbol_font_size,
+        number_font_size,
+        name_font_size,
+        value_font_size,
+        symbol_font_weight,
+        number_font_weight,
+      }}
+      reset_values={defaults}
+      on_reset_key={reset_control}
+      layout="grid"
+    >
+      <NumberRangeInput {...range_props.symbol_font_size} bind:value={symbol_font_size}
+        >Symbol size</NumberRangeInput
+      >
+      <NumberRangeInput {...range_props.number_font_size} bind:value={number_font_size}
+        >Number size</NumberRangeInput
+      >
+      <NumberRangeInput {...range_props.name_font_size} bind:value={name_font_size}
+        >Name size</NumberRangeInput
+      >
+      <NumberRangeInput {...range_props.value_font_size} bind:value={value_font_size}
+        >Value size</NumberRangeInput
+      >
+      <NumberRangeInput {...range_props.symbol_font_weight} bind:value={symbol_font_weight}
+        >Symbol weight</NumberRangeInput
+      >
+      <NumberRangeInput {...range_props.number_font_weight} bind:value={number_font_weight}
+        >Number weight</NumberRangeInput
+      >
+    </SettingsSection>
+  </div>
+
+  <div class="settings-card">
+    <SettingsSection
+      title="Tooltip"
+      current_values={{
+        tooltip_font_size,
+        tooltip_bg_color,
+        tooltip_border_radius,
+        tooltip_padding,
+        tooltip_line_height,
+        tooltip_text_align,
+      }}
+      reset_values={defaults}
+      on_reset_key={reset_control}
+      layout="grid"
+    >
+      <NumberRangeInput {...range_props.tooltip_font_size} bind:value={tooltip_font_size}
+        >Font size (px)</NumberRangeInput
+      >
+      <label data-key="tooltip_bg_color">
+        <span>Background color</span>
+        <input type="color" bind:value={tooltip_bg_color} />
+      </label>
+      <NumberRangeInput
+        {...range_props.tooltip_border_radius}
+        bind:value={tooltip_border_radius}>Border radius (px)</NumberRangeInput
+      >
+      <label data-key="tooltip_padding">
+        <span>Padding</span>
+        <input type="text" bind:value={tooltip_padding} placeholder="4px 6px" />
+      </label>
+      <NumberRangeInput {...range_props.tooltip_line_height} bind:value={tooltip_line_height}
+        >Line height</NumberRangeInput
+      >
+      <label data-key="tooltip_text_align">
+        <span>Text align</span>
+        <select bind:value={tooltip_text_align}>
+          <option value="left">Left</option>
+          <option value="center">Center</option>
+          <option value="right">Right</option>
+        </select>
+      </label>
+    </SettingsSection>
+  </div>
 </div>
 
 <style>
@@ -378,96 +311,61 @@
     padding: 0 1em;
     max-width: 1200px;
   }
-  section {
+  .settings-card {
     background: var(--surface-bg);
     border-radius: 6px;
     padding: 6pt 2ex;
+    --ctrl-label-w: 10em;
+    --ctrl-value-w: 4.2em;
+    --settings-row-gap: 0.6em;
   }
-  section h3 {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+  .settings-card :global(h4) {
     margin: 0 0 0.8em 0;
     border-bottom: 1px solid rgba(255, 255, 255, 0.2);
     padding-bottom: 0.3em;
     max-height: max-content;
   }
-  button.section-reset {
-    background: rgba(255, 255, 255, 0.1);
-    border: 1px solid rgba(255, 255, 255, 0.2);
-  }
-  section > label {
-    display: flex;
-    align-items: center;
-    gap: 0.5em;
-    margin: 0.6em 0;
+  .settings-card :global(.settings-section > label) {
     font-size: 0.9em;
-    flex-wrap: wrap;
   }
-  section > label > span {
-    min-width: 100px;
+  .settings-card :global(.settings-section > label > span:first-child) {
     font-weight: 500;
     font-size: 0.85em;
   }
-  section > label input[type='range'] {
-    flex: 1;
-    margin: 0 0.3em;
-  }
-  section > label input[type='number'] {
+  .settings-card :global(.settings-section > label input[type='number']) {
     width: 60px;
     padding: 2px 4px;
     border-radius: 3px;
   }
-  section > label input[type='text'] {
-    flex: 1;
+  .settings-card :global(.settings-section > label input[type='text']) {
+    box-sizing: border-box;
+    width: 100%;
     padding: 4px 6px;
     border-radius: 3px;
   }
-  section > label input[type='color'] {
+  .settings-card :global(.settings-section > label input[type='color']) {
     width: 50px;
     height: 20px;
     border-radius: 3px;
     border: 1px solid var(--border-color);
   }
-  section > label select {
-    flex: 1;
+  .settings-card :global(.settings-section > label select) {
+    box-sizing: border-box;
+    width: 100%;
     padding: 4px 6px;
     border-radius: 3px;
     cursor: pointer;
   }
-  section > label button {
-    background: rgba(255, 255, 255, 0.1);
-    border: 1px solid rgba(255, 255, 255, 0.2);
-    border-radius: 3px;
-    padding: 3px 6px;
-    font-size: 0.8em;
-    opacity: 0.7;
-    transition: opacity 0.2s;
-  }
-  section > label button:hover {
-    opacity: 1;
-  }
-  .category-colors {
-    display: grid;
+  .category-colors :global(.settings-section) {
     grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    column-gap: 1em;
+    --ctrl-cols: minmax(0, 1fr) auto 0;
   }
-  .category-colors label {
-    margin: 0;
-    display: flex;
-    align-items: center;
-    gap: 6pt;
-    flex-wrap: nowrap;
+  .category-colors :global(.settings-section > label) {
     text-transform: capitalize;
     transition: background-color 0.2s;
   }
-  .category-colors label span {
-    flex: 1;
-    min-width: 0; /* Allow text to truncate */
-    text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap;
-  }
-  .category-colors input[type='color'] {
+  .category-colors :global(.settings-section > label input[type='color']) {
     width: 25px;
     height: 25px;
     min-width: 25px;

--- a/src/lib/periodic-table/PeriodicTableControls.svelte
+++ b/src/lib/periodic-table/PeriodicTableControls.svelte
@@ -69,29 +69,7 @@
     tooltip_line_height = $bindable(defaults.tooltip_line_height),
     tooltip_text_align = $bindable(defaults.tooltip_text_align),
     ...rest
-  }: HTMLAttributes<HTMLDivElement> & {
-    // Appearance control values
-    tile_gap?: string
-    symbol_font_size?: number
-    number_font_size?: number
-    name_font_size?: number
-    value_font_size?: number
-    tooltip_font_size?: number
-    tooltip_bg_color?: string
-    tile_border_radius?: number
-    inner_transition_offset?: number
-    tile_font_color?: string
-    // Additional Element Tile controls
-    tile_transition_duration?: number
-    hover_border_width?: number
-    symbol_font_weight?: number
-    number_font_weight?: number
-    // Additional Tooltip controls
-    tooltip_border_radius?: number
-    tooltip_padding?: string
-    tooltip_line_height?: number
-    tooltip_text_align?: string
-  } = $props()
+  }: HTMLAttributes<HTMLDivElement> & Partial<typeof defaults> = $props()
 
   // Apply CSS custom properties to document root
   $effect(() => {
@@ -144,7 +122,12 @@
     tooltip_line_height: (value) => (tooltip_line_height = value),
     tooltip_text_align: (value) => (tooltip_text_align = value),
   } satisfies { [Key in ControlKey]: (value: (typeof defaults)[Key]) => void }
-  const reset_control = (key: string, reference_value: unknown): void => {
+  const reset_control = (
+    key: string,
+    reference_value: unknown,
+    reference_present: boolean,
+  ): void => {
+    if (!reference_present) throw new Error(`Missing reset value for fixed control ${key}`)
     control_setters[key as ControlKey]?.(reference_value as never)
   }
   const reset_category_color = (

--- a/src/lib/periodic-table/PeriodicTableControls.svelte
+++ b/src/lib/periodic-table/PeriodicTableControls.svelte
@@ -74,31 +74,28 @@
 
   // Apply CSS custom properties to document root
   $effect(() => {
-    if (typeof document !== `undefined`) {
-      const css_vars = {
-        '--ptable-gap': tile_gap,
-        '--elem-symbol-font-size': `${symbol_font_size}cqw`,
-        '--elem-number-font-size': `${number_font_size}cqw`,
-        '--elem-name-font-size': `${name_font_size}cqw`,
-        '--elem-value-font-size': `${value_font_size}cqw`,
-        '--tooltip-font-size': `${tooltip_font_size}px`,
-        '--tooltip-bg': tooltip_bg_color,
-        '--elem-tile-border-radius': `${tile_border_radius}pt`,
-        '--ptable-spacer-ratio': `${1 / inner_transition_offset}`,
-        '--elem-tile-font-color': tile_font_color,
-        '--elem-tile-transition-duration': `${tile_transition_duration}s`,
-        '--elem-tile-hover-border-width': `${hover_border_width}px`,
-        '--elem-symbol-font-weight': `${symbol_font_weight}`,
-        '--elem-number-font-weight': `${number_font_weight}`,
-        '--tooltip-border-radius': `${tooltip_border_radius}px`,
-        '--tooltip-padding': tooltip_padding,
-        '--tooltip-line-height': `${tooltip_line_height}`,
-        '--tooltip-text-align': tooltip_text_align,
-      }
-
-      for (const [prop, val] of Object.entries(css_vars)) {
-        document.documentElement.style.setProperty(prop, val)
-      }
+    const css_vars = {
+      '--ptable-gap': tile_gap,
+      '--elem-symbol-font-size': `${symbol_font_size}cqw`,
+      '--elem-number-font-size': `${number_font_size}cqw`,
+      '--elem-name-font-size': `${name_font_size}cqw`,
+      '--elem-value-font-size': `${value_font_size}cqw`,
+      '--tooltip-font-size': `${tooltip_font_size}px`,
+      '--tooltip-bg': tooltip_bg_color,
+      '--elem-tile-border-radius': `${tile_border_radius}pt`,
+      '--ptable-spacer-ratio': `${1 / inner_transition_offset}`,
+      '--elem-tile-font-color': tile_font_color,
+      '--elem-tile-transition-duration': `${tile_transition_duration}s`,
+      '--elem-tile-hover-border-width': `${hover_border_width}px`,
+      '--elem-symbol-font-weight': `${symbol_font_weight}`,
+      '--elem-number-font-weight': `${number_font_weight}`,
+      '--tooltip-border-radius': `${tooltip_border_radius}px`,
+      '--tooltip-padding': tooltip_padding,
+      '--tooltip-line-height': `${tooltip_line_height}`,
+      '--tooltip-text-align': tooltip_text_align,
+    }
+    for (const [prop, val] of Object.entries(css_vars)) {
+      document.documentElement.style.setProperty(prop, val)
     }
   })
 
@@ -122,16 +119,15 @@
     tooltip_line_height: (value) => (tooltip_line_height = value),
     tooltip_text_align: (value) => (tooltip_text_align = value),
   } satisfies { [Key in ControlKey]: (value: (typeof defaults)[Key]) => void }
-  const is_control_key = (key: string): key is ControlKey =>
-    Object.hasOwn(control_setters, key)
   const reset_control = (
     key: string,
     reference_value: unknown,
     reference_present: boolean,
   ): void => {
-    if (!is_control_key(key)) throw new Error(`Unknown fixed control key ${key}`)
+    const setter = control_setters[key as ControlKey]
+    if (!setter) throw new Error(`Unknown fixed control key ${key}`)
     if (!reference_present) throw new Error(`Missing reset value for fixed control ${key}`)
-    control_setters[key](reference_value as never)
+    setter(reference_value as never)
   }
   const reset_category_color = (
     category: string,

--- a/src/lib/phase-diagram/PhaseDiagramControls.svelte
+++ b/src/lib/phase-diagram/PhaseDiagramControls.svelte
@@ -4,8 +4,7 @@
   // NOTE: Axis config objects must be reassigned (not mutated) to trigger $bindable reactivity.
   import { css_color_to_hex } from '$lib/colors'
   import { format_num } from '$lib/labels'
-  import NumberRangeInput from '$lib/layout/NumberRangeInput.svelte'
-  import SettingsSection from '$lib/layout/SettingsSection.svelte'
+  import { NumberRangeInput, SettingsGroup, SettingsSection } from '$lib/layout'
   import type { AxisConfig } from '$lib/plot'
   import type { ComponentProps, Snippet } from 'svelte'
   import { tooltip } from 'svelte-widgets/attachments'
@@ -92,12 +91,26 @@
   const component_b = $derived(data?.components?.[1])
   const title = $derived(
     component_a && component_b
-      ? `${component_a}-${component_b} Phase Diagram`
-      : `Phase Diagram Controls`,
+      ? `${component_a}-${component_b} phase diagram`
+      : `Phase diagram controls`,
   )
   const temp_unit = $derived(data?.temperature_unit ?? `K`)
   const comp_unit = $derived(data?.composition_unit ?? `at%`)
   const has_special_points = $derived((data?.special_points?.length ?? 0) > 0)
+
+  // [tie_line config key, row label, tooltip, min, max, step]
+  const tie_line_rows = [
+    [`stroke_width`, `Line width`, `Thickness of the tie-line`, 0.5, 5, 0.5],
+    [
+      `endpoint_radius`,
+      `Endpoint radius`,
+      `Radius of phase boundary endpoint markers`,
+      2,
+      10,
+      1,
+    ],
+    [`cursor_radius`, `Cursor radius`, `Radius of the cursor position marker`, 2, 10, 1],
+  ] as const
 </script>
 
 <DraggablePane
@@ -120,104 +133,104 @@
 
   {@render children?.({ controls_open })}
 
-  <!-- Visibility Section -->
-  <SettingsSection
-    title="Visibility"
-    current_values={{
-      show_boundaries,
-      show_labels,
-      show_special_points,
-      show_grid,
-      show_component_labels,
-    }}
-    on_reset={() => {
-      show_boundaries = PHASE_DIAGRAM_DEFAULTS.show_boundaries
-      show_labels = PHASE_DIAGRAM_DEFAULTS.show_labels
-      show_special_points = PHASE_DIAGRAM_DEFAULTS.show_special_points
-      show_grid = PHASE_DIAGRAM_DEFAULTS.show_grid
-      show_component_labels = PHASE_DIAGRAM_DEFAULTS.show_component_labels
-    }}
-  >
-    <div class="visibility-grid">
+  <SettingsGroup title="Diagram" open>
+    <SettingsSection
+      title="Visibility"
+      current_values={{
+        show_boundaries,
+        show_labels,
+        show_special_points,
+        show_grid,
+        show_component_labels,
+      }}
+      on_reset={() =>
+        ({
+          show_boundaries,
+          show_labels,
+          show_special_points,
+          show_grid,
+          show_component_labels,
+        } = PHASE_DIAGRAM_DEFAULTS)}
+      layout="grid"
+      class="visibility-grid"
+    >
       <label {@attach tooltip({ content: `Show phase boundary lines` })}>
+        <span>Boundaries</span>
         <input type="checkbox" bind:checked={show_boundaries} />
-        Boundaries
       </label>
       <label {@attach tooltip({ content: `Show phase region labels` })}>
+        <span>Labels</span>
         <input type="checkbox" bind:checked={show_labels} />
-        Labels
       </label>
       <label {@attach tooltip({ content: `Show background grid lines` })}>
+        <span>Grid</span>
         <input type="checkbox" bind:checked={show_grid} />
-        Grid
       </label>
       {#if has_special_points}
         <label {@attach tooltip({ content: `Show eutectic/peritectic points` })}>
+          <span>Special pts</span>
           <input type="checkbox" bind:checked={show_special_points} />
-          Special Pts
         </label>
       {/if}
       <label {@attach tooltip({ content: `Show component labels at axes` })}>
+        <span>Comp. labels</span>
         <input type="checkbox" bind:checked={show_component_labels} />
-        Comp. Labels
       </label>
-    </div>
-  </SettingsSection>
+    </SettingsSection>
 
-  <!-- Appearance Section -->
-  <SettingsSection
-    title="Appearance"
-    current_values={{
-      font_size: merged_config.font_size,
-      special_point_radius: merged_config.special_point_radius,
-    }}
-    on_reset={() => {
-      update_config(`font_size`, PHASE_DIAGRAM_DEFAULTS.font_size)
-      update_config(`special_point_radius`, PHASE_DIAGRAM_DEFAULTS.special_point_radius)
-    }}
-  >
-    <NumberRangeInput
-      min={8}
-      max={20}
-      step={1}
-      title="Font size for axis labels and tick marks"
-      bind:value={() => merged_config.font_size, (val) => update_config(`font_size`, val)}
-      >Font size</NumberRangeInput
+    <SettingsSection
+      title="Appearance"
+      current_values={{
+        font_size: merged_config.font_size,
+        special_point_radius: merged_config.special_point_radius,
+      }}
+      on_reset={() => {
+        update_config(`font_size`, PHASE_DIAGRAM_DEFAULTS.font_size)
+        update_config(`special_point_radius`, PHASE_DIAGRAM_DEFAULTS.special_point_radius)
+      }}
+      layout="grid"
     >
-    {#if has_special_points}
       <NumberRangeInput
-        min={2}
-        max={12}
+        min={8}
+        max={20}
         step={1}
-        title="Radius of special point markers (eutectic, peritectic, etc.)"
-        bind:value={
-          () => merged_config.special_point_radius,
-          (val) => update_config(`special_point_radius`, val)
-        }>Special pt radius</NumberRangeInput
+        title="Font size for axis labels and tick marks"
+        bind:value={() => merged_config.font_size, (val) => update_config(`font_size`, val)}
+        >Font size</NumberRangeInput
       >
-    {/if}
-  </SettingsSection>
+      {#if has_special_points}
+        <NumberRangeInput
+          min={2}
+          max={12}
+          step={1}
+          title="Radius of special point markers (eutectic, peritectic, etc.)"
+          bind:value={
+            () => merged_config.special_point_radius,
+            (val) => update_config(`special_point_radius`, val)
+          }>Special pt radius</NumberRangeInput
+        >
+      {/if}
+    </SettingsSection>
 
-  <!-- Colors Section -->
-  {@const color_options = [
-    [`background`, `#ffffff`, `Background`, `Background color of the plot area`],
-    [`grid`, `#888888`, `Grid`, `Color of grid lines`],
-    [`boundary`, `#333333`, `Boundaries`, `Color of phase boundary lines`],
-    [`special_point`, `#d32f2f`, `Special Pts`, `Color of special point markers`],
-    [`axis`, `#333333`, `Axis`, `Color of axis lines`],
-    [`text`, `#333333`, `Text`, `Color of text labels`],
-  ] as const}
-  <SettingsSection
-    title="Colors"
-    current_values={{ ...merged_config.colors }}
-    on_reset={() => {
-      config = { ...config, colors: { ...PHASE_DIAGRAM_DEFAULTS.colors } }
-    }}
-  >
-    <div class="color-grid">
+    {@const color_options = [
+      [`background`, `#ffffff`, `Background`, `Background color of the plot area`],
+      [`grid`, `#888888`, `Grid`, `Color of grid lines`],
+      [`boundary`, `#333333`, `Boundaries`, `Color of phase boundary lines`],
+      [`special_point`, `#d32f2f`, `Special pts`, `Color of special point markers`],
+      [`axis`, `#333333`, `Axis`, `Color of axis lines`],
+      [`text`, `#333333`, `Text`, `Color of text labels`],
+    ] as const}
+    <SettingsSection
+      title="Colors"
+      current_values={{ ...merged_config.colors }}
+      on_reset={() => {
+        config = { ...config, colors: { ...PHASE_DIAGRAM_DEFAULTS.colors } }
+      }}
+      layout="grid"
+    >
       {#each color_options as [key, fallback, label, tip] (key)}
         <label {@attach tooltip({ content: tip })}>
-          {label}
+          <span>{label}</span>
           <input
             type="color"
             value={css_color_to_hex(merged_config.colors[key], fallback)}
@@ -225,86 +238,70 @@
           />
         </label>
       {/each}
-    </div>
-  </SettingsSection>
+    </SettingsSection>
+  </SettingsGroup>
 
-  <!-- Tie-line Section -->
-  <SettingsSection
-    title="Tie-line Display"
-    current_values={{
-      ...merged_config.tie_line,
-      lever_rule_mode,
-    }}
-    on_reset={() => {
-      config = {
-        ...config,
-        tie_line: { ...PHASE_DIAGRAM_DEFAULTS.tie_line },
-      }
-      lever_rule_mode = `horizontal`
-    }}
-  >
-    <span {@attach tooltip({ content: `Direction of the lever rule tie-line` })}>
-      Direction
-      <div class="pane-row">
-        <label>
-          <input type="radio" bind:group={lever_rule_mode} value="horizontal" />
-          Horizontal
-        </label>
-        <label>
-          <input type="radio" bind:group={lever_rule_mode} value="vertical" />
-          Vertical
-        </label>
+  <SettingsGroup title="Interaction" open>
+    <SettingsSection
+      title="Tie-line display"
+      current_values={{
+        ...merged_config.tie_line,
+        lever_rule_mode,
+      }}
+      on_reset={() => {
+        config = {
+          ...config,
+          tie_line: { ...PHASE_DIAGRAM_DEFAULTS.tie_line },
+        }
+        lever_rule_mode = `horizontal`
+      }}
+      layout="grid"
+    >
+      <div
+        class="setting"
+        {@attach tooltip({ content: `Direction of the lever rule tie-line` })}
+      >
+        <span>Direction</span>
+        <div class="pane-row">
+          <label>
+            <input type="radio" bind:group={lever_rule_mode} value="horizontal" />
+            Horizontal
+          </label>
+          <label>
+            <input type="radio" bind:group={lever_rule_mode} value="vertical" />
+            Vertical
+          </label>
+        </div>
       </div>
-    </span>
-    <NumberRangeInput
-      min={0.5}
-      max={5}
-      step={0.5}
-      title="Thickness of the tie-line"
-      bind:value={
-        () => merged_config.tie_line.stroke_width,
-        (val) => update_nested(`tie_line`, `stroke_width`, val)
-      }>Line width</NumberRangeInput
-    >
-    <NumberRangeInput
-      min={2}
-      max={10}
-      step={1}
-      title="Radius of phase boundary endpoint markers"
-      bind:value={
-        () => merged_config.tie_line.endpoint_radius,
-        (val) => update_nested(`tie_line`, `endpoint_radius`, val)
-      }>Endpoint radius</NumberRangeInput
-    >
-    <NumberRangeInput
-      min={2}
-      max={10}
-      step={1}
-      title="Radius of the cursor position marker"
-      bind:value={
-        () => merged_config.tie_line.cursor_radius,
-        (val) => update_nested(`tie_line`, `cursor_radius`, val)
-      }>Cursor radius</NumberRangeInput
-    >
-  </SettingsSection>
+      {#each tie_line_rows as [key, label, title, min, max, step] (key)}
+        <NumberRangeInput
+          {min}
+          {max}
+          {step}
+          {title}
+          bind:value={
+            () => merged_config.tie_line[key], (val) => update_nested(`tie_line`, key, val)
+          }>{label}</NumberRangeInput
+        >
+      {/each}
+    </SettingsSection>
 
-  <!-- Axis Configuration Section -->
-  {@const axis_configs = [
-    [x_axis, `x`, comp_unit, `composition`],
-    [y_axis, `y`, temp_unit, `temperature`],
-  ] as const}
-  <SettingsSection
-    title="Axes"
-    current_values={{ x_ticks: x_axis.ticks, y_ticks: y_axis.ticks }}
-    on_reset={() => {
-      x_axis = { ...x_axis, ticks: PHASE_DIAGRAM_DEFAULTS.x_ticks }
-      y_axis = { ...y_axis, ticks: PHASE_DIAGRAM_DEFAULTS.y_ticks }
-    }}
-  >
-    <div class="pane-row">
+    {@const axis_configs = [
+      [x_axis, `x`, comp_unit, `composition`],
+      [y_axis, `y`, temp_unit, `temperature`],
+    ] as const}
+    <SettingsSection
+      title="Axes"
+      current_values={{ x_ticks: x_axis.ticks, y_ticks: y_axis.ticks }}
+      on_reset={() => {
+        x_axis = { ...x_axis, ticks: PHASE_DIAGRAM_DEFAULTS.x_ticks }
+        y_axis = { ...y_axis, ticks: PHASE_DIAGRAM_DEFAULTS.y_ticks }
+      }}
+      layout="grid"
+    >
       {#each axis_configs as [axis_cfg, axis_name, unit, desc] (axis_name)}
         <label {@attach tooltip({ content: `Ticks on ${desc} axis (${unit})` })}>
-          {axis_name.toUpperCase()}-axis ticks
+          <span>{axis_name.toUpperCase()}-axis ticks</span>
           <input
             type="number"
             min={2}
@@ -318,10 +315,9 @@
           />
         </label>
       {/each}
-    </div>
-  </SettingsSection>
+    </SettingsSection>
+  </SettingsGroup>
 
-  <!-- Export Section (if enabled) -->
   {#if enable_export}
     <SettingsSection
       title="Export"
@@ -329,26 +325,19 @@
       on_reset={() => {
         png_dpi = PHASE_DIAGRAM_DEFAULTS.png_dpi
       }}
+      layout="grid"
     >
       <label
         {@attach tooltip({
           content: `DPI (dots per inch) for PNG export. Higher values produce larger, higher-quality images.`,
         })}
       >
-        PNG DPI
-        <input
-          type="number"
-          min={72}
-          max={600}
-          step={50}
-          style="width: 3.5em"
-          bind:value={png_dpi}
-        />
+        <span>PNG DPI</span>
+        <span class="dpi-value" style="display: inline-flex; align-items: baseline; gap: 1pt">
+          <input type="number" min={72} max={600} step={50} bind:value={png_dpi} />
+          <span style="font-size: 0.85em; opacity: 0.8">{format_num(png_dpi, `d`)} dpi</span>
+        </span>
         <input type="range" min={72} max={600} step={50} bind:value={png_dpi} />
-        <span style="font-size: 0.85em; opacity: 0.7"
-          >{format_num(png_dpi, `d`)}
-          dpi</span
-        >
       </label>
     </SettingsSection>
   {/if}
@@ -362,11 +351,8 @@
     max-width: 320px;
     --pane-padding: 10px;
     --pane-gap: 4px;
-  }
-  :global(.phase-diagram-controls-pane section) {
-    display: flex;
-    flex-direction: column;
-    gap: 4pt;
+    --ctrl-label-w: 8.5em;
+    --ctrl-value-w: 5.5em;
   }
   :global(.phase-diagram-controls-pane h4) {
     margin: 6pt 0 2pt !important;
@@ -377,26 +363,11 @@
   .pane-row {
     display: flex;
     gap: 12pt;
-  }
-  .visibility-grid {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 4pt 10pt;
-  }
-  .color-grid {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 6pt;
-  }
-  .color-grid label {
-    flex-direction: column;
-    align-items: center;
-    font-size: 0.9em;
-  }
-  label {
-    display: flex;
-    align-items: center;
-    gap: 6pt;
+    label {
+      display: flex;
+      align-items: center;
+      gap: 4pt;
+    }
   }
   input {
     font-size: inherit;
@@ -406,7 +377,6 @@
     width: 3.5em;
   }
   input[type='range'] {
-    flex: 1;
     min-width: 40px;
   }
   input[type='color'] {

--- a/src/lib/phase-diagram/PhaseDiagramControls.svelte
+++ b/src/lib/phase-diagram/PhaseDiagramControls.svelte
@@ -308,7 +308,9 @@
             max={15}
             value={axis_cfg.ticks ?? PHASE_DIAGRAM_DEFAULTS[`${axis_name}_ticks`]}
             oninput={(ev) => {
-              const new_ticks = Number(ev.currentTarget.value)
+              const parsed_ticks = ev.currentTarget.valueAsNumber
+              if (!Number.isFinite(parsed_ticks)) return
+              const new_ticks = Math.max(2, Math.min(15, Math.round(parsed_ticks)))
               if (axis_name === `x`) x_axis = { ...x_axis, ticks: new_ticks }
               else if (axis_name === `y`) y_axis = { ...y_axis, ticks: new_ticks }
             }}

--- a/src/lib/phase-diagram/PhaseDiagramControls.svelte
+++ b/src/lib/phase-diagram/PhaseDiagramControls.svelte
@@ -87,11 +87,9 @@
   }
 
   // Derive component info from data
-  const component_a = $derived(data?.components?.[0])
-  const component_b = $derived(data?.components?.[1])
   const title = $derived(
-    component_a && component_b
-      ? `${component_a}-${component_b} phase diagram`
+    data?.components?.[0] && data.components[1]
+      ? `${data.components[0]}-${data.components[1]} phase diagram`
       : `Phase diagram controls`,
   )
   const temp_unit = $derived(data?.temperature_unit ?? `K`)
@@ -223,9 +221,7 @@
     <SettingsSection
       title="Colors"
       current_values={{ ...merged_config.colors }}
-      on_reset={() => {
-        config = { ...config, colors: { ...PHASE_DIAGRAM_DEFAULTS.colors } }
-      }}
+      on_reset={() => (config = { ...config, colors: { ...PHASE_DIAGRAM_DEFAULTS.colors } })}
       layout="grid"
     >
       {#each color_options as [key, fallback, label, tip] (key)}
@@ -312,7 +308,7 @@
               if (!Number.isFinite(parsed_ticks)) return
               const new_ticks = Math.max(2, Math.min(15, Math.round(parsed_ticks)))
               if (axis_name === `x`) x_axis = { ...x_axis, ticks: new_ticks }
-              else if (axis_name === `y`) y_axis = { ...y_axis, ticks: new_ticks }
+              else y_axis = { ...y_axis, ticks: new_ticks }
             }}
           />
         </label>
@@ -324,9 +320,7 @@
     <SettingsSection
       title="Export"
       current_values={{ png_dpi }}
-      on_reset={() => {
-        png_dpi = PHASE_DIAGRAM_DEFAULTS.png_dpi
-      }}
+      on_reset={() => (png_dpi = PHASE_DIAGRAM_DEFAULTS.png_dpi)}
       layout="grid"
     >
       <label

--- a/src/lib/plot/bar/BarPlotControls.svelte
+++ b/src/lib/plot/bar/BarPlotControls.svelte
@@ -42,10 +42,7 @@
   <SettingsSection
     title="Layout"
     current_values={{ orientation, mode }}
-    on_reset={() => {
-      orientation = initial_layout.orientation
-      mode = initial_layout.mode
-    }}
+    on_reset={() => ({ orientation, mode } = initial_layout)}
     layout="grid"
   >
     <label>

--- a/src/lib/plot/bar/BarPlotControls.svelte
+++ b/src/lib/plot/bar/BarPlotControls.svelte
@@ -3,11 +3,7 @@
   import type { BarMode, PlotConfig } from '$lib/plot'
   import { PlotControls } from '$lib/plot'
   import type { Orientation, PlotControlsProps } from '$lib/plot/core/types'
-  import { unique_id } from '$lib/plot/core/utils'
-  import type { Snippet } from 'svelte'
-
-  // Unique ID prefix to avoid conflicts when multiple instances on same page
-  const uid = unique_id(`bar-ctrl`)
+  import { type Snippet, untrack } from 'svelte'
 
   let {
     orientation = $bindable(`vertical`),
@@ -28,6 +24,8 @@
     controls_open?: boolean
     children?: Snippet<[{ orientation: Orientation; mode: BarMode } & Required<PlotConfig>]>
   } = $props()
+
+  const initial_layout = untrack(() => ({ orientation, mode }))
 </script>
 
 <PlotControls
@@ -44,21 +42,25 @@
   <SettingsSection
     title="Layout"
     current_values={{ orientation, mode }}
-    style="display: flex; gap: 2ex"
+    on_reset={() => {
+      orientation = initial_layout.orientation
+      mode = initial_layout.mode
+    }}
+    layout="grid"
   >
-    <label style="flex: 1">
-      Orientation:
-      <select bind:value={orientation} id="{uid}-orientation">
+    <label>
+      <span>Orientation</span>
+      <select bind:value={orientation}>
         <option value="vertical">Vertical</option>
         <option value="horizontal">Horizontal</option>
       </select>
     </label>
-    <label style="flex: 1">
-      Mode:
-      <select bind:value={mode} id="{uid}-mode">
+    <label>
+      <span>Mode</span>
+      <select bind:value={mode}>
         <option value="overlay">Overlay</option>
         <option value="stacked">Stacked</option>
-        <option value="grouped">Grouped (Side-by-Side)</option>
+        <option value="grouped">Grouped (side-by-side)</option>
       </select>
     </label>
   </SettingsSection>

--- a/src/lib/plot/box/BoxPlotControls.svelte
+++ b/src/lib/plot/box/BoxPlotControls.svelte
@@ -3,12 +3,8 @@
   import type { Orientation, PlotConfig, ViolinKind, ViolinSide, WhiskerMode } from '$lib/plot'
   import { PlotControls } from '$lib/plot'
   import type { PlotControlsProps } from '$lib/plot/core/types'
-  import { unique_id } from '$lib/plot/core/utils'
   import { DEFAULTS } from '$lib/settings'
   import type { Snippet } from 'svelte'
-
-  // Unique ID prefix to avoid conflicts when multiple instances on same page
-  const uid = unique_id(`box-ctrl`)
 
   let {
     orientation = $bindable(`vertical`),
@@ -51,59 +47,55 @@
 >
   {@render children?.({ orientation, x_axis, x2_axis, y_axis, y2_axis, display })}
   <SettingsSection
-    title="Box / Violin"
+    title="Box / violin"
     current_values={{ orientation, kind, side, whisker_mode, show_outliers, show_mean }}
     on_reset={() => {
       orientation = `vertical`
-      kind = DEFAULTS.box.kind
-      side = DEFAULTS.box.side
-      whisker_mode = DEFAULTS.box.whisker_mode
-      show_outliers = DEFAULTS.box.show_outliers
-      show_mean = DEFAULTS.box.show_mean
+      ;({ kind, side, whisker_mode, show_outliers, show_mean } = DEFAULTS.box)
     }}
-    style="display: flex; flex-wrap: wrap; gap: 2ex"
+    layout="grid"
   >
-    <label style="flex: 1">
-      Orientation:
-      <select bind:value={orientation} id="{uid}-orientation">
+    <label>
+      <span>Orientation</span>
+      <select bind:value={orientation}>
         <option value="vertical">Vertical</option>
         <option value="horizontal">Horizontal</option>
       </select>
     </label>
-    <label style="flex: 1">
-      Glyph:
-      <select bind:value={kind} id="{uid}-kind">
+    <label>
+      <span>Glyph</span>
+      <select bind:value={kind}>
         <option value="box">Box</option>
         <option value="violin">Violin</option>
-        <option value="violin+box">Violin + Box</option>
+        <option value="violin+box">Violin + box</option>
       </select>
     </label>
     {#if kind !== `box`}
-      <label style="flex: 1">
-        Violin side:
-        <select bind:value={side} id="{uid}-side">
+      <label>
+        <span>Violin side</span>
+        <select bind:value={side}>
           <option value="both">Both</option>
           <option value="positive">Positive</option>
           <option value="negative">Negative</option>
         </select>
       </label>
     {/if}
-    <label style="flex: 1">
-      Whiskers:
-      <select bind:value={whisker_mode} id="{uid}-whisker-mode">
+    <label>
+      <span>Whiskers</span>
+      <select bind:value={whisker_mode}>
         <option value="tukey">Tukey (1.5·IQR)</option>
-        <option value="minmax">Min/Max</option>
+        <option value="minmax">Min/max</option>
         <option value="percentile">Percentile</option>
-        <option value="std">Std Dev</option>
+        <option value="std">Std dev</option>
       </select>
     </label>
-    <label style="flex: 1 1 100%">
+    <label>
+      <span>Show outliers</span>
       <input type="checkbox" bind:checked={show_outliers} />
-      Show outliers
     </label>
-    <label style="flex: 1 1 100%">
+    <label>
+      <span>Show mean</span>
       <input type="checkbox" bind:checked={show_mean} />
-      Show mean
     </label>
   </SettingsSection>
 </PlotControls>

--- a/src/lib/plot/core/components/ColorScaleSelect.svelte
+++ b/src/lib/plot/core/components/ColorScaleSelect.svelte
@@ -10,7 +10,11 @@
       key.startsWith(`interpolate`),
     ) as D3InterpolateName[],
     value = $bindable(options[0]),
-    selected = $bindable([]),
+    // Seeded from `value`, the way MultiSelect seeds its own `selected` default. Hardcoding
+    // `[]` overrides that default, and MultiSelect's selected -> value sync then writes the
+    // empty selection back, nulling the caller's value on mount unless they also bind
+    // `selected` purely to work around it.
+    selected = $bindable(value == null ? [] : [value]),
     minSelect = 1,
     placeholder = `Select a color scale`,
     color_bar = {},

--- a/src/lib/plot/core/components/HierarchyControls.svelte
+++ b/src/lib/plot/core/components/HierarchyControls.svelte
@@ -109,101 +109,76 @@
       title={chart === `sunburst` ? `Sunburst` : `Treemap`}
       {current_values}
       on_reset={reset_to_defaults}
-      style="display: flex; flex-wrap: wrap; gap: 2ex"
+      layout="grid"
     >
       <!-- select options come from the settings schema so labels/values have a
       single source of truth -->
       {#if chart === `sunburst`}
-        <label style="flex: 1">
-          Shape:
+        <label>
+          <span>Shape</span>
           <select bind:value={shape}>
             {@render options(SETTINGS_CONFIG.sunburst.shape.enum ?? {})}
           </select>
         </label>
       {/if}
-      <label style="flex: 1">
-        Value mode:
+      <label>
+        <span>Value mode</span>
         <select bind:value={value_mode}>
           {@render options(SETTINGS_CONFIG[chart].value_mode.enum ?? {})}
         </select>
       </label>
       {#if chart === `sunburst` && shape === `sunburst`}
         <!-- icicle labels are always horizontal; inner radius/pad angle are polar-only -->
-        <label style="flex: 1">
-          Labels:
+        <label>
+          <span>Labels</span>
           <select bind:value={label_rotation}>
             {@render options(SETTINGS_CONFIG.sunburst.label_rotation.enum ?? {})}
           </select>
         </label>
       {/if}
-      <label style="flex: 1">
-        Label text:
+      <label>
+        <span>Label text</span>
         <select bind:value={label_text}>
           {@render options(SETTINGS_CONFIG[chart].label_text.enum ?? {})}
         </select>
       </label>
-      <NumberRangeInput min={0} max={10} step={1} bind:value={max_depth} style="flex: 1 1 100%"
-        >Max depth (0 = all):</NumberRangeInput
+      <NumberRangeInput min={0} max={10} step={1} bind:value={max_depth}
+        >Max depth (0 = all)</NumberRangeInput
       >
       {#if chart === `sunburst`}
         {#if shape === `sunburst`}
-          <NumberRangeInput
-            min={0}
-            max={0.8}
-            step={0.05}
-            bind:value={inner_radius}
-            style="flex: 1 1 100%">Inner radius:</NumberRangeInput
+          <NumberRangeInput min={0} max={0.8} step={0.05} bind:value={inner_radius}
+            >Inner radius</NumberRangeInput
           >
-          <NumberRangeInput
-            min={0}
-            max={4}
-            step={0.1}
-            bind:value={pad_angle}
-            style="flex: 1 1 100%">Pad angle (°):</NumberRangeInput
+          <NumberRangeInput min={0} max={4} step={0.1} bind:value={pad_angle}
+            >Pad angle (°)</NumberRangeInput
           >
         {/if}
       {:else}
-        <NumberRangeInput
-          min={0}
-          max={10}
-          step={0.5}
-          bind:value={padding_inner}
-          style="flex: 1 1 100%">Cell gap (px):</NumberRangeInput
+        <NumberRangeInput min={0} max={10} step={0.5} bind:value={padding_inner}
+          >Cell gap (px)</NumberRangeInput
         >
-        <NumberRangeInput
-          min={0}
-          max={40}
-          step={1}
-          bind:value={padding_top}
-          style="flex: 1 1 100%">Header height (px, 0 = none):</NumberRangeInput
+        <NumberRangeInput min={0} max={40} step={1} bind:value={padding_top}
+          >Header height (px, 0 = none)</NumberRangeInput
         >
-        <NumberRangeInput
-          min={0}
-          max={10}
-          step={0.5}
-          bind:value={padding_outer}
-          style="flex: 1 1 100%">Child inset (px):</NumberRangeInput
+        <NumberRangeInput min={0} max={10} step={0.5} bind:value={padding_outer}
+          >Child inset (px)</NumberRangeInput
         >
       {/if}
-      <NumberRangeInput
-        min={0}
-        max={0.2}
-        step={0.005}
-        bind:value={min_fraction}
-        style="flex: 1 1 100%"
-        >Group {chart === `sunburst` ? `slices` : `cells`} below (fraction of total):</NumberRangeInput
+      <NumberRangeInput min={0} max={0.2} step={0.005} bind:value={min_fraction}
+        >Group {chart === `sunburst` ? `slices` : `cells`} below (fraction of total)</NumberRangeInput
       >
-      <label style="flex: 1 1 100%">
+      <label>
+        <span>Show {chart === `sunburst` ? `arc` : `cell`} labels</span>
         <input type="checkbox" bind:checked={show_labels} />
-        Show {chart === `sunburst` ? `arc` : `cell`} labels
       </label>
-      <label style="flex: 1 1 100%">
+      <label>
+        <span>Zoom on click</span>
         <input type="checkbox" bind:checked={zoom_on_click} />
-        Zoom on click
       </label>
-      <label style="flex: 1 1 100%">
+      <label>
+        <span>Show breadcrumbs when zoomed</span>
         <input type="checkbox" bind:checked={show_breadcrumbs} />
-        Show breadcrumbs when zoomed
       </label>
     </SettingsSection>
     {#if export_buttons && on_export}
@@ -213,7 +188,7 @@
         class="export-row"
         style="--hier-btn-bg: var(--{chart}-btn-bg); --hier-btn-hover-bg: var(--{chart}-btn-hover-bg)"
       >
-        Export:
+        Export
         {#each [`svg`, `png`] as const as fmt (fmt)}
           <button
             type="button"

--- a/src/lib/plot/core/components/HierarchyControls.svelte
+++ b/src/lib/plot/core/components/HierarchyControls.svelte
@@ -145,16 +145,14 @@
       <NumberRangeInput min={0} max={10} step={1} bind:value={max_depth}
         >Max depth (0 = all)</NumberRangeInput
       >
-      {#if chart === `sunburst`}
-        {#if shape === `sunburst`}
-          <NumberRangeInput min={0} max={0.8} step={0.05} bind:value={inner_radius}
-            >Inner radius</NumberRangeInput
-          >
-          <NumberRangeInput min={0} max={4} step={0.1} bind:value={pad_angle}
-            >Pad angle (°)</NumberRangeInput
-          >
-        {/if}
-      {:else}
+      {#if chart === `sunburst` && shape === `sunburst`}
+        <NumberRangeInput min={0} max={0.8} step={0.05} bind:value={inner_radius}
+          >Inner radius</NumberRangeInput
+        >
+        <NumberRangeInput min={0} max={4} step={0.1} bind:value={pad_angle}
+          >Pad angle (°)</NumberRangeInput
+        >
+      {:else if chart === `treemap`}
         <NumberRangeInput min={0} max={10} step={0.5} bind:value={padding_inner}
           >Cell gap (px)</NumberRangeInput
         >

--- a/src/lib/plot/core/components/PlotControls.svelte
+++ b/src/lib/plot/core/components/PlotControls.svelte
@@ -11,6 +11,7 @@
   import type { Vec2 } from '$lib/math'
   import type { AxisConfig, AxisKey, PlotControlsProps } from '$lib/plot/core/types'
   import { normalize_y2_sync } from '$lib/plot/core/interactions'
+  import { untrack } from 'svelte'
   import {
     get_scale_type_name,
     is_scale_type_name,
@@ -54,6 +55,22 @@
     Math.min(lo, hi) <= 0 && Math.max(lo, hi) >= 0
 
   const all_axes = [`x`, `x2`, `y`, `y2`] as const
+  const zero_line_default = (axis: AxisKey): boolean =>
+    (axis === `x` && DEFAULTS.plot.show_x_zero_line) ||
+    (axis === `y` && DEFAULTS.plot.show_y_zero_line)
+  const grid_default = (axis: AxisKey): boolean =>
+    axis !== `x2` && DEFAULTS.scatter.display[`${axis}_grid`]
+  const zero_line_value = (axis: AxisKey): boolean =>
+    display[`${axis}_zero_line`] ?? zero_line_default(axis)
+  const grid_value = (axis: AxisKey): boolean => display[`${axis}_grid`] ?? grid_default(axis)
+  const display_values = (): Record<string, boolean> =>
+    Object.fromEntries(
+      all_axes.flatMap((axis) => [
+        [`${axis}_zero_line`, zero_line_value(axis)],
+        [`${axis}_grid`, grid_value(axis)],
+      ]),
+    )
+  const display_reset_values = untrack(display_values)
   const tick_axes = [
     { axis: `x`, label: `X-axis`, fallback: DEFAULTS.plot.x_ticks },
     { axis: `y`, label: `Y-axis`, fallback: DEFAULTS.plot.y_ticks },
@@ -67,6 +84,17 @@
   ])
   const axis_config = (axis: AxisKey): AxisConfig =>
     axis === `x` ? x_axis : axis === `x2` ? x2_axis : axis === `y` ? y_axis : y2_axis
+  const initial_ranges = untrack(
+    () =>
+      Object.fromEntries(all_axes.map((axis) => [axis, axis_config(axis).range])) as Record<
+        AxisKey,
+        AxisConfig[`range`]
+      >,
+  )
+  const initial_ticks = untrack(() => ({
+    x: x_axis.ticks ?? DEFAULTS.plot.x_ticks,
+    y: y_axis.ticks ?? DEFAULTS.plot.y_ticks,
+  }))
   const update_axis = (axis: AxisKey, updates: Partial<AxisConfig>): void => {
     if (axis === `x`) x_axis = { ...x_axis, ...updates }
     else if (axis === `x2`) x2_axis = { ...x2_axis, ...updates }
@@ -182,18 +210,8 @@
     <!-- Base Display controls -->
     <SettingsSection
       title="Display"
-      current_values={Object.fromEntries(
-        all_axes.flatMap((axis) => [
-          [`${axis}_zero_line`, display[`${axis}_zero_line`]],
-          [`${axis}_grid`, display[`${axis}_grid`]],
-        ]),
-      )}
-      on_reset={() => {
-        for (const axis of all_axes) {
-          display[`${axis}_zero_line`] = false
-          display[`${axis}_grid`] = DEFAULTS.plot[`show_${axis}_grid`]
-        }
-      }}
+      current_values={display_values()}
+      on_reset={() => (display = { ...display, ...display_reset_values })}
       layout="grid"
     >
       {#if all_axes.some((axis) => includes_zero[axis])}
@@ -203,7 +221,12 @@
             {#each visible_axes as [axis, label] (axis)}
               {#if includes_zero[axis]}
                 <label>
-                  <input type="checkbox" bind:checked={display[`${axis}_zero_line`]} />
+                  <input
+                    type="checkbox"
+                    checked={zero_line_value(axis)}
+                    onchange={(event) =>
+                      (display[`${axis}_zero_line`] = event.currentTarget.checked)}
+                  />
                   {label}
                 </label>
               {/if}
@@ -216,7 +239,11 @@
         <span class="control-options">
           {#each visible_axes as [axis, label] (axis)}
             <label>
-              <input type="checkbox" bind:checked={display[`${axis}_grid`]} />
+              <input
+                type="checkbox"
+                checked={grid_value(axis)}
+                onchange={(event) => (display[`${axis}_grid`] = event.currentTarget.checked)}
+              />
               {label}
             </label>
           {/each}
@@ -235,8 +262,8 @@
           y2_range: y2_axis.range,
         }}
         on_reset={() => {
-          for (const axis of all_axes) update_axis(axis, { range: [null, null] })
-          Object.values(range_els).forEach((el) => el.classList.remove(`invalid`))
+          for (const axis of all_axes) update_axis(axis, { range: initial_ranges[axis] })
+          Object.values(range_els).forEach((element) => element?.classList.remove(`invalid`))
         }}
         layout="grid"
       >
@@ -273,10 +300,13 @@
         {@const [min_ticks, max_ticks] = [2, 20]}
         <SettingsSection
           title="Ticks"
-          current_values={{ x_ticks: x_axis.ticks, y_ticks: y_axis.ticks }}
+          current_values={{
+            x_ticks: x_axis.ticks ?? DEFAULTS.plot.x_ticks,
+            y_ticks: y_axis.ticks ?? DEFAULTS.plot.y_ticks,
+          }}
           on_reset={() => {
-            for (const { axis, fallback } of tick_axes) {
-              update_axis(axis, { ticks: fallback })
+            for (const { axis } of tick_axes) {
+              update_axis(axis, { ticks: initial_ticks[axis] })
             }
           }}
           layout="grid"

--- a/src/lib/plot/core/components/PlotControls.svelte
+++ b/src/lib/plot/core/components/PlotControls.svelte
@@ -60,14 +60,11 @@
     (axis === `y` && DEFAULTS.plot.show_y_zero_line)
   const grid_default = (axis: AxisKey): boolean =>
     axis !== `x2` && DEFAULTS.scatter.display[`${axis}_grid`]
-  const zero_line_value = (axis: AxisKey): boolean =>
-    display[`${axis}_zero_line`] ?? zero_line_default(axis)
-  const grid_value = (axis: AxisKey): boolean => display[`${axis}_grid`] ?? grid_default(axis)
   const display_values = (): Record<string, boolean> =>
     Object.fromEntries(
       all_axes.flatMap((axis) => [
-        [`${axis}_zero_line`, zero_line_value(axis)],
-        [`${axis}_grid`, grid_value(axis)],
+        [`${axis}_zero_line`, display[`${axis}_zero_line`] ?? zero_line_default(axis)],
+        [`${axis}_grid`, display[`${axis}_grid`] ?? grid_default(axis)],
       ]),
     )
   const display_reset_values = untrack(display_values)
@@ -197,6 +194,32 @@
   })
 </script>
 
+{#snippet axis_checks(
+  label: string,
+  key: `zero_line` | `grid`,
+  fallback: (axis: AxisKey) => boolean,
+  visible: (axis: AxisKey) => boolean = () => true,
+)}
+  {@const axes = visible_axes.filter(([axis]) => visible(axis))}
+  {#if axes.length}
+    <div class="setting control-group" data-label={label.toLowerCase()}>
+      <span>{label}</span>
+      <span class="control-options">
+        {#each axes as [axis, axis_label] (axis)}
+          <label>
+            <input
+              type="checkbox"
+              checked={display[`${axis}_${key}`] ?? fallback(axis)}
+              onchange={(event) => (display[`${axis}_${key}`] = event.currentTarget.checked)}
+            />
+            {axis_label}
+          </label>
+        {/each}
+      </span>
+    </div>
+  {/if}
+{/snippet}
+
 {#if show_controls}
   <ControlPane
     bind:controls_open
@@ -214,41 +237,13 @@
       on_reset={() => (display = { ...display, ...display_reset_values })}
       layout="grid"
     >
-      {#if all_axes.some((axis) => includes_zero[axis])}
-        <div class="setting control-group" data-label="zero line">
-          <span>Zero line</span>
-          <span class="control-options">
-            {#each visible_axes as [axis, label] (axis)}
-              {#if includes_zero[axis]}
-                <label>
-                  <input
-                    type="checkbox"
-                    checked={zero_line_value(axis)}
-                    onchange={(event) =>
-                      (display[`${axis}_zero_line`] = event.currentTarget.checked)}
-                  />
-                  {label}
-                </label>
-              {/if}
-            {/each}
-          </span>
-        </div>
-      {/if}
-      <div class="setting control-group" data-label="grid">
-        <span>Grid</span>
-        <span class="control-options">
-          {#each visible_axes as [axis, label] (axis)}
-            <label>
-              <input
-                type="checkbox"
-                checked={grid_value(axis)}
-                onchange={(event) => (display[`${axis}_grid`] = event.currentTarget.checked)}
-              />
-              {label}
-            </label>
-          {/each}
-        </span>
-      </div>
+      {@render axis_checks(
+        `Zero line`,
+        `zero_line`,
+        zero_line_default,
+        (axis) => includes_zero[axis],
+      )}
+      {@render axis_checks(`Grid`, `grid`, grid_default)}
     </SettingsSection>
 
     <SettingsGroup title="Axes" open>

--- a/src/lib/plot/core/components/PlotControls.svelte
+++ b/src/lib/plot/core/components/PlotControls.svelte
@@ -2,14 +2,14 @@
   // NOTE: Axis config objects (x_axis, x2_axis, y_axis, y2_axis) must be reassigned (not mutated)
   // to trigger $bindable reactivity propagation to parent components.
   // Pattern: `x_axis = { ...x_axis, prop: value }` instead of `x_axis.prop = value`
-  import SettingsSection from '$lib/layout/SettingsSection.svelte'
+  import { SettingsGroup, SettingsSection } from '$lib/layout'
   import ControlPane from '$lib/plot/core/components/ControlPane.svelte'
   import { DEFAULTS } from '$lib/settings'
   import { format } from 'd3-format'
   import { timeFormat } from 'd3-time-format'
   import { tooltip } from 'svelte-widgets/attachments'
   import type { Vec2 } from '$lib/math'
-  import type { AxisKey, PlotControlsProps } from '$lib/plot/core/types'
+  import type { AxisConfig, AxisKey, PlotControlsProps } from '$lib/plot/core/types'
   import { normalize_y2_sync } from '$lib/plot/core/interactions'
   import {
     get_scale_type_name,
@@ -53,34 +53,55 @@
   const range_spans_zero = (lo: number, hi: number): boolean =>
     Math.min(lo, hi) <= 0 && Math.max(lo, hi) >= 0
 
-  let x_includes_zero = $derived(
-    range_spans_zero(
-      x_axis.range?.[0] ?? auto_x_range[0],
-      x_axis.range?.[1] ?? auto_x_range[1],
-    ),
+  const all_axes = [`x`, `x2`, `y`, `y2`] as const
+  const tick_axes = [
+    { axis: `x`, label: `X-axis`, fallback: DEFAULTS.plot.x_ticks },
+    { axis: `y`, label: `Y-axis`, fallback: DEFAULTS.plot.y_ticks },
+  ] as const
+  // readonly: the conditional entries are `as const` tuples, which a mutable array rejects
+  let visible_axes: readonly (readonly [AxisKey, string])[] = $derived([
+    [`x`, `X`],
+    ...(has_x2_points ? [[`x2`, `X2`] as const] : []),
+    [`y`, `Y`],
+    ...(has_y2_points ? [[`y2`, `Y2`] as const] : []),
+  ])
+  const axis_config = (axis: AxisKey): AxisConfig =>
+    axis === `x` ? x_axis : axis === `x2` ? x2_axis : axis === `y` ? y_axis : y2_axis
+  const update_axis = (axis: AxisKey, updates: Partial<AxisConfig>): void => {
+    if (axis === `x`) x_axis = { ...x_axis, ...updates }
+    else if (axis === `x2`) x2_axis = { ...x2_axis, ...updates }
+    else if (axis === `y`) y_axis = { ...y_axis, ...updates }
+    else y2_axis = { ...y2_axis, ...updates }
+  }
+  let auto_ranges = $derived({
+    x: auto_x_range,
+    x2: auto_x2_range,
+    y: auto_y_range,
+    y2: auto_y2_range,
+  } satisfies Record<AxisKey, Vec2 | undefined>)
+  // secondary axes only exist once their series do; primary axes always have an auto range
+  let axis_present = $derived({ x: true, x2: has_x2_points, y: true, y2: has_y2_points })
+  // whether each axis range spans zero, gating the zero-line toggles
+  let includes_zero = $derived(
+    Object.fromEntries(
+      all_axes.map((axis) => {
+        const auto = auto_ranges[axis]
+        const { range } = axis_config(axis)
+        return [
+          axis,
+          axis_present[axis] &&
+            auto != null &&
+            range_spans_zero(range?.[0] ?? auto[0], range?.[1] ?? auto[1]),
+        ]
+      }),
+    ) as Record<AxisKey, boolean>,
   )
-  let x2_includes_zero = $derived(
-    has_x2_points &&
-      auto_x2_range != null &&
-      range_spans_zero(
-        x2_axis.range?.[0] ?? auto_x2_range[0],
-        x2_axis.range?.[1] ?? auto_x2_range[1],
-      ),
-  )
-  let y_includes_zero = $derived(
-    range_spans_zero(
-      y_axis.range?.[0] ?? auto_y_range[0],
-      y_axis.range?.[1] ?? auto_y_range[1],
-    ),
-  )
-  let y2_includes_zero = $derived(
-    has_y2_points &&
-      auto_y2_range != null &&
-      range_spans_zero(
-        y2_axis.range?.[0] ?? auto_y2_range[0],
-        y2_axis.range?.[1] ?? auto_y2_range[1],
-      ),
-  )
+  const axis_format = {
+    x: { fallback: DEFAULTS.plot.x_format, placeholder: `.2~s / .0% / %Y-%m-%d` },
+    x2: { fallback: DEFAULTS.plot.x2_format, placeholder: `.2~s / .0% / %Y-%m-%d` },
+    y: { fallback: DEFAULTS.plot.y_format, placeholder: `d / .1e / .0%` },
+    y2: { fallback: DEFAULTS.plot.y2_format, placeholder: `.2f / .1e / .0%` },
+  } satisfies Record<AxisKey, { fallback: string | undefined; placeholder: string }>
 
   // Validation function for format specifiers
   function is_valid_format(format_string: string): boolean {
@@ -106,10 +127,7 @@
       return
     }
     input.classList.remove(`invalid`)
-    if (format_type === `x`) x_axis = { ...x_axis, format: input.value }
-    else if (format_type === `x2`) x2_axis = { ...x2_axis, format: input.value }
-    else if (format_type === `y`) y_axis = { ...y_axis, format: input.value }
-    else y2_axis = { ...y2_axis, format: input.value }
+    update_axis(format_type, { format: input.value })
   }
 
   // Handle range input changes
@@ -117,32 +135,26 @@
     const parsed = value === `` ? null : Number(value)
     range_inputs[axis][bound] = Number.isFinite(parsed) ? parsed : null
     const [min, max] = range_inputs[axis]
-    const auto = { x: auto_x_range, x2: auto_x2_range, y: auto_y_range, y2: auto_y2_range }[
-      axis
-    ]
+    const auto = auto_ranges[axis]
     const invalid = min !== null && max !== null && min >= max
     range_els[`${axis}-min`]?.classList.toggle(`invalid`, invalid)
     range_els[`${axis}-max`]?.classList.toggle(`invalid`, invalid)
     if (invalid) return
-    const axis_config = { x: x_axis, x2: x2_axis, y: y_axis, y2: y2_axis }[axis]
     const next_range =
       min === null && max === null
         ? undefined
         : ([min ?? auto?.[0] ?? 0, max ?? auto?.[1] ?? 1] as Vec2)
     // If auto range is undefined, only set if both min and max are provided
     if (!auto && (min === null || max === null)) return
-    if (axis === `x`) x_axis = { ...axis_config, range: next_range }
-    else if (axis === `x2`) x2_axis = { ...axis_config, range: next_range }
-    else if (axis === `y`) y_axis = { ...axis_config, range: next_range }
-    else y2_axis = { ...axis_config, range: next_range }
+    update_axis(axis, { range: next_range })
   }
 
   // Sync range inputs from props
   $effect(() => {
-    range_inputs.x = [x_axis.range?.[0] ?? null, x_axis.range?.[1] ?? null]
-    range_inputs.x2 = [x2_axis.range?.[0] ?? null, x2_axis.range?.[1] ?? null]
-    range_inputs.y = [y_axis.range?.[0] ?? null, y_axis.range?.[1] ?? null]
-    range_inputs.y2 = [y2_axis.range?.[0] ?? null, y2_axis.range?.[1] ?? null]
+    for (const axis of all_axes) {
+      const { range } = axis_config(axis)
+      range_inputs[axis] = [range?.[0] ?? null, range?.[1] ?? null]
+    }
   })
 
   let ctrl_state = $derived({
@@ -170,380 +182,285 @@
     <!-- Base Display controls -->
     <SettingsSection
       title="Display"
-      current_values={{
-        x_zero_line: display.x_zero_line,
-        x2_zero_line: display.x2_zero_line,
-        y_zero_line: display.y_zero_line,
-        y2_zero_line: display.y2_zero_line,
-        x_grid: display.x_grid,
-        x2_grid: display.x2_grid,
-        y_grid: display.y_grid,
-        y2_grid: display.y2_grid,
-      }}
+      current_values={Object.fromEntries(
+        all_axes.flatMap((axis) => [
+          [`${axis}_zero_line`, display[`${axis}_zero_line`]],
+          [`${axis}_grid`, display[`${axis}_grid`]],
+        ]),
+      )}
       on_reset={() => {
-        display.x_zero_line = false
-        display.x2_zero_line = false
-        display.y_zero_line = false
-        display.y2_zero_line = false
-        display.x_grid = DEFAULTS.plot.show_x_grid
-        display.x2_grid = DEFAULTS.plot.show_x2_grid
-        display.y_grid = DEFAULTS.plot.show_y_grid
-        display.y2_grid = DEFAULTS.plot.show_y2_grid
+        for (const axis of all_axes) {
+          display[`${axis}_zero_line`] = false
+          display[`${axis}_grid`] = DEFAULTS.plot[`show_${axis}_grid`]
+        }
       }}
-      style="display: flex; flex-wrap: wrap; gap: 1ex; align-items: center"
+      layout="grid"
     >
-      {#if x_includes_zero || x2_includes_zero || y_includes_zero || y2_includes_zero}
-        <span class="control-group" data-label="zero line"
-          >Zero line:
-          {#if x_includes_zero}
-            <label><input type="checkbox" bind:checked={display.x_zero_line} /> X</label>
-          {/if}
-          {#if x2_includes_zero}
-            <label
-              ><input type="checkbox" bind:checked={display.x2_zero_line} />
-              X2</label
-            >
-          {/if}
-          {#if y_includes_zero}
-            <label><input type="checkbox" bind:checked={display.y_zero_line} /> Y</label>
-          {/if}
-          {#if y2_includes_zero}
-            <label
-              ><input type="checkbox" bind:checked={display.y2_zero_line} />
-              Y2</label
-            >
-          {/if}
+      {#if all_axes.some((axis) => includes_zero[axis])}
+        <div class="setting control-group" data-label="zero line">
+          <span>Zero line</span>
+          <span class="control-options">
+            {#each visible_axes as [axis, label] (axis)}
+              {#if includes_zero[axis]}
+                <label>
+                  <input type="checkbox" bind:checked={display[`${axis}_zero_line`]} />
+                  {label}
+                </label>
+              {/if}
+            {/each}
+          </span>
+        </div>
+      {/if}
+      <div class="setting control-group" data-label="grid">
+        <span>Grid</span>
+        <span class="control-options">
+          {#each visible_axes as [axis, label] (axis)}
+            <label>
+              <input type="checkbox" bind:checked={display[`${axis}_grid`]} />
+              {label}
+            </label>
+          {/each}
         </span>
-      {/if}
-      <span class="control-group" data-label="grid"
-        >Grid:
-        <label><input type="checkbox" bind:checked={display.x_grid} /> X</label>
-        {#if has_x2_points}
-          <label><input type="checkbox" bind:checked={display.x2_grid} /> X2</label>
-        {/if}
-        <label><input type="checkbox" bind:checked={display.y_grid} /> Y</label>
-        {#if has_y2_points}
-          <label><input type="checkbox" bind:checked={display.y2_grid} /> Y2</label>
-        {/if}
-      </span>
+      </div>
     </SettingsSection>
 
-    <!-- Base Axis Range controls -->
-    <SettingsSection
-      title="Axis Range"
-      current_values={{
-        x_range: x_axis.range,
-        x2_range: x2_axis.range,
-        y_range: y_axis.range,
-        y2_range: y2_axis.range,
-      }}
-      on_reset={() => {
-        x_axis = { ...x_axis, range: [null, null] }
-        x2_axis = { ...x2_axis, range: [null, null] }
-        y_axis = { ...y_axis, range: [null, null] }
-        y2_axis = { ...y2_axis, range: [null, null] }
-        Object.values(range_els).forEach((el) => el.classList.remove(`invalid`))
-      }}
-      style="display: flex; flex-wrap: wrap; gap: 2pt"
-    >
-      {#each [[`x`, `X`], ...(has_x2_points ? [[`x2`, `X2`]] : []), [`y`, `Y`], ...(has_y2_points ? [[`y2`, `Y2`]] : [])] as [axis_key, label] (axis_key)}
-        {@const axis = axis_key as AxisKey}
-        <label
-          >{label}:
-          <input
-            type="number"
-            value={range_inputs[axis][0] ?? ``}
-            bind:this={range_els[`${axis}-min`]}
-            placeholder="auto"
-            class="range-input"
-            oninput={(evt) => update_range(axis, 0, evt.currentTarget.value)}
-            onkeydown={(evt) => evt.key === `Enter` && evt.currentTarget?.blur()}
-          />
-          to
-          <input
-            type="number"
-            value={range_inputs[axis][1] ?? ``}
-            bind:this={range_els[`${axis}-max`]}
-            placeholder="auto"
-            class="range-input"
-            oninput={(evt) => update_range(axis, 1, evt.currentTarget.value)}
-            onkeydown={(evt) => evt.key === `Enter` && evt.currentTarget?.blur()}
-          />
-        </label>
-      {/each}
-    </SettingsSection>
-
-    <!-- Optional Ticks controls -->
-    {#if show_ticks}
-      {@const [min_ticks, max_ticks] = [2, 20]}
+    <SettingsGroup title="Axes" open>
+      <!-- Base Axis Range controls -->
       <SettingsSection
-        title="Ticks"
-        current_values={{ x_ticks: x_axis.ticks, y_ticks: y_axis.ticks }}
-        on_reset={() => {
-          x_axis = { ...x_axis, ticks: DEFAULTS.plot.x_ticks }
-          y_axis = { ...y_axis, ticks: DEFAULTS.plot.y_ticks }
+        title="Axis range"
+        current_values={{
+          x_range: x_axis.range,
+          x2_range: x2_axis.range,
+          y_range: y_axis.range,
+          y2_range: y2_axis.range,
         }}
-        style="display: flex; flex-wrap: wrap; gap: 1ex"
+        on_reset={() => {
+          for (const axis of all_axes) update_axis(axis, { range: [null, null] })
+          Object.values(range_els).forEach((el) => el.classList.remove(`invalid`))
+        }}
+        layout="grid"
       >
-        <label
-          >X-axis:
-          <input
-            type="number"
-            min={min_ticks}
-            max={max_ticks}
-            step="1"
-            value={typeof x_axis.ticks === `number` ? x_axis.ticks : 8}
-            oninput={(evt) => {
-              const parsed = parseInt(evt.currentTarget.value, 10)
-              if (isNaN(parsed)) return
-              x_axis = {
-                ...x_axis,
-                ticks: Math.max(min_ticks, Math.min(max_ticks, parsed)),
-              }
-            }}
-          />
-        </label>
-        <label
-          >Y-axis:
-          <input
-            type="number"
-            min={min_ticks}
-            max={max_ticks}
-            step="1"
-            value={typeof y_axis.ticks === `number` ? y_axis.ticks : 6}
-            oninput={(evt) => {
-              const parsed = parseInt(evt.currentTarget.value, 10)
-              if (isNaN(parsed)) return
-              y_axis = {
-                ...y_axis,
-                ticks: Math.max(min_ticks, Math.min(max_ticks, parsed)),
-              }
-            }}
-          />
-        </label>
+        {#each visible_axes as [axis, label] (axis)}
+          <label>
+            <span>{label}</span>
+            <span class="range-pair">
+              <input
+                type="number"
+                value={range_inputs[axis][0] ?? ``}
+                bind:this={range_els[`${axis}-min`]}
+                placeholder="auto"
+                class="range-input"
+                oninput={(evt) => update_range(axis, 0, evt.currentTarget.value)}
+                onkeydown={(evt) => evt.key === `Enter` && evt.currentTarget?.blur()}
+              />
+              <span>to</span>
+              <input
+                type="number"
+                value={range_inputs[axis][1] ?? ``}
+                bind:this={range_els[`${axis}-max`]}
+                placeholder="auto"
+                class="range-input"
+                oninput={(evt) => update_range(axis, 1, evt.currentTarget.value)}
+                onkeydown={(evt) => evt.key === `Enter` && evt.currentTarget?.blur()}
+              />
+            </span>
+          </label>
+        {/each}
       </SettingsSection>
-    {/if}
 
-    <!-- Scale Type controls -->
-    <SettingsSection
-      title="Scale Type"
-      current_values={{
-        x_scale: get_scale_type_name(x_axis.scale_type),
-        x2_scale: get_scale_type_name(x2_axis.scale_type),
-        y_scale: get_scale_type_name(y_axis.scale_type),
-        y2_scale: get_scale_type_name(y2_axis.scale_type),
-      }}
-      on_reset={() => {
-        x_axis = { ...x_axis, scale_type: `linear` }
-        x2_axis = { ...x2_axis, scale_type: `linear` }
-        y_axis = { ...y_axis, scale_type: `linear` }
-        y2_axis = { ...y2_axis, scale_type: `linear` }
-      }}
-      style="display: flex; flex-wrap: wrap; gap: 1ex"
-    >
-      <label
-        >X:
-        <select
-          value={get_scale_type_name(x_axis.scale_type)}
-          onchange={(evt) => {
-            const val = evt.currentTarget.value
-            x_axis = {
-              ...x_axis,
-              scale_type: is_scale_type_name(val) ? val : `linear`,
+      <!-- Optional Ticks controls -->
+      {#if show_ticks}
+        {@const [min_ticks, max_ticks] = [2, 20]}
+        <SettingsSection
+          title="Ticks"
+          current_values={{ x_ticks: x_axis.ticks, y_ticks: y_axis.ticks }}
+          on_reset={() => {
+            for (const { axis, fallback } of tick_axes) {
+              update_axis(axis, { ticks: fallback })
             }
           }}
+          layout="grid"
         >
-          <option value="linear">Linear</option>
-          <option value="log">Log</option>
-          <option value="arcsinh">Arcsinh</option>
-        </select>
-      </label>
-      {#if has_x2_points}
-        <label
-          >X2:
-          <select
-            value={get_scale_type_name(x2_axis.scale_type)}
-            onchange={(evt) => {
-              const val = evt.currentTarget.value
-              x2_axis = {
-                ...x2_axis,
-                scale_type: is_scale_type_name(val) ? val : `linear`,
-              }
-            }}
-          >
-            <option value="linear">Linear</option>
-            <option value="log">Log</option>
-            <option value="arcsinh">Arcsinh</option>
-          </select>
-        </label>
+          {#each tick_axes as { axis, label, fallback } (axis)}
+            {@const ticks = axis_config(axis).ticks}
+            <label>
+              <span>{label}</span>
+              <input
+                type="number"
+                min={min_ticks}
+                max={max_ticks}
+                step="1"
+                value={typeof ticks === `number` ? ticks : fallback}
+                oninput={(evt) => {
+                  const parsed = parseInt(evt.currentTarget.value, 10)
+                  if (isNaN(parsed)) return
+                  update_axis(axis, {
+                    ticks: Math.max(min_ticks, Math.min(max_ticks, parsed)),
+                  })
+                }}
+              />
+            </label>
+          {/each}
+        </SettingsSection>
       {/if}
-      <label
-        >Y:
-        <select
-          value={get_scale_type_name(y_axis.scale_type)}
-          onchange={(evt) => {
-            const val = evt.currentTarget.value
-            y_axis = {
-              ...y_axis,
-              scale_type: is_scale_type_name(val) ? val : `linear`,
-            }
-          }}
-        >
-          <option value="linear">Linear</option>
-          <option value="log">Log</option>
-          <option value="arcsinh">Arcsinh</option>
-        </select>
-      </label>
+
+      <!-- Scale Type controls -->
+      <SettingsSection
+        title="Scale type"
+        current_values={{
+          x_scale: get_scale_type_name(x_axis.scale_type),
+          x2_scale: get_scale_type_name(x2_axis.scale_type),
+          y_scale: get_scale_type_name(y_axis.scale_type),
+          y2_scale: get_scale_type_name(y2_axis.scale_type),
+        }}
+        on_reset={() => {
+          for (const axis of all_axes) update_axis(axis, { scale_type: `linear` })
+        }}
+        data-testid="scale-type-section"
+        layout="grid"
+      >
+        {#each visible_axes as [axis, label] (axis)}
+          <label>
+            <span>{label}</span>
+            <select
+              value={get_scale_type_name(axis_config(axis).scale_type)}
+              onchange={(evt) => {
+                const scale_type = evt.currentTarget.value
+                update_axis(axis, {
+                  scale_type: is_scale_type_name(scale_type) ? scale_type : `linear`,
+                })
+              }}
+            >
+              <option value="linear">Linear</option>
+              <option value="log">Log</option>
+              <option value="arcsinh">Arcsinh</option>
+            </select>
+          </label>
+        {/each}
+      </SettingsSection>
+
+      <!-- Y2 Sync controls (only when y2 axis has points) -->
       {#if has_y2_points}
-        <label
-          >Y2:
-          <select
-            value={get_scale_type_name(y2_axis.scale_type)}
-            onchange={(evt) => {
-              const val = evt.currentTarget.value
-              y2_axis = {
-                ...y2_axis,
-                scale_type: is_scale_type_name(val) ? val : `linear`,
-              }
-            }}
-          >
-            <option value="linear">Linear</option>
-            <option value="log">Log</option>
-            <option value="arcsinh">Arcsinh</option>
-          </select>
-        </label>
-      {/if}
-    </SettingsSection>
-
-    <!-- Y2 Sync controls (only when y2 axis has points) -->
-    {#if has_y2_points}
-      {@const current_sync = normalize_y2_sync(y2_axis.sync)}
-      {@const y2_sync_tip = `Controls Y2 axis range:
+        {@const current_sync = normalize_y2_sync(y2_axis.sync)}
+        {@const y2_sync_tip = `Controls Y2 axis range:
 • Independent: Y2 has its own range based on its data
 • Synced: Y2 has exact same range as Y1
 • Align: Y2 expands to show all data, with a shared anchor point (default 0)`}
-      <SettingsSection
-        title="Y2 Sync"
-        current_values={{ y2_sync: current_sync.mode, align_value: current_sync.align_value }}
-        on_reset={() => {
-          y2_axis = { ...y2_axis, sync: undefined }
-        }}
-        style="display: flex; gap: 1ex; align-items: center; flex-wrap: wrap"
-      >
-        <label {@attach tooltip({ content: y2_sync_tip })}
-          >Mode:
-          <select
-            value={current_sync.mode}
-            aria-label="Y2 axis synchronization mode"
-            onchange={(evt) => {
-              const val = evt.currentTarget.value
-              const mode = is_y2_sync_mode(val) ? val : `none`
-              if (mode === `none`) {
-                y2_axis = { ...y2_axis, sync: undefined }
-              } else if (mode === `align`) {
-                y2_axis = {
-                  ...y2_axis,
-                  sync: { mode, align_value: current_sync.align_value ?? 0 },
-                }
-              } else {
-                y2_axis = { ...y2_axis, sync: mode }
-              }
-            }}
-          >
-            <option value="none">Independent</option>
-            <option value="synced">Synced</option>
-            <option value="align">Align</option>
-          </select>
-        </label>
-        {#if current_sync.mode === `align`}
-          <label
-            >Align at:
-            <input
-              type="number"
-              value={current_sync.align_value ?? 0}
-              aria-label="Value to align on both axes"
-              style="width: 5em"
+        <SettingsSection
+          title="Y2 sync"
+          current_values={{
+            y2_sync: current_sync.mode,
+            align_value: current_sync.align_value,
+          }}
+          on_reset={() => {
+            y2_axis = { ...y2_axis, sync: undefined }
+          }}
+          layout="grid"
+        >
+          <label {@attach tooltip({ content: y2_sync_tip })}>
+            <span>Mode</span>
+            <select
+              value={current_sync.mode}
+              aria-label="Y2 axis synchronization mode"
               onchange={(evt) => {
-                const val = parseFloat(evt.currentTarget.value)
-                y2_axis = {
-                  ...y2_axis,
-                  sync: {
-                    mode: `align`,
-                    align_value: Number.isFinite(val) ? val : 0,
-                  },
+                const val = evt.currentTarget.value
+                const mode = is_y2_sync_mode(val) ? val : `none`
+                if (mode === `none`) {
+                  y2_axis = { ...y2_axis, sync: undefined }
+                } else if (mode === `align`) {
+                  y2_axis = {
+                    ...y2_axis,
+                    sync: { mode, align_value: current_sync.align_value ?? 0 },
+                  }
+                } else {
+                  y2_axis = { ...y2_axis, sync: mode }
                 }
               }}
+            >
+              <option value="none">Independent</option>
+              <option value="synced">Synced</option>
+              <option value="align">Align</option>
+            </select>
+          </label>
+          {#if current_sync.mode === `align`}
+            <label>
+              <span>Align at</span>
+              <input
+                type="number"
+                value={current_sync.align_value ?? 0}
+                aria-label="Value to align on both axes"
+                style="width: 5em"
+                onchange={(evt) => {
+                  const val = parseFloat(evt.currentTarget.value)
+                  y2_axis = {
+                    ...y2_axis,
+                    sync: {
+                      mode: `align`,
+                      align_value: Number.isFinite(val) ? val : 0,
+                    },
+                  }
+                }}
+              />
+            </label>
+          {/if}
+        </SettingsSection>
+      {/if}
+
+      <!-- Base Tick Format controls -->
+      <SettingsSection
+        title="Tick format"
+        data-testid="tick-format-section"
+        class="tick-format-section"
+        current_values={{
+          x_format: x_axis.format,
+          x2_format: x2_axis.format,
+          y_format: y_axis.format,
+          y2_format: y2_axis.format,
+        }}
+        on_reset={() => {
+          for (const axis of all_axes) {
+            update_axis(axis, { format: axis_format[axis].fallback })
+          }
+        }}
+        layout="grid"
+      >
+        {#each visible_axes as [axis, label] (axis)}
+          <label>
+            <span>{label}-axis</span>
+            <input
+              type="text"
+              value={axis_config(axis).format ?? axis_format[axis].fallback}
+              placeholder={axis_format[axis].placeholder}
+              oninput={format_input_handler(axis)}
             />
           </label>
-        {/if}
+        {/each}
       </SettingsSection>
-    {/if}
-
-    <!-- Base Tick Format controls -->
-    <SettingsSection
-      title="Tick Format"
-      data-testid="tick-format-section"
-      current_values={{
-        x_format: x_axis.format,
-        x2_format: x2_axis.format,
-        y_format: y_axis.format,
-        y2_format: y2_axis.format,
-      }}
-      on_reset={() => {
-        x_axis = { ...x_axis, format: DEFAULTS.plot.x_format }
-        x2_axis = { ...x2_axis, format: DEFAULTS.plot.x2_format }
-        y_axis = { ...y_axis, format: DEFAULTS.plot.y_format }
-        y2_axis = { ...y2_axis, format: DEFAULTS.plot.y2_format }
-      }}
-      class="pane-grid"
-      style="grid-template-columns: 1fr 1fr"
-    >
-      <label style="white-space: nowrap"
-        >X-axis:
-        <input
-          type="text"
-          value={x_axis.format ?? DEFAULTS.plot.x_format}
-          placeholder=".2~s / .0% / %Y-%m-%d"
-          oninput={format_input_handler(`x`)}
-        />
-      </label>
-      {#if has_x2_points}
-        <label style="white-space: nowrap"
-          >X2-axis:
-          <input
-            type="text"
-            value={x2_axis.format ?? DEFAULTS.plot.x2_format}
-            placeholder=".2~s / .0% / %Y-%m-%d"
-            oninput={format_input_handler(`x2`)}
-            style="width: 100%"
-          />
-        </label>
-      {/if}
-      <label style="white-space: nowrap"
-        >Y-axis:
-        <input
-          type="text"
-          value={y_axis.format ?? DEFAULTS.plot.y_format}
-          placeholder="d / .1e / .0%"
-          oninput={format_input_handler(`y`)}
-          style="width: 100%"
-        />
-      </label>
-      {#if has_y2_points}
-        <label style="white-space: nowrap"
-          >Y2-axis:
-          <input
-            type="text"
-            value={y2_axis.format ?? DEFAULTS.plot.y2_format}
-            placeholder=".2f / .1e / .0%"
-            oninput={format_input_handler(`y2`)}
-            style="width: 100%"
-          />
-        </label>
-      {/if}
-    </SettingsSection>
+    </SettingsGroup>
 
     <!-- Custom controls after base controls -->
     {@render post_children?.(ctrl_state)}
   </ControlPane>
 {/if}
+
+<style>
+  :is(.control-options, .range-pair) {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 3pt 7pt;
+    min-width: 0;
+  }
+  .control-options label {
+    display: flex;
+    align-items: center;
+    gap: 3pt;
+  }
+  .range-pair input {
+    width: 6.5em;
+    min-width: 0;
+  }
+  :global(.tick-format-section input) {
+    width: 100%;
+  }
+</style>

--- a/src/lib/plot/core/components/PlotControls.svelte
+++ b/src/lib/plot/core/components/PlotControls.svelte
@@ -55,6 +55,13 @@
     Math.min(lo, hi) <= 0 && Math.max(lo, hi) >= 0
 
   const all_axes = [`x`, `x2`, `y`, `y2`] as const
+  const axis_record = <Value>(get_value: (axis: AxisKey) => Value): Record<AxisKey, Value> =>
+    Object.fromEntries(all_axes.map((axis) => [axis, get_value(axis)])) as Record<
+      AxisKey,
+      Value
+    >
+  const axis_values = <Value>(suffix: string, get_value: (axis: AxisKey) => Value) =>
+    Object.fromEntries(all_axes.map((axis) => [`${axis}_${suffix}`, get_value(axis)]))
   const zero_line_default = (axis: AxisKey): boolean =>
     (axis === `x` && DEFAULTS.plot.show_x_zero_line) ||
     (axis === `y` && DEFAULTS.plot.show_y_zero_line)
@@ -72,22 +79,10 @@
     { axis: `x`, label: `X-axis`, fallback: DEFAULTS.plot.x_ticks },
     { axis: `y`, label: `Y-axis`, fallback: DEFAULTS.plot.y_ticks },
   ] as const
-  // readonly: the conditional entries are `as const` tuples, which a mutable array rejects
-  let visible_axes: readonly (readonly [AxisKey, string])[] = $derived([
-    [`x`, `X`],
-    ...(has_x2_points ? [[`x2`, `X2`] as const] : []),
-    [`y`, `Y`],
-    ...(has_y2_points ? [[`y2`, `Y2`] as const] : []),
-  ])
+  const axis_labels = { x: `X`, x2: `X2`, y: `Y`, y2: `Y2` } as const
   const axis_config = (axis: AxisKey): AxisConfig =>
     axis === `x` ? x_axis : axis === `x2` ? x2_axis : axis === `y` ? y_axis : y2_axis
-  const initial_ranges = untrack(
-    () =>
-      Object.fromEntries(all_axes.map((axis) => [axis, axis_config(axis).range])) as Record<
-        AxisKey,
-        AxisConfig[`range`]
-      >,
-  )
+  const initial_ranges = untrack(() => axis_record((axis) => axis_config(axis).range))
   const initial_ticks = untrack(() => ({
     x: x_axis.ticks ?? DEFAULTS.plot.x_ticks,
     y: y_axis.ticks ?? DEFAULTS.plot.y_ticks,
@@ -106,20 +101,22 @@
   } satisfies Record<AxisKey, Vec2 | undefined>)
   // secondary axes only exist once their series do; primary axes always have an auto range
   let axis_present = $derived({ x: true, x2: has_x2_points, y: true, y2: has_y2_points })
+  let visible_axes = $derived(
+    all_axes
+      .filter((axis) => axis_present[axis])
+      .map((axis) => [axis, axis_labels[axis]] as const),
+  )
   // whether each axis range spans zero, gating the zero-line toggles
   let includes_zero = $derived(
-    Object.fromEntries(
-      all_axes.map((axis) => {
-        const auto = auto_ranges[axis]
-        const { range } = axis_config(axis)
-        return [
-          axis,
-          axis_present[axis] &&
-            auto != null &&
-            range_spans_zero(range?.[0] ?? auto[0], range?.[1] ?? auto[1]),
-        ]
-      }),
-    ) as Record<AxisKey, boolean>,
+    axis_record((axis) => {
+      const auto = auto_ranges[axis]
+      const { range } = axis_config(axis)
+      return (
+        axis_present[axis] &&
+        auto != null &&
+        range_spans_zero(range?.[0] ?? auto[0], range?.[1] ?? auto[1])
+      )
+    }),
   )
   const axis_format = {
     x: { fallback: DEFAULTS.plot.x_format, placeholder: `.2~s / .0% / %Y-%m-%d` },
@@ -250,12 +247,7 @@
       <!-- Base Axis Range controls -->
       <SettingsSection
         title="Axis range"
-        current_values={{
-          x_range: x_axis.range,
-          x2_range: x2_axis.range,
-          y_range: y_axis.range,
-          y2_range: y2_axis.range,
-        }}
+        current_values={axis_values(`range`, (axis) => axis_config(axis).range)}
         on_reset={() => {
           for (const axis of all_axes) update_axis(axis, { range: initial_ranges[axis] })
           Object.values(range_els).forEach((element) => element?.classList.remove(`invalid`))
@@ -332,12 +324,9 @@
       <!-- Scale Type controls -->
       <SettingsSection
         title="Scale type"
-        current_values={{
-          x_scale: get_scale_type_name(x_axis.scale_type),
-          x2_scale: get_scale_type_name(x2_axis.scale_type),
-          y_scale: get_scale_type_name(y_axis.scale_type),
-          y2_scale: get_scale_type_name(y2_axis.scale_type),
-        }}
+        current_values={axis_values(`scale`, (axis) =>
+          get_scale_type_name(axis_config(axis).scale_type),
+        )}
         on_reset={() => {
           for (const axis of all_axes) update_axis(axis, { scale_type: `linear` })
         }}
@@ -436,12 +425,7 @@
         title="Tick format"
         data-testid="tick-format-section"
         class="tick-format-section"
-        current_values={{
-          x_format: x_axis.format,
-          x2_format: x2_axis.format,
-          y_format: y_axis.format,
-          y2_format: y2_axis.format,
-        }}
+        current_values={axis_values(`format`, (axis) => axis_config(axis).format)}
         on_reset={() => {
           for (const axis of all_axes) {
             update_axis(axis, { format: axis_format[axis].fallback })

--- a/src/lib/plot/histogram/HistogramControls.svelte
+++ b/src/lib/plot/histogram/HistogramControls.svelte
@@ -98,7 +98,7 @@
           <span>Property</span>
           <select bind:value={selected_property}>
             <option value="">All</option>
-            {#each series_options as option (option)}
+            {#each series_options as option, option_idx (option_idx)}
               <option value={option}>{option}</option>
             {/each}
           </select>

--- a/src/lib/plot/histogram/HistogramControls.svelte
+++ b/src/lib/plot/histogram/HistogramControls.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   // NOTE: Axis config objects must be reassigned (not mutated) to trigger $bindable reactivity.
-  import { SettingsSection } from '$lib/layout'
+  import { NumberRangeInput, SettingsSection } from '$lib/layout'
   import type { Vec2 } from '$lib/math'
   import type { BarStyle, DataSeries, PlotConfig } from '$lib/plot'
   import { PlotControls } from '$lib/plot'
@@ -68,6 +68,8 @@
   bind:y2_axis
   {auto_x2_range}
   {auto_y2_range}
+  {has_x2_points}
+  {has_y2_points}
   {...rest}
 >
   {@render children?.({ x_axis, x2_axis, y_axis, y2_axis, display })}
@@ -80,147 +82,78 @@
       // plot does not suddenly grow a legend
       show_legend = legend_mode_to_prop(DEFAULTS.histogram.show_legend)
     }}
+    layout="grid"
   >
-    <div class="pane-row">
-      <label
-        >Bins:
-        <input type="range" min="5" max="100" step="5" bind:value={bins} />
-      </label>
-      <input type="number" min="5" max="100" step="5" bind:value={bins} />
-    </div>
+    <NumberRangeInput min={5} max={100} step={5} bind:value={bins}>Bins</NumberRangeInput>
     {#if has_multiple_series}
-      <div class="pane-row">
-        <label
-          >Mode:
-          <select bind:value={mode}>
-            <option value="single">Single</option>
-            <option value="overlay">Overlay</option>
+      <label>
+        <span>Mode</span>
+        <select bind:value={mode}>
+          <option value="single">Single</option>
+          <option value="overlay">Overlay</option>
+        </select>
+      </label>
+      {#if mode === `single`}
+        <label>
+          <span>Property</span>
+          <select bind:value={selected_property}>
+            <option value="">All</option>
+            {#each series_options as option (option)}
+              <option value={option}>{option}</option>
+            {/each}
           </select>
         </label>
-      </div>
-      {#if mode === `single`}
-        <div class="pane-row">
-          <label
-            >Property:
-            <select bind:value={selected_property}>
-              <option value="">All</option>
-              {#each series_options as option (option)}
-                <option value={option}>{option}</option>
-              {/each}
-            </select>
-          </label>
-        </div>
       {/if}
     {/if}
     <label>
+      <span>Show legend</span>
       <input
         type="checkbox"
         checked={show_legend ?? resolved_show_legend}
         onchange={(event) => (show_legend = event.currentTarget.checked)}
       />
-      Show legend
     </label>
   </SettingsSection>
 
   <SettingsSection
-    title="Bar Style"
+    title="Bar style"
     current_values={bar}
     on_reset={() => {
       bar = { ...DEFAULTS.histogram.bar }
     }}
-    class="pane-grid"
+    layout="grid"
   >
-    {#if bar}
-      {#if visible_series.length === 1}
-        <label>Fill: <input type="color" bind:value={bar.color} /></label>
-      {/if}
-      <label
-        >Opacity:
-        <input type="range" min="0" max="1" step="0.05" bind:value={bar.opacity} />
-        <input type="number" min="0" max="1" step="0.05" bind:value={bar.opacity} />
-      </label>
-      <label
-        >Stroke Width:
-        <input type="range" min="0" max="5" step="0.1" bind:value={bar.stroke_width} />
-        <input type="number" min="0" max="5" step="0.1" bind:value={bar.stroke_width} />
-      </label>
-      <label
-        >Stroke Color:
+    {#if visible_series.length === 1}
+      <label><span>Fill</span><input type="color" bind:value={bar.color} /></label>
+    {/if}
+    <NumberRangeInput min={0} max={1} step={0.05} bind:value={bar.opacity}
+      >Opacity</NumberRangeInput
+    >
+    <NumberRangeInput min={0} max={5} step={0.1} bind:value={bar.stroke_width}
+      >Stroke width</NumberRangeInput
+    >
+    <label>
+      <span>Stroke color</span>
+      <span class="stroke-value">
         <input type="color" bind:value={bar.stroke_color} />
-        <input
-          type="range"
-          min="0"
-          max="1"
-          step="0.05"
-          bind:value={bar.stroke_opacity}
-          title="Opacity"
-        />
         <input type="number" min="0" max="1" step="0.05" bind:value={bar.stroke_opacity} />
-      </label>
-    {/if}
-  </SettingsSection>
-
-  <SettingsSection
-    title="Scale Type"
-    data-testid="scale-type-section"
-    current_values={{
-      x_scale_type: x_axis.scale_type,
-      ...(has_x2_points ? { x2_scale_type: x2_axis.scale_type } : {}),
-      y_scale_type: y_axis.scale_type,
-      ...(has_y2_points ? { y2_scale_type: y2_axis.scale_type } : {}),
-    }}
-    on_reset={() => {
-      x_axis = {
-        ...x_axis,
-        scale_type: DEFAULTS.plot.x_scale_type as `linear` | `log`,
-      }
-      y_axis = {
-        ...y_axis,
-        scale_type: DEFAULTS.plot.y_scale_type as `linear` | `log`,
-      }
-      if (has_x2_points) {
-        x2_axis = {
-          ...x2_axis,
-          scale_type: DEFAULTS.plot.x_scale_type as `linear` | `log`,
-        }
-      }
-      if (has_y2_points) {
-        y2_axis = {
-          ...y2_axis,
-          scale_type: DEFAULTS.plot.y_scale_type as `linear` | `log`,
-        }
-      }
-    }}
-    class="pane-grid"
-    style="grid-template-columns: 1fr 1fr"
-  >
-    <label
-      >X: <select bind:value={x_axis.scale_type}>
-        <option value="linear">Linear</option>
-        <option value="log">Log</option>
-      </select></label
-    >
-    {#if has_x2_points}
-      <label
-        >X2: <select bind:value={x2_axis.scale_type}>
-          <option value="linear">Linear</option>
-          <option value="log">Log</option>
-        </select></label
-      >
-    {/if}
-    <label
-      >Y: <select bind:value={y_axis.scale_type}>
-        <option value="linear">Linear</option>
-        <option value="log">Log</option>
-      </select></label
-    >
-    {#if has_y2_points}
-      <label
-        >Y2: <select bind:value={y2_axis.scale_type}>
-          <option value="linear">Linear</option>
-          <option value="log">Log</option>
-        </select></label
-      >
-    {/if}
+      </span>
+      <input
+        type="range"
+        min="0"
+        max="1"
+        step="0.05"
+        bind:value={bar.stroke_opacity}
+        title="Opacity"
+      />
+    </label>
   </SettingsSection>
 </PlotControls>
+
+<style>
+  .stroke-value {
+    display: flex;
+    align-items: center;
+    gap: 4pt;
+  }
+</style>

--- a/src/lib/plot/sankey/SankeyControls.svelte
+++ b/src/lib/plot/sankey/SankeyControls.svelte
@@ -56,17 +56,17 @@
           show_node_labels,
         } = DEFAULTS.sankey)
       }}
-      style="display: flex; flex-wrap: wrap; gap: 2ex"
+      layout="grid"
     >
-      <label style="flex: 1">
-        Orientation:
+      <label>
+        <span>Orientation</span>
         <select bind:value={orientation}>
           <option value="horizontal">Horizontal</option>
           <option value="vertical">Vertical</option>
         </select>
       </label>
-      <label style="flex: 1">
-        Node align:
+      <label>
+        <span>Node align</span>
         <select bind:value={node_align}>
           <option value="justify">Justify</option>
           <option value="left">Left</option>
@@ -74,30 +74,18 @@
           <option value="center">Center</option>
         </select>
       </label>
-      <NumberRangeInput
-        min={4}
-        max={60}
-        step={1}
-        bind:value={node_width}
-        style="flex: 1 1 100%">Node width:</NumberRangeInput
+      <NumberRangeInput min={4} max={60} step={1} bind:value={node_width}
+        >Node width</NumberRangeInput
       >
-      <NumberRangeInput
-        min={0}
-        max={40}
-        step={1}
-        bind:value={node_padding}
-        style="flex: 1 1 100%">Node padding:</NumberRangeInput
+      <NumberRangeInput min={0} max={40} step={1} bind:value={node_padding}
+        >Node padding</NumberRangeInput
       >
-      <NumberRangeInput
-        min={0.05}
-        max={1}
-        step={0.05}
-        bind:value={link_opacity}
-        style="flex: 1 1 100%">Link opacity:</NumberRangeInput
+      <NumberRangeInput min={0.05} max={1} step={0.05} bind:value={link_opacity}
+        >Link opacity</NumberRangeInput
       >
-      <label style="flex: 1 1 100%">
+      <label>
+        <span>Show node labels</span>
         <input type="checkbox" bind:checked={show_node_labels} />
-        Show node labels
       </label>
     </SettingsSection>
   </ControlPane>

--- a/src/lib/plot/scatter-3d/ScatterPlot3DControls.svelte
+++ b/src/lib/plot/scatter-3d/ScatterPlot3DControls.svelte
@@ -65,17 +65,9 @@
     return [min_val - padding, max_val + padding]
   }
 
-  // flatMap already creates new array, no need to spread
-  let all_x_values = $derived(series.flatMap((srs) => srs.x))
-  let all_y_values = $derived(series.flatMap((srs) => srs.y))
-  let all_z_values = $derived(series.flatMap((srs) => srs.z))
-
-  let auto_x_range = $derived(calc_auto_range(all_x_values))
-  let auto_y_range = $derived(calc_auto_range(all_y_values))
-  let auto_z_range = $derived(calc_auto_range(all_z_values))
-
-  type InputControlEvent = Event & { currentTarget: HTMLInputElement }
-  const get_input_value = (event: InputControlEvent) => event.currentTarget.value
+  let auto_x_range = $derived(calc_auto_range(series.flatMap((srs) => srs.x)))
+  let auto_y_range = $derived(calc_auto_range(series.flatMap((srs) => srs.y)))
+  let auto_z_range = $derived(calc_auto_range(series.flatMap((srs) => srs.z)))
 
   const set_display = (key: `projection_opacity` | `projection_scale`) => (val?: number) => {
     // Guard against cleared/invalid input - preserve existing value
@@ -94,18 +86,21 @@
   // Round to 4 decimal places for display
   const round4 = (val: number) => Math.round(val * 1e4) / 1e4
 
-  // Helper for axis label updates
-  const update_axis_label =
-    <T extends { label?: string }>(axis: T, setter: (val: T) => void) =>
-    (event: InputControlEvent) => {
-      setter({ ...axis, label: get_input_value(event) })
-    }
-
   type AxisEntry = {
     name: string
     axis: AxisConfig3D
     auto_range: Vec2
     set: (val: AxisConfig3D) => void
+  }
+  const set_axis_range = (
+    { axis, auto_range, set }: AxisEntry,
+    bound: 0 | 1,
+    value: number,
+  ): void => {
+    if (!Number.isFinite(value)) return
+    const range: Vec2 = [axis.range?.[0] ?? auto_range[0], axis.range?.[1] ?? auto_range[1]]
+    range[bound] = value
+    set({ ...axis, range })
   }
   const axes = $derived<AxisEntry[]>([
     { name: `X`, axis: x_axis, auto_range: auto_x_range, set: (val) => (x_axis = val) },
@@ -242,14 +237,15 @@
       }}
       layout="grid"
     >
-      {#each axes as { name, axis, auto_range, set } (name)}
+      {#each axes as entry (entry.name)}
+        {@const { name, axis, auto_range, set } = entry}
         <div class="setting">
           <span>{name}</span>
           <div class="axis-inputs">
             <input
               type="text"
               value={axis.label}
-              oninput={update_axis_label(axis, set)}
+              oninput={(event) => set({ ...axis, label: event.currentTarget.value })}
               placeholder="{name} label"
               aria-label="{name} label"
               class="axis-label-input"
@@ -258,11 +254,7 @@
               type="number"
               step="any"
               value={round4(axis.range?.[0] ?? auto_range[0])}
-              oninput={(event) => {
-                const val = parseFloat(event.currentTarget.value)
-                if (Number.isNaN(val)) return
-                set({ ...axis, range: [val, axis.range?.[1] ?? auto_range[1]] })
-              }}
+              oninput={(event) => set_axis_range(entry, 0, event.currentTarget.valueAsNumber)}
               aria-label="{name} min"
               class="axis-range-input"
             />
@@ -271,11 +263,7 @@
               type="number"
               step="any"
               value={round4(axis.range?.[1] ?? auto_range[1])}
-              oninput={(event) => {
-                const val = parseFloat(event.currentTarget.value)
-                if (Number.isNaN(val)) return
-                set({ ...axis, range: [axis.range?.[0] ?? auto_range[0], val] })
-              }}
+              oninput={(event) => set_axis_range(entry, 1, event.currentTarget.valueAsNumber)}
               aria-label="{name} max"
               class="axis-range-input"
             />

--- a/src/lib/plot/scatter-3d/ScatterPlot3DControls.svelte
+++ b/src/lib/plot/scatter-3d/ScatterPlot3DControls.svelte
@@ -3,7 +3,7 @@
   import { DraggablePane, type PaneProps, type PaneToggleProps } from '$lib/overlays'
   // NOTE: Axis config objects must be reassigned (not mutated) to trigger $bindable reactivity.
   // Pattern: `x_axis = { ...x_axis, prop: value }` instead of `x_axis.prop = value`
-  import { SettingsSection } from '$lib/layout'
+  import { NumberRangeInput, SettingsSection } from '$lib/layout'
   import type { Vec2 } from '$lib/math'
   import type {
     AxisConfig3D,
@@ -13,12 +13,19 @@
     Surface3DConfig,
   } from '$lib/plot/core/types'
   import { calculate_domain } from '$lib/plot/core/scales'
-  import { unique_id } from '$lib/plot/core/utils'
-  import { parse_num_token } from '$lib/utils'
   import type { Snippet } from 'svelte'
 
-  // Unique ID prefix to avoid conflicts when multiple instances on same page
-  const uid = unique_id(`scatter3d-ctrl`)
+  const defaults = {
+    camera_projection: `perspective` as CameraProjection3D,
+    auto_rotate: 0,
+    show_axes: true,
+    show_grid: true,
+    show_axis_labels: true,
+    show_bounding_box: false,
+    projections: { xy: false, xz: false, yz: false },
+    projection_opacity: 0.3,
+    projection_scale: 0.5,
+  }
 
   let {
     show_controls = $bindable(true),
@@ -27,8 +34,8 @@
     y_axis = $bindable({}),
     z_axis = $bindable({}),
     display = $bindable({}),
-    camera_projection = $bindable(`perspective`),
-    auto_rotate = $bindable(0),
+    camera_projection = $bindable(defaults.camera_projection),
+    auto_rotate = $bindable(defaults.auto_rotate),
     series = [],
     surfaces = [],
     toggle_props,
@@ -70,11 +77,9 @@
   type InputControlEvent = Event & { currentTarget: HTMLInputElement }
   const get_input_value = (event: InputControlEvent) => event.currentTarget.value
 
-  // Helpers to update display properties - avoids verbose inline handlers
-  const update_display = (key: keyof DisplayConfig3D) => (event: InputControlEvent) => {
-    const parsed = parse_num_token(get_input_value(event))
+  const set_display = (key: `projection_opacity` | `projection_scale`) => (val?: number) => {
     // Guard against cleared/invalid input - preserve existing value
-    if (!Number.isNaN(parsed)) display = { ...display, [key]: parsed }
+    if (val != null && Number.isFinite(val)) display = { ...display, [key]: val }
   }
   const toggle_display = (key: keyof DisplayConfig3D) => () => {
     display = { ...display, [key]: !display[key] }
@@ -103,25 +108,18 @@
     set: (val: AxisConfig3D) => void
   }
   const axes = $derived<AxisEntry[]>([
-    {
-      name: `X`,
-      axis: x_axis,
-      auto_range: auto_x_range,
-      set: (val) => (x_axis = val),
-    },
-    {
-      name: `Y`,
-      axis: y_axis,
-      auto_range: auto_y_range,
-      set: (val) => (y_axis = val),
-    },
-    {
-      name: `Z`,
-      axis: z_axis,
-      auto_range: auto_z_range,
-      set: (val) => (z_axis = val),
-    },
+    { name: `X`, axis: x_axis, auto_range: auto_x_range, set: (val) => (x_axis = val) },
+    { name: `Y`, axis: y_axis, auto_range: auto_y_range, set: (val) => (y_axis = val) },
+    { name: `Z`, axis: z_axis, auto_range: auto_z_range, set: (val) => (z_axis = val) },
   ])
+
+  const display_toggles = [
+    [`show_axes`, `Axes`],
+    [`show_grid`, `Grid`],
+    [`show_axis_labels`, `Labels`],
+    [`show_bounding_box`, `Bounds`],
+  ] as const
+  const projection_planes = [`xy`, `xz`, `yz`] as const
 </script>
 
 {#if show_controls}
@@ -129,7 +127,7 @@
     bind:open={controls_open}
     {toggle_props}
     pane_props={{
-      title: `3D Plot Settings`,
+      title: `3D plot settings`,
       ...pane_props,
       style: `--pane-max-height: 80cqh; ${pane_props?.style ?? ``}`,
     }}
@@ -140,80 +138,37 @@
     <SettingsSection
       title="Camera"
       current_values={{ projection: camera_projection, auto_rotate }}
-      on_reset={() => {
-        camera_projection = `perspective`
-        auto_rotate = 0
-      }}
+      on_reset={() => ({ camera_projection, auto_rotate } = defaults)}
+      layout="grid"
     >
-      <div class="pane-row">
-        <label for="{uid}-camera-projection">Projection:</label>
-        <select id="{uid}-camera-projection" bind:value={camera_projection}>
+      <label>
+        <span>Projection</span>
+        <select bind:value={camera_projection}>
           <option value="perspective">Perspective</option>
           <option value="orthographic">Orthographic</option>
         </select>
-      </div>
-      <div class="pane-row">
-        <label for="{uid}-auto-rotate">Auto Rotate:</label>
-        <input
-          id="{uid}-auto-rotate"
-          type="range"
-          min="0"
-          max="5"
-          step="0.1"
-          bind:value={auto_rotate}
-        />
-        <input type="number" min="0" max="5" step="0.1" bind:value={auto_rotate} />
-      </div>
+      </label>
+      <NumberRangeInput min={0} max={5} step={0.1} bind:value={auto_rotate}
+        >Auto-rotate</NumberRangeInput
+      >
     </SettingsSection>
 
     <!-- Display Controls -->
     <SettingsSection
       title="Display"
-      current_values={{
-        show_axes: display.show_axes,
-        show_grid: display.show_grid,
-        show_axis_labels: display.show_axis_labels,
-        show_bounding_box: display.show_bounding_box,
-      }}
+      current_values={Object.fromEntries(display_toggles.map(([key]) => [key, display[key]]))}
       on_reset={() => {
-        display = {
-          ...display,
-          show_axes: true,
-          show_grid: true,
-          show_axis_labels: true,
-          show_bounding_box: false,
-        }
+        const { show_axes, show_grid, show_axis_labels, show_bounding_box } = defaults
+        display = { ...display, show_axes, show_grid, show_axis_labels, show_bounding_box }
       }}
-      style="display: flex; flex-wrap: wrap; gap: 1ex"
+      layout="grid"
     >
-      <label>
-        <input
-          type="checkbox"
-          checked={display.show_axes}
-          onchange={toggle_display(`show_axes`)}
-        /> Axes
-      </label>
-      <label>
-        <input
-          type="checkbox"
-          checked={display.show_grid}
-          onchange={toggle_display(`show_grid`)}
-        /> Grid
-      </label>
-      <label>
-        <input
-          type="checkbox"
-          checked={display.show_axis_labels}
-          onchange={toggle_display(`show_axis_labels`)}
-        /> Labels
-      </label>
-      <label>
-        <input
-          type="checkbox"
-          checked={display.show_bounding_box}
-          onchange={toggle_display(`show_bounding_box`)}
-        /> Bounds
-      </label>
+      {#each display_toggles as [key, label] (key)}
+        <label>
+          <span>{label}</span>
+          <input type="checkbox" checked={display[key]} onchange={toggle_display(key)} />
+        </label>
+      {/each}
     </SettingsSection>
 
     <!-- Projections: only when there's data to project -->
@@ -221,86 +176,56 @@
       <SettingsSection
         title="Projections"
         current_values={{
-          xy: display.projections?.xy,
-          xz: display.projections?.xz,
-          yz: display.projections?.yz,
+          ...Object.fromEntries(
+            projection_planes.map((plane) => [plane, display.projections?.[plane]]),
+          ),
           opacity: display.projection_opacity,
           scale: display.projection_scale,
         }}
         on_reset={() => {
+          const { projections, projection_opacity, projection_scale } = defaults
           display = {
             ...display,
-            projections: { xy: false, xz: false, yz: false },
-            projection_opacity: 0.3,
-            projection_scale: 0.5,
+            projections: { ...projections },
+            projection_opacity,
+            projection_scale,
           }
         }}
+        layout="grid"
       >
-        <div style="display: flex; flex-wrap: wrap; gap: 1ex">
-          <label>
-            <input
-              type="checkbox"
-              checked={display.projections?.xy}
-              onchange={toggle_projection(`xy`)}
-            /> XY
-          </label>
-          <label>
-            <input
-              type="checkbox"
-              checked={display.projections?.xz}
-              onchange={toggle_projection(`xz`)}
-            /> XZ
-          </label>
-          <label>
-            <input
-              type="checkbox"
-              checked={display.projections?.yz}
-              onchange={toggle_projection(`yz`)}
-            /> YZ
-          </label>
+        <div class="setting">
+          <span>Planes</span>
+          <div class="check-options">
+            {#each projection_planes as plane (plane)}
+              <label>
+                <input
+                  type="checkbox"
+                  checked={display.projections?.[plane]}
+                  onchange={toggle_projection(plane)}
+                />
+                {plane.toUpperCase()}
+              </label>
+            {/each}
+          </div>
         </div>
-        <div class="pane-row">
-          <label for="{uid}-proj-opacity">Opacity:</label>
-          <input
-            id="{uid}-proj-opacity"
-            type="range"
-            min="0"
-            max="1"
-            step="0.05"
-            value={display.projection_opacity ?? 0.3}
-            oninput={update_display(`projection_opacity`)}
-          />
-          <input
-            type="number"
-            min="0"
-            max="1"
-            step="0.05"
-            value={display.projection_opacity ?? 0.3}
-            oninput={update_display(`projection_opacity`)}
-            style="width: 3.5em"
-          />
-        </div>
-        <div class="pane-row">
-          <label for="{uid}-proj-scale">Size:</label>
-          <input
-            id="{uid}-proj-scale"
-            type="range"
-            min="0.1"
-            max="1"
-            step="0.05"
-            value={display.projection_scale ?? 0.5}
-            oninput={update_display(`projection_scale`)}
-          />
-          <input
-            type="number"
-            min="0.1"
-            max="1"
-            step="0.05"
-            value={display.projection_scale ?? 0.5}
-            oninput={update_display(`projection_scale`)}
-            style="width: 3.5em"
-          />
-        </div>
+        <NumberRangeInput
+          min={0}
+          max={1}
+          step={0.05}
+          bind:value={
+            () => display.projection_opacity ?? defaults.projection_opacity,
+            set_display(`projection_opacity`)
+          }>Opacity</NumberRangeInput
+        >
+        <NumberRangeInput
+          min={0.1}
+          max={1}
+          step={0.05}
+          bind:value={
+            () => display.projection_scale ?? defaults.projection_scale,
+            set_display(`projection_scale`)
+          }>Size</NumberRangeInput
+        >
       </SettingsSection>
     {/if}
 
@@ -313,47 +238,48 @@
         z_range: z_axis.range,
       }}
       on_reset={() => {
-        x_axis = { ...x_axis, range: [null, null] }
-        y_axis = { ...y_axis, range: [null, null] }
-        z_axis = { ...z_axis, range: [null, null] }
+        for (const { axis, set } of axes) set({ ...axis, range: [null, null] })
       }}
+      layout="grid"
     >
       {#each axes as { name, axis, auto_range, set } (name)}
-        <div class="axis-row">
-          <span class="axis-name">{name}</span>
-          <input
-            type="text"
-            value={axis.label}
-            oninput={update_axis_label(axis, set)}
-            placeholder="{name} label"
-            aria-label="{name} label"
-            class="axis-label-input"
-          />
-          <input
-            type="number"
-            step="any"
-            value={round4(axis.range?.[0] ?? auto_range[0])}
-            oninput={(event) => {
-              const val = parseFloat(event.currentTarget.value)
-              if (Number.isNaN(val)) return
-              set({ ...axis, range: [val, axis.range?.[1] ?? auto_range[1]] })
-            }}
-            aria-label="{name} min"
-            class="axis-range-input"
-          />
-          <span style="flex-shrink: 0; opacity: 0.5">–</span>
-          <input
-            type="number"
-            step="any"
-            value={round4(axis.range?.[1] ?? auto_range[1])}
-            oninput={(event) => {
-              const val = parseFloat(event.currentTarget.value)
-              if (Number.isNaN(val)) return
-              set({ ...axis, range: [axis.range?.[0] ?? auto_range[0], val] })
-            }}
-            aria-label="{name} max"
-            class="axis-range-input"
-          />
+        <div class="setting">
+          <span>{name}</span>
+          <div class="axis-inputs">
+            <input
+              type="text"
+              value={axis.label}
+              oninput={update_axis_label(axis, set)}
+              placeholder="{name} label"
+              aria-label="{name} label"
+              class="axis-label-input"
+            />
+            <input
+              type="number"
+              step="any"
+              value={round4(axis.range?.[0] ?? auto_range[0])}
+              oninput={(event) => {
+                const val = parseFloat(event.currentTarget.value)
+                if (Number.isNaN(val)) return
+                set({ ...axis, range: [val, axis.range?.[1] ?? auto_range[1]] })
+              }}
+              aria-label="{name} min"
+              class="axis-range-input"
+            />
+            <span style="flex-shrink: 0; opacity: 0.5">–</span>
+            <input
+              type="number"
+              step="any"
+              value={round4(axis.range?.[1] ?? auto_range[1])}
+              oninput={(event) => {
+                const val = parseFloat(event.currentTarget.value)
+                if (Number.isNaN(val)) return
+                set({ ...axis, range: [axis.range?.[0] ?? auto_range[0], val] })
+              }}
+              aria-label="{name} max"
+              class="axis-range-input"
+            />
+          </div>
         </div>
       {/each}
     </SettingsSection>
@@ -380,46 +306,30 @@
 {/if}
 
 <style>
-  .pane-row {
+  :is(.check-options, .axis-inputs) {
     display: flex;
     align-items: center;
-    gap: 0.5em;
-    margin: 0.3em 0;
-    font-size: 0.9em;
-  }
-  .pane-row label {
-    min-width: 4em;
-    flex-shrink: 0;
-  }
-  .pane-row input[type='number'] {
-    width: 5em;
-  }
-  .pane-row input[type='range'] {
-    flex: 1;
-    min-width: 4em;
-  }
-  .pane-row select {
-    flex: 1;
+    flex-wrap: wrap;
+    gap: 4px;
     min-width: 0;
   }
-  .axis-row {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    margin: 2px 0;
+  .check-options {
+    gap: 1ex;
+    label {
+      display: flex;
+      align-items: center;
+      gap: 3pt;
+    }
+  }
+  .axis-inputs {
     font-size: 0.9em;
-  }
-  .axis-row input {
-    box-sizing: border-box;
-    height: 1.4em;
-    padding: 0 3px;
-    font-size: inherit;
-    line-height: 1;
-  }
-  .axis-name {
-    font-weight: 600;
-    width: 1.2em;
-    flex-shrink: 0;
+    input {
+      box-sizing: border-box;
+      height: 1.4em;
+      padding: 0 3px;
+      font-size: inherit;
+      line-height: 1;
+    }
   }
   .axis-label-input {
     width: 6em;

--- a/src/lib/plot/scatter/ScatterPlotControls.svelte
+++ b/src/lib/plot/scatter/ScatterPlotControls.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { SettingsSection } from '$lib/layout'
+  import { NumberRangeInput, SettingsSection } from '$lib/layout'
   import { PlotControls } from '$lib/plot'
   import type {
     DataSeries,
@@ -7,13 +7,9 @@
     PlotControlsProps,
     StyleOverrides,
   } from '$lib/plot/core/types'
-  import { unique_id } from '$lib/plot/core/utils'
   import { DEFAULTS } from '$lib/settings'
   import type { Snippet } from 'svelte'
   import { tooltip } from 'svelte-widgets/attachments'
-
-  // Unique ID prefix to avoid conflicts when multiple instances on same page
-  const uid = unique_id(`scatter-ctrl`)
 
   let {
     series = [],
@@ -68,6 +64,11 @@
     const key = target.closest(`[data-key]`)?.getAttribute(`data-key`)
     if (key) on_touch?.(key)
   }
+
+  const reset_style = (kind: `point` | `line`) => () => {
+    styles[kind] = { ...DEFAULTS.scatter[kind] }
+    for (const key of Object.keys(DEFAULTS.scatter[kind])) on_touch?.(`${kind}.${key}`)
+  }
 </script>
 
 <PlotControls
@@ -97,7 +98,7 @@
         styles.show_points = DEFAULTS.scatter.show_points
         styles.show_lines = DEFAULTS.scatter.show_lines
       }}
-      style="display: flex; flex-wrap: wrap; gap: 1ex"
+      layout="grid"
     >
       {#if has_any_points}
         <label
@@ -105,7 +106,8 @@
             content: `Toggle visibility of data points in the scatter plot`,
           })}
         >
-          <input type="checkbox" bind:checked={styles.show_points} /> Show points
+          <span>Show points</span>
+          <input type="checkbox" bind:checked={styles.show_points} />
         </label>
       {/if}
       {#if has_any_lines}
@@ -114,7 +116,8 @@
             content: `Toggle visibility of connecting lines between data points`,
           })}
         >
-          <input type="checkbox" bind:checked={styles.show_lines} /> Show lines
+          <span>Show lines</span>
+          <input type="checkbox" bind:checked={styles.show_lines} />
         </label>
       {/if}
     </SettingsSection>
@@ -123,120 +126,72 @@
   {#snippet post_children()}
     <!-- Series Selection (for multi-series style controls) -->
     {#if has_multiple_series}
-      <div class="pane-row">
-        <label for="{uid}-series">Series</label>
-        <select bind:value={selected_series_idx} id="{uid}-series">
-          {#each series as srs, idx (idx)}
-            {#if srs}
-              <option value={idx}>
-                {srs.label ?? `Series ${idx + 1}`}
-              </option>
-            {/if}
-          {/each}
-        </select>
-      </div>
+      <SettingsSection title="Series" layout="grid">
+        <label>
+          <span>Series</span>
+          <select bind:value={selected_series_idx}>
+            {#each series as srs, idx (idx)}
+              {#if srs}
+                <option value={idx}>
+                  {srs.label ?? `Series ${idx + 1}`}
+                </option>
+              {/if}
+            {/each}
+          </select>
+        </label>
+      </SettingsSection>
     {/if}
 
     <!-- Point Style Controls: only when points exist and are visible -->
     {#if has_any_points && styles.show_points}
       <SettingsSection
-        title="Point Style"
+        title="Point style"
         current_values={styles.point ?? {}}
-        on_reset={() => {
-          styles.point = { ...DEFAULTS.scatter.point }
-          Object.keys(DEFAULTS.scatter.point).forEach((key) => on_touch?.(`point.${key}`))
-        }}
+        on_reset={reset_style(`point`)}
         oninput={touch}
+        layout="grid"
       >
         {#if styles.point}
           {#if !has_size_data}
-            <div class="pane-row" data-key="point.size">
-              <label for="{uid}-point-size">Size:</label>
-              <input
-                id="{uid}-point-size"
-                type="range"
-                min="1"
-                max="20"
-                step="0.5"
-                bind:value={styles.point.size}
-              />
-              <input
-                type="number"
-                min="1"
-                max="20"
-                step="0.5"
-                bind:value={styles.point.size}
-              />
-            </div>
+            <NumberRangeInput
+              data-key="point.size"
+              min={1}
+              max={20}
+              step={0.5}
+              bind:value={styles.point.size}>Size</NumberRangeInput
+            >
           {/if}
           {#if !has_color_data}
-            <div class="pane-row" data-key="point.color">
-              <label for="{uid}-point-color">Color:</label>
-              <input id="{uid}-point-color" type="color" bind:value={styles.point.color} />
-            </div>
+            <label data-key="point.color">
+              <span>Color</span>
+              <input type="color" bind:value={styles.point.color} />
+            </label>
           {/if}
-          <div class="pane-row" data-key="point.opacity">
-            <label for="{uid}-point-opacity">Opacity:</label>
-            <input
-              id="{uid}-point-opacity"
-              type="range"
-              min="0"
-              max="1"
-              step="0.05"
-              bind:value={styles.point.opacity}
-            />
-            <input
-              type="number"
-              min="0"
-              max="1"
-              step="0.05"
-              bind:value={styles.point.opacity}
-            />
-          </div>
-          <div class="pane-row" data-key="point.stroke_width">
-            <label for="{uid}-point-stroke-width">Stroke Width:</label>
-            <input
-              id="{uid}-point-stroke-width"
-              type="range"
-              min="0"
-              max="5"
-              step="0.1"
-              bind:value={styles.point.stroke_width}
-            />
-            <input
-              type="number"
-              min="0"
-              max="5"
-              step="0.1"
-              bind:value={styles.point.stroke_width}
-            />
-          </div>
-          <div class="pane-row" data-key="point.stroke_color">
-            <label for="{uid}-point-stroke-color">Stroke Color:</label>
-            <input
-              id="{uid}-point-stroke-color"
-              type="color"
-              bind:value={styles.point.stroke_color}
-            />
-          </div>
-          <div class="pane-row" data-key="point.stroke_opacity">
-            <label for="{uid}-point-stroke-opacity">Stroke Opacity:</label>
-            <input
-              id="{uid}-point-stroke-opacity"
-              type="range"
-              min="0"
-              max="1"
-              step="0.05"
-              bind:value={styles.point.stroke_opacity}
-            />
-            <input
-              type="number"
-              min="0"
-              max="1"
-              step="0.05"
-              bind:value={styles.point.stroke_opacity}
-            />
-          </div>
+          <NumberRangeInput
+            data-key="point.opacity"
+            min={0}
+            max={1}
+            step={0.05}
+            bind:value={styles.point.opacity}>Opacity</NumberRangeInput
+          >
+          <NumberRangeInput
+            data-key="point.stroke_width"
+            min={0}
+            max={5}
+            step={0.1}
+            bind:value={styles.point.stroke_width}>Stroke width</NumberRangeInput
+          >
+          <label data-key="point.stroke_color">
+            <span>Stroke color</span>
+            <input type="color" bind:value={styles.point.stroke_color} />
+          </label>
+          <NumberRangeInput
+            data-key="point.stroke_opacity"
+            min={0}
+            max={1}
+            step={0.05}
+            bind:value={styles.point.stroke_opacity}>Stroke opacity</NumberRangeInput
+          >
         {/if}
       </SettingsSection>
     {/if}
@@ -244,66 +199,42 @@
     <!-- Line Style Controls: only when lines exist and are visible -->
     {#if has_any_lines && styles.show_lines}
       <SettingsSection
-        title="Line Style"
+        title="Line style"
         current_values={styles.line ?? {}}
-        on_reset={() => {
-          styles.line = { ...DEFAULTS.scatter.line }
-          Object.keys(DEFAULTS.scatter.line).forEach((key) => on_touch?.(`line.${key}`))
-        }}
+        on_reset={reset_style(`line`)}
         oninput={touch}
+        layout="grid"
       >
         {#if styles.line}
-          <div class="pane-row" data-key="line.width">
-            <label for="{uid}-line-width">Width:</label>
-            <input
-              id="{uid}-line-width"
-              type="range"
-              min="0.5"
-              max="10"
-              step="0.5"
-              bind:value={styles.line.width}
-            />
-            <input
-              type="number"
-              min="0.5"
-              max="10"
-              step="0.5"
-              bind:value={styles.line.width}
-            />
-          </div>
+          <NumberRangeInput
+            data-key="line.width"
+            min={0.5}
+            max={10}
+            step={0.5}
+            bind:value={styles.line.width}>Width</NumberRangeInput
+          >
           {#if !has_color_data}
-            <div class="pane-row" data-key="line.color">
-              <label for="{uid}-line-color">Color:</label>
-              <input id="{uid}-line-color" type="color" bind:value={styles.line.color} />
-            </div>
+            <label data-key="line.color">
+              <span>Color</span>
+              <input type="color" bind:value={styles.line.color} />
+            </label>
           {/if}
-          <div class="pane-row" data-key="line.opacity">
-            <label for="{uid}-line-opacity">Opacity:</label>
-            <input
-              id="{uid}-line-opacity"
-              type="range"
-              min="0"
-              max="1"
-              step="0.05"
-              bind:value={styles.line.opacity}
-            />
-            <input
-              type="number"
-              min="0"
-              max="1"
-              step="0.05"
-              bind:value={styles.line.opacity}
-            />
-          </div>
-          <div class="pane-row" data-key="line.dash">
-            <label for="{uid}-line-style">Style:</label>
-            <select id="{uid}-line-style" bind:value={styles.line.dash}>
+          <NumberRangeInput
+            data-key="line.opacity"
+            min={0}
+            max={1}
+            step={0.05}
+            bind:value={styles.line.opacity}>Opacity</NumberRangeInput
+          >
+          <label data-key="line.dash">
+            <span>Style</span>
+            <select bind:value={styles.line.dash}>
               <option value="solid">Solid</option>
               <option value="4,4">Dashed</option>
               <option value="2,2">Dotted</option>
               <option value="8,4,2,4">Dash-dot</option>
             </select>
-          </div>
+          </label>
         {/if}
       </SettingsSection>
     {/if}

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -687,7 +687,7 @@ export const SETTINGS_CONFIG: SettingsConfig = {
       value: 0.07,
       description: `Thickness of bonds relative to atom radius`,
       minimum: 0.01,
-      maximum: 1.0,
+      maximum: 0.5,
     },
     auto_bond_order: {
       value: false,
@@ -814,13 +814,19 @@ export const SETTINGS_CONFIG: SettingsConfig = {
       maximum: 150,
     },
     rotation_damping: {
-      value: 0.1,
-      description: `Camera rotation damping factor (0 = no damping, 1 = heavy damping)`,
+      // Larger factors settle sooner, not slower: the queued rotation decays by (1 - factor)
+      // per frame, so 0.1 keeps drifting for ~0.7 s after release (a fast flick lands another
+      // 30°+ past where the pointer stopped) while 0.2 is done in ~0.35 s.
+      value: 0.2,
+      description: `Camera rotation damping factor (0 disables damping; higher values stop rotation sooner)`,
       minimum: 0,
-      maximum: 1,
+      maximum: 0.3,
     },
     rotate_speed: {
-      value: 1.0,
+      // Rotation is 360° * drag_px * rotate_speed / canvas_height_px, so 1.0 spins a full turn
+      // per canvas height (0.72 °/px at the default 500 px) — small enough that trackpad jitter
+      // swings the view. 0.6 makes a 15° nudge a deliberate ~35 px drag.
+      value: 0.6,
       description: `Mouse rotation sensitivity (set to 0 to disable rotation)`,
       minimum: 0,
       maximum: 2.0,
@@ -829,12 +835,12 @@ export const SETTINGS_CONFIG: SettingsConfig = {
       value: 0.5,
       description: `Mouse wheel zoom sensitivity`,
       minimum: 0.1,
-      maximum: 2.0,
+      maximum: 0.8,
     },
     pan_speed: {
       value: 0.5,
-      description: `Mouse pan sensitivity`,
-      minimum: 0.1,
+      description: `Mouse pan sensitivity (set to 0 to disable panning)`,
+      minimum: 0,
       maximum: 2.0,
     },
     zoom_to_cursor: {
@@ -858,7 +864,7 @@ export const SETTINGS_CONFIG: SettingsConfig = {
       value: 0,
       description: `Automatic rotation speed (0 = disabled, positive = clockwise)`,
       minimum: 0,
-      maximum: 10,
+      maximum: 2,
     },
     rotation: {
       value: [0, 0, 0] as const,
@@ -874,7 +880,7 @@ export const SETTINGS_CONFIG: SettingsConfig = {
       value: 1,
       description: `Font size for atom labels`,
       minimum: 0.5,
-      maximum: 5,
+      maximum: 2,
     },
     site_label_color: { value: `#111111`, description: `Text color for atom labels` },
     site_label_bg_color: {
@@ -885,7 +891,7 @@ export const SETTINGS_CONFIG: SettingsConfig = {
       value: 2,
       description: `Padding around atom labels in pixels`,
       minimum: 0,
-      maximum: 20,
+      maximum: 10,
     },
     site_label_offset: {
       value: [0, 0.5, 0] as const,
@@ -914,7 +920,7 @@ export const SETTINGS_CONFIG: SettingsConfig = {
     vector_scale: {
       value: 0.75,
       description: `Scale factor for site vector arrows`,
-      minimum: 0.1,
+      minimum: 0.001,
       maximum: 10.0,
     },
     vector_color: {

--- a/src/lib/settings/viewer-state.ts
+++ b/src/lib/settings/viewer-state.ts
@@ -1,4 +1,4 @@
-import { DEFAULTS, SETTINGS_CONFIG, type DefaultSettings, type SettingType } from '../settings'
+import { SETTINGS_CONFIG, type DefaultSettings, type SettingType } from '../settings'
 
 export const STRUCTURE_VIEW_STATE_VERSION = 1 as const
 export const STRUCTURE_VIEW_STATE_STORAGE_KEY = `matterviz:structure-view:v1`
@@ -241,15 +241,17 @@ const get_storage = (): Storage | null => {
   }
 }
 
-// Storage is untrusted browser input; failure to remove it must not break the viewer.
-const discard_stored_state = (storage: Storage): boolean => {
+// Storage is untrusted browser input; failures must not break the viewer.
+const try_storage_action = (action: () => void): boolean => {
   try {
-    storage.removeItem(STRUCTURE_VIEW_STATE_STORAGE_KEY)
+    action()
     return true
   } catch {
     return false
   }
 }
+const discard_stored_state = (storage: Storage): boolean =>
+  try_storage_action(() => storage.removeItem(STRUCTURE_VIEW_STATE_STORAGE_KEY))
 
 export const load_structure_view_state = (): StructureViewState | null => {
   const storage = get_storage()
@@ -272,12 +274,9 @@ export const save_structure_view_state = (state: StructureViewState): boolean =>
   const serialized = serialize_structure_view_state(state)
   // Storing a state identical to the defaults would pin today's defaults for good, so drop it.
   if (serialized === DEFAULT_VIEW_STATE_JSON) return discard_stored_state(storage)
-  try {
-    storage.setItem(STRUCTURE_VIEW_STATE_STORAGE_KEY, serialized)
-    return true
-  } catch {
-    return false
-  }
+  return try_storage_action(() =>
+    storage.setItem(STRUCTURE_VIEW_STATE_STORAGE_KEY, serialized),
+  )
 }
 
 export const clear_structure_view_state = (): boolean => {
@@ -285,12 +284,7 @@ export const clear_structure_view_state = (): boolean => {
   return storage ? discard_stored_state(storage) : false
 }
 
-export const DEFAULT_STRUCTURE_VIEW_STATE = create_structure_view_state({
-  lattice_props: DEFAULTS.structure,
-  color_scheme: DEFAULTS.color_scheme,
-  background_opacity: DEFAULTS.background_opacity,
-  show_image_atoms: DEFAULTS.structure.show_image_atoms,
-})
+export const DEFAULT_STRUCTURE_VIEW_STATE = create_structure_view_state()
 
 // every save compares against this, so serialize the defaults once rather than per keystroke
 const DEFAULT_VIEW_STATE_JSON = serialize_structure_view_state(DEFAULT_STRUCTURE_VIEW_STATE)

--- a/src/lib/settings/viewer-state.ts
+++ b/src/lib/settings/viewer-state.ts
@@ -1,5 +1,4 @@
 import { DEFAULTS, SETTINGS_CONFIG, type DefaultSettings, type SettingType } from '../settings'
-import { SvelteSet } from 'svelte/reactivity'
 
 export const STRUCTURE_VIEW_STATE_VERSION = 1 as const
 export const STRUCTURE_VIEW_STATE_STORAGE_KEY = `matterviz:structure-view:v1`
@@ -45,10 +44,8 @@ export type StructureViewStateParseResult =
 
 // Absolute camera coordinates and vector property keys belong to one particular structure.
 // Restoring either globally can mis-frame or suppress vector discovery on the next structure.
-const NON_PORTABLE_STRUCTURE_KEYS = new SvelteSet<StructureSettingKey>([
-  `camera_position`,
-  `vector_configs`,
-])
+const is_non_portable_structure_key = (key: StructureSettingKey): boolean =>
+  key === `camera_position` || key === `vector_configs`
 
 const is_record = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === `object` && !Array.isArray(value)
@@ -118,21 +115,13 @@ export const validate_setting_value = <Value>(
 const is_web_setting = (setting: SettingType): boolean =>
   setting.context === undefined || setting.context === `all` || setting.context === `web`
 
+const in_range = (value: unknown, min: number, max: number): value is number =>
+  typeof value === `number` && Number.isFinite(value) && value >= min && value <= max
+
 const normalize_pane_size = (value: unknown): StructurePaneSize | undefined => {
   if (!is_record(value)) return undefined
   const { width, height } = value
-  if (
-    typeof width !== `number` ||
-    !Number.isFinite(width) ||
-    width < 200 ||
-    width > 10000 ||
-    typeof height !== `number` ||
-    !Number.isFinite(height) ||
-    height < 100 ||
-    height > 10000
-  ) {
-    return undefined
-  }
+  if (!in_range(width, 200, 10000) || !in_range(height, 100, 10000)) return undefined
   return { width, height }
 }
 
@@ -158,86 +147,70 @@ const structure_setting_source = (
 }
 
 const normalize_structure_settings = (
-  raw_settings: Record<string, unknown>,
+  setting_value: (key: StructureSettingKey) => unknown,
 ): Partial<StructureSettings> => {
   const settings: Partial<StructureSettings> = {}
   for (const [raw_key, raw_setting] of Object.entries(SETTINGS_CONFIG.structure)) {
     const key = raw_key as StructureSettingKey
     const setting = raw_setting as SettingType<StructureSettings[StructureSettingKey]>
-    if (!is_web_setting(setting) || NON_PORTABLE_STRUCTURE_KEYS.has(key)) continue
+    if (!is_web_setting(setting) || is_non_portable_structure_key(key)) continue
     Object.assign(settings, {
-      [key]: validate_setting_value(raw_settings[key], setting),
+      [key]: validate_setting_value(setting_value(key), setting),
     })
   }
   return settings
 }
 
-export const create_structure_view_state = (
-  source: StructureViewStateSource = {},
+// Normalize flat live props and nested stored records into the same persisted shape.
+const build_view_state = (
+  settings: Record<string, unknown>,
+  viewer: Record<string, unknown>,
+  structure_setting: (key: StructureSettingKey) => unknown,
 ): StructureViewState => {
-  const raw_structure = Object.fromEntries(
-    Object.keys(SETTINGS_CONFIG.structure)
-      .map((raw_key) => raw_key as StructureSettingKey)
-      .filter((key) => !NON_PORTABLE_STRUCTURE_KEYS.has(key))
-      .map((key) => [key, structure_setting_source(key, source)]),
-  )
-  const controls_pane_size = normalize_pane_size(source.controls_pane_size)
+  const controls_pane_size = normalize_pane_size(viewer.controls_pane_size)
   return {
     version: STRUCTURE_VIEW_STATE_VERSION,
     settings: {
-      color_scheme: validate_setting_value(source.color_scheme, SETTINGS_CONFIG.color_scheme),
+      color_scheme: validate_setting_value(
+        settings.color_scheme,
+        SETTINGS_CONFIG.color_scheme,
+      ),
       background_color:
-        source.background_color === undefined
+        settings.background_color === undefined
           ? undefined
-          : validate_setting_value(source.background_color, SETTINGS_CONFIG.background_color),
+          : validate_setting_value(
+              settings.background_color,
+              SETTINGS_CONFIG.background_color,
+            ),
       background_opacity: validate_setting_value(
-        source.background_opacity,
+        settings.background_opacity,
         SETTINGS_CONFIG.background_opacity,
       ),
-      structure: normalize_structure_settings(raw_structure),
+      structure: normalize_structure_settings(structure_setting),
     },
     viewer: {
-      supercell_scaling: normalize_supercell_scaling(source.supercell_scaling),
-      cell_type: normalize_cell_type(source.cell_type),
-      multi_view: typeof source.multi_view === `boolean` ? source.multi_view : false,
+      supercell_scaling: normalize_supercell_scaling(viewer.supercell_scaling),
+      cell_type: normalize_cell_type(viewer.cell_type),
+      multi_view: typeof viewer.multi_view === `boolean` ? viewer.multi_view : false,
       ...(controls_pane_size && { controls_pane_size }),
     },
   }
 }
 
+export const create_structure_view_state = (
+  source: StructureViewStateSource = {},
+): StructureViewState =>
+  build_view_state(source, source, (key) => structure_setting_source(key, source))
+
 export const validate_structure_view_state = (value: unknown): StructureViewState | null => {
   if (!is_record(value) || value.version !== STRUCTURE_VIEW_STATE_VERSION) return null
-  const raw_settings = is_record(value.settings) ? value.settings : {}
-  const raw_structure = is_record(raw_settings.structure) ? raw_settings.structure : {}
-  const raw_viewer = is_record(value.viewer) ? value.viewer : {}
-  const controls_pane_size = normalize_pane_size(raw_viewer.controls_pane_size)
-  return {
-    version: STRUCTURE_VIEW_STATE_VERSION,
-    settings: {
-      color_scheme: validate_setting_value(
-        raw_settings.color_scheme,
-        SETTINGS_CONFIG.color_scheme,
-      ),
-      background_color:
-        raw_settings.background_color === undefined
-          ? undefined
-          : validate_setting_value(
-              raw_settings.background_color,
-              SETTINGS_CONFIG.background_color,
-            ),
-      background_opacity: validate_setting_value(
-        raw_settings.background_opacity,
-        SETTINGS_CONFIG.background_opacity,
-      ),
-      structure: normalize_structure_settings(raw_structure),
-    },
-    viewer: {
-      supercell_scaling: normalize_supercell_scaling(raw_viewer.supercell_scaling),
-      cell_type: normalize_cell_type(raw_viewer.cell_type),
-      multi_view: typeof raw_viewer.multi_view === `boolean` ? raw_viewer.multi_view : false,
-      ...(controls_pane_size && { controls_pane_size }),
-    },
-  }
+  const settings = is_record(value.settings) ? value.settings : {}
+  const structure = is_record(settings.structure) ? settings.structure : {}
+  return build_view_state(
+    settings,
+    is_record(value.viewer) ? value.viewer : {},
+    (key) => structure[key],
+  )
 }
 
 export const deserialize_structure_view_state = (
@@ -277,35 +250,39 @@ const get_storage = (): Storage | null => {
   }
 }
 
+// Storage is untrusted browser input; failure to remove it must not break the viewer.
+const discard_stored_state = (storage: Storage): boolean => {
+  try {
+    storage.removeItem(STRUCTURE_VIEW_STATE_STORAGE_KEY)
+    return true
+  } catch {
+    return false
+  }
+}
+
 export const load_structure_view_state = (): StructureViewState | null => {
   const storage = get_storage()
   if (!storage) return null
   try {
     const stored = storage.getItem(STRUCTURE_VIEW_STATE_STORAGE_KEY)
     if (stored === null) return null
-    const result = deserialize_structure_view_state(stored)
-    if (result.state) return result.state
-    storage.removeItem(STRUCTURE_VIEW_STATE_STORAGE_KEY)
-    return null
+    const { state } = deserialize_structure_view_state(stored)
+    if (state) return state
   } catch {
-    try {
-      storage.removeItem(STRUCTURE_VIEW_STATE_STORAGE_KEY)
-    } catch {
-      // Storage is untrusted browser input; failure to remove it must not break the viewer.
-    }
-    return null
+    // fall through and purge whatever we could not read back
   }
+  discard_stored_state(storage)
+  return null
 }
 
 export const save_structure_view_state = (state: StructureViewState): boolean => {
   const storage = get_storage()
   if (!storage) return false
   const serialized = serialize_structure_view_state(state)
-  const default_serialized = serialize_structure_view_state(DEFAULT_STRUCTURE_VIEW_STATE)
+  // Storing a state identical to the defaults would pin today's defaults for good, so drop it.
+  if (serialized === DEFAULT_VIEW_STATE_JSON) return discard_stored_state(storage)
   try {
-    if (serialized === default_serialized) {
-      storage.removeItem(STRUCTURE_VIEW_STATE_STORAGE_KEY)
-    } else storage.setItem(STRUCTURE_VIEW_STATE_STORAGE_KEY, serialized)
+    storage.setItem(STRUCTURE_VIEW_STATE_STORAGE_KEY, serialized)
     return true
   } catch {
     return false
@@ -314,13 +291,7 @@ export const save_structure_view_state = (state: StructureViewState): boolean =>
 
 export const clear_structure_view_state = (): boolean => {
   const storage = get_storage()
-  if (!storage) return false
-  try {
-    storage.removeItem(STRUCTURE_VIEW_STATE_STORAGE_KEY)
-    return true
-  } catch {
-    return false
-  }
+  return storage ? discard_stored_state(storage) : false
 }
 
 export const DEFAULT_STRUCTURE_VIEW_STATE = create_structure_view_state({
@@ -330,3 +301,6 @@ export const DEFAULT_STRUCTURE_VIEW_STATE = create_structure_view_state({
   background_opacity: DEFAULTS.background_opacity,
   show_image_atoms: DEFAULTS.structure.show_image_atoms,
 })
+
+// every save compares against this, so serialize the defaults once rather than per keystroke
+const DEFAULT_VIEW_STATE_JSON = serialize_structure_view_state(DEFAULT_STRUCTURE_VIEW_STATE)

--- a/src/lib/settings/viewer-state.ts
+++ b/src/lib/settings/viewer-state.ts
@@ -1,0 +1,332 @@
+import { DEFAULTS, SETTINGS_CONFIG, type DefaultSettings, type SettingType } from '../settings'
+import { SvelteSet } from 'svelte/reactivity'
+
+export const STRUCTURE_VIEW_STATE_VERSION = 1 as const
+export const STRUCTURE_VIEW_STATE_STORAGE_KEY = `matterviz:structure-view:v1`
+
+type StructureSettings = DefaultSettings[`structure`]
+type StructureSettingKey = keyof StructureSettings
+
+export type StructurePaneSize = { width: number; height: number }
+
+export type StructureViewState = {
+  version: typeof STRUCTURE_VIEW_STATE_VERSION
+  settings: {
+    color_scheme: DefaultSettings[`color_scheme`]
+    background_color?: DefaultSettings[`background_color`]
+    background_opacity: DefaultSettings[`background_opacity`]
+    structure: Partial<StructureSettings>
+  }
+  viewer: {
+    supercell_scaling: string
+    cell_type: `original` | `conventional` | `primitive`
+    multi_view: boolean
+    controls_pane_size?: StructurePaneSize
+  }
+}
+
+export type StructureViewStateSource = {
+  scene_props?: object
+  lattice_props?: object
+  color_scheme?: unknown
+  background_color?: unknown
+  background_opacity?: unknown
+  show_image_atoms?: unknown
+  atom_color_config?: object
+  supercell_scaling?: unknown
+  cell_type?: unknown
+  multi_view?: unknown
+  controls_pane_size?: unknown
+}
+
+export type StructureViewStateParseResult =
+  | { state: StructureViewState; error?: never }
+  | { state?: never; error: string }
+
+// Absolute camera coordinates and vector property keys belong to one particular structure.
+// Restoring either globally can mis-frame or suppress vector discovery on the next structure.
+const NON_PORTABLE_STRUCTURE_KEYS = new SvelteSet<StructureSettingKey>([
+  `camera_position`,
+  `vector_configs`,
+])
+
+const is_record = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === `object` && !Array.isArray(value)
+
+const clone_value = <Value>(value: Value): Value => {
+  if (Array.isArray(value)) return value.map(clone_value) as Value
+  if (!is_record(value)) return value
+  return Object.fromEntries(
+    Object.entries(value).map(([key, nested]) => [key, clone_value(nested)]),
+  ) as Value
+}
+
+const object_value = (source: object | undefined, key: PropertyKey): unknown =>
+  source && Reflect.has(source, key) ? Reflect.get(source, key) : undefined
+
+const valid_number = (value: unknown, setting: SettingType<number>): value is number => {
+  if (typeof value !== `number` || !Number.isFinite(value)) return false
+  if (setting.minimum !== undefined && value < setting.minimum) return false
+  if (setting.maximum !== undefined && value > setting.maximum) return false
+  if (setting.multipleOf !== undefined) {
+    const quotient = value / setting.multipleOf
+    const tolerance = Number.EPSILON * Math.max(1, Math.abs(quotient)) * 4
+    if (Math.abs(quotient - Math.round(quotient)) > tolerance) return false
+  }
+  return true
+}
+
+const same_primitive_type = (value: unknown, reference: unknown): boolean =>
+  typeof value === typeof reference && (typeof value !== `number` || Number.isFinite(value))
+
+const valid_array = (value: unknown, setting: SettingType<readonly unknown[]>): boolean => {
+  if (!Array.isArray(value)) return false
+  if (setting.minItems !== undefined && value.length < setting.minItems) return false
+  if (setting.maxItems !== undefined && value.length > setting.maxItems) return false
+  const reference = setting.value
+  // The only empty-array settings in the schema are element-symbol lists.
+  if (reference.length === 0) return value.every((item) => typeof item === `string`)
+  return value.every((item, item_idx) =>
+    same_primitive_type(item, reference[item_idx] ?? reference[0]),
+  )
+}
+
+export const validate_setting_value = <Value>(
+  value: unknown,
+  setting: SettingType<Value>,
+): Value => {
+  const fallback = clone_value(setting.value)
+  if (setting.enum) {
+    return typeof value === `string` && Object.hasOwn(setting.enum, value)
+      ? (value as Value)
+      : fallback
+  }
+  if (typeof setting.value === `number`) {
+    return valid_number(value, setting as SettingType<number>) ? (value as Value) : fallback
+  }
+  if (Array.isArray(setting.value)) {
+    return valid_array(value, setting as SettingType<readonly unknown[]>)
+      ? (clone_value(value) as Value)
+      : fallback
+  }
+  if (is_record(setting.value)) {
+    return is_record(value) ? (clone_value(value) as Value) : fallback
+  }
+  return same_primitive_type(value, setting.value) ? (value as Value) : fallback
+}
+
+const is_web_setting = (setting: SettingType): boolean =>
+  setting.context === undefined || setting.context === `all` || setting.context === `web`
+
+const normalize_pane_size = (value: unknown): StructurePaneSize | undefined => {
+  if (!is_record(value)) return undefined
+  const { width, height } = value
+  if (
+    typeof width !== `number` ||
+    !Number.isFinite(width) ||
+    width < 200 ||
+    width > 10000 ||
+    typeof height !== `number` ||
+    !Number.isFinite(height) ||
+    height < 100 ||
+    height > 10000
+  ) {
+    return undefined
+  }
+  return { width, height }
+}
+
+const normalize_supercell_scaling = (value: unknown): string => {
+  if (typeof value !== `string` || !/^\d+(?:x\d+x\d+)?$/.test(value)) return `1x1x1`
+  return value.split(`x`).every((factor) => Number(factor) > 0) ? value : `1x1x1`
+}
+
+const normalize_cell_type = (value: unknown): `original` | `conventional` | `primitive` =>
+  value === `conventional` || value === `primitive` ? value : `original`
+
+const structure_setting_source = (
+  key: StructureSettingKey,
+  source: StructureViewStateSource,
+): unknown => {
+  if (key === `show_image_atoms`) return source.show_image_atoms
+  if (key === `atom_color_mode`) return object_value(source.atom_color_config, `mode`)
+  if (key === `atom_color_scale`) return object_value(source.atom_color_config, `scale`)
+  if (key === `atom_color_scale_type`)
+    return object_value(source.atom_color_config, `scale_type`)
+  const lattice_value = object_value(source.lattice_props, key)
+  return lattice_value === undefined ? object_value(source.scene_props, key) : lattice_value
+}
+
+const normalize_structure_settings = (
+  raw_settings: Record<string, unknown>,
+): Partial<StructureSettings> => {
+  const settings: Partial<StructureSettings> = {}
+  for (const [raw_key, raw_setting] of Object.entries(SETTINGS_CONFIG.structure)) {
+    const key = raw_key as StructureSettingKey
+    const setting = raw_setting as SettingType<StructureSettings[StructureSettingKey]>
+    if (!is_web_setting(setting) || NON_PORTABLE_STRUCTURE_KEYS.has(key)) continue
+    Object.assign(settings, {
+      [key]: validate_setting_value(raw_settings[key], setting),
+    })
+  }
+  return settings
+}
+
+export const create_structure_view_state = (
+  source: StructureViewStateSource = {},
+): StructureViewState => {
+  const raw_structure = Object.fromEntries(
+    Object.keys(SETTINGS_CONFIG.structure)
+      .map((raw_key) => raw_key as StructureSettingKey)
+      .filter((key) => !NON_PORTABLE_STRUCTURE_KEYS.has(key))
+      .map((key) => [key, structure_setting_source(key, source)]),
+  )
+  const controls_pane_size = normalize_pane_size(source.controls_pane_size)
+  return {
+    version: STRUCTURE_VIEW_STATE_VERSION,
+    settings: {
+      color_scheme: validate_setting_value(source.color_scheme, SETTINGS_CONFIG.color_scheme),
+      background_color:
+        source.background_color === undefined
+          ? undefined
+          : validate_setting_value(source.background_color, SETTINGS_CONFIG.background_color),
+      background_opacity: validate_setting_value(
+        source.background_opacity,
+        SETTINGS_CONFIG.background_opacity,
+      ),
+      structure: normalize_structure_settings(raw_structure),
+    },
+    viewer: {
+      supercell_scaling: normalize_supercell_scaling(source.supercell_scaling),
+      cell_type: normalize_cell_type(source.cell_type),
+      multi_view: typeof source.multi_view === `boolean` ? source.multi_view : false,
+      ...(controls_pane_size && { controls_pane_size }),
+    },
+  }
+}
+
+export const validate_structure_view_state = (value: unknown): StructureViewState | null => {
+  if (!is_record(value) || value.version !== STRUCTURE_VIEW_STATE_VERSION) return null
+  const raw_settings = is_record(value.settings) ? value.settings : {}
+  const raw_structure = is_record(raw_settings.structure) ? raw_settings.structure : {}
+  const raw_viewer = is_record(value.viewer) ? value.viewer : {}
+  const controls_pane_size = normalize_pane_size(raw_viewer.controls_pane_size)
+  return {
+    version: STRUCTURE_VIEW_STATE_VERSION,
+    settings: {
+      color_scheme: validate_setting_value(
+        raw_settings.color_scheme,
+        SETTINGS_CONFIG.color_scheme,
+      ),
+      background_color:
+        raw_settings.background_color === undefined
+          ? undefined
+          : validate_setting_value(
+              raw_settings.background_color,
+              SETTINGS_CONFIG.background_color,
+            ),
+      background_opacity: validate_setting_value(
+        raw_settings.background_opacity,
+        SETTINGS_CONFIG.background_opacity,
+      ),
+      structure: normalize_structure_settings(raw_structure),
+    },
+    viewer: {
+      supercell_scaling: normalize_supercell_scaling(raw_viewer.supercell_scaling),
+      cell_type: normalize_cell_type(raw_viewer.cell_type),
+      multi_view: typeof raw_viewer.multi_view === `boolean` ? raw_viewer.multi_view : false,
+      ...(controls_pane_size && { controls_pane_size }),
+    },
+  }
+}
+
+export const deserialize_structure_view_state = (
+  json: string,
+): StructureViewStateParseResult => {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(json)
+  } catch {
+    return { error: `Invalid JSON` }
+  }
+  if (!is_record(parsed)) return { error: `View state must be a JSON object` }
+  if (parsed.version !== STRUCTURE_VIEW_STATE_VERSION) {
+    return {
+      error: `Unsupported view-state version ${String(parsed.version)}; expected ${STRUCTURE_VIEW_STATE_VERSION}`,
+    }
+  }
+  const state = validate_structure_view_state(parsed)
+  if (!state) return { error: `Invalid view state` }
+  return { state }
+}
+
+export const serialize_structure_view_state = (state: StructureViewState): string => {
+  const validated = validate_structure_view_state(state)
+  if (!validated) {
+    throw new Error(`Cannot serialize structure view state version ${String(state.version)}`)
+  }
+  return JSON.stringify(validated, null, 2)
+}
+
+const get_storage = (): Storage | null => {
+  try {
+    const storage = globalThis.localStorage
+    return storage && typeof storage.getItem === `function` ? storage : null
+  } catch {
+    return null
+  }
+}
+
+export const load_structure_view_state = (): StructureViewState | null => {
+  const storage = get_storage()
+  if (!storage) return null
+  try {
+    const stored = storage.getItem(STRUCTURE_VIEW_STATE_STORAGE_KEY)
+    if (stored === null) return null
+    const result = deserialize_structure_view_state(stored)
+    if (result.state) return result.state
+    storage.removeItem(STRUCTURE_VIEW_STATE_STORAGE_KEY)
+    return null
+  } catch {
+    try {
+      storage.removeItem(STRUCTURE_VIEW_STATE_STORAGE_KEY)
+    } catch {
+      // Storage is untrusted browser input; failure to remove it must not break the viewer.
+    }
+    return null
+  }
+}
+
+export const save_structure_view_state = (state: StructureViewState): boolean => {
+  const storage = get_storage()
+  if (!storage) return false
+  const serialized = serialize_structure_view_state(state)
+  const default_serialized = serialize_structure_view_state(DEFAULT_STRUCTURE_VIEW_STATE)
+  try {
+    if (serialized === default_serialized) {
+      storage.removeItem(STRUCTURE_VIEW_STATE_STORAGE_KEY)
+    } else storage.setItem(STRUCTURE_VIEW_STATE_STORAGE_KEY, serialized)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export const clear_structure_view_state = (): boolean => {
+  const storage = get_storage()
+  if (!storage) return false
+  try {
+    storage.removeItem(STRUCTURE_VIEW_STATE_STORAGE_KEY)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export const DEFAULT_STRUCTURE_VIEW_STATE = create_structure_view_state({
+  scene_props: DEFAULTS.structure,
+  lattice_props: DEFAULTS.structure,
+  color_scheme: DEFAULTS.color_scheme,
+  background_opacity: DEFAULTS.background_opacity,
+  show_image_atoms: DEFAULTS.structure.show_image_atoms,
+})

--- a/src/lib/settings/viewer-state.ts
+++ b/src/lib/settings/viewer-state.ts
@@ -24,7 +24,7 @@ export type StructureViewState = {
   }
 }
 
-export type StructureViewStateSource = {
+type StructureViewStateSource = {
   scene_props?: object
   lattice_props?: object
   color_scheme?: unknown
@@ -38,7 +38,7 @@ export type StructureViewStateSource = {
   controls_pane_size?: unknown
 }
 
-export type StructureViewStateParseResult =
+type StructureViewStateParseResult =
   | { state: StructureViewState; error?: never }
   | { state?: never; error: string }
 
@@ -88,10 +88,7 @@ const valid_array = (value: unknown, setting: SettingType<readonly unknown[]>): 
   )
 }
 
-export const validate_setting_value = <Value>(
-  value: unknown,
-  setting: SettingType<Value>,
-): Value => {
+const validate_setting_value = <Value>(value: unknown, setting: SettingType<Value>): Value => {
   const fallback = clone_value(setting.value)
   if (setting.enum) {
     return typeof value === `string` && Object.hasOwn(setting.enum, value)
@@ -202,7 +199,7 @@ export const create_structure_view_state = (
 ): StructureViewState =>
   build_view_state(source, source, (key) => structure_setting_source(key, source))
 
-export const validate_structure_view_state = (value: unknown): StructureViewState | null => {
+const validate_structure_view_state = (value: unknown): StructureViewState | null => {
   if (!is_record(value) || value.version !== STRUCTURE_VIEW_STATE_VERSION) return null
   const settings = is_record(value.settings) ? value.settings : {}
   const structure = is_record(settings.structure) ? settings.structure : {}

--- a/src/lib/settings/viewer-state.ts
+++ b/src/lib/settings/viewer-state.ts
@@ -163,6 +163,10 @@ const build_view_state = (
   structure_setting: (key: StructureSettingKey) => unknown,
 ): StructureViewState => {
   const controls_pane_size = normalize_pane_size(viewer.controls_pane_size)
+  const background_color =
+    settings.background_color === undefined
+      ? undefined
+      : validate_setting_value(settings.background_color, SETTINGS_CONFIG.background_color)
   return {
     version: STRUCTURE_VIEW_STATE_VERSION,
     settings: {
@@ -170,13 +174,7 @@ const build_view_state = (
         settings.color_scheme,
         SETTINGS_CONFIG.color_scheme,
       ),
-      background_color:
-        settings.background_color === undefined
-          ? undefined
-          : validate_setting_value(
-              settings.background_color,
-              SETTINGS_CONFIG.background_color,
-            ),
+      background_color,
       background_opacity: validate_setting_value(
         settings.background_opacity,
         SETTINGS_CONFIG.background_opacity,
@@ -186,7 +184,7 @@ const build_view_state = (
     viewer: {
       supercell_scaling: normalize_supercell_scaling(viewer.supercell_scaling),
       cell_type: normalize_cell_type(viewer.cell_type),
-      multi_view: typeof viewer.multi_view === `boolean` ? viewer.multi_view : false,
+      multi_view: viewer.multi_view === true,
       ...(controls_pane_size && { controls_pane_size }),
     },
   }
@@ -288,7 +286,6 @@ export const clear_structure_view_state = (): boolean => {
 }
 
 export const DEFAULT_STRUCTURE_VIEW_STATE = create_structure_view_state({
-  scene_props: DEFAULTS.structure,
   lattice_props: DEFAULTS.structure,
   color_scheme: DEFAULTS.color_scheme,
   background_opacity: DEFAULTS.background_opacity,

--- a/src/lib/settings/viewer-state.ts
+++ b/src/lib/settings/viewer-state.ts
@@ -151,9 +151,7 @@ const normalize_structure_settings = (
     const key = raw_key as StructureSettingKey
     const setting = raw_setting as SettingType<StructureSettings[StructureSettingKey]>
     if (!is_web_setting(setting) || is_non_portable_structure_key(key)) continue
-    Object.assign(settings, {
-      [key]: validate_setting_value(setting_value(key), setting),
-    })
+    Reflect.set(settings, key, validate_setting_value(setting_value(key), setting))
   }
   return settings
 }
@@ -199,8 +197,9 @@ export const create_structure_view_state = (
 ): StructureViewState =>
   build_view_state(source, source, (key) => structure_setting_source(key, source))
 
-const validate_structure_view_state = (value: unknown): StructureViewState | null => {
-  if (!is_record(value) || value.version !== STRUCTURE_VIEW_STATE_VERSION) return null
+const normalize_structure_view_state = (
+  value: StructureViewState | Record<string, unknown>,
+): StructureViewState => {
   const settings = is_record(value.settings) ? value.settings : {}
   const structure = is_record(settings.structure) ? settings.structure : {}
   return build_view_state(
@@ -225,17 +224,14 @@ export const deserialize_structure_view_state = (
       error: `Unsupported view-state version ${String(parsed.version)}; expected ${STRUCTURE_VIEW_STATE_VERSION}`,
     }
   }
-  const state = validate_structure_view_state(parsed)
-  if (!state) return { error: `Invalid view state` }
-  return { state }
+  return { state: normalize_structure_view_state(parsed) }
 }
 
 export const serialize_structure_view_state = (state: StructureViewState): string => {
-  const validated = validate_structure_view_state(state)
-  if (!validated) {
+  if (state.version !== STRUCTURE_VIEW_STATE_VERSION) {
     throw new Error(`Cannot serialize structure view state version ${String(state.version)}`)
   }
-  return JSON.stringify(validated, null, 2)
+  return JSON.stringify(normalize_structure_view_state(state), null, 2)
 }
 
 const get_storage = (): Storage | null => {

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -1848,7 +1848,7 @@
       {fullscreen}
       {fullscreen_toggle}
       {wrapper}
-      style="--viewer-buttons-gap: 4pt; --viewer-buttons-btn-padding: 1px 2px; --viewer-buttons-right: calc(1ex - 5px); --viewer-buttons-align: stretch; --viewer-buttons-hover-bg: transparent; --viewer-buttons-hover-color: light-dark(#000, #fff)"
+      style="--viewer-buttons-gap: 4pt; --viewer-buttons-btn-padding: 1px 2px; --viewer-buttons-align: stretch; --viewer-buttons-hover-bg: transparent; --viewer-buttons-hover-color: light-dark(#000, #fff)"
     >
       {#if layout_control_visible}
         <div

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -178,7 +178,7 @@
     background_color = $bindable(),
     background_opacity = $bindable(0.1),
     show_controls,
-    persist_settings = true,
+    persist_settings = false,
     fullscreen = $bindable(false),
     wrapper = $bindable(),
     width = $bindable(0),

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -178,6 +178,7 @@
     background_color = $bindable(),
     background_opacity = $bindable(0.1),
     show_controls,
+    persist_settings = true,
     fullscreen = $bindable(false),
     wrapper = $bindable(),
     width = $bindable(0),
@@ -2155,6 +2156,7 @@
           on_reset_camera={reset_camera_available ? reset_all_cameras : undefined}
           {reset_text}
           bind:fly_to_request
+          {persist_settings}
         />
       {/if}
 

--- a/src/lib/structure/StructureControls.svelte
+++ b/src/lib/structure/StructureControls.svelte
@@ -685,7 +685,7 @@ a disabled state, a non-scene_props target) stay written out in full. -->
   pane_props={{
     ...pane_props,
     class: `controls-pane ${pane_props?.class ?? ``}`,
-    style: `--pane-max-height: 70vh; ${pane_props?.style ?? ``}`,
+    style: `--pane-max-height: 70vh; --pane-padding: 1ex 1ex 0; ${pane_props?.style ?? ``}`,
   }}
   toggle_props={{
     title: controls_open ? `` : `Structure controls`,

--- a/src/lib/structure/StructureControls.svelte
+++ b/src/lib/structure/StructureControls.svelte
@@ -149,7 +149,8 @@
     toggle_props?: PaneToggleProps
   } = $props()
 
-  // ColorScaleSelect requires a concrete bound value during initial render.
+  // ColorScaleSelect requires a concrete bound value during initial render; the synchronization
+  // effect below repeats this after callers replace atom_color_config with another partial object.
   atom_color_config.scale ??= DEFAULTS.structure.atom_color_scale
 
   const lattice_setting_keys = [
@@ -191,6 +192,10 @@
     controls_pane_size = state.viewer.controls_pane_size
       ? { ...state.viewer.controls_pane_size }
       : undefined
+    if (!controls_pane_size && controls_pane) {
+      controls_pane.style.width = ``
+      controls_pane.style.height = ``
+    }
   }
 
   const restore_view_state = (): StructureViewState | null =>
@@ -213,18 +218,16 @@
       controls_pane_size,
     }),
   )
-  let current_view_state_json = $derived(serialize_structure_view_state(current_view_state))
-  let initial_view_state_json: string | undefined
+  let last_saved_view_state_json: string | undefined
 
   $effect(() => {
     const state = current_view_state
-    const serialized = current_view_state_json
-    if (initial_view_state_json === undefined) {
-      initial_view_state_json = serialized
-      return
-    }
-    if (!persist_settings || serialized === initial_view_state_json) return
-    const save_timeout = setTimeout(() => save_structure_view_state(state), 150)
+    const serialized = serialize_structure_view_state(state)
+    last_saved_view_state_json ??= serialized
+    if (!persist_settings || serialized === last_saved_view_state_json) return
+    const save_timeout = setTimeout(() => {
+      if (save_structure_view_state(state)) last_saved_view_state_json = serialized
+    }, 150)
     return () => clearTimeout(save_timeout)
   })
 
@@ -255,52 +258,49 @@
     return () => observer.disconnect()
   })
 
+  const set_status = (message: string, error = false): void => {
+    settings_import_status = { message, error }
+  }
+
   const { copied: copied_view_state, copy: copy_view_state_text } = create_clipboard_feedback(
     1200,
     (error) => {
       console.error(`Failed to copy viewer settings to clipboard`, error)
-      settings_import_status = { message: `Clipboard access failed`, error: true }
+      set_status(`Clipboard access failed`, true)
     },
   )
 
-  const copy_view_state = (): void => {
-    void copy_view_state_text(current_view_state_json, `viewer-settings`)
-  }
-
-  const download_view_state = (): void => {
-    download(current_view_state_json, `matterviz-view-settings.json`, `application/json`)
-  }
+  const serialize_current_view_state = (): string =>
+    serialize_structure_view_state(current_view_state)
+  const copy_view_state = (): void =>
+    void copy_view_state_text(serialize_current_view_state(), `viewer-settings`)
+  const download_view_state = (): void =>
+    download(
+      serialize_current_view_state(),
+      `matterviz-view-settings.json`,
+      `application/json`,
+    )
 
   const import_view_state = async (event: Event): Promise<void> => {
     const input = event.currentTarget
     if (!(input instanceof HTMLInputElement)) return
     const file = input.files?.[0]
+    // Clear before reading so re-picking the same file still fires a change event
     input.value = ``
     if (!file) return
-    let text: string
-    try {
-      text = await file.text()
-    } catch {
-      settings_import_status = { message: `Could not read ${file.name}`, error: true }
-      return
-    }
-    const result = deserialize_structure_view_state(text)
-    if (!result.state) {
-      settings_import_status = { message: result.error, error: true }
-      return
-    }
-    apply_view_state(result.state)
-    settings_import_status = { message: `Imported ${file.name}`, error: false }
+    const text = await file.text().catch(() => null)
+    if (text === null) return set_status(`Could not read ${file.name}`, true)
+    const { state, error } = deserialize_structure_view_state(text)
+    if (!state) return set_status(error, true)
+    apply_view_state(state)
+    set_status(`Imported ${file.name}`)
   }
 
   const reset_all_view_settings = (): void => {
     apply_view_state(DEFAULT_STRUCTURE_VIEW_STATE)
-    if (controls_pane) {
-      controls_pane.style.width = ``
-      controls_pane.style.height = ``
-    }
+    scene_props.vector_configs = {}
     if (persist_settings) clear_structure_view_state()
-    settings_import_status = { message: `Restored all viewer defaults`, error: false }
+    set_status(`Restored all viewer defaults`)
   }
 
   type StructureSettingKey = keyof typeof SETTINGS_CONFIG.structure
@@ -350,11 +350,16 @@
   })
   // Bounds for a NumberRangeInput row, read off the schema here so the input itself stays a
   // generic control. `step` is the one bound the schema usually leaves to the call site.
-  type NumericSettingKey = {
-    [Key in StructureSettingKey]: (typeof SETTINGS_CONFIG.structure)[Key] extends SettingType<number>
+  type SettingKeysOfType<Value> = {
+    [Key in StructureSettingKey]: (typeof SETTINGS_CONFIG.structure)[Key] extends SettingType<Value>
       ? Key
       : never
   }[StructureSettingKey]
+  type NumericSettingKey = SettingKeysOfType<number>
+  // Rows rendered by the shared snippets must both name a setting and bind to the matching
+  // scene prop, so intersect the schema's keys with the ones scene_props actually holds.
+  type BooleanSettingKey = SettingKeysOfType<boolean> & keyof typeof scene_props
+  type EnumSettingKey = SettingKeysOfType<string> & keyof typeof scene_props
   const setting_range = (key: NumericSettingKey, step?: number) => {
     const { minimum, maximum, multipleOf, description } = SETTINGS_CONFIG.structure[key]
     return {
@@ -576,6 +581,14 @@
         ? `transparent`
         : `color-mix(in srgb, ${hex_color} ${format_num(opacity, `.1~%`)}, transparent)`
   }
+  // The swatch, the opacity slider and the two reset accessors all pair the same getter with the
+  // same setter. Naming each pair once stops a change to one from desynchronising the others.
+  const get_label_bg_hex = (): string => site_label_bg.hex_color
+  const set_label_bg_hex = (hex_color: string): void =>
+    set_site_label_bg(hex_color, site_label_bg.opacity)
+  const get_label_bg_opacity = (): number => site_label_bg.opacity
+  const set_label_bg_opacity = (opacity: number | undefined): void =>
+    set_site_label_bg(site_label_bg.hex_color, opacity ?? 0)
 
   // Collect available vector property keys from the structure
   let available_vector_keys = $derived(structure ? get_structure_vector_keys(structure) : [])
@@ -646,6 +659,23 @@
   {#each Object.entries(SETTINGS_CONFIG.structure[key].enum ?? {}) as [value, label] (value)}
     <option {value}>{label}</option>
   {/each}
+{/snippet}
+
+<!-- The two rows that carry no per-setting detail: a bare toggle and a bare enum picker, both
+reading the row's key straight off scene_props. Rows needing anything else (a conditional swatch,
+a disabled state, a non-scene_props target) stay written out in full. -->
+{#snippet toggle(key: BooleanSettingKey, label: string)}
+  <label {...setting_row(key)}>
+    <span>{label}</span>
+    <input type="checkbox" bind:checked={scene_props[key]} />
+  </label>
+{/snippet}
+
+{#snippet enum_row(key: EnumSettingKey, label: string)}
+  <label {...setting_row(key)}>
+    <span>{label}</span>
+    <select bind:value={scene_props[key]}>{@render enum_options(key)}</select>
+  </label>
 {/snippet}
 
 <DraggablePane
@@ -805,18 +835,8 @@
               </label>
             {/each}
           </div>
-          <label {...setting_row(`show_bonds`)}>
-            <span>Bonds</span>
-            <select bind:value={scene_props.show_bonds}>
-              {@render enum_options(`show_bonds`)}
-            </select>
-          </label>
-          <label {...setting_row(`show_polyhedra`)}>
-            <span>Polyhedra</span>
-            <select bind:value={scene_props.show_polyhedra}>
-              {@render enum_options(`show_polyhedra`)}
-            </select>
-          </label>
+          {@render enum_row(`show_bonds`, `Bonds`)}
+          {@render enum_row(`show_polyhedra`, `Polyhedra`)}
         </SettingsSection>
       {/key}
 
@@ -853,10 +873,7 @@
           {...setting_range(`atom_radius`, 0.05)}
           bind:value={scene_props.atom_radius}>Radius <small>(Å)</small></NumberRangeInput
         >
-        <label {...setting_row(`same_size_atoms`)}>
-          <span>Same size</span>
-          <input type="checkbox" bind:checked={scene_props.same_size_atoms} />
-        </label>
+        {@render toggle(`same_size_atoms`, `Same size`)}
         <label {...setting_row(`color_scheme`)}>
           <span>Color scheme</span>
           <Select
@@ -939,23 +956,10 @@
             `bond_thickness`,
           ])}
         >
-          <label {...setting_row(`bonding_strategy`)}>
-            <span>Strategy</span>
-            <select bind:value={scene_props.bonding_strategy}>
-              {@render enum_options(`bonding_strategy`)}
-            </select>
-          </label>
-          <label {...setting_row(`auto_bond_order`)}>
-            <span>Auto bond order</span>
-            <input type="checkbox" bind:checked={scene_props.auto_bond_order} />
-          </label>
+          {@render enum_row(`bonding_strategy`, `Strategy`)}
+          {@render toggle(`auto_bond_order`, `Auto bond order`)}
           {#if scene_props.auto_bond_order}
-            <label {...setting_row(`aromatic_display`)}>
-              <span>Aromatic</span>
-              <select bind:value={scene_props.aromatic_display}>
-                {@render enum_options(`aromatic_display`)}
-              </select>
-            </label>
+            {@render enum_row(`aromatic_display`, `Aromatic`)}
           {/if}
           <label {...setting_row(`bond_color`)}>
             <span>Color</span>
@@ -1017,10 +1021,7 @@
               {/if}
             </span>
           </label>
-          <label {...setting_row(`polyhedra_hide_center_atoms`)}>
-            <span>Hide centers</span>
-            <input type="checkbox" bind:checked={scene_props.polyhedra_hide_center_atoms} />
-          </label>
+          {@render toggle(`polyhedra_hide_center_atoms`, `Hide centers`)}
           <NumberRangeInput
             {...setting_range(`polyhedra_min_neighbors`, 1)}
             bind:value={scene_props.polyhedra_min_neighbors}>Min neighbors</NumberRangeInput
@@ -1067,14 +1068,8 @@
               // One CSS string drives two controls, so each half gets its own key: keying both
               // rows off site_label_bg_color would offer a reset on the swatch for an edit the
               // user made with the opacity slider.
-              site_label_bg_hex: local(
-                () => site_label_bg.hex_color,
-                (hex_color) => set_site_label_bg(hex_color, site_label_bg.opacity),
-              ),
-              site_label_bg_opacity: local(
-                () => site_label_bg.opacity,
-                (opacity) => set_site_label_bg(site_label_bg.hex_color, opacity),
-              ),
+              site_label_bg_hex: local(get_label_bg_hex, set_label_bg_hex),
+              site_label_bg_opacity: local(get_label_bg_opacity, set_label_bg_opacity),
             },
           )}
         >
@@ -1100,10 +1095,7 @@
               class="swatch"
               type="color"
               aria-label="Site label background color"
-              bind:value={
-                () => site_label_bg.hex_color,
-                (hex_color) => set_site_label_bg(hex_color, site_label_bg.opacity)
-              }
+              bind:value={get_label_bg_hex, set_label_bg_hex}
             />
           </label>
           <NumberRangeInput
@@ -1112,10 +1104,7 @@
             max={1}
             step={0.01}
             title={description_for(`site_label_bg_opacity`)}
-            bind:value={
-              () => site_label_bg.opacity,
-              (opacity) => set_site_label_bg(site_label_bg.hex_color, opacity ?? 0)
-            }>Opacity</NumberRangeInput
+            bind:value={get_label_bg_opacity, set_label_bg_opacity}>Opacity</NumberRangeInput
           >
           <NumberRangeInput
             {...setting_range(`site_label_padding`, 1)}
@@ -1151,89 +1140,85 @@
       {/if}
 
       {#if available_vector_keys.length > 0 && any_vectors_visible}
-        <SettingsSection
-          title="Site vectors"
-          layout="grid"
-          {...scene_section(
-            [
-              `vector_scale`,
-              `vector_color`,
-              `vector_normalize`,
-              `vector_uniform_thickness`,
-              `vector_color_mode`,
-              `vector_color_scale`,
-              `vector_origin_gap`,
-            ],
-            // per-key scales live in vector_configs rather than on a scene_props key of their
-            // own, so without an accessor here a scale-only edit would never reveal a reset
-            Object.fromEntries(
-              available_vector_keys.map((key) => [
-                `vector_scale:${key}`,
-                local(
-                  () => scene_props.vector_configs?.[key]?.scale ?? null,
-                  (scale) => update_vector_config(key, { scale }),
-                ),
-              ]),
-            ),
-          )}
-        >
-          <NumberRangeInput
-            {...setting_range(`vector_scale`, 0.001)}
-            bind:value={scene_props.vector_scale}>Global scale</NumberRangeInput
+        {#key available_vector_keys.join(`\0`)}
+          <SettingsSection
+            title="Site vectors"
+            layout="grid"
+            {...scene_section(
+              [
+                `vector_scale`,
+                `vector_color`,
+                `vector_normalize`,
+                `vector_uniform_thickness`,
+                `vector_color_mode`,
+                `vector_color_scale`,
+                `vector_origin_gap`,
+              ],
+              // per-key scales live in vector_configs rather than on a scene_props key of their
+              // own, so without an accessor here a scale-only edit would never reveal a reset
+              Object.fromEntries(
+                available_vector_keys.map((key) => [
+                  `vector_scale:${key}`,
+                  local(
+                    () => scene_props.vector_configs?.[key]?.scale ?? null,
+                    (scale) => update_vector_config(key, { scale }),
+                  ),
+                ]),
+              ),
+            )}
           >
-          <label {...setting_row(`vector_normalize`)}>
-            <span>Normalize</span>
-            <input type="checkbox" bind:checked={scene_props.vector_normalize} />
-          </label>
-          <label {...setting_row(`vector_uniform_thickness`)}>
-            <span>Uniform width</span>
-            <input type="checkbox" bind:checked={scene_props.vector_uniform_thickness} />
-          </label>
-          <label {...setting_row(`vector_color_mode`)}>
-            <span>Color by</span>
-            <select bind:value={scene_props.vector_color_mode}>
-              {#each VECTOR_COLOR_MODES as mode (mode)}
-                <option value={mode}>{mode.replaceAll(`_`, ` `)}</option>
-              {/each}
-            </select>
-          </label>
-          {#if scene_props.vector_color_mode === `magnitude`}
-            <label {...setting_row(`vector_color_scale`)}>
-              <span>Color scale</span>
-              <ColorScaleSelect bind:value={scene_props.vector_color_scale} />
-            </label>
-          {:else if scene_props.vector_color_mode === `uniform`}
-            <label {...setting_row(`vector_color`)}>
-              <span>Color</span>
-              <input class="swatch" type="color" bind:value={scene_props.vector_color} />
-            </label>
-          {/if}
-          {#if available_vector_keys.length > 1}
             <NumberRangeInput
-              {...setting_range(`vector_origin_gap`, 0.02)}
-              bind:value={scene_props.vector_origin_gap}>Origin gap</NumberRangeInput
+              {...setting_range(`vector_scale`, 0.001)}
+              bind:value={scene_props.vector_scale}>Global scale</NumberRangeInput
             >
-            {#each available_vector_keys as key (key)}
-              {#if is_key_visible(key)}
-                {@const description = `Scale multiplier for ${key} arrows (applied on top of global scale)`}
-                <NumberRangeInput
-                  data-key={`vector_scale:${key}`}
-                  data-description={description}
-                  min={0.1}
-                  max={5}
-                  step={0.1}
-                  title={description}
-                  bind:value={
-                    () => scene_props.vector_configs?.[key]?.scale ?? 1.0,
-                    (scale) => update_vector_config(key, { scale: scale ?? 1.0 })
-                  }
-                >
-                  <span>{key} scale</span>
-                </NumberRangeInput>
-              {/if}
-            {/each}
-          {/if}
-        </SettingsSection>
+            {@render toggle(`vector_normalize`, `Normalize`)}
+            {@render toggle(`vector_uniform_thickness`, `Uniform width`)}
+            <label {...setting_row(`vector_color_mode`)}>
+              <span>Color by</span>
+              <select bind:value={scene_props.vector_color_mode}>
+                {#each VECTOR_COLOR_MODES as mode (mode)}
+                  <option value={mode}>{mode.replaceAll(`_`, ` `)}</option>
+                {/each}
+              </select>
+            </label>
+            {#if scene_props.vector_color_mode === `magnitude`}
+              <label {...setting_row(`vector_color_scale`)}>
+                <span>Color scale</span>
+                <ColorScaleSelect bind:value={scene_props.vector_color_scale} />
+              </label>
+            {:else if scene_props.vector_color_mode === `uniform`}
+              <label {...setting_row(`vector_color`)}>
+                <span>Color</span>
+                <input class="swatch" type="color" bind:value={scene_props.vector_color} />
+              </label>
+            {/if}
+            {#if available_vector_keys.length > 1}
+              <NumberRangeInput
+                {...setting_range(`vector_origin_gap`, 0.02)}
+                bind:value={scene_props.vector_origin_gap}>Origin gap</NumberRangeInput
+              >
+              {#each available_vector_keys as key (key)}
+                {#if is_key_visible(key)}
+                  {@const description = `Scale multiplier for ${key} arrows (applied on top of global scale)`}
+                  <NumberRangeInput
+                    data-key={`vector_scale:${key}`}
+                    data-description={description}
+                    min={0.1}
+                    max={5}
+                    step={0.1}
+                    title={description}
+                    bind:value={
+                      () => scene_props.vector_configs?.[key]?.scale ?? 1.0,
+                      (scale) => update_vector_config(key, { scale: scale ?? 1.0 })
+                    }
+                  >
+                    <span>{key} scale</span>
+                  </NumberRangeInput>
+                {/if}
+              {/each}
+            {/if}
+          </SettingsSection>
+        {/key}
       {/if}
 
       {#if has_lattice}
@@ -1331,20 +1316,12 @@
           ),
         })}
       >
-        <label {...setting_row(`camera_projection`)}>
-          <span>Projection</span>
-          <select bind:value={scene_props.camera_projection}>
-            {@render enum_options(`camera_projection`)}
-          </select>
-        </label>
+        {@render enum_row(`camera_projection`, `Projection`)}
         <NumberRangeInput
           {...setting_range(`auto_rotate`, 0.01)}
           bind:value={scene_props.auto_rotate}>Auto-rotate speed</NumberRangeInput
         >
-        <label {...setting_row(`zoom_to_cursor`)}>
-          <span>Zoom to cursor</span>
-          <input type="checkbox" bind:checked={scene_props.zoom_to_cursor} />
-        </label>
+        {@render toggle(`zoom_to_cursor`, `Zoom to cursor`)}
         {#if multi_view_control_visible && display_mode === `structure`}
           <label {...setting_row(`multi_view`)} class:disabled={multi_view_blocked}>
             <span>Multi-view grid</span>
@@ -1515,10 +1492,7 @@
                   >
                 </span>
               </div>
-              <label {...setting_row(`show_displacement_arrows`)}>
-                <span>Show arrows</span>
-                <input type="checkbox" bind:checked={scene_props.show_displacement_arrows} />
-              </label>
+              {@render toggle(`show_displacement_arrows`, `Show arrows`)}
               <NumberRangeInput
                 {...setting_range(`displacement_arrow_scale`, 0.1)}
                 bind:value={scene_props.displacement_arrow_scale}>Arrow scale</NumberRangeInput
@@ -1594,18 +1568,8 @@
                 bind:value={scene_props.trajectory_line_frame_stride}
                 >Frame stride</NumberRangeInput
               >
-              <label {...setting_row(`trajectory_line_color_mode`)}>
-                <span>Color by</span>
-                <select bind:value={scene_props.trajectory_line_color_mode}>
-                  {@render enum_options(`trajectory_line_color_mode`)}
-                </select>
-              </label>
-              <label {...setting_row(`trajectory_line_wrap_mode`)}>
-                <span>Boundaries</span>
-                <select bind:value={scene_props.trajectory_line_wrap_mode}>
-                  {@render enum_options(`trajectory_line_wrap_mode`)}
-                </select>
-              </label>
+              {@render enum_row(`trajectory_line_color_mode`, `Color by`)}
+              {@render enum_row(`trajectory_line_wrap_mode`, `Boundaries`)}
               {#if trajectory_lines_result}
                 {@const { point_count, segment_count, atom_count, max_segment_length } =
                   trajectory_lines_result}
@@ -1665,6 +1629,7 @@
     </div>
     {#if settings_import_status}
       <small
+        class="settings-import-status"
         class:error={settings_import_status.error}
         role={settings_import_status.error ? `alert` : `status`}
       >

--- a/src/lib/structure/StructureControls.svelte
+++ b/src/lib/structure/StructureControls.svelte
@@ -60,7 +60,7 @@
   import type { CellType } from '$lib/symmetry'
   import { to_error } from '$lib/utils'
   import type { MoyoDataset } from '@spglib/moyo-wasm'
-  import type { ComponentProps } from 'svelte'
+  import { untrack, type ComponentProps } from 'svelte'
   import { createAttachmentKey } from 'svelte/attachments'
   import { SvelteSet } from 'svelte/reactivity'
   import { Icon, MultiSelect as Select } from 'svelte-widgets'
@@ -198,9 +198,9 @@
     }
   }
 
-  const restore_view_state = (): StructureViewState | null =>
-    persist_settings ? load_structure_view_state() : null
-  const restored_view_state = restore_view_state()
+  const restored_view_state = untrack(() =>
+    persist_settings ? load_structure_view_state() : null,
+  )
   if (restored_view_state) apply_view_state(restored_view_state)
 
   let current_view_state = $derived(

--- a/src/lib/structure/StructureControls.svelte
+++ b/src/lib/structure/StructureControls.svelte
@@ -108,7 +108,7 @@
     on_reset_camera,
     reset_text = `Reset view (r, or double-click)`,
     fly_to_request = $bindable(undefined),
-    persist_settings = true,
+    persist_settings = false,
     pane_props = {},
     toggle_props = {},
     ...rest
@@ -144,7 +144,7 @@
     on_reset_camera?: () => void // undefined while camera at home (hides button)
     reset_text?: string
     fly_to_request?: Vec3 // (output) one-shot zone-axis camera command
-    persist_settings?: boolean
+    persist_settings?: boolean // Opt-in browser persistence for safely scoped single-view usage
     pane_props?: PaneProps
     toggle_props?: PaneToggleProps
   } = $props()

--- a/src/lib/structure/StructureControls.svelte
+++ b/src/lib/structure/StructureControls.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
-  import { DraggablePane, type PaneProps, type PaneToggleProps } from '$lib/overlays'
-  import type { ColorSchemeName, D3InterpolateName } from '$lib/colors'
+  import {
+    create_clipboard_feedback,
+    DraggablePane,
+    type PaneProps,
+    type PaneToggleProps,
+  } from '$lib/overlays'
+  import type { ColorSchemeName } from '$lib/colors'
   import { AXIS_COLORS, ELEMENT_COLOR_SCHEMES } from '$lib/colors'
   import Spinner from '$lib/feedback/Spinner.svelte'
   import IsosurfaceControls from '$lib/isosurface/IsosurfaceControls.svelte'
@@ -8,18 +13,34 @@
   import type { VolumeSliceSettings } from '$lib/isosurface/slice-settings'
   import type { IsosurfaceSettings, VolumetricData } from '$lib/isosurface/types'
   import { format_num } from '$lib/labels'
-  import { NumberRangeInput, SettingsSection } from '$lib/layout'
+  import { download } from '$lib/io/fetch'
+  import {
+    NumberRangeInput,
+    SettingsGroup,
+    SettingsSearch,
+    SettingsSection,
+  } from '$lib/layout'
   import type { Vec3 } from '$lib/math'
   import { to_degrees, to_radians } from '$lib/math'
   import MillerIndexInput from '$lib/MillerIndexInput.svelte'
   import type { ZoneAxisMode } from '$lib/scene'
   import { is_valid_zone_axis, ZONE_AXIS_MODE_LABELS, zone_axis_direction } from '$lib/scene'
   import { ColorScaleSelect } from '$lib/plot'
-  import type { VectorLayerConfig } from '$lib/settings'
+  import type { SettingType, VectorLayerConfig } from '$lib/settings'
   import { DEFAULTS, SETTINGS_CONFIG, VECTOR_COLOR_MODES } from '$lib/settings'
+  import {
+    clear_structure_view_state,
+    create_structure_view_state,
+    DEFAULT_STRUCTURE_VIEW_STATE,
+    deserialize_structure_view_state,
+    load_structure_view_state,
+    save_structure_view_state,
+    serialize_structure_view_state,
+    type StructurePaneSize,
+    type StructureViewState,
+  } from '$lib/settings/viewer-state'
   import type { AnyStructure, StructureDisplayMode } from '$lib/structure'
   import {
-    default_vector_configs,
     get_structure_vector_keys,
     Lattice,
     StructureScene,
@@ -40,6 +61,8 @@
   import { to_error } from '$lib/utils'
   import type { MoyoDataset } from '@spglib/moyo-wasm'
   import type { ComponentProps } from 'svelte'
+  import { createAttachmentKey } from 'svelte/attachments'
+  import { SvelteSet } from 'svelte/reactivity'
   import { Icon, MultiSelect as Select } from 'svelte-widgets'
   import { Cross, Reset, Settings } from 'svelte-widgets/icons'
   import { tooltip } from 'svelte-widgets/attachments'
@@ -85,6 +108,7 @@
     on_reset_camera,
     reset_text = `Reset view (r, or double-click)`,
     fly_to_request = $bindable(undefined),
+    persist_settings = true,
     pane_props = {},
     toggle_props = {},
     ...rest
@@ -120,26 +144,280 @@
     on_reset_camera?: () => void // undefined while camera at home (hides button)
     reset_text?: string
     fly_to_request?: Vec3 // (output) one-shot zone-axis camera command
+    persist_settings?: boolean
     pane_props?: PaneProps
     toggle_props?: PaneToggleProps
   } = $props()
 
-  // Both halves of a section's reset wiring come from one key list, so a new setting can't be
-  // registered in the "changed" indicator and forgotten in the reset (or the other way round).
-  // `extra_reset` covers section state that doesn't live in scene_props.
-  type SceneSettingKey = keyof ComponentProps<typeof StructureScene> &
-    keyof typeof DEFAULTS.structure
-  const scene_section = (keys: SceneSettingKey[], extra_reset?: () => void) => ({
-    current_values: Object.fromEntries(keys.map((key) => [key, scene_props[key]])),
-    on_reset: () => {
-      for (const key of keys) {
-        const value = DEFAULTS.structure[key]
-        // copy array defaults, else editing one in place later would corrupt DEFAULTS
-        Object.assign(scene_props, { [key]: Array.isArray(value) ? [...value] : value })
-      }
-      extra_reset?.()
-    },
+  // ColorScaleSelect requires a concrete bound value during initial render.
+  atom_color_config.scale ??= DEFAULTS.structure.atom_color_scale
+
+  const lattice_setting_keys = [
+    `cell_edge_color`,
+    `cell_edge_opacity`,
+    `cell_surface_color`,
+    `cell_surface_opacity`,
+    `cell_edge_width`,
+    `show_cell_vectors`,
+  ] as const
+  let controls_pane = $state<HTMLDivElement | null>(null)
+  let controls_pane_size = $state<StructurePaneSize>()
+  let settings_import_status = $state<{ message: string; error: boolean }>()
+
+  const apply_view_state = (state: StructureViewState): void => {
+    const structure_settings = structuredClone(state.settings.structure)
+    Object.assign(scene_props, structure_settings)
+    for (const key of lattice_setting_keys) {
+      const value = structure_settings[key]
+      if (value !== undefined) Object.assign(lattice_props, { [key]: value })
+    }
+    show_image_atoms =
+      structure_settings.show_image_atoms ?? DEFAULTS.structure.show_image_atoms
+    show_trajectory_lines =
+      structure_settings.show_trajectory_lines ?? DEFAULTS.structure.show_trajectory_lines
+    atom_color_config.mode =
+      structure_settings.atom_color_mode ?? DEFAULTS.structure.atom_color_mode
+    atom_color_config.scale =
+      structure_settings.atom_color_scale ?? DEFAULTS.structure.atom_color_scale
+    atom_color_config.scale_type =
+      structure_settings.atom_color_scale_type ?? DEFAULTS.structure.atom_color_scale_type
+    delete atom_color_config.property_key
+    color_scheme = state.settings.color_scheme
+    background_color = state.settings.background_color
+    background_opacity = state.settings.background_opacity
+    supercell_scaling = state.viewer.supercell_scaling
+    cell_type = state.viewer.cell_type
+    multi_view = state.viewer.multi_view
+    controls_pane_size = state.viewer.controls_pane_size
+      ? { ...state.viewer.controls_pane_size }
+      : undefined
+  }
+
+  const restore_view_state = (): StructureViewState | null =>
+    persist_settings ? load_structure_view_state() : null
+  const restored_view_state = restore_view_state()
+  if (restored_view_state) apply_view_state(restored_view_state)
+
+  let current_view_state = $derived(
+    create_structure_view_state({
+      scene_props,
+      lattice_props,
+      color_scheme,
+      background_color,
+      background_opacity,
+      show_image_atoms,
+      atom_color_config,
+      supercell_scaling,
+      cell_type,
+      multi_view,
+      controls_pane_size,
+    }),
+  )
+  let current_view_state_json = $derived(serialize_structure_view_state(current_view_state))
+  let initial_view_state_json: string | undefined
+
+  $effect(() => {
+    const state = current_view_state
+    const serialized = current_view_state_json
+    if (initial_view_state_json === undefined) {
+      initial_view_state_json = serialized
+      return
+    }
+    if (!persist_settings || serialized === initial_view_state_json) return
+    const save_timeout = setTimeout(() => save_structure_view_state(state), 150)
+    return () => clearTimeout(save_timeout)
   })
+
+  $effect(() => {
+    const pane = controls_pane
+    const size = controls_pane_size
+    if (!pane || !size) return
+    pane.style.width = `${size.width}px`
+    pane.style.height = `${size.height}px`
+  })
+
+  $effect(() => {
+    const pane = controls_pane
+    if (!pane) return
+    const observer = new ResizeObserver(() => {
+      const width_style = pane.style.width
+      const height_style = pane.style.height
+      if (!width_style || !height_style) return
+      const width = Number(width_style.replace(/px$/, ``))
+      const height = Number(height_style.replace(/px$/, ``))
+      if (!Number.isFinite(width) || !Number.isFinite(height)) return
+      if (controls_pane_size?.width === width && controls_pane_size.height === height) {
+        return
+      }
+      controls_pane_size = { width, height }
+    })
+    observer.observe(pane)
+    return () => observer.disconnect()
+  })
+
+  const { copied: copied_view_state, copy: copy_view_state_text } = create_clipboard_feedback(
+    1200,
+    (error) => {
+      console.error(`Failed to copy viewer settings to clipboard`, error)
+      settings_import_status = { message: `Clipboard access failed`, error: true }
+    },
+  )
+
+  const copy_view_state = (): void => {
+    void copy_view_state_text(current_view_state_json, `viewer-settings`)
+  }
+
+  const download_view_state = (): void => {
+    download(current_view_state_json, `matterviz-view-settings.json`, `application/json`)
+  }
+
+  const import_view_state = async (event: Event): Promise<void> => {
+    const input = event.currentTarget
+    if (!(input instanceof HTMLInputElement)) return
+    const file = input.files?.[0]
+    input.value = ``
+    if (!file) return
+    let text: string
+    try {
+      text = await file.text()
+    } catch {
+      settings_import_status = { message: `Could not read ${file.name}`, error: true }
+      return
+    }
+    const result = deserialize_structure_view_state(text)
+    if (!result.state) {
+      settings_import_status = { message: result.error, error: true }
+      return
+    }
+    apply_view_state(result.state)
+    settings_import_status = { message: `Imported ${file.name}`, error: false }
+  }
+
+  const reset_all_view_settings = (): void => {
+    apply_view_state(DEFAULT_STRUCTURE_VIEW_STATE)
+    if (controls_pane) {
+      controls_pane.style.width = ``
+      controls_pane.style.height = ``
+    }
+    if (persist_settings) clear_structure_view_state()
+    settings_import_status = { message: `Restored all viewer defaults`, error: false }
+  }
+
+  type StructureSettingKey = keyof typeof SETTINGS_CONFIG.structure
+  const pointer_settings = [
+    [`rotate_speed`, `Rotate`, 0.05],
+    [`zoom_speed`, `Zoom`, 0.02],
+    [`pan_speed`, `Pan`, 0.01],
+    [`rotation_damping`, `Damping`, 0.01],
+  ] as const
+  const cell_style_settings = [
+    [`Edge`, `cell_edge_color`, `cell_edge_opacity`, 0.05],
+    [`Surface`, `cell_surface_color`, `cell_surface_opacity`, 0.01],
+  ] as const
+  // Descriptions for every row this pane renders: the schema for real settings, plus entries
+  // for the pseudo-keys used by rows that drive more than one setting at once.
+  const structure_setting_metadata = {
+    ...SETTINGS_CONFIG.structure,
+    color_scheme: SETTINGS_CONFIG.color_scheme,
+    background_color: SETTINGS_CONFIG.background_color,
+    background_opacity: SETTINGS_CONFIG.background_opacity,
+    atom_color_property_key: `Per-atom property mapped onto the selected color scale`,
+    cell_type: `Transform the displayed structure to its original, conventional, or primitive cell`,
+    multi_view: `Show synchronized structure views from multiple directions`,
+    polyhedra_centers: `Elements used as centers when constructing coordination polyhedra`,
+    polyhedra_color: `Color mode and optional uniform color for coordination polyhedra`,
+    polyhedra_edges: `Visibility and color of coordination-polyhedra edges`,
+    site_label_bg_hex: `Background color behind atom labels`,
+    site_label_bg_opacity: `Opacity of the background behind atom labels`,
+    supercell_scaling: `Repeat the unit cell along each lattice direction. Examples: "2x2x2", "3x1x2", or "2"`,
+    trajectory_line_elements: `Atomic species whose trajectory trails are displayed`,
+    zone_axis: `Point the camera along a crystallographic direction or plane normal`,
+  }
+  type SettingKey = keyof typeof structure_setting_metadata
+  const description_for = (key: SettingKey): string => {
+    const metadata = structure_setting_metadata[key]
+    return typeof metadata === `string` ? metadata : metadata.description
+  }
+  const setting_attachment_key = createAttachmentKey()
+  // Spread onto a row to tag it for per-row reset/search AND give it its description as a
+  // tooltip. Both are keyed off the same setting, so writing them separately meant naming it
+  // twice per row. Spread (not an attachment) so `data-key` is a real attribute from the first
+  // render, which is when SettingsSection's row enhancer takes its inventory. `tip` is only for
+  // the handful of rows whose advice depends on the structure (no lattice, no symmetry yet).
+  const setting_row = (key: SettingKey, tip?: string) => ({
+    'data-key': key,
+    [setting_attachment_key]: tooltip({ content: tip ?? description_for(key) }),
+  })
+  // Bounds for a NumberRangeInput row, read off the schema here so the input itself stays a
+  // generic control. `step` is the one bound the schema usually leaves to the call site.
+  type NumericSettingKey = {
+    [Key in StructureSettingKey]: (typeof SETTINGS_CONFIG.structure)[Key] extends SettingType<number>
+      ? Key
+      : never
+  }[StructureSettingKey]
+  const setting_range = (key: NumericSettingKey, step?: number) => {
+    const { minimum, maximum, multipleOf, description } = SETTINGS_CONFIG.structure[key]
+    return {
+      'data-key': key,
+      min: minimum,
+      max: maximum,
+      step: step ?? multipleOf,
+      title: description,
+    }
+  }
+
+  // One key list drives both a section's "changed" indicator and its reset, so a new setting
+  // can't be registered in one and forgotten in the other. Keys not held directly on `target`
+  // (local bindables, or one row standing for several settings) pass an accessor instead.
+  // No section-level reset: SettingsSection replays `on_reset_key` over every changed key, so
+  // the section heading and the per-row buttons both restore what this pane mounted with.
+  // "Reset all" under Preferences is the affordance for going back to shipped defaults.
+  type DefaultedKey<T> = Extract<keyof T, keyof typeof DEFAULTS.structure>
+  type Accessor = { get: () => unknown; set: (value: unknown, present: boolean) => void }
+  const local = <T>(get: () => T, set: (value: T, present: boolean) => void): Accessor => ({
+    get,
+    set: (value, present) => set(value as T, present),
+  })
+  // One row driving two scene props (a mode plus its color, say). Sharing a key means the row's
+  // reset restores both halves at once instead of leaving a half-reverted pair behind.
+  const scene_pair = (left: keyof typeof scene_props, right: keyof typeof scene_props) =>
+    local(
+      () => ({ [left]: scene_props[left], [right]: scene_props[right] }),
+      (reference) => Object.assign(scene_props, reference),
+    )
+  const settings_section = <T extends object>(
+    target: T,
+    keys: DefaultedKey<T>[],
+    accessors: Record<string, Accessor> = {},
+  ) => ({
+    current_values: {
+      ...Object.fromEntries(
+        keys.map((key) => [
+          key,
+          target[key] === undefined ? DEFAULTS.structure[key] : target[key],
+        ]),
+      ),
+      ...Object.fromEntries(
+        Object.entries(accessors).map(([key, accessor]) => [key, accessor.get()]),
+      ),
+    },
+    on_reset_key: (key: string, reference_value: unknown, reference_present: boolean) => {
+      const accessor = accessors[key]
+      if (accessor) accessor.set(reference_value, reference_present)
+      else if ((keys as string[]).includes(key)) {
+        if (reference_present) Object.assign(target, { [key]: reference_value })
+        else Reflect.deleteProperty(target, key)
+      }
+    },
+    setting_metadata: structure_setting_metadata,
+  })
+  const scene_section = (
+    keys: DefaultedKey<typeof scene_props>[],
+    accessors?: Record<string, Accessor>,
+  ) => settings_section(scene_props, keys, accessors)
+  // A section whose every value lives outside scene_props and lattice_props
+  const local_section = (accessors: Record<string, Accessor>) =>
+    settings_section({}, [], accessors)
 
   $effect(() => {
     scene_props.show_trajectory_lines = show_trajectory_lines
@@ -149,29 +427,6 @@
   const multi_view_hint_id = `multi-view-hint-${controls_id}`
   let multi_view_blocked = $derived(Boolean(multi_view_unavailable_reason) && !multi_view)
 
-  // Color scheme selection state
-  let color_scheme_selected = $state([color_scheme])
-  $effect(() => {
-    if (color_scheme_selected.length > 0) {
-      color_scheme = color_scheme_selected[0] as string
-    }
-  })
-
-  // Atom color config selection state
-  let color_scale_selected = $state<D3InterpolateName[]>([
-    atom_color_config.scale || DEFAULTS.structure.atom_color_scale,
-  ])
-
-  // Sync local selection to config
-  $effect(() => {
-    if (color_scale_selected[0] && color_scale_selected[0] !== atom_color_config.scale)
-      atom_color_config.scale = color_scale_selected[0]
-  })
-  // Sync config to local selection (for external updates)
-  $effect(() => {
-    if (atom_color_config.scale && atom_color_config.scale !== color_scale_selected[0])
-      color_scale_selected = [atom_color_config.scale]
-  })
   // Selective-dynamics coloring needs at least one site declaring the property (POSCAR
   // "Selective dynamics" block); without it every atom would land in one `unknown` bucket.
   let has_selective_dynamics = $derived(structure_has_selective_dynamics(structure))
@@ -179,9 +434,11 @@
   // Per-site scalars/vec3s available to color by (charge, velocity, c_pe, ...). Empty for
   // structures whose parser produced no extra columns, in which case the mode is disabled.
   let colorable_property_keys = $derived(get_colorable_property_keys(structure))
-  // Keep scale_type and the colored-by key in step with the mode, also when the structure
-  // changes under a mode that was already selected (a stale key resets to the first one).
-  $effect(() => sync_atom_color_mode(atom_color_config, colorable_property_keys))
+  // Keep partial configs and mode-derived fields valid after both nested edits and prop replacement.
+  $effect(() => {
+    atom_color_config.scale ??= DEFAULTS.structure.atom_color_scale
+    sync_atom_color_mode(atom_color_config, colorable_property_keys)
+  })
 
   // Zone-axis camera: [uvw] is a direct-lattice direction, (hkl) a reciprocal one, so both
   // need a lattice — molecules have no crystallographic directions to look down.
@@ -223,7 +480,9 @@
   // actually use as centers - minority occupancies of disordered sites never are.
   let structure_elements = $derived(
     [
-      ...new Set((structure?.sites ?? []).flatMap((site) => get_majority_element(site) ?? [])),
+      ...new SvelteSet(
+        (structure?.sites ?? []).flatMap((site) => get_majority_element(site) ?? []),
+      ),
     ].toSorted(),
   )
 
@@ -248,18 +507,18 @@
     const excluded = scene_props.polyhedra_excluded_elements ?? []
     const included = scene_props.polyhedra_included_elements ?? []
     if (is_polyhedra_center_enabled(element)) {
-      scene_props.polyhedra_excluded_elements = [...new Set([...excluded, element])]
+      scene_props.polyhedra_excluded_elements = [...new SvelteSet([...excluded, element])]
       scene_props.polyhedra_included_elements = included.filter((el) => el !== element)
     } else {
       scene_props.polyhedra_excluded_elements = excluded.filter((el) => el !== element)
-      scene_props.polyhedra_included_elements = [...new Set([...included, element])]
+      scene_props.polyhedra_included_elements = [...new SvelteSet([...included, element])]
     }
   }
 
   // Species in the collected trajectory stream, for the trail filter. A Li-ion conductor
   // wants Li trails and not the framework, so narrowing this is usually the first move.
   let trail_elements = $derived(
-    [...new Set(scene_props.trajectory_position_stream?.elements)].toSorted(),
+    [...new SvelteSet(scene_props.trajectory_position_stream?.elements)].toSorted(),
   )
   // A null filter means "every species", which is also the state the checkboxes start in
   const is_trail_element_on = (element: ElementSymbol): boolean =>
@@ -279,90 +538,44 @@
   const as_hex_color = (color: string | undefined, fallback: string): string =>
     color?.match(hex_color_pattern)?.[0] ?? fallback
 
+  // Every unparsable background (`transparent` included) reports zero opacity, so a picked hex
+  // would be lost the moment the slider bottoms out. `remembered_hex` carries it across.
   const parse_label_bg_color = (
     color: string | undefined,
-    fallback_hex_color: string,
-    fallback_opacity: number,
+    remembered_hex: string,
   ): { hex_color: string; opacity: number } => {
-    if (color === `transparent`) {
-      return { hex_color: fallback_hex_color, opacity: 0 }
-    }
     const color_mix = color?.match(color_mix_pattern)
     if (color_mix) {
-      const percentage = Math.max(0, Math.min(100, Number(color_mix[2])))
       return {
         hex_color: color_mix[1],
-        opacity: percentage / 100,
+        opacity: Math.max(0, Math.min(100, Number(color_mix[2]))) / 100,
       }
     }
     const hex_color = color?.match(hex_color_pattern)?.[0]
     return hex_color === undefined
-      ? { hex_color: fallback_hex_color, opacity: fallback_opacity }
+      ? { hex_color: remembered_hex, opacity: 0 }
       : { hex_color, opacity: 1 }
   }
 
   const default_site_label_color = as_hex_color(DEFAULTS.structure.site_label_color, `#111111`)
-  const default_site_label_bg = parse_label_bg_color(
-    DEFAULTS.structure.site_label_bg_color,
-    `#000000`,
-    0,
+  // Derived from scene_props rather than mirrored into local state: the two label colors are
+  // CSS strings the scene owns, and only the hex behind a fully transparent background has
+  // nowhere in that string to live.
+  let site_label_bg_hex = $state(
+    parse_label_bg_color(scene_props.site_label_bg_color, `#000000`).hex_color,
   )
-  const initial_site_label_bg = parse_label_bg_color(
-    scene_props.site_label_bg_color,
-    default_site_label_bg.hex_color,
-    default_site_label_bg.opacity,
+  let site_label_bg = $derived(
+    parse_label_bg_color(scene_props.site_label_bg_color, site_label_bg_hex),
   )
-
-  // Atom label color management
-  let site_label_hex_color = $state(
-    as_hex_color(scene_props.site_label_color, default_site_label_color),
-  )
-  let site_label_bg_hex_color = $state(initial_site_label_bg.hex_color)
-  let site_label_background_opacity = $state(initial_site_label_bg.opacity)
-  let last_synced_site_label_color = scene_props.site_label_color
-  let last_synced_site_label_bg_color = scene_props.site_label_bg_color
-
-  $effect(() => {
-    const external_color_changed =
-      scene_props.site_label_color !== last_synced_site_label_color
-    const external_bg_changed =
-      scene_props.site_label_bg_color !== last_synced_site_label_bg_color
-
-    if (external_color_changed) {
-      site_label_hex_color = as_hex_color(
-        scene_props.site_label_color,
-        default_site_label_color,
-      )
-    }
-    if (external_bg_changed) {
-      const next_bg = parse_label_bg_color(
-        scene_props.site_label_bg_color,
-        default_site_label_bg.hex_color,
-        default_site_label_bg.opacity,
-      )
-      site_label_bg_hex_color = next_bg.hex_color
-      site_label_background_opacity = next_bg.opacity
-    }
-
-    if (!external_color_changed) scene_props.site_label_color = site_label_hex_color
-    if (!external_bg_changed) {
-      // Fully transparent round-trips as `transparent`, else merely mounting the controls
-      // rewrites that default into an equivalent color-mix nobody asked for.
-      scene_props.site_label_bg_color =
-        site_label_background_opacity === 0
-          ? `transparent`
-          : `color-mix(in srgb, ${site_label_bg_hex_color} ${format_num(
-              site_label_background_opacity,
-              `.1~%`,
-            )}, transparent)`
-    }
-
-    last_synced_site_label_color = scene_props.site_label_color
-    last_synced_site_label_bg_color = scene_props.site_label_bg_color
-  })
-
-  // Ensure site_label_offset is always available
-  scene_props.site_label_offset ??= [...DEFAULTS.structure.site_label_offset]
+  const set_site_label_bg = (hex_color: string, opacity: number): void => {
+    site_label_bg_hex = hex_color
+    // Fully transparent round-trips as `transparent`, else merely touching the slider rewrites
+    // that default into an equivalent color-mix nobody asked for.
+    scene_props.site_label_bg_color =
+      opacity === 0
+        ? `transparent`
+        : `color-mix(in srgb, ${hex_color} ${format_num(opacity, `.1~%`)}, transparent)`
+  }
 
   // Collect available vector property keys from the structure
   let available_vector_keys = $derived(structure ? get_structure_vector_keys(structure) : [])
@@ -388,11 +601,6 @@
   // Validate supercell input
   let supercell_input_valid = $derived(is_valid_supercell_input(supercell_scaling))
 
-  // Ensure rotation is always an array
-  $effect(() => {
-    scene_props.rotation ??= [...DEFAULTS.structure.rotation]
-  })
-
   let rotation_degrees = $derived(
     scene_props.rotation?.map((rad) => {
       const deg = to_degrees(rad)
@@ -417,10 +625,32 @@
     if (!scheme) return []
     return [`H`, `C`, `N`, `O`].map((elem) => scheme[elem] || scheme.H || `#cccccc`)
   }
+
+  // Which top-level groups start expanded. Appearance is what people came for; camera and
+  // scene are set-once topics, so they stay folded until asked for. Conditional groups open
+  // when present — they only render at all because the data made them relevant.
+  let open_groups = $state({ appearance: true, camera: false, scene: false })
+  let has_overlays = $derived(
+    Boolean(displacement_summary) || scene_props.trajectory_position_stream !== undefined,
+  )
+  // Collapsed groups still need to say what is inside them, so each summary carries a hint
+  let camera_summary = $derived(
+    `${scene_props.camera_projection ?? DEFAULTS.structure.camera_projection}${
+      (scene_props.auto_rotate ?? 0) > 0 ? `, auto-rotating` : ``
+    }`,
+  )
 </script>
+
+<!-- Declared outside <DraggablePane> so it is a template snippet, not a prop of the pane -->
+{#snippet enum_options(key: StructureSettingKey)}
+  {#each Object.entries(SETTINGS_CONFIG.structure[key].enum ?? {}) as [value, label] (value)}
+    <option {value}>{label}</option>
+  {/each}
+{/snippet}
 
 <DraggablePane
   bind:open={controls_open}
+  bind:pane={controls_pane}
   resize="both"
   pane_props={{
     ...pane_props,
@@ -436,1161 +666,1190 @@
   closed_icon={Settings}
   {...rest}
 >
-  {#if volumetric_data?.length}
-    {#if display_mode === `slice` && slice_settings}
-      <VolumeSliceControls
-        bind:settings={slice_settings}
-        volumes={volumetric_data}
-        bind:active_volume_idx
-        on_settings_change={on_slice_settings_change}
-      />
-    {:else if isosurface_settings}
-      <IsosurfaceControls
-        bind:settings={isosurface_settings}
-        bind:volumes={volumetric_data}
-        bind:active_volume_idx
-      />
-    {/if}
+  {#if on_reset_camera}
+    <!-- Hoisted out of the Camera group: the one action people reach for repeatedly should
+      not sit behind a disclosure triangle -->
+    <button type="button" class="reset-camera" title={reset_text} onclick={on_reset_camera}>
+      <Icon icon={Reset} />
+      <span>Reset view</span>
+      <kbd>r</kbd>
+    </button>
   {/if}
 
-  {#if multi_view_control_visible && display_mode === `structure`}
-    <SettingsSection
-      title="Layout"
-      current_values={{ multi_view }}
-      on_reset={() => (multi_view = false)}
-    >
-      <label class:disabled={multi_view_blocked}>
-        <input
-          type="checkbox"
-          bind:checked={multi_view}
-          disabled={multi_view_blocked}
-          aria-describedby={multi_view_unavailable_reason ? multi_view_hint_id : undefined}
-        />
-        Multi-view grid
-      </label>
-      {#if multi_view_unavailable_reason}
-        <small id={multi_view_hint_id} class="setting-hint">
-          {multi_view_unavailable_reason}
-        </small>
-      {/if}
-    </SettingsSection>
-  {/if}
-
-  <SettingsSection
-    title="Visibility"
-    current_values={{
-      show_atoms: scene_props.show_atoms,
-      show_bonds: scene_props.show_bonds,
-      show_polyhedra: scene_props.show_polyhedra,
-      show_image_atoms,
-      show_site_labels: scene_props.show_site_labels,
-      show_site_indices: scene_props.show_site_indices,
-      vector_configs: scene_props.vector_configs,
-      show_cell_vectors: lattice_props.show_cell_vectors,
-    }}
-    on_reset={() => {
-      scene_props.show_atoms = DEFAULTS.structure.show_atoms
-      scene_props.show_bonds = DEFAULTS.structure.show_bonds
-      scene_props.show_polyhedra = DEFAULTS.structure.show_polyhedra
-      scene_props.show_site_labels = DEFAULTS.structure.show_site_labels
-      scene_props.show_site_indices = DEFAULTS.structure.show_site_indices
-      scene_props.vector_configs = default_vector_configs(available_vector_keys)
-      show_image_atoms = DEFAULTS.structure.show_image_atoms
-      lattice_props.show_cell_vectors = DEFAULTS.structure.show_cell_vectors
-    }}
-    style="display: flex; flex-direction: row; flex-wrap: wrap; gap: 12pt"
-  >
-    Show <label
-      {@attach tooltip({ content: SETTINGS_CONFIG.structure.show_atoms.description })}
-      style="gap: 6pt"
-    >
-      <input type="checkbox" bind:checked={scene_props.show_atoms} />
-      Atoms
-    </label>
-    <label
-      {@attach tooltip({ content: SETTINGS_CONFIG.structure.show_image_atoms.description })}
-      style="gap: 6pt"
-    >
-      <input type="checkbox" bind:checked={show_image_atoms} />
-      Image Atoms
-    </label>
-    <label
-      {@attach tooltip({ content: SETTINGS_CONFIG.structure.show_site_labels.description })}
-      style="gap: 6pt"
-    >
-      <input type="checkbox" bind:checked={scene_props.show_site_labels} />
-      Site Labels
-    </label>
-    <label
-      {@attach tooltip({ content: SETTINGS_CONFIG.structure.show_site_indices.description })}
-      style="gap: 6pt"
-    >
-      <input type="checkbox" bind:checked={scene_props.show_site_indices} />
-      Site Indices
-    </label>
-    {#if available_vector_keys.length > 0}
-      {#each available_vector_keys as key, idx (key)}
-        {@const key_visible = is_key_visible(key)}
-        <label
-          {@attach tooltip({
-            content: `Toggle ${key} vectors`,
-          })}
-          style="gap: 4pt"
-        >
-          <input
-            type="checkbox"
-            checked={key_visible}
-            onchange={() => update_vector_config(key, { visible: !key_visible })}
+  <SettingsSearch>
+    {#if volumetric_data?.length}
+      <SettingsGroup
+        title="Volumetric data"
+        open
+        subtitle={display_mode === `slice` ? `cross-section` : `isosurface`}
+      >
+        {#if display_mode === `slice` && slice_settings}
+          <VolumeSliceControls
+            bind:settings={slice_settings}
+            volumes={volumetric_data}
+            bind:active_volume_idx
+            on_settings_change={on_slice_settings_change}
           />
-          <input
-            type="color"
-            aria-label={`${key} vector color`}
-            value={scene_props.vector_configs?.[key]?.color ??
-              VECTOR_PALETTE[idx % VECTOR_PALETTE.length]}
-            onchange={(evt) =>
-              update_vector_config(key, {
-                color: evt.currentTarget.value,
-              })}
-            style="width: 22px; height: 22px; padding: 0; border: none; cursor: pointer"
+        {:else if isosurface_settings}
+          <IsosurfaceControls
+            bind:settings={isosurface_settings}
+            bind:volumes={volumetric_data}
+            bind:active_volume_idx
           />
-          {key}
-          {#if scene_props.vector_configs?.[key]?.color != null}
-            <button
-              type="button"
-              aria-label={`Reset ${key} color to default`}
-              onclick={() => update_vector_config(key, { color: null })}
-              style="padding: 0 3pt; font-size: 0.8em; line-height: 1; cursor: pointer"
-            >
-              ×
-            </button>
-          {/if}
-        </label>
-      {/each}
+        {/if}
+      </SettingsGroup>
     {/if}
-    <label style="gap: 6pt">
-      <input type="checkbox" bind:checked={lattice_props.show_cell_vectors} />
-      Lattice Vectors
-    </label>
-    <label
-      {@attach tooltip({ content: SETTINGS_CONFIG.structure.show_bonds.description })}
-      style="gap: 6pt"
-    >
-      Bonds:
-      <select bind:value={scene_props.show_bonds}>
-        {#each Object.entries(SETTINGS_CONFIG.structure.show_bonds.enum ?? {}) as [value, label] (value)}
-          <option {value}>{label}</option>
-        {/each}
-      </select>
-    </label>
-    <label
-      {@attach tooltip({ content: SETTINGS_CONFIG.structure.show_polyhedra.description })}
-      style="gap: 6pt"
-    >
-      Polyhedra:
-      <select bind:value={scene_props.show_polyhedra}>
-        {#each Object.entries(SETTINGS_CONFIG.structure.show_polyhedra.enum ?? {}) as [value, label] (value)}
-          <option {value}>{label}</option>
-        {/each}
-      </select>
-    </label>
-  </SettingsSection>
 
-  <SettingsSection
-    title="Camera"
-    {...scene_section([
-      `camera_projection`,
-      `auto_rotate`,
-      `rotate_speed`,
-      `zoom_speed`,
-      `pan_speed`,
-      `zoom_to_cursor`,
-      `rotation_damping`,
-      `rotation`,
-    ])}
-  >
-    {#if on_reset_camera}
-      <button type="button" class="reset-camera" title={reset_text} onclick={on_reset_camera}>
-        <Icon icon={Reset} />
-        <span>Reset view <kbd>r</kbd></span>
-      </button>
-    {/if}
-    <label>
-      <span
-        {@attach tooltip({ content: SETTINGS_CONFIG.structure.camera_projection.description })}
-      >
-        Projection
-      </span>
-      <select bind:value={scene_props.camera_projection}>
-        {#each Object.entries(SETTINGS_CONFIG.structure.camera_projection.enum ?? {}) as [value, label] (value)}
-          <option {value}>{label}</option>
-        {/each}
-      </select>
-    </label>
-    <NumberRangeInput
-      min={0}
-      max={2}
-      step={0.01}
-      bind:value={scene_props.auto_rotate}
-      title={SETTINGS_CONFIG.structure.auto_rotate.description}
-      >Auto-rotate speed</NumberRangeInput
-    >
-    <label
-      {@attach tooltip({ content: SETTINGS_CONFIG.structure.zoom_to_cursor.description })}
-    >
-      <input type="checkbox" bind:checked={scene_props.zoom_to_cursor} />
-      <span>Zoom to cursor</span>
-    </label>
-    <!-- Collapsed: four sliders almost nobody moves, crowding out settings people do reach for -->
-    <details class="advanced">
-      <summary>Pointer sensitivity</summary>
-      <NumberRangeInput
-        min={0}
-        max={2}
-        step={0.05}
-        bind:value={scene_props.rotate_speed}
-        title={SETTINGS_CONFIG.structure.rotate_speed.description}
-        >Rotate speed</NumberRangeInput
-      >
-      <NumberRangeInput
-        min={0.1}
-        max={0.8}
-        step={0.02}
-        bind:value={scene_props.zoom_speed}
-        title={SETTINGS_CONFIG.structure.zoom_speed.description}>Zoom speed</NumberRangeInput
-      >
-      <NumberRangeInput
-        min={0}
-        max={2}
-        step={0.01}
-        bind:value={scene_props.pan_speed}
-        title={SETTINGS_CONFIG.structure.pan_speed.description}>Pan speed</NumberRangeInput
-      >
-      <NumberRangeInput
-        min={0.01}
-        max={0.3}
-        step={0.01}
-        bind:value={scene_props.rotation_damping}
-        title={SETTINGS_CONFIG.structure.rotation_damping.description}
-        >Rotation damping</NumberRangeInput
-      >
-    </details>
-
-    Axis Rotation
-    <div class="rotation-axes">
-      {#each AXIS_COLORS as [axis, color], idx (axis)}
-        <div>
-          <div {@attach tooltip()} title="{axis}-axis rotation in degrees" style:color>
-            <span>{axis.toUpperCase()} = </span>
-            <input
-              type="number"
-              min={0}
-              max={360}
-              step={1}
-              value={rotation_degrees[idx].toFixed(0)}
-              oninput={(event) => update_rotation(axis, Number(event.currentTarget.value))}
-              style:color
-              style="margin: 0"
-            />
-            °
-          </div>
-          <input
-            type="range"
-            min={0}
-            max={360}
-            step={1}
-            value={rotation_degrees[idx].toFixed(0)}
-            oninput={(event) => update_rotation(axis, Number(event.currentTarget.value))}
-            style:--thumb-color={color}
-            style="width: 100%"
-          />
-        </div>
-      {/each}
-    </div>
-
-    Crystallographic View
-    <div class="pane-row zone-axis">
-      <select
-        bind:value={zone_axis_mode}
-        aria-label="Zone axis index type"
-        disabled={!lattice_matrix}
-      >
-        {#each Object.entries(ZONE_AXIS_MODE_LABELS) as [mode, mode_label] (mode)}
-          <option value={mode}>{mode_label}</option>
-        {/each}
-      </select>
-      <MillerIndexInput
-        bind:value={zone_axis_indices}
-        label={zone_axis_mode}
-        disabled={!lattice_matrix}
-      />
-      <button
-        type="button"
-        onclick={fly_to_zone_axis}
-        disabled={!zone_axis.direction}
-        title={lattice_matrix
-          ? `Point the camera along this crystallographic direction`
-          : `Needs a lattice — molecules have no crystallographic directions`}
-      >
-        View
-      </button>
-      {#if zone_axis.error}
-        <span class="control-error">{zone_axis.error}</span>
-      {/if}
-    </div>
-  </SettingsSection>
-
-  <SettingsSection
-    title="Atoms"
-    current_values={{
-      atom_radius: scene_props.atom_radius,
-      same_size_atoms: scene_props.same_size_atoms,
-      color_scheme,
-      ...atom_color_config,
-    }}
-    on_reset={() => {
-      scene_props.atom_radius = DEFAULTS.structure.atom_radius
-      scene_props.same_size_atoms = DEFAULTS.structure.same_size_atoms
-      color_scheme = DEFAULTS.color_scheme
-      color_scheme_selected = [DEFAULTS.color_scheme]
-      atom_color_config.mode = DEFAULTS.structure.atom_color_mode
-      atom_color_config.scale = DEFAULTS.structure.atom_color_scale
-      atom_color_config.scale_type = DEFAULTS.structure.atom_color_scale_type
-      delete atom_color_config.property_key
-      color_scale_selected = [DEFAULTS.structure.atom_color_scale]
-    }}
-  >
-    <NumberRangeInput
-      min={0.2}
-      max={2}
-      step={0.05}
-      bind:value={scene_props.atom_radius}
-      title={SETTINGS_CONFIG.structure.atom_radius.description}
-      >Radius <small>(Å)</small></NumberRangeInput
-    >
-    <label
-      {@attach tooltip({ content: SETTINGS_CONFIG.structure.same_size_atoms.description })}
-    >
-      Same size atoms
-      <input type="checkbox" bind:checked={scene_props.same_size_atoms} />
-    </label>
-    <label {@attach tooltip({ content: SETTINGS_CONFIG.color_scheme.description })}>
-      Color scheme
-      <Select
-        options={Object.keys(ELEMENT_COLOR_SCHEMES)}
-        maxSelect={1}
-        minSelect={1}
-        bind:selected={color_scheme_selected}
-        liOptionStyle="padding: 3pt 6pt;"
-        liSelectedStyle="background-color: transparent;"
-        ulSelectedStyle="display: contents;"
-        inputStyle="flex: none; min-width: 0; width: 0; opacity: 0;"
-        style="flex: 1; min-width: 0; border: none; margin-left: 4pt"
-        aria-label="Color scheme"
-      >
-        {#snippet children({ option })}
-          {@const option_style = `display: flex; align-items: center; gap: 6pt; justify-content: space-between;`}
-          <div style={option_style}>
-            {option}
-            <div style="display: flex; gap: 3pt">
-              {#each get_representative_colors(String(option)) as color (color)}
-                {@const color_style = `width: 15px; height: 15px; border-radius: 2px; background: ${color};`}
-                <div style={color_style}></div>
-              {/each}
-            </div>
-          </div>
-        {/snippet}
-      </Select>
-    </label>
-    <label
-      {@attach tooltip({ content: SETTINGS_CONFIG.structure.atom_color_mode.description })}
-    >
-      Atom coloring
-      <select bind:value={atom_color_config.mode}>
-        {#each Object.entries(SETTINGS_CONFIG.structure.atom_color_mode.enum || {}) as [value, label] (value)}
-          {@const disabled =
-            (value === `wyckoff` && !sym_data) ||
-            (value === `selective_dynamics` && !has_selective_dynamics) ||
-            (value === `property` && colorable_property_keys.length === 0)}
-          <option
-            {value}
-            {disabled}
-            title={value === `property` && disabled
-              ? `No per-atom properties on this structure — load a file that carries extra columns (extXYZ Properties=..., LAMMPS dump)`
-              : undefined}>{label}</option
-          >
-        {/each}
-      </select>
-    </label>
-    {#if atom_color_config.mode === `property` && colorable_property_keys.length > 0}
-      <label {@attach tooltip({ content: `Per-atom property to map onto the color scale` })}>
-        Property
-        <select bind:value={atom_color_config.property_key}>
-          {#each colorable_property_keys as key (key)}
-            <option value={key}>{key}</option>
-          {/each}
-        </select>
-      </label>
-    {/if}
-    {#if atom_color_config.mode !== `element`}
-      <label
-        {@attach tooltip({ content: SETTINGS_CONFIG.structure.atom_color_scale.description })}
-      >
-        Color scale
-        <ColorScaleSelect
-          bind:value={atom_color_config.scale}
-          bind:selected={color_scale_selected}
-          color_bar={{
-            tick_labels: 0,
-            wrapper_style: `width: 100%;`,
-          }}
-          style="flex: 1; min-width: 0; border: none"
-          aria-label="Color scale"
-        />
-      </label>
-    {/if}
-  </SettingsSection>
-
-  {#if scene_props.show_site_labels || scene_props.show_site_indices}
-    <SettingsSection
-      title="Labels"
-      current_values={{
-        site_label_size: scene_props.site_label_size,
-        site_label_hex_color,
-        site_label_bg_hex_color,
-        site_label_background_opacity,
-        site_label_padding: scene_props.site_label_padding,
-        site_label_offset: scene_props.site_label_offset,
-      }}
-      on_reset={() => {
-        scene_props.site_label_size = DEFAULTS.structure.site_label_size
-        scene_props.site_label_padding = DEFAULTS.structure.site_label_padding
-        scene_props.site_label_offset = [...DEFAULTS.structure.site_label_offset]
-        site_label_hex_color = default_site_label_color
-        site_label_bg_hex_color = default_site_label_bg.hex_color
-        site_label_background_opacity = default_site_label_bg.opacity
-      }}
-    >
-      <div class="pane-row">
-        <label>
-          Color
-          <input
-            type="color"
-            aria-label="Site label color"
-            bind:value={site_label_hex_color}
-          />
-        </label>
-        <label>
-          Size
-          <input
-            type="range"
-            min="0.5"
-            max="2"
-            step="0.1"
-            bind:value={scene_props.site_label_size}
-          />
-        </label>
-      </div>
-      <div class="pane-row">
-        <label>
-          Background
-          <input
-            type="color"
-            aria-label="Site label background color"
-            bind:value={site_label_bg_hex_color}
-          />
-        </label>
-        <label>
-          Opacity
-          <input
-            type="number"
-            min="0"
-            max="1"
-            step="0.01"
-            aria-label="Site label background opacity"
-            bind:value={site_label_background_opacity}
-          />
-          <input
-            type="range"
-            min="0"
-            max="1"
-            step="0.01"
-            aria-label="Site label background opacity slider"
-            bind:value={site_label_background_opacity}
-          />
-        </label>
-      </div>
-      <div class="pane-row">
-        <label>
-          Padding
-          <input
-            type="number"
-            min="0"
-            max="10"
-            step="1"
-            bind:value={scene_props.site_label_padding}
-          />
-          <input
-            type="range"
-            min="0"
-            max="10"
-            step="1"
-            bind:value={scene_props.site_label_padding}
-          />
-        </label>
-      </div>
-      <div class="pane-row">
-        Offset
-        {#each [`X`, `Y`, `Z`] as axis, idx (axis)}
-          <label>
-            {axis}
-            <input
-              type="number"
-              min="-1"
-              max="1"
-              step="0.1"
-              bind:value={scene_props.site_label_offset![idx]}
-            />
-          </label>
-        {/each}
-      </div>
-    </SettingsSection>
-  {/if}
-
-  {#if displacement_summary}
-    <SettingsSection
-      title="Displacement Overlay"
-      {...scene_section([
-        `show_displacement_arrows`,
-        `displacement_arrow_scale`,
-        `displacement_arrow_color`,
-      ])}
-    >
-      <!-- `!== null` (not truthiness) so the union discriminates: an empty error string
-        would leave the else branch un-narrowed and rmsd possibly undefined -->
-      {#if displacement_summary.error !== null}
-        <span class="control-error">{displacement_summary.error}</span>
-      {:else}
-        <div class="pane-row">
-          <span>RMSD <strong>{format_num(displacement_summary.rmsd, `.4~f`)} Å</strong></span>
-          <span>
-            Max <strong>{format_num(displacement_summary.max_displacement, `.4~f`)} Å</strong>
-          </span>
-        </div>
-        <label
-          {@attach tooltip({
-            content: SETTINGS_CONFIG.structure.show_displacement_arrows.description,
-          })}
-          style="gap: 6pt"
+    <SettingsGroup title="Appearance" bind:open={open_groups.appearance}>
+      {#key available_vector_keys.join(`\0`)}
+        <SettingsSection
+          title="Visibility"
+          layout="grid"
+          {...scene_section(
+            [
+              `show_atoms`,
+              `show_bonds`,
+              `show_polyhedra`,
+              `show_site_labels`,
+              `show_site_indices`,
+            ],
+            {
+              show_image_atoms: local(
+                () => show_image_atoms,
+                (value) => (show_image_atoms = value),
+              ),
+              show_cell_vectors: local(
+                () => lattice_props.show_cell_vectors,
+                (value) => (lattice_props.show_cell_vectors = value),
+              ),
+              // A vector row owns visibility and color only. Tracking the whole config here would
+              // make a per-key scale edit (owned by Site vectors) light up this section's reset,
+              // which would then wipe that scale on its way past.
+              ...Object.fromEntries(
+                available_vector_keys.map((key, key_idx) => [
+                  `vector_config:${key}`,
+                  local(
+                    () => ({
+                      visible: is_key_visible(key),
+                      color:
+                        scene_props.vector_configs?.[key]?.color ??
+                        (available_vector_keys.length > 1
+                          ? VECTOR_PALETTE[key_idx % VECTOR_PALETTE.length]
+                          : null),
+                    }),
+                    (reference, present) =>
+                      update_vector_config(
+                        key,
+                        present ? reference : { visible: true, color: null },
+                      ),
+                  ),
+                ]),
+              ),
+            },
+          )}
         >
-          <input type="checkbox" bind:checked={scene_props.show_displacement_arrows} />
-          Show displacement arrows
-        </label>
-        <NumberRangeInput
-          min={0.1}
-          max={20}
-          step={0.1}
-          bind:value={scene_props.displacement_arrow_scale}
-          title={SETTINGS_CONFIG.structure.displacement_arrow_scale.description}
-          >Arrow scale</NumberRangeInput
-        >
-        <label
-          {@attach tooltip({
-            content: SETTINGS_CONFIG.structure.displacement_arrow_color.description,
-          })}
-        >
-          Arrow color
-          <input
-            type="color"
-            aria-label="Displacement arrow color"
-            bind:value={scene_props.displacement_arrow_color}
-          />
-        </label>
-      {/if}
-    </SettingsSection>
-  {/if}
-
-  <!-- Only the trajectory viewer can collect a whole-run position stream, so this section is
-    absent for plain structures rather than showing dead controls -->
-  {#if scene_props.trajectory_position_stream !== undefined}
-    <SettingsSection
-      title="Trajectory Trails"
-      {...scene_section(
-        [
-          `show_trajectory_lines`,
-          `trajectory_line_trail_frames`,
-          `trajectory_line_frame_stride`,
-          `trajectory_line_color_mode`,
-          `trajectory_line_wrap_mode`,
-        ],
-        () => {
-          show_trajectory_lines = DEFAULTS.structure.show_trajectory_lines
-          scene_props.trajectory_line_elements = null
-        },
-      )}
-    >
-      <label
-        {@attach tooltip({
-          content: SETTINGS_CONFIG.structure.show_trajectory_lines.description,
-        })}
-        style="gap: 6pt"
-      >
-        <input type="checkbox" bind:checked={show_trajectory_lines} />
-        Show trajectory trails
-      </label>
-      {#if show_trajectory_lines && scene_props.trajectory_position_stream}
-        {#if trail_elements.length > 1}
-          <div class="pane-row" style="flex-wrap: wrap; gap: 8pt">
-            Species
-            {#each trail_elements as element (element)}
-              <label style="gap: 4pt">
+          <div class="toggle-grid">
+            <label {...setting_row(`show_atoms`)}>
+              <input type="checkbox" bind:checked={scene_props.show_atoms} />
+              Atoms
+            </label>
+            <label {...setting_row(`show_image_atoms`)}>
+              <input type="checkbox" bind:checked={show_image_atoms} />
+              Image atoms
+            </label>
+            <label {...setting_row(`show_site_labels`)}>
+              <input type="checkbox" bind:checked={scene_props.show_site_labels} />
+              Site labels
+            </label>
+            <label {...setting_row(`show_site_indices`)}>
+              <input type="checkbox" bind:checked={scene_props.show_site_indices} />
+              Site indices
+            </label>
+            <label {...setting_row(`show_cell_vectors`)}>
+              <input type="checkbox" bind:checked={lattice_props.show_cell_vectors} />
+              Lattice vectors
+            </label>
+            {#each available_vector_keys as key, idx (key)}
+              {@const key_visible = is_key_visible(key)}
+              {@const description = `Visibility and color of ${key} vectors`}
+              <label
+                data-key={`vector_config:${key}`}
+                data-description={description}
+                {@attach tooltip({ content: description })}
+              >
                 <input
                   type="checkbox"
-                  checked={is_trail_element_on(element)}
-                  onchange={() => toggle_trail_element(element)}
+                  checked={key_visible}
+                  onchange={() => update_vector_config(key, { visible: !key_visible })}
                 />
-                {element}
+                <input
+                  class="swatch"
+                  type="color"
+                  aria-label={`${key} vector color`}
+                  value={scene_props.vector_configs?.[key]?.color ??
+                    VECTOR_PALETTE[idx % VECTOR_PALETTE.length]}
+                  onchange={(evt) =>
+                    update_vector_config(key, { color: evt.currentTarget.value })}
+                />
+                {key}
+                {#if scene_props.vector_configs?.[key]?.color != null}
+                  <button
+                    type="button"
+                    class="clear-color"
+                    aria-label={`Reset ${key} color to default`}
+                    onclick={() => update_vector_config(key, { color: null })}
+                  >
+                    ×
+                  </button>
+                {/if}
               </label>
             {/each}
           </div>
-        {/if}
-        <NumberRangeInput
-          min={0}
-          max={Math.max(1, scene_props.trajectory_position_stream.n_frames)}
-          step={1}
-          bind:value={scene_props.trajectory_line_trail_frames}
-          title={SETTINGS_CONFIG.structure.trajectory_line_trail_frames.description}
-          >Trail length <small>(0 = full run)</small></NumberRangeInput
-        >
-        <NumberRangeInput
-          min={1}
-          max={100}
-          step={1}
-          bind:value={scene_props.trajectory_line_frame_stride}
-          title={SETTINGS_CONFIG.structure.trajectory_line_frame_stride.description}
-          >Frame stride</NumberRangeInput
-        >
-        <label
-          {@attach tooltip({
-            content: SETTINGS_CONFIG.structure.trajectory_line_color_mode.description,
-          })}
-        >
-          Color by
-          <select bind:value={scene_props.trajectory_line_color_mode}>
-            {#each Object.entries(SETTINGS_CONFIG.structure.trajectory_line_color_mode.enum ?? {}) as [value, label] (value)}
-              <option {value}>{label}</option>
-            {/each}
-          </select>
-        </label>
-        <label
-          {@attach tooltip({
-            content: SETTINGS_CONFIG.structure.trajectory_line_wrap_mode.description,
-          })}
-        >
-          Boundaries
-          <select bind:value={scene_props.trajectory_line_wrap_mode}>
-            {#each Object.entries(SETTINGS_CONFIG.structure.trajectory_line_wrap_mode.enum ?? {}) as [value, label] (value)}
-              <option {value}>{label}</option>
-            {/each}
-          </select>
-        </label>
-        {#if trajectory_lines_result}
-          {@const { point_count, segment_count, atom_count, max_segment_length } =
-            trajectory_lines_result}
-          <div class="pane-row">
-            <span>{format_num(atom_count, `.3~s`)} atoms</span>
-            <span>{format_num(point_count, `.3~s`)} vertices</span>
-            <span>{format_num(segment_count, `.3~s`)} segments</span>
-            <span
-              {@attach tooltip({
-                content:
-                  `Longest drawn segment. With unwrapping on this stays at the scale of a ` +
-                  `real per-step displacement; a value near a cell diagonal means the path ` +
-                  `is jumping across the box.`,
-              })}
-            >
-              max step <strong>{format_num(max_segment_length, `.3~f`)} Å</strong>
-            </span>
-          </div>
-        {/if}
-      {:else if show_trajectory_lines}
-        <Spinner text="Collecting trajectory positions..." style="margin: 4pt 0" />
-      {/if}
-    </SettingsSection>
-  {/if}
+          <label {...setting_row(`show_bonds`)}>
+            <span>Bonds</span>
+            <select bind:value={scene_props.show_bonds}>
+              {@render enum_options(`show_bonds`)}
+            </select>
+          </label>
+          <label {...setting_row(`show_polyhedra`)}>
+            <span>Polyhedra</span>
+            <select bind:value={scene_props.show_polyhedra}>
+              {@render enum_options(`show_polyhedra`)}
+            </select>
+          </label>
+        </SettingsSection>
+      {/key}
 
-  {#if available_vector_keys.length > 0 && any_vectors_visible}
-    <SettingsSection
-      title="Site Vectors"
-      {...scene_section(
-        [
-          `vector_scale`,
-          `vector_color`,
-          `vector_normalize`,
-          `vector_uniform_thickness`,
-          `vector_color_mode`,
-          `vector_color_scale`,
-          `vector_origin_gap`,
-        ],
-        () => {
-          for (const key of available_vector_keys) update_vector_config(key, { scale: null })
-        },
-      )}
-    >
-      <NumberRangeInput min={0.001} max={5} step={0.001} bind:value={scene_props.vector_scale}
-        >Global Scale</NumberRangeInput
-      >
-      <label
-        {@attach tooltip({ content: SETTINGS_CONFIG.structure.vector_normalize.description })}
-        style="gap: 6pt"
-      >
-        <input type="checkbox" bind:checked={scene_props.vector_normalize} />
-        Normalize
-      </label>
-      <label
-        {@attach tooltip({
-          content: SETTINGS_CONFIG.structure.vector_uniform_thickness.description,
+      <SettingsSection
+        title="Atoms"
+        layout="grid"
+        {...scene_section([`atom_radius`, `same_size_atoms`], {
+          color_scheme: local(
+            () => color_scheme,
+            (value) => (color_scheme = value),
+          ),
+          // scale_type is derived from the mode, so the two travel as one row
+          atom_color_mode: local(
+            () => ({
+              mode: atom_color_config.mode,
+              scale_type: atom_color_config.scale_type,
+            }),
+            (reference) => Object.assign(atom_color_config, reference),
+          ),
+          atom_color_scale: local(
+            () => atom_color_config.scale,
+            (value) => (atom_color_config.scale = value),
+          ),
+          atom_color_property_key: local(
+            () => atom_color_config.property_key,
+            (value, present) => {
+              if (present) atom_color_config.property_key = value
+              else delete atom_color_config.property_key
+            },
+          ),
         })}
-        style="gap: 6pt"
       >
-        <input type="checkbox" bind:checked={scene_props.vector_uniform_thickness} />
-        Uniform Thickness
-      </label>
-      <label
-        {@attach tooltip({ content: SETTINGS_CONFIG.structure.vector_color_mode.description })}
-      >
-        Color Mode
-        <select bind:value={scene_props.vector_color_mode}>
-          {#each VECTOR_COLOR_MODES as mode (mode)}
-            <option value={mode}>{mode.replaceAll(`_`, ` `)}</option>
-          {/each}
-        </select>
-      </label>
-      {#if scene_props.vector_color_mode === `magnitude`}
-        <label>
-          Scale
-          <ColorScaleSelect
-            bind:value={scene_props.vector_color_scale}
-            style="max-width: 180px"
-          />
-        </label>
-      {/if}
-      {#if scene_props.vector_color_mode === `uniform`}
-        <label>
-          Color
-          <input type="color" bind:value={scene_props.vector_color} />
-        </label>
-      {/if}
-      {#if available_vector_keys.length > 1}
         <NumberRangeInput
-          min={0}
-          max={0.5}
-          step={0.02}
-          bind:value={scene_props.vector_origin_gap}
-          title={SETTINGS_CONFIG.structure.vector_origin_gap.description}
-          >Origin Gap</NumberRangeInput
+          {...setting_range(`atom_radius`, 0.05)}
+          bind:value={scene_props.atom_radius}>Radius <small>(Å)</small></NumberRangeInput
         >
-        {#each available_vector_keys as key (key)}
-          {#if is_key_visible(key)}
-            {@const on_scale = (evt: Event & { currentTarget: HTMLInputElement }) => {
-              const parsed = parseFloat(evt.currentTarget.value)
-              update_vector_config(key, { scale: Number.isNaN(parsed) ? 1.0 : parsed })
-            }}
-            <label
-              {@attach tooltip({
-                content: `Scale multiplier for ${key} arrows (applied on top of global scale)`,
-              })}
-            >
-              {key} scale
-              <input
-                type="number"
-                min={0.1}
-                max={5}
-                step={0.1}
-                value={scene_props.vector_configs?.[key]?.scale ?? 1.0}
-                onchange={on_scale}
-              />
-              <input
-                type="range"
-                min={0.1}
-                max={5}
-                step={0.1}
-                value={scene_props.vector_configs?.[key]?.scale ?? 1.0}
-                oninput={on_scale}
-              />
+        <label {...setting_row(`same_size_atoms`)}>
+          <span>Same size</span>
+          <input type="checkbox" bind:checked={scene_props.same_size_atoms} />
+        </label>
+        <label {...setting_row(`color_scheme`)}>
+          <span>Color scheme</span>
+          <Select
+            options={Object.keys(ELEMENT_COLOR_SCHEMES)}
+            maxSelect={1}
+            minSelect={1}
+            bind:value={color_scheme}
+            liOptionStyle="padding: 3pt 6pt;"
+            liSelectedStyle="background-color: transparent;"
+            ulSelectedStyle="display: contents;"
+            inputStyle="flex: none; min-width: 0; width: 0; opacity: 0;"
+            style="min-width: 0; border: none"
+            aria-label="Color scheme"
+          >
+            {#snippet children({ option })}
+              <div class="scheme-option">
+                {option}
+                <div class="scheme-swatches">
+                  {#each get_representative_colors(String(option)) as color (color)}
+                    <div style:background={color}></div>
+                  {/each}
+                </div>
+              </div>
+            {/snippet}
+          </Select>
+        </label>
+        <label {...setting_row(`atom_color_mode`)}>
+          <span>Color by</span>
+          <select bind:value={atom_color_config.mode}>
+            {#each Object.entries(SETTINGS_CONFIG.structure.atom_color_mode.enum || {}) as [value, label] (value)}
+              {@const disabled =
+                (value === `wyckoff` && !sym_data) ||
+                (value === `selective_dynamics` && !has_selective_dynamics) ||
+                (value === `property` && colorable_property_keys.length === 0)}
+              <option
+                {value}
+                {disabled}
+                title={value === `property` && disabled
+                  ? `No per-atom properties on this structure — load a file that carries extra columns (extXYZ Properties=..., LAMMPS dump)`
+                  : undefined}>{label}</option
+              >
+            {/each}
+          </select>
+        </label>
+        {#if atom_color_config.mode === `property` && colorable_property_keys.length > 0}
+          <label {...setting_row(`atom_color_property_key`)}>
+            <span>Property</span>
+            <select bind:value={atom_color_config.property_key}>
+              {#each colorable_property_keys as key (key)}
+                <option value={key}>{key}</option>
+              {/each}
+            </select>
+          </label>
+        {/if}
+        {#if atom_color_config.mode !== `element`}
+          <label {...setting_row(`atom_color_scale`)}>
+            <span>Color scale</span>
+            <ColorScaleSelect
+              bind:value={
+                () => atom_color_config.scale ?? DEFAULTS.structure.atom_color_scale,
+                (scale) => (atom_color_config.scale = scale)
+              }
+              color_bar={{ tick_labels: 0, wrapper_style: `width: 100%;` }}
+              style="min-width: 0; border: none"
+              aria-label="Color scale"
+            />
+          </label>
+        {/if}
+      </SettingsSection>
+
+      {#if scene_props.show_bonds && scene_props.show_bonds !== `never`}
+        <SettingsSection
+          title="Bonds"
+          layout="grid"
+          {...scene_section([
+            `bonding_strategy`,
+            `auto_bond_order`,
+            `aromatic_display`,
+            `bond_color`,
+            `bond_thickness`,
+          ])}
+        >
+          <label {...setting_row(`bonding_strategy`)}>
+            <span>Strategy</span>
+            <select bind:value={scene_props.bonding_strategy}>
+              {@render enum_options(`bonding_strategy`)}
+            </select>
+          </label>
+          <label {...setting_row(`auto_bond_order`)}>
+            <span>Auto bond order</span>
+            <input type="checkbox" bind:checked={scene_props.auto_bond_order} />
+          </label>
+          {#if scene_props.auto_bond_order}
+            <label {...setting_row(`aromatic_display`)}>
+              <span>Aromatic</span>
+              <select bind:value={scene_props.aromatic_display}>
+                {@render enum_options(`aromatic_display`)}
+              </select>
             </label>
           {/if}
-        {/each}
+          <label {...setting_row(`bond_color`)}>
+            <span>Color</span>
+            <input class="swatch" type="color" bind:value={scene_props.bond_color} />
+          </label>
+          <NumberRangeInput
+            {...setting_range(`bond_thickness`, 0.01)}
+            bind:value={scene_props.bond_thickness}>Thickness</NumberRangeInput
+          >
+        </SettingsSection>
       {/if}
-    </SettingsSection>
-  {/if}
 
-  {#if has_lattice}
-    <SettingsSection
-      title="Cell"
-      current_values={{
-        cell_edge_color: lattice_props.cell_edge_color,
-        cell_edge_opacity: lattice_props.cell_edge_opacity,
-        cell_surface_color: lattice_props.cell_surface_color,
-        cell_surface_opacity: lattice_props.cell_surface_opacity,
-        supercell_scaling,
-        cell_type,
-      }}
-      on_reset={() => {
-        lattice_props.cell_edge_color = DEFAULTS.structure.cell_edge_color
-        lattice_props.cell_edge_opacity = DEFAULTS.structure.cell_edge_opacity
-        lattice_props.cell_surface_color = DEFAULTS.structure.cell_surface_color
-        lattice_props.cell_surface_opacity = DEFAULTS.structure.cell_surface_opacity
-        supercell_scaling = `1x1x1`
-        cell_type = `original`
-      }}
-    >
-      <label
-        {@attach tooltip({
-          content: sym_data
-            ? `Transform to conventional or primitive cell using crystallographic symmetry`
-            : `Symmetry analysis required. Wait for analysis to complete.`,
+      {#if scene_props.show_polyhedra && scene_props.show_polyhedra !== `never`}
+        <SettingsSection
+          title="Polyhedra"
+          layout="grid"
+          {...scene_section(
+            [
+              `polyhedra_opacity`,
+              `polyhedra_hide_center_atoms`,
+              `polyhedra_min_neighbors`,
+              `polyhedra_max_neighbors`,
+            ],
+            {
+              polyhedra_color: scene_pair(`polyhedra_color_mode`, `polyhedra_color`),
+              polyhedra_edges: scene_pair(`polyhedra_show_edges`, `polyhedra_edge_color`),
+              polyhedra_centers: scene_pair(
+                `polyhedra_excluded_elements`,
+                `polyhedra_included_elements`,
+              ),
+            },
+          )}
+        >
+          <NumberRangeInput
+            {...setting_range(`polyhedra_opacity`, 0.05)}
+            bind:value={scene_props.polyhedra_opacity}>Opacity</NumberRangeInput
+          >
+          <label {...setting_row(`polyhedra_color`)}>
+            <span>Color</span>
+            <span class="ctrl-pair">
+              <select bind:value={scene_props.polyhedra_color_mode}>
+                {@render enum_options(`polyhedra_color_mode`)}
+              </select>
+              {#if scene_props.polyhedra_color_mode === `uniform`}
+                <input class="swatch" type="color" bind:value={scene_props.polyhedra_color} />
+              {/if}
+            </span>
+          </label>
+          <label {...setting_row(`polyhedra_edges`)}>
+            <span>Edges</span>
+            <span class="ctrl-pair">
+              <input type="checkbox" bind:checked={scene_props.polyhedra_show_edges} />
+              {#if scene_props.polyhedra_show_edges}
+                <input
+                  class="swatch"
+                  type="color"
+                  bind:value={scene_props.polyhedra_edge_color}
+                />
+              {/if}
+            </span>
+          </label>
+          <label {...setting_row(`polyhedra_hide_center_atoms`)}>
+            <span>Hide centers</span>
+            <input type="checkbox" bind:checked={scene_props.polyhedra_hide_center_atoms} />
+          </label>
+          <NumberRangeInput
+            {...setting_range(`polyhedra_min_neighbors`, 1)}
+            bind:value={scene_props.polyhedra_min_neighbors}>Min neighbors</NumberRangeInput
+          >
+          <NumberRangeInput
+            {...setting_range(`polyhedra_max_neighbors`, 1)}
+            bind:value={scene_props.polyhedra_max_neighbors}>Max neighbors</NumberRangeInput
+          >
+          {#if structure_elements.length > 0}
+            <div
+              class="setting"
+              {...setting_row(
+                `polyhedra_centers`,
+                `${description_for(`polyhedra_excluded_elements`)}. Force-including a spectator ` +
+                  `center (alkali or heavy alkaline-earth, e.g. Li, Na, Ba) may render its ` +
+                  `polyhedra truncated at cell boundaries.`,
+              )}
+            >
+              <span>Centers</span>
+              <div class="chip-row">
+                {#each structure_elements as element (element)}
+                  <label>
+                    <input
+                      type="checkbox"
+                      checked={is_polyhedra_center_enabled(element)}
+                      onchange={() => toggle_polyhedra_element(element)}
+                    />
+                    {element}
+                  </label>
+                {/each}
+              </div>
+            </div>
+          {/if}
+        </SettingsSection>
+      {/if}
+
+      {#if scene_props.show_site_labels || scene_props.show_site_indices}
+        <SettingsSection
+          title="Labels"
+          layout="grid"
+          {...scene_section(
+            [`site_label_size`, `site_label_padding`, `site_label_offset`, `site_label_color`],
+            {
+              // One CSS string drives two controls, so each half gets its own key: keying both
+              // rows off site_label_bg_color would offer a reset on the swatch for an edit the
+              // user made with the opacity slider.
+              site_label_bg_hex: local(
+                () => site_label_bg.hex_color,
+                (hex_color) => set_site_label_bg(hex_color, site_label_bg.opacity),
+              ),
+              site_label_bg_opacity: local(
+                () => site_label_bg.opacity,
+                (opacity) => set_site_label_bg(site_label_bg.hex_color, opacity),
+              ),
+            },
+          )}
+        >
+          <label {...setting_row(`site_label_color`)}>
+            <span>Color</span>
+            <input
+              class="swatch"
+              type="color"
+              aria-label="Site label color"
+              bind:value={
+                () => as_hex_color(scene_props.site_label_color, default_site_label_color),
+                (hex_color) => (scene_props.site_label_color = hex_color)
+              }
+            />
+          </label>
+          <NumberRangeInput
+            {...setting_range(`site_label_size`, 0.1)}
+            bind:value={scene_props.site_label_size}>Size</NumberRangeInput
+          >
+          <label {...setting_row(`site_label_bg_hex`)}>
+            <span>Background</span>
+            <input
+              class="swatch"
+              type="color"
+              aria-label="Site label background color"
+              bind:value={
+                () => site_label_bg.hex_color,
+                (hex_color) => set_site_label_bg(hex_color, site_label_bg.opacity)
+              }
+            />
+          </label>
+          <NumberRangeInput
+            data-key="site_label_bg_opacity"
+            min={0}
+            max={1}
+            step={0.01}
+            title={description_for(`site_label_bg_opacity`)}
+            bind:value={
+              () => site_label_bg.opacity,
+              (opacity) => set_site_label_bg(site_label_bg.hex_color, opacity ?? 0)
+            }>Opacity</NumberRangeInput
+          >
+          <NumberRangeInput
+            {...setting_range(`site_label_padding`, 1)}
+            bind:value={scene_props.site_label_padding}>Padding</NumberRangeInput
+          >
+          <div class="setting" {...setting_row(`site_label_offset`)}>
+            <span>Offset</span>
+            <div class="axis-inputs">
+              {#each [`X`, `Y`, `Z`] as axis, idx (axis)}
+                <label>
+                  {axis}
+                  <input
+                    type="number"
+                    min="-1"
+                    max="1"
+                    step="0.1"
+                    value={scene_props.site_label_offset?.[idx] ??
+                      DEFAULTS.structure.site_label_offset[idx]}
+                    oninput={(event) => {
+                      const site_label_offset = [
+                        ...(scene_props.site_label_offset ??
+                          DEFAULTS.structure.site_label_offset),
+                      ] as Vec3
+                      site_label_offset[idx] = Number(event.currentTarget.value)
+                      scene_props.site_label_offset = site_label_offset
+                    }}
+                  />
+                </label>
+              {/each}
+            </div>
+          </div>
+        </SettingsSection>
+      {/if}
+
+      {#if available_vector_keys.length > 0 && any_vectors_visible}
+        <SettingsSection
+          title="Site vectors"
+          layout="grid"
+          {...scene_section(
+            [
+              `vector_scale`,
+              `vector_color`,
+              `vector_normalize`,
+              `vector_uniform_thickness`,
+              `vector_color_mode`,
+              `vector_color_scale`,
+              `vector_origin_gap`,
+            ],
+            // per-key scales live in vector_configs rather than on a scene_props key of their
+            // own, so without an accessor here a scale-only edit would never reveal a reset
+            Object.fromEntries(
+              available_vector_keys.map((key) => [
+                `vector_scale:${key}`,
+                local(
+                  () => scene_props.vector_configs?.[key]?.scale ?? null,
+                  (scale) => update_vector_config(key, { scale }),
+                ),
+              ]),
+            ),
+          )}
+        >
+          <NumberRangeInput
+            {...setting_range(`vector_scale`, 0.001)}
+            bind:value={scene_props.vector_scale}>Global scale</NumberRangeInput
+          >
+          <label {...setting_row(`vector_normalize`)}>
+            <span>Normalize</span>
+            <input type="checkbox" bind:checked={scene_props.vector_normalize} />
+          </label>
+          <label {...setting_row(`vector_uniform_thickness`)}>
+            <span>Uniform width</span>
+            <input type="checkbox" bind:checked={scene_props.vector_uniform_thickness} />
+          </label>
+          <label {...setting_row(`vector_color_mode`)}>
+            <span>Color by</span>
+            <select bind:value={scene_props.vector_color_mode}>
+              {#each VECTOR_COLOR_MODES as mode (mode)}
+                <option value={mode}>{mode.replaceAll(`_`, ` `)}</option>
+              {/each}
+            </select>
+          </label>
+          {#if scene_props.vector_color_mode === `magnitude`}
+            <label {...setting_row(`vector_color_scale`)}>
+              <span>Color scale</span>
+              <ColorScaleSelect bind:value={scene_props.vector_color_scale} />
+            </label>
+          {:else if scene_props.vector_color_mode === `uniform`}
+            <label {...setting_row(`vector_color`)}>
+              <span>Color</span>
+              <input class="swatch" type="color" bind:value={scene_props.vector_color} />
+            </label>
+          {/if}
+          {#if available_vector_keys.length > 1}
+            <NumberRangeInput
+              {...setting_range(`vector_origin_gap`, 0.02)}
+              bind:value={scene_props.vector_origin_gap}>Origin gap</NumberRangeInput
+            >
+            {#each available_vector_keys as key (key)}
+              {#if is_key_visible(key)}
+                {@const description = `Scale multiplier for ${key} arrows (applied on top of global scale)`}
+                <NumberRangeInput
+                  data-key={`vector_scale:${key}`}
+                  data-description={description}
+                  min={0.1}
+                  max={5}
+                  step={0.1}
+                  title={description}
+                  bind:value={
+                    () => scene_props.vector_configs?.[key]?.scale ?? 1.0,
+                    (scale) => update_vector_config(key, { scale: scale ?? 1.0 })
+                  }
+                >
+                  <span>{key} scale</span>
+                </NumberRangeInput>
+              {/if}
+            {/each}
+          {/if}
+        </SettingsSection>
+      {/if}
+
+      {#if has_lattice}
+        <SettingsSection
+          title="Cell"
+          layout="grid"
+          {...settings_section(
+            lattice_props,
+            [
+              `cell_edge_color`,
+              `cell_edge_opacity`,
+              `cell_surface_color`,
+              `cell_surface_opacity`,
+            ],
+            {
+              supercell_scaling: local(
+                () => supercell_scaling,
+                (value) => (supercell_scaling = value),
+              ),
+              cell_type: local(
+                () => cell_type,
+                (value) => (cell_type = value),
+              ),
+            },
+          )}
+        >
+          <label
+            {...setting_row(
+              `cell_type`,
+              sym_data
+                ? description_for(`cell_type`)
+                : `Symmetry analysis required. Wait for analysis to complete.`,
+            )}
+          >
+            <span>Cell type</span>
+            <select bind:value={cell_type} disabled={!sym_data}>
+              <option value="original">Original</option>
+              <option value="conventional">Conventional</option>
+              <option value="primitive">Primitive</option>
+            </select>
+          </label>
+          <label {...setting_row(`supercell_scaling`)}>
+            <span>Supercell</span>
+            <input
+              type="text"
+              bind:value={supercell_scaling}
+              placeholder="1x1x1"
+              style="border: {supercell_input_valid
+                ? undefined
+                : `1px dashed red`}; opacity: {supercell_loading ? 0.5 : 1}"
+              disabled={supercell_loading}
+              inputmode="text"
+              autocomplete="off"
+              spellcheck="false"
+              pattern="^(\d+|\d+x\d+x\d+)$"
+              aria-invalid={!supercell_input_valid}
+              title={supercell_input_valid
+                ? `Valid supercell scaling: ${supercell_scaling}`
+                : `Invalid format. Use "2x2x2", "3x1x2", or "2"`}
+            />
+          </label>
+          {#if supercell_loading}
+            <Spinner
+              text="Generating supercell..."
+              style="--spinner-size: 12px; --spinner-border-width: 2px; --spinner-margin: 4pt 0 0; font-size: 0.85em; color: var(--accent-color)"
+            />
+          {/if}
+          {#if !supercell_input_valid}
+            <small data-testid="supercell-input-error" class="control-error">
+              Invalid format. Use patterns like "2x2x2", "3x1x2", or "2".
+            </small>
+          {/if}
+          {#each cell_style_settings as [label, color_setting, opacity_setting, step] (label)}
+            <label {...setting_row(color_setting)}>
+              <span>{label} color</span>
+              <input class="swatch" type="color" bind:value={lattice_props[color_setting]} />
+            </label>
+            <NumberRangeInput
+              {...setting_range(opacity_setting, step)}
+              bind:value={lattice_props[opacity_setting]}>{label} opacity</NumberRangeInput
+            >
+          {/each}
+        </SettingsSection>
+      {/if}
+    </SettingsGroup>
+
+    <SettingsGroup title="Camera" bind:open={open_groups.camera} subtitle={camera_summary}>
+      <SettingsSection
+        title="View"
+        layout="grid"
+        {...scene_section([`camera_projection`, `auto_rotate`, `zoom_to_cursor`, `rotation`], {
+          multi_view: local(
+            () => multi_view,
+            (value) => (multi_view = value),
+          ),
         })}
       >
-        <span>Cell Type</span>
-        <select bind:value={cell_type} disabled={!sym_data}>
-          <option value="original">Original</option>
-          <option value="conventional">Conventional</option>
-          <option value="primitive">Primitive</option>
-        </select>
-      </label>
-      <label>
-        <span
-          {@attach tooltip({
-            content: `Create supercells by repeating the unit cell. Examples: "2x2x2", "3x1x2", or "2"`,
-          })}
-        >
-          Supercell Scaling
-        </span>
-        <input
-          type="text"
-          bind:value={supercell_scaling}
-          placeholder="1x1x1"
-          style="border: {supercell_input_valid
-            ? undefined
-            : `1px dashed red`}; opacity: {supercell_loading ? 0.5 : 1}"
-          disabled={supercell_loading}
-          inputmode="text"
-          autocomplete="off"
-          spellcheck="false"
-          pattern="^(\d+|\d+x\d+x\d+)$"
-          aria-invalid={!supercell_input_valid}
-          title={supercell_input_valid
-            ? `Valid supercell scaling: ${supercell_scaling}`
-            : `Invalid format. Use "2x2x2", "3x1x2", or "2"`}
-        />
-      </label>
-      {#if supercell_loading}
-        <Spinner
-          text="Generating supercell..."
-          style="--spinner-size: 12px; --spinner-border-width: 2px; --spinner-margin: 4pt 0 0; font-size: 0.85em; color: var(--accent-color)"
-        />
-      {/if}
-
-      {#if !supercell_input_valid}
-        <div
-          data-testid="supercell-input-error"
-          style="color: red; font-size: 0.8em; margin-top: 4pt"
-        >
-          Invalid format. Use patterns like "2x2x2", "3x1x2", or "2".
-        </div>
-      {/if}
-
-      {#each [{ label: `Edge color`, color_prop: `cell_edge_color`, opacity_prop: `cell_edge_opacity`, step: 0.05 }, { label: `Surface color`, color_prop: `cell_surface_color`, opacity_prop: `cell_surface_opacity`, step: 0.01 }] as const as { label, color_prop, opacity_prop, step } (label)}
-        <div class="pane-row">
-          <label>
-            {label}
-            <input type="color" bind:value={lattice_props[color_prop]} />
-          </label>
-          <NumberRangeInput min={0} max={1} {step} bind:value={lattice_props[opacity_prop]}>
-            opacity
-          </NumberRangeInput>
-        </div>
-      {/each}
-    </SettingsSection>
-  {/if}
-
-  <SettingsSection
-    title="Background"
-    current_values={{
-      background_color,
-      background_opacity,
-    }}
-    on_reset={() => {
-      background_color = undefined
-      background_opacity = DEFAULTS.background_opacity
-    }}
-  >
-    <div class="pane-row">
-      <label>
-        Color
-        <!-- not using bind:value to not give a default value of #000000 to background_color, needs to stay undefined to not override --struct-bg theme color -->
-        <input
-          type="color"
-          value={background_color}
-          oninput={(event) => {
-            background_color = event.currentTarget.value
-          }}
-        />
-      </label>
-      <NumberRangeInput min={0} max={1} step={0.02} bind:value={background_opacity}>
-        Opacity
-      </NumberRangeInput>
-    </div>
-  </SettingsSection>
-
-  <SettingsSection title="Lighting" {...scene_section([`directional_light`, `ambient_light`])}>
-    <NumberRangeInput
-      min={0}
-      max={4}
-      step={0.01}
-      bind:value={scene_props.directional_light}
-      title={SETTINGS_CONFIG.structure.directional_light.description}
-      >Directional light</NumberRangeInput
-    >
-    <NumberRangeInput
-      min={0.5}
-      max={3}
-      step={0.05}
-      bind:value={scene_props.ambient_light}
-      title={SETTINGS_CONFIG.structure.ambient_light.description}
-      >Ambient light</NumberRangeInput
-    >
-  </SettingsSection>
-
-  {#if scene_props.show_bonds && scene_props.show_bonds !== `never`}
-    <SettingsSection
-      title="Bonds"
-      {...scene_section([
-        `bonding_strategy`,
-        `auto_bond_order`,
-        `aromatic_display`,
-        `bond_color`,
-        `bond_thickness`,
-      ])}
-    >
-      <label>
-        Strategy <select bind:value={scene_props.bonding_strategy}>
-          {#each Object.entries(SETTINGS_CONFIG.structure.bonding_strategy.enum ?? {}) as [value, label] (value)}
-            <option {value}>{label}</option>
-          {/each}
-        </select>
-      </label>
-      <label
-        style="gap: 6pt"
-        {@attach tooltip({ content: SETTINGS_CONFIG.structure.auto_bond_order.description })}
-      >
-        <input type="checkbox" bind:checked={scene_props.auto_bond_order} />
-        Auto bond order (perceive double/triple/aromatic)
-      </label>
-      {#if scene_props.auto_bond_order}
-        <label
-          {@attach tooltip({
-            content: SETTINGS_CONFIG.structure.aromatic_display.description,
-          })}
-        >
-          Aromatic display <select bind:value={scene_props.aromatic_display}>
-            {#each Object.entries(SETTINGS_CONFIG.structure.aromatic_display.enum ?? {}) as [value, label] (value)}
-              <option {value}>{label}</option>
-            {/each}
+        <label {...setting_row(`camera_projection`)}>
+          <span>Projection</span>
+          <select bind:value={scene_props.camera_projection}>
+            {@render enum_options(`camera_projection`)}
           </select>
         </label>
-      {/if}
-      <label>
-        Color <input type="color" bind:value={scene_props.bond_color} />
-      </label>
-      <NumberRangeInput
-        min={0.05}
-        max={0.5}
-        step={0.05}
-        bind:value={scene_props.bond_thickness}
-      >
-        Thickness
-      </NumberRangeInput>
-    </SettingsSection>
-  {/if}
-
-  {#if scene_props.show_polyhedra && scene_props.show_polyhedra !== `never`}
-    <SettingsSection
-      title="Polyhedra"
-      {...scene_section([
-        `polyhedra_opacity`,
-        `polyhedra_show_edges`,
-        `polyhedra_edge_color`,
-        `polyhedra_color_mode`,
-        `polyhedra_color`,
-        `polyhedra_hide_center_atoms`,
-        `polyhedra_min_neighbors`,
-        `polyhedra_max_neighbors`,
-        `polyhedra_excluded_elements`,
-        `polyhedra_included_elements`,
-      ])}
-    >
-      <NumberRangeInput
-        min={0}
-        max={1}
-        step={0.05}
-        bind:value={scene_props.polyhedra_opacity}
-        title={SETTINGS_CONFIG.structure.polyhedra_opacity.description}
-        >Opacity</NumberRangeInput
-      >
-      <label
-        {@attach tooltip({
-          content: SETTINGS_CONFIG.structure.polyhedra_color_mode.description,
-        })}
-      >
-        Color <select bind:value={scene_props.polyhedra_color_mode}>
-          {#each Object.entries(SETTINGS_CONFIG.structure.polyhedra_color_mode.enum ?? {}) as [value, label] (value)}
-            <option {value}>{label}</option>
-          {/each}
-        </select>
-        {#if scene_props.polyhedra_color_mode === `uniform`}
-          <input type="color" bind:value={scene_props.polyhedra_color} />
-        {/if}
-      </label>
-      <label
-        style="gap: 6pt"
-        {@attach tooltip({
-          content: SETTINGS_CONFIG.structure.polyhedra_show_edges.description,
-        })}
-      >
-        <input type="checkbox" bind:checked={scene_props.polyhedra_show_edges} />
-        Edges
-        {#if scene_props.polyhedra_show_edges}
-          <input type="color" bind:value={scene_props.polyhedra_edge_color} />
-        {/if}
-      </label>
-      <label
-        style="gap: 6pt"
-        {@attach tooltip({
-          content: SETTINGS_CONFIG.structure.polyhedra_hide_center_atoms.description,
-        })}
-      >
-        <input type="checkbox" bind:checked={scene_props.polyhedra_hide_center_atoms} />
-        Hide center atoms
-      </label>
-      <NumberRangeInput
-        min={4}
-        max={12}
-        step={1}
-        bind:value={scene_props.polyhedra_min_neighbors}
-        title={SETTINGS_CONFIG.structure.polyhedra_min_neighbors.description}
-        >Min neighbors</NumberRangeInput
-      >
-      <NumberRangeInput
-        min={4}
-        max={16}
-        step={1}
-        bind:value={scene_props.polyhedra_max_neighbors}
-        title={SETTINGS_CONFIG.structure.polyhedra_max_neighbors.description}
-        >Max neighbors</NumberRangeInput
-      >
-      {#if structure_elements.length > 0}
-        <div
-          style="display: flex; flex-wrap: wrap; gap: 8pt; align-items: center"
-          {@attach tooltip({
-            content: `${
-              SETTINGS_CONFIG.structure.polyhedra_excluded_elements.description
-            }. Force-including a spectator center (alkali or heavy alkaline-earth, e.g. Li, Na, Ba) may render its polyhedra truncated at cell boundaries.`,
-          })}
+        <NumberRangeInput
+          {...setting_range(`auto_rotate`, 0.01)}
+          bind:value={scene_props.auto_rotate}>Auto-rotate speed</NumberRangeInput
         >
-          Centers:
-          {#each structure_elements as element (element)}
-            <label style="gap: 4pt">
-              <input
-                type="checkbox"
-                checked={is_polyhedra_center_enabled(element)}
-                onchange={() => toggle_polyhedra_element(element)}
-              />
-              {element}
-            </label>
+        <label {...setting_row(`zoom_to_cursor`)}>
+          <span>Zoom to cursor</span>
+          <input type="checkbox" bind:checked={scene_props.zoom_to_cursor} />
+        </label>
+        {#if multi_view_control_visible && display_mode === `structure`}
+          <label {...setting_row(`multi_view`)} class:disabled={multi_view_blocked}>
+            <span>Multi-view grid</span>
+            <input
+              type="checkbox"
+              bind:checked={multi_view}
+              disabled={multi_view_blocked}
+              aria-describedby={multi_view_unavailable_reason ? multi_view_hint_id : undefined}
+            />
+          </label>
+          {#if multi_view_unavailable_reason}
+            <small id={multi_view_hint_id} class="setting-hint">
+              {multi_view_unavailable_reason}
+            </small>
+          {/if}
+        {/if}
+        <div class="rotation-axes" data-key="rotation">
+          {#each AXIS_COLORS as [axis, color], idx (axis)}
+            <NumberRangeInput
+              min={0}
+              max={360}
+              step={1}
+              title="{axis}-axis rotation in degrees"
+              style={`--thumb-color: ${color}`}
+              bind:value={
+                () => Math.round(rotation_degrees[idx]),
+                (degrees) => update_rotation(axis, degrees ?? 0)
+              }
+            >
+              <span style:color>{axis.toUpperCase()} rotation</span>
+            </NumberRangeInput>
           {/each}
         </div>
-      {/if}
-    </SettingsSection>
-  {/if}
+        <!-- Two rows rather than one: the mode names are sentences ("Plane normal (hkl)") and
+        sharing a row with the indices and the button truncated all three -->
+        <div
+          class="zone-axis"
+          {...setting_row(
+            `zone_axis`,
+            lattice_matrix
+              ? description_for(`zone_axis`)
+              : `Needs a lattice — molecules have no crystallographic directions`,
+          )}
+        >
+          <label>
+            <span>Look down</span>
+            <select
+              bind:value={zone_axis_mode}
+              aria-label="Zone axis index type"
+              disabled={!lattice_matrix}
+            >
+              {#each Object.entries(ZONE_AXIS_MODE_LABELS) as [mode, mode_label] (mode)}
+                <option value={mode}>{mode_label}</option>
+              {/each}
+            </select>
+          </label>
+          <div class="setting">
+            <span>Indices</span>
+            <span class="ctrl-pair">
+              <MillerIndexInput
+                bind:value={zone_axis_indices}
+                label={zone_axis_mode}
+                disabled={!lattice_matrix}
+              />
+              <button type="button" onclick={fly_to_zone_axis} disabled={!zone_axis.direction}>
+                View
+              </button>
+            </span>
+          </div>
+          {#if zone_axis.error}
+            <small class="control-error">{zone_axis.error}</small>
+          {/if}
+        </div>
+      </SettingsSection>
+
+      <SettingsSection
+        title="Pointer sensitivity"
+        layout="grid"
+        {...scene_section([`rotate_speed`, `zoom_speed`, `pan_speed`, `rotation_damping`])}
+      >
+        {#each pointer_settings as [setting, label, step] (setting)}
+          <NumberRangeInput
+            {...setting_range(setting, step)}
+            bind:value={() => scene_props[setting], (value) => (scene_props[setting] = value)}
+            >{label}</NumberRangeInput
+          >
+        {/each}
+      </SettingsSection>
+    </SettingsGroup>
+
+    <SettingsGroup title="Scene" bind:open={open_groups.scene}>
+      <SettingsSection
+        title="Background"
+        layout="grid"
+        {...local_section({
+          background_color: local(
+            () => background_color,
+            (value) => (background_color = value),
+          ),
+          background_opacity: local(
+            () => background_opacity,
+            (value) => (background_opacity = value),
+          ),
+        })}
+      >
+        <label {...setting_row(`background_color`)}>
+          <span>Color</span>
+          <!-- not using bind:value to not give a default value of #000000 to background_color,
+          needs to stay undefined to not override --struct-bg theme color -->
+          <input
+            class="swatch"
+            type="color"
+            value={background_color}
+            oninput={(event) => (background_color = event.currentTarget.value)}
+          />
+        </label>
+        <NumberRangeInput
+          data-key="background_opacity"
+          min={0}
+          max={1}
+          step={0.02}
+          title={description_for(`background_opacity`)}
+          bind:value={background_opacity}>Opacity</NumberRangeInput
+        >
+      </SettingsSection>
+
+      <SettingsSection
+        title="Lighting"
+        layout="grid"
+        {...scene_section([`directional_light`, `ambient_light`])}
+      >
+        <NumberRangeInput
+          {...setting_range(`directional_light`, 0.01)}
+          bind:value={scene_props.directional_light}>Directional light</NumberRangeInput
+        >
+        <NumberRangeInput
+          {...setting_range(`ambient_light`, 0.05)}
+          bind:value={scene_props.ambient_light}>Ambient light</NumberRangeInput
+        >
+      </SettingsSection>
+    </SettingsGroup>
+
+    {#if has_overlays}
+      <SettingsGroup title="Overlays" open>
+        {#if displacement_summary}
+          <SettingsSection
+            title="Displacement Overlay"
+            layout="grid"
+            {...scene_section([
+              `show_displacement_arrows`,
+              `displacement_arrow_scale`,
+              `displacement_arrow_color`,
+            ])}
+          >
+            <!-- `!== null` (not truthiness) so the union discriminates: an empty error string
+            would leave the else branch un-narrowed and rmsd possibly undefined -->
+            {#if displacement_summary.error !== null}
+              <small class="control-error">{displacement_summary.error}</small>
+            {:else}
+              <div class="readout">
+                <span
+                  >RMSD <strong>{format_num(displacement_summary.rmsd, `.4~f`)} Å</strong
+                  ></span
+                >
+                <span>
+                  Max <strong
+                    >{format_num(displacement_summary.max_displacement, `.4~f`)} Å</strong
+                  >
+                </span>
+              </div>
+              <label {...setting_row(`show_displacement_arrows`)}>
+                <span>Show arrows</span>
+                <input type="checkbox" bind:checked={scene_props.show_displacement_arrows} />
+              </label>
+              <NumberRangeInput
+                {...setting_range(`displacement_arrow_scale`, 0.1)}
+                bind:value={scene_props.displacement_arrow_scale}>Arrow scale</NumberRangeInput
+              >
+              <label {...setting_row(`displacement_arrow_color`)}>
+                <span>Arrow color</span>
+                <input
+                  class="swatch"
+                  type="color"
+                  aria-label="Displacement arrow color"
+                  bind:value={scene_props.displacement_arrow_color}
+                />
+              </label>
+            {/if}
+          </SettingsSection>
+        {/if}
+
+        <!-- Only the trajectory viewer can collect a whole-run position stream, so this section
+        is absent for plain structures rather than showing dead controls -->
+        {#if scene_props.trajectory_position_stream !== undefined}
+          <SettingsSection
+            title="Trajectory Trails"
+            layout="grid"
+            {...scene_section(
+              [
+                `trajectory_line_trail_frames`,
+                `trajectory_line_frame_stride`,
+                `trajectory_line_color_mode`,
+                `trajectory_line_wrap_mode`,
+              ],
+              {
+                show_trajectory_lines: local(
+                  () => show_trajectory_lines,
+                  (value) => (show_trajectory_lines = value),
+                ),
+                trajectory_line_elements: local(
+                  () => scene_props.trajectory_line_elements,
+                  (value) => (scene_props.trajectory_line_elements = value),
+                ),
+              },
+            )}
+          >
+            <label {...setting_row(`show_trajectory_lines`)}>
+              <span>Show trajectory trails</span>
+              <input type="checkbox" bind:checked={show_trajectory_lines} />
+            </label>
+            {#if show_trajectory_lines && scene_props.trajectory_position_stream}
+              {#if trail_elements.length > 1}
+                <div class="setting" {...setting_row(`trajectory_line_elements`)}>
+                  <span>Species</span>
+                  <div class="chip-row">
+                    {#each trail_elements as element (element)}
+                      <label>
+                        <input
+                          type="checkbox"
+                          checked={is_trail_element_on(element)}
+                          onchange={() => toggle_trail_element(element)}
+                        />
+                        {element}
+                      </label>
+                    {/each}
+                  </div>
+                </div>
+              {/if}
+              <NumberRangeInput
+                {...setting_range(`trajectory_line_trail_frames`)}
+                max={Math.max(1, scene_props.trajectory_position_stream.n_frames)}
+                bind:value={scene_props.trajectory_line_trail_frames}
+                >Trail length <small>(0 = all)</small></NumberRangeInput
+              >
+              <NumberRangeInput
+                {...setting_range(`trajectory_line_frame_stride`)}
+                bind:value={scene_props.trajectory_line_frame_stride}
+                >Frame stride</NumberRangeInput
+              >
+              <label {...setting_row(`trajectory_line_color_mode`)}>
+                <span>Color by</span>
+                <select bind:value={scene_props.trajectory_line_color_mode}>
+                  {@render enum_options(`trajectory_line_color_mode`)}
+                </select>
+              </label>
+              <label {...setting_row(`trajectory_line_wrap_mode`)}>
+                <span>Boundaries</span>
+                <select bind:value={scene_props.trajectory_line_wrap_mode}>
+                  {@render enum_options(`trajectory_line_wrap_mode`)}
+                </select>
+              </label>
+              {#if trajectory_lines_result}
+                {@const { point_count, segment_count, atom_count, max_segment_length } =
+                  trajectory_lines_result}
+                <div class="readout">
+                  <span>{format_num(atom_count, `.3~s`)} atoms</span>
+                  <span>{format_num(point_count, `.3~s`)} vertices</span>
+                  <span>{format_num(segment_count, `.3~s`)} segments</span>
+                  <span
+                    {@attach tooltip({
+                      content:
+                        `Longest drawn segment. With unwrapping on this stays at the scale of a ` +
+                        `real per-step displacement; a value near a cell diagonal means the path ` +
+                        `is jumping across the box.`,
+                    })}
+                  >
+                    max step <strong>{format_num(max_segment_length, `.3~f`)} Å</strong>
+                  </span>
+                </div>
+              {/if}
+            {:else if show_trajectory_lines}
+              <Spinner text="Collecting trajectory positions..." style="margin: 4pt 0" />
+            {/if}
+          </SettingsSection>
+        {/if}
+      </SettingsGroup>
+    {/if}
+  </SettingsSearch>
+
+  <SettingsGroup
+    title="Preferences"
+    subtitle={persist_settings ? `saved in this browser` : `session only`}
+  >
+    <div class="settings-actions">
+      <button type="button" onclick={copy_view_state} aria-label="Copy viewer settings JSON">
+        {copied_view_state.has(`viewer-settings`) ? `Copied ✓` : `Copy JSON`}
+      </button>
+      <button
+        type="button"
+        onclick={download_view_state}
+        aria-label="Download viewer settings JSON">Download JSON</button
+      >
+      <label class="import-settings">
+        Import JSON
+        <input
+          type="file"
+          accept=".json,application/json"
+          aria-label="Import viewer settings JSON"
+          onchange={import_view_state}
+        />
+      </label>
+      <button
+        type="button"
+        class="reset-all-settings"
+        onclick={reset_all_view_settings}
+        aria-label="Reset all viewer settings to defaults">Reset all</button
+      >
+    </div>
+    {#if settings_import_status}
+      <small
+        class:error={settings_import_status.error}
+        role={settings_import_status.error ? `alert` : `status`}
+      >
+        {settings_import_status.message}
+      </small>
+    {/if}
+  </SettingsGroup>
 </DraggablePane>
 
 <style>
+  /* Column rhythm for every grid section in this pane. Widening the pane widens the slider
+     track only, so the label and value columns stay put and the eye can run straight down. */
+  :global(.controls-pane) {
+    font-size: 0.85em;
+    --ctrl-label-w: 9.4em;
+    --ctrl-value-w: 3.6em;
+    --ctrl-cols: var(--ctrl-label-w) var(--ctrl-value-w) minmax(0, 1fr);
+  }
+  /* Sections that opted out of the grid keep the historical stacked flow (the nested
+     isosurface and volume-slice panes render their own markup in here) */
+  :global(.controls-pane section.flow) {
+    display: flex;
+    flex-direction: column;
+    gap: 6pt;
+  }
+  :global(.controls-pane h4) {
+    margin: 8pt 0 3pt !important;
+    font-size: 0.95em;
+    opacity: 0.75;
+  }
+  /* only the heading that opens a group, not every heading following the first section —
+     `section:first-of-type + h4` would match the *second* section's heading */
+  :global(.controls-pane h4:first-of-type) {
+    margin-top: 0 !important;
+  }
   .reset-camera {
     display: flex;
     align-items: center;
     justify-content: center;
     gap: 5pt;
+    margin-bottom: 4pt;
     padding: 3pt;
     cursor: pointer;
     border: 1px solid color-mix(in srgb, currentColor 20%, transparent);
     border-radius: var(--border-radius, 3pt);
     background: color-mix(in srgb, currentColor 8%, transparent);
     color: inherit;
+    &:hover {
+      background: color-mix(in srgb, currentColor 16%, transparent);
+    }
     kbd {
       padding: 0 4px;
       border-radius: 2pt;
       background: color-mix(in srgb, currentColor 14%, transparent);
     }
   }
-  .advanced {
+  .settings-actions {
     display: flex;
-    flex-direction: column;
-    gap: 6pt;
-    summary {
-      cursor: pointer;
-      opacity: 0.75;
-    }
-    &[open] summary {
-      margin-bottom: 6pt;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 4pt;
+    button,
+    .import-settings {
+      font: inherit;
     }
   }
-  .rotation-axes {
-    display: flex;
-    gap: 10pt;
+  .import-settings {
+    display: inline-flex;
+    align-items: center;
+    gap: 4pt;
+    input {
+      max-width: 13em;
+    }
   }
-  .rotation-axes > div {
+  small.error {
+    color: var(--error-color, #e74c3c);
+  }
+  /* Boolean toggles read faster as a wrapped two-column block than as one row each */
+  .toggle-grid {
     display: grid;
-    gap: 0.4em;
-    place-items: center;
+    grid-template-columns: repeat(auto-fit, minmax(8.4em, 1fr));
+    gap: 2pt 8pt;
+    margin-bottom: 2pt;
+    label {
+      display: flex;
+      align-items: center;
+      gap: 5pt;
+      min-height: 1.7em;
+    }
   }
-  :global(.controls-pane) {
-    font-size: 0.85em;
-  }
-
-  :global(.controls-pane section) {
+  .chip-row {
     display: flex;
-    flex-direction: column;
-    gap: 6pt;
+    flex-wrap: wrap;
+    gap: 2pt 8pt;
+    align-items: center;
+    label {
+      display: flex;
+      align-items: center;
+      gap: 4pt;
+    }
   }
-  :global(.controls-pane h4) {
-    margin: 10pt 0 4pt !important;
-  }
-  :global(.controls-pane h4:first-of-type) {
-    margin-top: 0 !important;
-  }
-  .pane-row {
+  /* Two controls sharing one row's control area (select + swatch, checkbox + swatch) */
+  .ctrl-pair {
     display: flex;
-    gap: 12pt;
-    justify-content: space-between;
-    width: 100%;
-  }
-  .zone-axis {
     align-items: center;
     gap: 6pt;
+    min-width: 0;
     select {
       flex: 1;
       min-width: 0;
     }
   }
+  .axis-inputs {
+    display: flex;
+    gap: 6pt;
+    label {
+      display: flex;
+      align-items: center;
+      gap: 3pt;
+      min-width: 0;
+    }
+    input {
+      min-width: 0;
+    }
+  }
+  /* These wrappers sit one level below the section (they carry the classes tests select on),
+     so SettingsSection's direct-child rules miss them and their rows opt in explicitly */
+  .rotation-axes,
+  .zone-axis {
+    display: grid;
+    gap: 4pt 0;
+    > :is(label, .setting) {
+      display: grid;
+      grid-template-columns: var(--ctrl-cols);
+      align-items: center;
+      column-gap: var(--ctrl-gap, 7pt);
+      min-height: 1.9em;
+      > :nth-child(2):last-child {
+        grid-column: 2 / -1;
+      }
+    }
+  }
+  .zone-axis button {
+    padding: 1pt 6pt;
+    cursor: pointer;
+  }
+  .readout {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2pt 10pt;
+    opacity: 0.85;
+  }
+  .swatch {
+    box-sizing: border-box;
+    width: 2.4em;
+    height: 1.5em;
+    padding: 0;
+    border: 1px solid color-mix(in srgb, currentColor 25%, transparent);
+    border-radius: 2pt;
+    cursor: pointer;
+  }
+  .clear-color {
+    padding: 0 3pt;
+    font-size: 0.8em;
+    line-height: 1;
+    cursor: pointer;
+  }
+  .scheme-option {
+    display: flex;
+    align-items: center;
+    gap: 6pt;
+    justify-content: space-between;
+  }
+  .scheme-swatches {
+    display: flex;
+    gap: 3pt;
+    div {
+      width: 15px;
+      height: 15px;
+      border-radius: 2px;
+    }
+  }
   .control-error {
     color: var(--error-color, #e74c3c);
     font-size: 0.9em;
-  }
-  label {
-    display: flex;
-    align-items: center;
-    gap: 10pt;
   }
   label.disabled {
     opacity: 0.6;
@@ -1598,15 +1857,11 @@
   .setting-hint {
     color: var(--text-color-muted, color-mix(in srgb, currentColor 65%, transparent));
     line-height: 1.35;
-    max-width: 32em;
   }
   input,
   select {
     font-size: inherit;
     font-family: inherit;
-  }
-  input[type='range'] {
-    flex: 1;
-    min-width: 40px;
+    min-width: 0;
   }
 </style>

--- a/src/lib/structure/StructureControls.svelte
+++ b/src/lib/structure/StructureControls.svelte
@@ -233,21 +233,15 @@
 
   $effect(() => {
     const pane = controls_pane
-    const size = controls_pane_size
-    if (!pane || !size) return
-    pane.style.width = `${size.width}px`
-    pane.style.height = `${size.height}px`
-  })
-
-  $effect(() => {
-    const pane = controls_pane
     if (!pane) return
+    if (controls_pane_size) {
+      pane.style.width = `${controls_pane_size.width}px`
+      pane.style.height = `${controls_pane_size.height}px`
+    }
     const observer = new ResizeObserver(() => {
-      const width_style = pane.style.width
-      const height_style = pane.style.height
-      if (!width_style || !height_style) return
-      const width = Number(width_style.replace(/px$/, ``))
-      const height = Number(height_style.replace(/px$/, ``))
+      if (!pane.style.width || !pane.style.height) return
+      const width = Number(pane.style.width.replace(/px$/, ``))
+      const height = Number(pane.style.height.replace(/px$/, ``))
       if (!Number.isFinite(width) || !Number.isFinite(height)) return
       if (controls_pane_size?.width === width && controls_pane_size.height === height) {
         return
@@ -358,6 +352,7 @@
   type NumericSettingKey = SettingKeysOfType<number>
   // Rows rendered by the shared snippets must both name a setting and bind to the matching
   // scene prop, so intersect the schema's keys with the ones scene_props actually holds.
+  type NumericSceneSettingKey = NumericSettingKey & keyof typeof scene_props
   type BooleanSettingKey = SettingKeysOfType<boolean> & keyof typeof scene_props
   type EnumSettingKey = SettingKeysOfType<string> & keyof typeof scene_props
   const setting_range = (key: NumericSettingKey, step?: number) => {
@@ -395,24 +390,18 @@
     keys: DefaultedKey<T>[],
     accessors: Record<string, Accessor> = {},
   ) => ({
-    current_values: {
-      ...Object.fromEntries(
-        keys.map((key) => [
-          key,
-          target[key] === undefined ? DEFAULTS.structure[key] : target[key],
-        ]),
-      ),
-      ...Object.fromEntries(
-        Object.entries(accessors).map(([key, accessor]) => [key, accessor.get()]),
-      ),
-    },
+    current_values: Object.fromEntries([
+      ...keys.map((key) => [
+        key,
+        target[key] === undefined ? DEFAULTS.structure[key] : target[key],
+      ]),
+      ...Object.entries(accessors).map(([key, accessor]) => [key, accessor.get()]),
+    ]),
     on_reset_key: (key: string, reference_value: unknown, reference_present: boolean) => {
       const accessor = accessors[key]
-      if (accessor) accessor.set(reference_value, reference_present)
-      else if ((keys as string[]).includes(key)) {
-        if (reference_present) Object.assign(target, { [key]: reference_value })
-        else Reflect.deleteProperty(target, key)
-      }
+      if (accessor) return accessor.set(reference_value, reference_present)
+      if (reference_present) Object.assign(target, { [key]: reference_value })
+      else Reflect.deleteProperty(target, key)
     },
     setting_metadata: structure_setting_metadata,
   })
@@ -675,6 +664,21 @@ a disabled state, a non-scene_props target) stay written out in full. -->
   <label {...setting_row(key)}>
     <span>{label}</span>
     <select bind:value={scene_props[key]}>{@render enum_options(key)}</select>
+  </label>
+{/snippet}
+
+{#snippet numeric_row(key: NumericSceneSettingKey, label: string, step?: number)}
+  <NumberRangeInput
+    {...setting_range(key, step)}
+    bind:value={() => scene_props[key], (value) => (scene_props[key] = value)}
+    >{label}</NumberRangeInput
+  >
+{/snippet}
+
+{#snippet color_row(key: EnumSettingKey, label: string, aria_label?: string)}
+  <label {...setting_row(key)}>
+    <span>{label}</span>
+    <input class="swatch" type="color" aria-label={aria_label} bind:value={scene_props[key]} />
   </label>
 {/snippet}
 
@@ -961,14 +965,8 @@ a disabled state, a non-scene_props target) stay written out in full. -->
           {#if scene_props.auto_bond_order}
             {@render enum_row(`aromatic_display`, `Aromatic`)}
           {/if}
-          <label {...setting_row(`bond_color`)}>
-            <span>Color</span>
-            <input class="swatch" type="color" bind:value={scene_props.bond_color} />
-          </label>
-          <NumberRangeInput
-            {...setting_range(`bond_thickness`, 0.01)}
-            bind:value={scene_props.bond_thickness}>Thickness</NumberRangeInput
-          >
+          {@render color_row(`bond_color`, `Color`)}
+          {@render numeric_row(`bond_thickness`, `Thickness`, 0.01)}
         </SettingsSection>
       {/if}
 
@@ -993,10 +991,7 @@ a disabled state, a non-scene_props target) stay written out in full. -->
             },
           )}
         >
-          <NumberRangeInput
-            {...setting_range(`polyhedra_opacity`, 0.05)}
-            bind:value={scene_props.polyhedra_opacity}>Opacity</NumberRangeInput
-          >
+          {@render numeric_row(`polyhedra_opacity`, `Opacity`, 0.05)}
           <label {...setting_row(`polyhedra_color`)}>
             <span>Color</span>
             <span class="ctrl-pair">
@@ -1022,14 +1017,8 @@ a disabled state, a non-scene_props target) stay written out in full. -->
             </span>
           </label>
           {@render toggle(`polyhedra_hide_center_atoms`, `Hide centers`)}
-          <NumberRangeInput
-            {...setting_range(`polyhedra_min_neighbors`, 1)}
-            bind:value={scene_props.polyhedra_min_neighbors}>Min neighbors</NumberRangeInput
-          >
-          <NumberRangeInput
-            {...setting_range(`polyhedra_max_neighbors`, 1)}
-            bind:value={scene_props.polyhedra_max_neighbors}>Max neighbors</NumberRangeInput
-          >
+          {@render numeric_row(`polyhedra_min_neighbors`, `Min neighbors`, 1)}
+          {@render numeric_row(`polyhedra_max_neighbors`, `Max neighbors`, 1)}
           {#if structure_elements.length > 0}
             <div
               class="setting"
@@ -1085,10 +1074,7 @@ a disabled state, a non-scene_props target) stay written out in full. -->
               }
             />
           </label>
-          <NumberRangeInput
-            {...setting_range(`site_label_size`, 0.1)}
-            bind:value={scene_props.site_label_size}>Size</NumberRangeInput
-          >
+          {@render numeric_row(`site_label_size`, `Size`, 0.1)}
           <label {...setting_row(`site_label_bg_hex`)}>
             <span>Background</span>
             <input
@@ -1106,10 +1092,7 @@ a disabled state, a non-scene_props target) stay written out in full. -->
             title={description_for(`site_label_bg_opacity`)}
             bind:value={get_label_bg_opacity, set_label_bg_opacity}>Opacity</NumberRangeInput
           >
-          <NumberRangeInput
-            {...setting_range(`site_label_padding`, 1)}
-            bind:value={scene_props.site_label_padding}>Padding</NumberRangeInput
-          >
+          {@render numeric_row(`site_label_padding`, `Padding`, 1)}
           <div class="setting" {...setting_row(`site_label_offset`)}>
             <span>Offset</span>
             <div class="axis-inputs">
@@ -1167,10 +1150,7 @@ a disabled state, a non-scene_props target) stay written out in full. -->
               ),
             )}
           >
-            <NumberRangeInput
-              {...setting_range(`vector_scale`, 0.001)}
-              bind:value={scene_props.vector_scale}>Global scale</NumberRangeInput
-            >
+            {@render numeric_row(`vector_scale`, `Global scale`, 0.001)}
             {@render toggle(`vector_normalize`, `Normalize`)}
             {@render toggle(`vector_uniform_thickness`, `Uniform width`)}
             <label {...setting_row(`vector_color_mode`)}>
@@ -1187,16 +1167,10 @@ a disabled state, a non-scene_props target) stay written out in full. -->
                 <ColorScaleSelect bind:value={scene_props.vector_color_scale} />
               </label>
             {:else if scene_props.vector_color_mode === `uniform`}
-              <label {...setting_row(`vector_color`)}>
-                <span>Color</span>
-                <input class="swatch" type="color" bind:value={scene_props.vector_color} />
-              </label>
+              {@render color_row(`vector_color`, `Color`)}
             {/if}
             {#if available_vector_keys.length > 1}
-              <NumberRangeInput
-                {...setting_range(`vector_origin_gap`, 0.02)}
-                bind:value={scene_props.vector_origin_gap}>Origin gap</NumberRangeInput
-              >
+              {@render numeric_row(`vector_origin_gap`, `Origin gap`, 0.02)}
               {#each available_vector_keys as key (key)}
                 {#if is_key_visible(key)}
                   {@const description = `Scale multiplier for ${key} arrows (applied on top of global scale)`}
@@ -1317,10 +1291,7 @@ a disabled state, a non-scene_props target) stay written out in full. -->
         })}
       >
         {@render enum_row(`camera_projection`, `Projection`)}
-        <NumberRangeInput
-          {...setting_range(`auto_rotate`, 0.01)}
-          bind:value={scene_props.auto_rotate}>Auto-rotate speed</NumberRangeInput
-        >
+        {@render numeric_row(`auto_rotate`, `Auto-rotate speed`, 0.01)}
         {@render toggle(`zoom_to_cursor`, `Zoom to cursor`)}
         {#if multi_view_control_visible && display_mode === `structure`}
           <label {...setting_row(`multi_view`)} class:disabled={multi_view_blocked}>
@@ -1403,11 +1374,7 @@ a disabled state, a non-scene_props target) stay written out in full. -->
         {...scene_section([`rotate_speed`, `zoom_speed`, `pan_speed`, `rotation_damping`])}
       >
         {#each pointer_settings as [setting, label, step] (setting)}
-          <NumberRangeInput
-            {...setting_range(setting, step)}
-            bind:value={() => scene_props[setting], (value) => (scene_props[setting] = value)}
-            >{label}</NumberRangeInput
-          >
+          {@render numeric_row(setting, label, step)}
         {/each}
       </SettingsSection>
     </SettingsGroup>
@@ -1453,14 +1420,8 @@ a disabled state, a non-scene_props target) stay written out in full. -->
         layout="grid"
         {...scene_section([`directional_light`, `ambient_light`])}
       >
-        <NumberRangeInput
-          {...setting_range(`directional_light`, 0.01)}
-          bind:value={scene_props.directional_light}>Directional light</NumberRangeInput
-        >
-        <NumberRangeInput
-          {...setting_range(`ambient_light`, 0.05)}
-          bind:value={scene_props.ambient_light}>Ambient light</NumberRangeInput
-        >
+        {@render numeric_row(`directional_light`, `Directional light`, 0.01)}
+        {@render numeric_row(`ambient_light`, `Ambient light`, 0.05)}
       </SettingsSection>
     </SettingsGroup>
 
@@ -1486,26 +1447,19 @@ a disabled state, a non-scene_props target) stay written out in full. -->
                   >RMSD <strong>{format_num(displacement_summary.rmsd, `.4~f`)} Å</strong
                   ></span
                 >
-                <span>
-                  Max <strong
+                <span
+                  >Max <strong
                     >{format_num(displacement_summary.max_displacement, `.4~f`)} Å</strong
-                  >
-                </span>
+                  ></span
+                >
               </div>
               {@render toggle(`show_displacement_arrows`, `Show arrows`)}
-              <NumberRangeInput
-                {...setting_range(`displacement_arrow_scale`, 0.1)}
-                bind:value={scene_props.displacement_arrow_scale}>Arrow scale</NumberRangeInput
-              >
-              <label {...setting_row(`displacement_arrow_color`)}>
-                <span>Arrow color</span>
-                <input
-                  class="swatch"
-                  type="color"
-                  aria-label="Displacement arrow color"
-                  bind:value={scene_props.displacement_arrow_color}
-                />
-              </label>
+              {@render numeric_row(`displacement_arrow_scale`, `Arrow scale`, 0.1)}
+              {@render color_row(
+                `displacement_arrow_color`,
+                `Arrow color`,
+                `Displacement arrow color`,
+              )}
             {/if}
           </SettingsSection>
         {/if}
@@ -1563,11 +1517,7 @@ a disabled state, a non-scene_props target) stay written out in full. -->
                 bind:value={scene_props.trajectory_line_trail_frames}
                 >Trail length <small>(0 = all)</small></NumberRangeInput
               >
-              <NumberRangeInput
-                {...setting_range(`trajectory_line_frame_stride`)}
-                bind:value={scene_props.trajectory_line_frame_stride}
-                >Frame stride</NumberRangeInput
-              >
+              {@render numeric_row(`trajectory_line_frame_stride`, `Frame stride`)}
               {@render enum_row(`trajectory_line_color_mode`, `Color by`)}
               {@render enum_row(`trajectory_line_wrap_mode`, `Boundaries`)}
               {#if trajectory_lines_result}
@@ -1686,10 +1636,23 @@ a disabled state, a non-scene_props target) stay written out in full. -->
       background: color-mix(in srgb, currentColor 14%, transparent);
     }
   }
-  .settings-actions {
+  :is(
+    .settings-actions,
+    .import-settings,
+    .toggle-grid label,
+    .chip-row,
+    .chip-row label,
+    .ctrl-pair,
+    .axis-inputs,
+    .axis-inputs label,
+    .readout,
+    .scheme-option
+  ) {
     display: flex;
-    flex-wrap: wrap;
     align-items: center;
+  }
+  .settings-actions {
+    flex-wrap: wrap;
     gap: 4pt;
     button,
     .import-settings {
@@ -1697,8 +1660,6 @@ a disabled state, a non-scene_props target) stay written out in full. -->
     }
   }
   .import-settings {
-    display: inline-flex;
-    align-items: center;
     gap: 4pt;
     input {
       max-width: 13em;
@@ -1714,27 +1675,19 @@ a disabled state, a non-scene_props target) stay written out in full. -->
     gap: 2pt 8pt;
     margin-bottom: 2pt;
     label {
-      display: flex;
-      align-items: center;
       gap: 5pt;
       min-height: 1.7em;
     }
   }
   .chip-row {
-    display: flex;
     flex-wrap: wrap;
     gap: 2pt 8pt;
-    align-items: center;
     label {
-      display: flex;
-      align-items: center;
       gap: 4pt;
     }
   }
   /* Two controls sharing one row's control area (select + swatch, checkbox + swatch) */
   .ctrl-pair {
-    display: flex;
-    align-items: center;
     gap: 6pt;
     min-width: 0;
     select {
@@ -1743,11 +1696,8 @@ a disabled state, a non-scene_props target) stay written out in full. -->
     }
   }
   .axis-inputs {
-    display: flex;
     gap: 6pt;
     label {
-      display: flex;
-      align-items: center;
       gap: 3pt;
       min-width: 0;
     }
@@ -1777,7 +1727,6 @@ a disabled state, a non-scene_props target) stay written out in full. -->
     cursor: pointer;
   }
   .readout {
-    display: flex;
     flex-wrap: wrap;
     gap: 2pt 10pt;
     opacity: 0.85;
@@ -1798,8 +1747,6 @@ a disabled state, a non-scene_props target) stay written out in full. -->
     cursor: pointer;
   }
   .scheme-option {
-    display: flex;
-    align-items: center;
     gap: 6pt;
     justify-content: space-between;
   }

--- a/src/lib/structure/StructureInfoPane.svelte
+++ b/src/lib/structure/StructureInfoPane.svelte
@@ -44,11 +44,11 @@
     },
     {
       label: `Navigation`,
-      value: `Hold Shift/Cmd/Ctrl + drag to pan the scene`,
+      value: `Drag to rotate, scroll to zoom, hold Shift/Cmd/Ctrl + drag to pan. Rotate, zoom and pan sensitivity are adjustable under Camera in the settings pane`,
     },
     {
       label: `Camera Reset`,
-      value: `Press r, double-click the canvas, or use Reset view in the Camera settings`,
+      value: `Press r, double-click the canvas, or use Reset view at the top of the settings pane`,
     },
     {
       label: `Colors`,

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -35,6 +35,7 @@
   } from '$lib/structure'
   import {
     atomic_radii,
+    camera_needs_fit,
     camera_position_for_target,
     Cylinder,
     get_all_site_vectors,
@@ -1121,6 +1122,9 @@
   let computed_zoom = $state(untrack(() => initial_zoom))
   // Untracked fit_extent avoids trajectory jumps; effect.pre reframes camera resets.
   let current_fit_zoom = $state(0)
+  // Non-reactive: this only compares successive effect runs and must not schedule another run.
+  const camera_fit_cache: { previous_view?: string } = {}
+  let camera_view = $derived(`${camera_projection}:${camera_direction?.join(`,`) ?? ``}`)
   let zoom_bounds = $derived(
     get_orthographic_zoom_bounds(current_fit_zoom, min_zoom, max_zoom),
   )
@@ -1143,13 +1147,12 @@
   })
 
   $effect.pre(() => {
+    const previous_view = camera_fit_cache.previous_view
+    const view_changed = previous_view !== undefined && previous_view !== camera_view
+    const should_fit = camera_needs_fit(camera_position, previous_view, camera_view)
+    camera_fit_cache.previous_view = camera_view
     // Auto-place at content center; missing/zero camera_direction → default angled view.
-    if (
-      camera_position.every((coordinate) => coordinate === 0) &&
-      structure &&
-      width > 0 &&
-      height > 0
-    ) {
+    if (should_fit && structure && width > 0 && height > 0) {
       computed_zoom = zoom_for(fit_extent)
       current_fit_zoom = computed_zoom
       initial_computed_zoom = computed_zoom
@@ -1163,8 +1166,8 @@
               effective_fov,
             )
           : Math.max(1, fit_extent) * 2
-      const target = camera_target ?? fit_frame.center
-      if (camera_target === undefined) camera_target = target
+      const target = view_changed ? fit_frame.center : (camera_target ?? fit_frame.center)
+      if (view_changed || camera_target === undefined) camera_target = target
       rotation_target_ref = target
       camera_position = camera_position_for_target(target, distance, camera_direction)
     }

--- a/src/lib/structure/StructureScene.svelte
+++ b/src/lib/structure/StructureScene.svelte
@@ -22,7 +22,7 @@
   import type { SceneControlProps } from '$lib/scene'
   import type { ShowBonds, VectorColorMode, VectorLayerConfig } from '$lib/settings'
   import { DEFAULTS, SETTINGS_CONFIG } from '$lib/settings'
-  import { create_pulse_animation } from '$lib/effects.svelte'
+  import { create_pulse_animation, pulsing_highlight_opacity } from '$lib/effects.svelte'
   import { colors } from '$lib/state.svelte'
   import type {
     AnyStructure,
@@ -408,7 +408,7 @@
     () => selected_sites.length > 0 || active_sites.length > 0,
     { step: 0.015, frequency: 5 },
   )
-  let pulse_opacity = $derived(0.15 + 0.25 * pulse.unit)
+  let pulse_opacity = $derived(pulsing_highlight_opacity(pulse.unit))
   const threlte = bind_renderer((threlte_scene, threlte_camera) => {
     scene = threlte_scene
     camera = threlte_camera

--- a/src/lib/structure/StructureViewport.svelte
+++ b/src/lib/structure/StructureViewport.svelte
@@ -548,11 +548,11 @@
     left: 5px;
     z-index: var(--z-index-viewer-label, 1);
     pointer-events: none;
-    font-size: var(--struct-viewport-label-font-size, 0.8em);
-    font-weight: 500;
+    font-size: var(--struct-viewport-label-font-size, 0.75em);
+    font-weight: 400;
     padding: 1px 5px;
     border-radius: var(--border-radius, 3pt);
-    color: var(--struct-viewport-label-color, var(--text-color, currentColor));
+    color: var(--struct-viewport-label-color, var(--text-color-muted, currentColor));
     background: var(
       --struct-viewport-label-bg,
       color-mix(in srgb, var(--page-bg, Canvas) 65%, transparent)

--- a/src/lib/structure/camera-fit.ts
+++ b/src/lib/structure/camera-fit.ts
@@ -7,8 +7,8 @@ import type { Vec3 } from '$lib/math'
 import * as math from '$lib/math'
 import type { AnyStructure, Site } from '$lib/structure'
 
-// Occupy at most 85% of the shorter viewport edge.
-export const DEFAULT_FIT_PADDING = 1 / 0.85
+// Occupy at most 92% of the shorter viewport edge.
+export const DEFAULT_FIT_PADDING = 1 / 0.92
 // Paired with DEFAULTS.structure.initial_zoom (50): default zoom = min(w,h) / fit_extent.
 export const FIT_ZOOM_REF_PX = 50
 // Unnormalized — keeps legacy offset [d, 0.3d, 0.8d] (do not unit-normalize).
@@ -26,6 +26,14 @@ export type StructureFitOpts = {
 export type StructureFitFrame = { center: Vec3; extent: number }
 
 const empty_frame = (): StructureFitFrame => ({ center: [0, 0, 0], extent: 10 })
+
+export const camera_needs_fit = (
+  position: Vec3,
+  previous_view: string | undefined,
+  camera_view: string,
+): boolean =>
+  position.every((coordinate) => coordinate === 0) ||
+  (previous_view !== undefined && previous_view !== camera_view)
 
 const element_radius = (
   element: ElementSymbol,

--- a/src/routes/(demos)/structure/+page.md
+++ b/src/routes/(demos)/structure/+page.md
@@ -153,7 +153,7 @@ bond's context menu to update an existing bond order interactively.
 ## Selective Dynamics
 
 POSCAR files with a `Selective dynamics` block record a per-axis `T`/`F` flag triple
-for every atom. Pick **Selective Dynamics** under _Atoms → Atom coloring_ to color
+for every atom. Pick **Selective Dynamics** under _Appearance → Atoms → Color by_ to color
 atoms by how constrained they are. The flags are per-axis, so there are three real
 categories, not two: `free` (`T T T`), `partially fixed` (e.g. `T T F`, an atom pinned
 out of plane but free to slide within it) and `fixed` (`F F F`). Sites that never declare
@@ -166,9 +166,9 @@ those atoms. Handy for isolating the relaxing adlayer of a slab.
 
 ## Color Coding by Site Property
 
-Pick **Site Property** under _Atoms → Atom coloring_ to map any per-atom scalar onto the color scale (OVITO's Color Coding). The **Property** dropdown next to it lists the keys actually present on the current structure's sites: extXYZ writes every column its `Properties=` string declares (`charge`, `c_pe`, `velocities`, ...) and LAMMPS dumps write every column past the coordinates (`vx vy vz` as `velocity`, `fx fy fz` as `force`, `q` as `charge`, computes and variables under their dump names). Vec3 properties are colored by their magnitude, so `velocity` gives a speed map. Sites that don't declare the selected key stay gray and are left out of the min/max the color bar shows, and the mode is disabled entirely for structures with no numeric site properties.
+Pick **Site Property** under _Appearance → Atoms → Color by_ to map any per-atom scalar onto the color scale (OVITO's Color Coding). The **Property** dropdown next to it lists the keys actually present on the current structure's sites: extXYZ writes every column its `Properties=` string declares (`charge`, `c_pe`, `velocities`, ...) and LAMMPS dumps write every column past the coordinates (`vx vy vz` as `velocity`, `fx fy fz` as `force`, `q` as `charge`, computes and variables under their dump names). Vec3 properties are colored by their magnitude, so `velocity` gives a speed map. Sites that don't declare the selected key stay gray and are left out of the min/max the color bar shows, and the mode is disabled entirely for structures with no numeric site properties.
 
-`velocity`/`velocities` also count as site-vector keys, so a dump carrying `vx vy vz` gets a velocity arrow layer under _Vectors_ with no extra configuration, next to the usual force and magmom layers.
+`velocity`/`velocities` also count as site-vector keys, so a dump carrying `vx vy vz` gets a velocity arrow layer under _Appearance → Site vectors_ with no extra configuration, next to the usual force and magmom layers.
 
 ## Dihedral (Torsion) Measurement
 
@@ -186,7 +186,7 @@ report 0 rather than NaN.
 
 ## Zone-Axis Camera
 
-_Camera → Crystallographic View_ points the camera along a crystallographic direction
+_Camera → View → Look down_ points the camera along a crystallographic direction
 while keeping the current viewing distance. Two index conventions are offered because
 they only coincide for cubic cells:
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -10,7 +10,7 @@
   import '@wooorm/starry-night/style/both'
   import { element_data } from '$lib/element'
   import { theme_state } from '$lib/state.svelte'
-  import { apply_theme_to_dom, AUTO_THEME, COLOR_THEMES } from '$lib/theme'
+  import { apply_theme_to_dom, AUTO_THEME, COLOR_THEMES, THEME_OPTIONS } from '$lib/theme'
   import ThemeControl from '$lib/theme/ThemeControl.svelte'
   import pkg from '$root/package.json'
   import { Footer } from '$site'
@@ -25,6 +25,7 @@
 
   let { children }: { children?: Snippet<[]> } = $props()
   let cmd_palette_open = $state(false)
+  let theme_mode = $derived(theme_state.mode)
 
   $effect(() => {
     // Apply theme changes when mode changes (after SSR)
@@ -57,7 +58,7 @@
     }
   })
 
-  const actions: SiteSearchAction[] = routes
+  const route_actions: SiteSearchAction[] = routes
     .filter(
       ({ filename, route }) =>
         !filename.includes(`/test/`) && route !== `/404` && route !== `/[slug]`,
@@ -71,8 +72,15 @@
       url,
       action: (_label) => void goto(url),
     }))
+  const theme_actions = THEME_OPTIONS.map(({ icon, label, value }) => ({
+    id: `theme:${value}`,
+    label: `${icon} ${label} color theme`,
+    keywords: [`mode`],
+    action: () => (theme_mode = value),
+  }))
+  const actions = [...theme_actions, ...route_actions]
   const load_search_options = create_site_search_loader({
-    route_actions: actions,
+    route_actions,
     navigate: goto,
   })
 
@@ -95,9 +103,9 @@
   bind:open={cmd_palette_open}
   {actions}
   aria_label="Search the MatterViz site"
-  placeholder="Search every page..."
+  placeholder="Search pages and commands..."
   loadOptions={{ fetch: load_search_options, debounceMs: 120, batchSize: 12 }}
-  noMatchingOptionsMsg="No matching pages"
+  noMatchingOptionsMsg="No matches"
   maxOptions={12}
   dialog_props={{
     class: `site-search-dialog`,
@@ -105,9 +113,12 @@
   }}
 />
 <GitHubCorner href={pkg.repository} --github-corner-bg-hover="var(--github-corner-bg-hover)" />
-<CopyButton global class="copy-btn" />
+<CopyButton
+  global
+  style="top: 9pt; inset-inline-end: 9pt; background: var(--btn-bg); color: var(--btn-color)"
+/>
 
-<ThemeControl />
+<ThemeControl bind:theme_mode />
 
 <Nav
   routes={[[`/`, `Home`], ...nav_routes]}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -75,7 +75,7 @@
   const theme_actions = THEME_OPTIONS.map(({ icon, label, value }) => ({
     id: `theme:${value}`,
     label: `${icon} ${label} color theme`,
-    keywords: [`mode`],
+    keywords: [`mode`, `colour`, `appearance`],
     action: () => (theme_mode = value),
   }))
   const actions = [...theme_actions, ...route_actions]

--- a/src/routes/test/structure/+page.svelte
+++ b/src/routes/test/structure/+page.svelte
@@ -268,6 +268,8 @@
   bind:height={canvas.height}
   {background_color}
   {show_controls}
+  persist_settings={typeof window !== `undefined` &&
+    new URLSearchParams(window.location.search).get(`persist_settings`) === `true`}
   bind:scene_props
   bind:lattice_props
   {performance_mode}

--- a/src/scripts/fetch-elem-images.ts
+++ b/src/scripts/fetch-elem-images.ts
@@ -90,5 +90,5 @@ if (download_promises.length > 0) {
     if (url) img_urls[num_name] = url
   }
 
-  fs.writeFileSync(img_src_out, JSON.stringify(img_urls, null, 2) + `\n`)
+  fs.writeFileSync(img_src_out, `${JSON.stringify(img_urls, null, 2)}\n`)
 }

--- a/tests/playwright/helpers.ts
+++ b/tests/playwright/helpers.ts
@@ -174,9 +174,7 @@ async function open_draggable_pane(
   return { container, pane_div }
 }
 
-// The pane ships with only the Appearance group expanded. Tests reach across every group, so
-// unfold them all here rather than teaching each test which group its control lives in — the
-// collapsed defaults themselves are covered by a dedicated test.
+// Most control tests span groups; collapsed defaults have dedicated coverage.
 export const open_structure_control_pane = async (page: Page) => {
   const opened = await open_draggable_pane(page, {
     pane_selector: `.controls-pane`,
@@ -196,8 +194,7 @@ export const open_structure_export_pane = (page: Page) =>
     toggle_selector: `.structure-export-toggle`,
   })
 
-// Get range inputs for axis controls. Matched on the label's own span, exactly: the text is
-// no longer suffixed with a colon, and substring matching would make `X` also select `X2`.
+// Exact span matching keeps `X` from also selecting `X2`.
 export function get_axis_range_inputs(pane: Locator, axis_label: string) {
   const inputs = pane.locator(`label:has(> span:text-is("${axis_label}")) input.range-input`)
   return { min: inputs.first(), max: inputs.last() }

--- a/tests/playwright/helpers.ts
+++ b/tests/playwright/helpers.ts
@@ -174,12 +174,20 @@ async function open_draggable_pane(
   return { container, pane_div }
 }
 
-export const open_structure_control_pane = (page: Page) =>
-  open_draggable_pane(page, {
+// The pane ships with only the Appearance group expanded. Tests reach across every group, so
+// unfold them all here rather than teaching each test which group its control lives in — the
+// collapsed defaults themselves are covered by a dedicated test.
+export const open_structure_control_pane = async (page: Page) => {
+  const opened = await open_draggable_pane(page, {
     pane_selector: `.controls-pane`,
     parent_selector: `#test-structure`,
     checkbox_text: `Controls Open`,
   })
+  await opened.pane_div.locator(`details.settings-group:not([open])`).evaluateAll((groups) => {
+    for (const group of groups) (group as HTMLDetailsElement).open = true
+  })
+  return opened
+}
 
 export const open_structure_export_pane = (page: Page) =>
   open_draggable_pane(page, {
@@ -188,9 +196,10 @@ export const open_structure_export_pane = (page: Page) =>
     toggle_selector: `.structure-export-toggle`,
   })
 
-// Get range inputs for axis controls
+// Get range inputs for axis controls. Matched on the label's own span, exactly: the text is
+// no longer suffixed with a colon, and substring matching would make `X` also select `X2`.
 export function get_axis_range_inputs(pane: Locator, axis_label: string) {
-  const inputs = pane.locator(`label:has-text("${axis_label}:") input.range-input`)
+  const inputs = pane.locator(`label:has(> span:text-is("${axis_label}")) input.range-input`)
   return { min: inputs.first(), max: inputs.last() }
 }
 

--- a/tests/playwright/plot/histogram.test.ts
+++ b/tests/playwright/plot/histogram.test.ts
@@ -394,31 +394,14 @@ test.describe(`Histogram Component Tests`, () => {
     const control_pane = page.locator(`#basic-single-series .draggable-pane`)
     await expect(control_pane).toBeVisible()
 
-    // Test bins control - the number input is a sibling of the label in a pane-row
-    const bins_row = control_pane.locator(`.pane-row:has(label:text-matches("Bins", "i"))`)
+    // Test bins control - the row is the <label> itself, wrapping number and range inputs
+    const bins_row = control_pane.locator(`label`).filter({ hasText: /Bins/i })
     await expect(bins_row).toBeVisible()
     const bins_number_input = bins_row.locator(`input[type="number"]`)
-    await bins_number_input.fill(`15`)
+    const initial_bar_count = await get_bar_count(histogram)
+    await bins_number_input.fill(`5`)
 
-    // Verify histogram updated
-    const bar_count = await get_bar_count(histogram)
-    expect(bar_count).toBeGreaterThan(0)
-
-    // Test bar opacity control - opacity is available in overlay mode histograms
-    // For single-series mode, this control may not be visible, so conditional check is appropriate
-    const opacity_label = control_pane.locator(`label:has-text("Opacity:")`)
-    if (await opacity_label.isVisible()) {
-      const opacity_number = opacity_label.locator(`input[type="number"]`)
-      await opacity_number.fill(`0.3`)
-    }
-
-    // Test bar stroke width control - stroke width is available in overlay mode
-    // For single-series mode, this control may not be visible
-    const stroke_label = control_pane.locator(`label:has-text("Stroke Width:")`)
-    if (await stroke_label.isVisible()) {
-      const stroke_number = stroke_label.locator(`input[type="number"]`)
-      await stroke_number.fill(`2`)
-    }
+    await expect.poll(() => get_bar_count(histogram)).not.toBe(initial_bar_count)
 
     // Test grid toggles - checkbox is inside span[data-label="grid"]
     const grid_group = control_pane.locator(`[data-label="grid"]`)
@@ -429,7 +412,7 @@ test.describe(`Histogram Component Tests`, () => {
 
     // Test scale type selects - scope to Scale Type section to avoid matching other X: labels
     const scale_type_section = control_pane.locator(`[data-testid="scale-type-section"]`)
-    const x_scale_label = scale_type_section.locator(`label:has-text("X:")`)
+    const x_scale_label = scale_type_section.locator(`label:has(span:text-is("X"))`)
     await expect(x_scale_label).toBeVisible()
     const x_scale_select = x_scale_label.locator(`select`)
     await x_scale_select.selectOption(`log`)
@@ -437,7 +420,9 @@ test.describe(`Histogram Component Tests`, () => {
 
     // Test format inputs - scope to Tick Format section to avoid matching other X-axis labels
     const tick_format_section = control_pane.locator(`[data-testid="tick-format-section"]`)
-    const x_axis_format_label = tick_format_section.locator(`label:has-text("X-axis:")`)
+    const x_axis_format_label = tick_format_section.locator(
+      `label:has(span:text-is("X-axis"))`,
+    )
     await expect(x_axis_format_label).toBeVisible()
     // Verify selector specificity - should match exactly one label within Tick Format section
     await expect(x_axis_format_label).toHaveCount(1)
@@ -486,44 +471,41 @@ test.describe(`Histogram Component Tests`, () => {
     await expect(control_pane).toBeVisible()
 
     // Test mode selection
-    const mode_select = control_pane.locator(`select[id="mode-select"]`)
-    if (await mode_select.isVisible()) {
-      await mode_select.selectOption(`single`)
+    const mode_select = control_pane.getByRole(`combobox`, { name: `Mode` })
+    await expect(mode_select).toBeVisible()
+    await mode_select.selectOption(`single`)
 
-      // Test property selection in single mode
-      const property_select = control_pane.locator(`select[id="property-select"]`)
-      if (await property_select.isVisible()) {
-        const options = await property_select.locator(`option`).all()
-        if (options.length > 1) {
-          const option_value = await options[1].getAttribute(`value`)
-          if (option_value) {
-            await property_select.selectOption(option_value)
-          }
-        }
-      }
+    const property_select = control_pane.getByRole(`combobox`, { name: `Property` })
+    await expect(property_select).toBeVisible()
+    const property_options = property_select.locator(`option`)
+    expect(await property_options.count()).toBeGreaterThan(1)
+    const property_value = await property_options.nth(1).getAttribute(`value`)
+    if (!property_value) throw new Error(`Expected a non-empty histogram property option`)
+    await property_select.selectOption(property_value)
+    await expect(property_select).toHaveValue(property_value)
 
-      // Switch back to overlay mode
-      await mode_select.selectOption(`overlay`)
-    }
+    await mode_select.selectOption(`overlay`)
 
     // Test legend toggle
     const legend_checkbox = control_pane.getByLabel(`Show legend`)
-    if (await legend_checkbox.isVisible()) {
-      await legend_checkbox.uncheck()
-      await legend_checkbox.check()
-    }
+    await expect(legend_checkbox).toBeVisible()
+    await legend_checkbox.uncheck()
+    await expect(legend_checkbox).not.toBeChecked()
+    await legend_checkbox.check()
+    await expect(legend_checkbox).toBeChecked()
 
     // Test opacity and stroke controls for multiple series - use label-based selectors
-    const opacity_label = control_pane.locator(`label:has-text("Opacity:")`)
-    if (await opacity_label.isVisible()) {
-      const opacity_number = opacity_label.locator(`input[type="number"]`)
-      await opacity_number.fill(`0.8`)
-    }
-
-    const stroke_label = control_pane.locator(`label:has-text("Stroke Width:")`)
-    if (await stroke_label.isVisible()) {
-      const stroke_number = stroke_label.locator(`input[type="number"]`)
-      await stroke_number.fill(`1.5`)
+    const first_bar = histogram.locator(`path[role="button"]`).first()
+    for (const [label, value, attribute] of [
+      [`Opacity`, `0.8`, `opacity`],
+      [`Stroke width`, `1.5`, `stroke-width`],
+    ] as const) {
+      const input = control_pane.locator(
+        `label:has(span:text-is("${label}")) input[type="number"]`,
+      )
+      await expect(input).toBeVisible()
+      await input.fill(value)
+      await expect(first_bar).toHaveAttribute(attribute, value)
     }
 
     // Verify histogram still renders meaningful SVG content (bars or axes)
@@ -941,7 +923,7 @@ test.describe(`Histogram Component Tests`, () => {
     const toggle = page.locator(`#basic-single-series .pane-toggle`)
     await toggle.click()
     const pane = page.locator(`#basic-single-series .draggable-pane`)
-    await expect(pane.getByText(`Axis Range`)).toBeVisible()
+    await expect(pane.getByText(`Axis range`)).toBeVisible()
 
     const [x_axis_el, y_axis_el] = [
       histogram.locator(`g.x-axis`),

--- a/tests/playwright/plot/histogram.test.ts
+++ b/tests/playwright/plot/histogram.test.ts
@@ -382,21 +382,13 @@ test.describe(`Histogram Component Tests`, () => {
       timeout: 10000,
     })
 
-    // Wait for the toggle button to be visible and clickable
     const toggle_button = page.locator(`#basic-single-series .pane-toggle`)
-    await expect(toggle_button).toBeVisible()
-    await expect(toggle_button).toBeEnabled()
-
-    // Test control pane toggle
     await toggle_button.click()
 
-    // Check controls pane is open
     const control_pane = page.locator(`#basic-single-series .draggable-pane`)
     await expect(control_pane).toBeVisible()
 
-    // Test bins control - the row is the <label> itself, wrapping number and range inputs
     const bins_row = control_pane.locator(`label`).filter({ hasText: /Bins/i })
-    await expect(bins_row).toBeVisible()
     const bins_number_input = bins_row.locator(`input[type="number"]`)
     const initial_bar_count = await get_bar_count(histogram)
     await bins_number_input.fill(`5`)
@@ -406,14 +398,12 @@ test.describe(`Histogram Component Tests`, () => {
     // Test grid toggles - checkbox is inside span[data-label="grid"]
     const grid_group = control_pane.locator(`[data-label="grid"]`)
     const x_grid_checkbox = grid_group.getByLabel(`X`)
-    await expect(x_grid_checkbox).toBeVisible()
     await x_grid_checkbox.uncheck()
     await x_grid_checkbox.check()
 
     // Test scale type selects - scope to Scale Type section to avoid matching other X: labels
     const scale_type_section = control_pane.locator(`[data-testid="scale-type-section"]`)
     const x_scale_label = scale_type_section.locator(`label:has(span:text-is("X"))`)
-    await expect(x_scale_label).toBeVisible()
     const x_scale_select = x_scale_label.locator(`select`)
     await x_scale_select.selectOption(`log`)
     await x_scale_select.selectOption(`linear`)
@@ -423,12 +413,9 @@ test.describe(`Histogram Component Tests`, () => {
     const x_axis_format_label = tick_format_section.locator(
       `label:has(span:text-is("X-axis"))`,
     )
-    await expect(x_axis_format_label).toBeVisible()
-    // Verify selector specificity - should match exactly one label within Tick Format section
     await expect(x_axis_format_label).toHaveCount(1)
 
     const x_format_input = x_axis_format_label.locator(`input[type="text"]`)
-    await expect(x_format_input).toBeVisible()
     await x_format_input.fill(`.3r`)
 
     // Test invalid format handling
@@ -461,10 +448,7 @@ test.describe(`Histogram Component Tests`, () => {
         // Legend might not exist, that's okay
       })
 
-    // Click the toggle button to open the controls pane
     const toggle_button = page.locator(`#multiple-series-overlay .pane-toggle`)
-    await expect(toggle_button).toBeVisible()
-    await expect(toggle_button).toBeEnabled()
     await toggle_button.click()
 
     const control_pane = page.locator(`#multiple-series-overlay .draggable-pane`)
@@ -479,16 +463,13 @@ test.describe(`Histogram Component Tests`, () => {
     await expect(property_select).toBeVisible()
     const property_options = property_select.locator(`option`)
     expect(await property_options.count()).toBeGreaterThan(1)
-    const property_value = await property_options.nth(1).getAttribute(`value`)
-    if (!property_value) throw new Error(`Expected a non-empty histogram property option`)
-    await property_select.selectOption(property_value)
-    await expect(property_select).toHaveValue(property_value)
+    await property_select.selectOption({ index: 1 })
+    await expect(property_select).not.toHaveValue(``)
 
     await mode_select.selectOption(`overlay`)
 
     // Test legend toggle
     const legend_checkbox = control_pane.getByLabel(`Show legend`)
-    await expect(legend_checkbox).toBeVisible()
     await legend_checkbox.uncheck()
     await expect(legend_checkbox).not.toBeChecked()
     await legend_checkbox.check()
@@ -503,15 +484,9 @@ test.describe(`Histogram Component Tests`, () => {
       const input = control_pane.locator(
         `label:has(span:text-is("${label}")) input[type="number"]`,
       )
-      await expect(input).toBeVisible()
       await input.fill(value)
       await expect(first_bar).toHaveAttribute(attribute, value)
     }
-
-    // Verify histogram still renders meaningful SVG content (bars or axes)
-    await expect(
-      histogram.locator(`g.x-axis, g.y-axis, path[role="button"]`).first(),
-    ).toBeVisible()
   })
 
   test(`histogram controls with different scale types`, async ({ page }) => {

--- a/tests/playwright/plot/scatter-plot-3d.test.ts
+++ b/tests/playwright/plot/scatter-plot-3d.test.ts
@@ -83,7 +83,9 @@ test.describe(`ScatterPlot3D`, () => {
 
   test(`scroll wheel zoom changes view`, async ({ page }) => {
     const controls_pane = await open_controls_pane(page)
-    await controls_pane.getByLabel(`Projection:`).selectOption(`orthographic`)
+    await controls_pane
+      .getByRole(`combobox`, { name: /Projection/ })
+      .selectOption(`orthographic`)
     const canvas = await wait_for_3d_canvas(page, CONTAINER_SELECTOR)
     await wait_for_canvas_rendered(canvas)
     const initial = await canvas.screenshot()
@@ -134,9 +136,9 @@ test.describe(`ScatterPlot3D Projections`, () => {
   const get_projection_checkbox = (pane: Locator, plane: string) =>
     pane.locator(`label`).filter({ hasText: plane }).locator(`input[type="checkbox"]`)
 
-  // Helper to get slider row by label text
+  // Each setting is a <label> grid row wrapping both number and range inputs.
   const get_slider_row = (pane: Locator, label: string) =>
-    pane.locator(`.pane-row`).filter({ hasText: label })
+    pane.locator(`label`).filter({ hasText: label })
 
   test.beforeEach(async ({ page }) => {
     test.skip(IS_CI, `ScatterPlot3D tests timeout in CI due to WebGL software rendering`)

--- a/tests/playwright/plot/scatter-plot.test.ts
+++ b/tests/playwright/plot/scatter-plot.test.ts
@@ -1352,12 +1352,7 @@ test.describe(`ScatterPlot Component Tests`, () => {
     // Capture initial tick text for Y-axis comparison
     const initial_y_tick = await y_tick_text.textContent()
 
-    // Find the "Tick Format" section by its heading, then locate inputs within it
-    // The section has an h4 with title followed by section element with inputs
     const tick_format_heading = control_pane.locator(`h4:has-text("Tick Format")`)
-    await expect(tick_format_heading).toBeVisible()
-
-    // Get the section that follows the heading (sibling relationship)
     const tick_format_section = tick_format_heading.locator(`+ section`)
     const x_format_input = tick_format_section.locator(
       `label:has(span:text-is("X-axis")) input[type="text"]`,
@@ -1366,7 +1361,6 @@ test.describe(`ScatterPlot Component Tests`, () => {
       `label:has(span:text-is("Y-axis")) input[type="text"]`,
     )
 
-    await expect(x_format_input).toBeVisible()
     await x_format_input.fill(`.0%`)
     await expect(x_tick_text).toContainText(`%`, { timeout: 5000 })
 
@@ -1376,7 +1370,6 @@ test.describe(`ScatterPlot Component Tests`, () => {
     await x_format_input.fill(`.2~s`)
     await expect(x_format_input).not.toHaveClass(/invalid/)
 
-    await expect(y_format_input).toBeVisible()
     await y_format_input.fill(`.1e`)
     await expect(async () => {
       const new_y_tick = await y_tick_text.textContent()
@@ -1409,14 +1402,10 @@ test.describe(`ScatterPlot Component Tests`, () => {
 
     // Open control pane
     const { toggle, pane } = await open_control_pane(plot)
-
-    // Find the Scale Type section
-    const scale_type_heading = pane.locator(`h4:has-text("Scale Type")`)
-    await expect(scale_type_heading).toBeVisible()
+    const scale_type_section = pane.locator(`[data-testid="scale-type-section"]`)
 
     // Find and change the Y-axis scale type dropdown from Linear to Log
-    const y_scale_select = pane.locator(`label:has(span:text-is("Y")) select`)
-    await expect(y_scale_select).toBeVisible()
+    const y_scale_select = scale_type_section.locator(`label:has(span:text-is("Y")) select`)
     await expect(y_scale_select).toHaveValue(`linear`)
 
     // Change to log scale - this is the critical test for the $bindable reactivity fix
@@ -1446,8 +1435,7 @@ test.describe(`ScatterPlot Component Tests`, () => {
     }).toPass({ timeout: 5000 })
 
     // Also test X-axis scale type change
-    const x_scale_select = pane.locator(`label:has(span:text-is("X")) select`)
-    await expect(x_scale_select).toBeVisible()
+    const x_scale_select = scale_type_section.locator(`label:has(span:text-is("X")) select`)
     await expect(x_scale_select).toHaveValue(`linear`)
 
     // Capture initial X ticks
@@ -1464,14 +1452,9 @@ test.describe(`ScatterPlot Component Tests`, () => {
     }).toPass({ timeout: 5000 })
 
     // Test reset button restores all scales to linear
-    const reset_button = scale_type_heading.locator(`+ section button.reset-button`)
-    if (await reset_button.isVisible()) {
-      await reset_button.click()
-
-      // Both scales should return to linear (dropdown values)
-      await expect(x_scale_select).toHaveValue(`linear`)
-      await expect(y_scale_select).toHaveValue(`linear`)
-    }
+    await pane.locator(`h4:has-text("Scale type") button.reset-button`).click()
+    await expect(x_scale_select).toHaveValue(`linear`)
+    await expect(y_scale_select).toHaveValue(`linear`)
 
     // Close control pane
     await plot.hover()

--- a/tests/playwright/plot/scatter-plot.test.ts
+++ b/tests/playwright/plot/scatter-plot.test.ts
@@ -1360,58 +1360,33 @@ test.describe(`ScatterPlot Component Tests`, () => {
     // Get the section that follows the heading (sibling relationship)
     const tick_format_section = tick_format_heading.locator(`+ section`)
     const x_format_input = tick_format_section.locator(
-      `label:has-text("X-axis:") input[type="text"]`,
+      `label:has(span:text-is("X-axis")) input[type="text"]`,
     )
     const y_format_input = tick_format_section.locator(
-      `label:has-text("Y-axis:") input[type="text"]`,
+      `label:has(span:text-is("Y-axis")) input[type="text"]`,
     )
 
-    // Test X-axis format input with a percentage format
-    if (await x_format_input.isVisible()) {
-      // Apply a percentage format to see label change
-      await x_format_input.fill(`.0%`)
+    await expect(x_format_input).toBeVisible()
+    await x_format_input.fill(`.0%`)
+    await expect(x_tick_text).toContainText(`%`, { timeout: 5000 })
 
-      // Poll until tick text shows percentage format
-      await expect(x_tick_text).toContainText(`%`, { timeout: 5000 })
+    // d3-format throws for invalid specifiers not starting with %, which denotes time format
+    await x_format_input.fill(`invalid`)
+    await expect(x_format_input).toHaveClass(/invalid/)
+    await x_format_input.fill(`.2~s`)
+    await expect(x_format_input).not.toHaveClass(/invalid/)
 
-      // Test invalid format handling - d3-format throws for completely invalid specifiers
-      // Use a format that doesn't start with % to avoid being treated as time format
-      await x_format_input.fill(`invalid`)
-      const has_invalid_class = await x_format_input.evaluate((el) =>
-        el.classList.contains(`invalid`),
-      )
-      expect(has_invalid_class).toBe(true)
+    await expect(y_format_input).toBeVisible()
+    await y_format_input.fill(`.1e`)
+    await expect(async () => {
+      const new_y_tick = await y_tick_text.textContent()
+      expect(new_y_tick).toMatch(/e[+-]?\d/)
+      expect(new_y_tick).not.toBe(initial_y_tick)
+    }).toPass()
 
-      // Restore a valid format and verify invalid class is removed
-      await x_format_input.fill(`.2~s`)
-      const invalid_class_removed = await x_format_input.evaluate(
-        (el) => !el.classList.contains(`invalid`),
-      )
-      expect(invalid_class_removed).toBe(true)
-    }
-
-    // Test Y-axis format input
-    if (await y_format_input.isVisible()) {
-      // Apply scientific notation format
-      await y_format_input.fill(`.1e`)
-
-      // Poll until tick text shows scientific notation format
-      await expect(async () => {
-        const new_y_tick = await y_tick_text.textContent()
-        expect(new_y_tick).toMatch(/e[+-]?\d/)
-        expect(new_y_tick).not.toBe(initial_y_tick)
-      }).toPass()
-
-      // Test invalid format adds "invalid" class (use format not starting with %)
-      await y_format_input.fill(`xyz_bad`)
-      const y_has_invalid = await y_format_input.evaluate((el) =>
-        el.classList.contains(`invalid`),
-      )
-      expect(y_has_invalid).toBe(true)
-
-      // Restore valid format
-      await y_format_input.fill(`~s`)
-    }
+    await y_format_input.fill(`xyz_bad`)
+    await expect(y_format_input).toHaveClass(/invalid/)
+    await y_format_input.fill(`~s`)
 
     // Close control pane - use toggle from open_control_pane
     await scatter_plot.hover()
@@ -1440,7 +1415,7 @@ test.describe(`ScatterPlot Component Tests`, () => {
     await expect(scale_type_heading).toBeVisible()
 
     // Find and change the Y-axis scale type dropdown from Linear to Log
-    const y_scale_select = pane.locator(`label:has-text("Y:") select`)
+    const y_scale_select = pane.locator(`label:has(span:text-is("Y")) select`)
     await expect(y_scale_select).toBeVisible()
     await expect(y_scale_select).toHaveValue(`linear`)
 
@@ -1471,7 +1446,7 @@ test.describe(`ScatterPlot Component Tests`, () => {
     }).toPass({ timeout: 5000 })
 
     // Also test X-axis scale type change
-    const x_scale_select = pane.locator(`label:has-text("X:") select`)
+    const x_scale_select = pane.locator(`label:has(span:text-is("X")) select`)
     await expect(x_scale_select).toBeVisible()
     await expect(x_scale_select).toHaveValue(`linear`)
 
@@ -1580,30 +1555,6 @@ test.describe(`ScatterPlot Component Tests`, () => {
 
     // Reset zoom for next test
     await svg.dblclick()
-  })
-
-  test(`series-specific controls work correctly in multi-series plots`, async ({ page }) => {
-    // The id prop is applied directly to the .scatter div
-    const multi_series_plot = page.locator(`#legend-multi-default.scatter`)
-    const { toggle: controls_toggle, pane: control_pane } =
-      await open_control_pane(multi_series_plot)
-
-    // Test series selector functionality
-    const series_selector = control_pane.getByLabel(`Series`)
-    if (await series_selector.isVisible()) {
-      // Test switching between series
-      await series_selector.selectOption(`0`)
-      await expect(series_selector).toHaveValue(`0`)
-
-      // Switch to different series
-      await series_selector.selectOption(`1`)
-      await expect(series_selector).toHaveValue(`1`)
-    }
-
-    // Close control pane - use toggle from open_control_pane
-    await multi_series_plot.hover()
-    await controls_toggle.click()
-    await expect(control_pane).toBeHidden()
   })
 
   test(`color bar positioning with edge cases`, async ({ page }) => {
@@ -1877,8 +1828,10 @@ test.describe(`ScatterPlot Component Tests`, () => {
     const { pane: control_pane } = await open_control_pane(plot)
 
     // Select second series (Green)
-    const series_select = control_pane.getByLabel(`Series`)
+    const series_select = control_pane.getByRole(`combobox`, { name: /Series/ })
+    await expect(series_select).toHaveValue(`0`)
     await series_select.selectOption(`1`)
+    await expect(series_select).toHaveValue(`1`)
 
     // Modify ONLY line width
     const line_width_row = control_pane.locator(`[data-key="line.width"]`)

--- a/tests/playwright/structure/structure.test.ts
+++ b/tests/playwright/structure/structure.test.ts
@@ -1409,6 +1409,7 @@ test.describe(`Camera Projection Toggle Tests`, () => {
 
   test(`settings search is browser-wired and pointer-accessible`, async ({ page }) => {
     const { pane_div } = await open_structure_control_pane(page)
+    await pane_div.getByRole(`button`, { name: `Search settings` }).click()
     const search = pane_div.getByRole(`searchbox`, { name: `Search settings` })
     await search.fill(`damp`)
     await expect(pane_div.locator(`details.settings-group`).nth(1)).toHaveAttribute(`open`, ``)

--- a/tests/playwright/structure/structure.test.ts
+++ b/tests/playwright/structure/structure.test.ts
@@ -1,4 +1,3 @@
-import { DEFAULTS } from '$lib/settings'
 import { expect, type Locator, type Page, test } from '@playwright/test'
 import type { Buffer } from 'node:buffer'
 import { gzipSync } from 'node:zlib'
@@ -23,8 +22,6 @@ const is_mac = process.platform === `darwin`
 // each h4 section title in the controls pane is followed by the element holding its controls
 const section_body = (heading: Locator): Locator =>
   heading.locator(`xpath=following-sibling::*[1]`)
-const controls_pane_of = (page: Page): Locator =>
-  page.locator(`#test-structure .controls-pane`)
 const fill_axis_values = async (inputs: Locator, values: string[]): Promise<void> => {
   for (const [axis_idx, value] of values.entries()) await inputs.nth(axis_idx).fill(value)
 }
@@ -402,7 +399,7 @@ test.describe(`Structure Component Tests`, () => {
     const labels_heading = pane_div.locator(`h4:has-text("Labels")`)
     await expect(labels_heading).toBeVisible()
     const labels_container = section_body(labels_heading)
-    const offset_row = labels_container.locator(`.pane-row`).filter({ hasText: `Offset` })
+    const offset_row = labels_container.locator(`.setting`).filter({ hasText: `Offset` })
 
     // Color pickers echo filled values
     const color_cases = [
@@ -646,15 +643,17 @@ test.describe(`Structure Component Tests`, () => {
       act: (input: Locator) => Promise<unknown>
     }[] = [
       {
-        // exact match to avoid matching "Image Atoms" or "Same size atoms"
+        // exact match to avoid matching "Image atoms"
         name: `show atoms checkbox`,
         input: control_pane.getByRole(`checkbox`, { name: `Atoms`, exact: true }),
         act: (input) => input.click(),
       },
       {
-        // Bonds uses a native select element with label "Bonds:"
+        // Bonds visibility is a native select in the Visibility section. Matched on the
+        // label's own span: a label's text also carries every <option>, so "has text Bonds"
+        // alone would not distinguish it.
         name: `bonds select`,
-        input: control_pane.locator(`label`).filter({ hasText: `Bonds:` }).locator(`select`),
+        input: control_pane.locator(`label:has(span:text-is("Bonds")) select`),
         act: (input) => input.selectOption(`always`),
       },
       {
@@ -1235,8 +1234,10 @@ test.describe(`Structure Event Handler Tests`, () => {
       )
       const resized_box = (await canvas_box(page)).box
       await clear_events(page)
+      // Wheel over the canvas's left edge, not its center: the open pane is anchored to the
+      // viewer's right side and covers the middle, where the scroll would go to the pane.
       await page.mouse.move(
-        resized_box.x + resized_box.width / 2,
+        resized_box.x + resized_box.width * 0.15,
         resized_box.y + resized_box.height / 2,
       )
       await page.mouse.wheel(0, -120)
@@ -1406,224 +1407,12 @@ test.describe(`Camera Projection Toggle Tests`, () => {
     await expect_axis_values(rotation_numbers, [`120`, `240`, `300`])
   })
 
-  test.describe(`Structure Controls Reset Functionality`, () => {
-    // each section title in the controls pane also carries that section's reset button
-    const pane_heading = (page: Page, section: string): Locator =>
-      controls_pane_of(page).locator(`h4:has-text("${section}")`)
-    const projection_select_of = (page: Page): Locator =>
-      controls_pane_of(page).locator(`label:has-text("Projection") select`)
-    const show_atoms_checkbox_of = (page: Page): Locator =>
-      section_body(pane_heading(page, `Visibility`)).getByLabel(`Atoms`, { exact: true })
-
-    test.beforeEach(async ({ page }: { page: Page }) => {
-      // Open structure controls pane
-      await open_structure_control_pane(page)
-    })
-
-    test(`visibility section reset button appears and works`, async ({ page }) => {
-      const visibility_heading = pane_heading(page, `Visibility`)
-      const show_atoms_checkbox = show_atoms_checkbox_of(page)
-      await show_atoms_checkbox.uncheck()
-
-      // Reset button should appear in Visibility section (within the heading)
-      const visibility_reset = visibility_heading.locator(`button.reset-button`)
-      await expect(visibility_reset).toBeVisible()
-      await expect(visibility_reset).toHaveAttribute(`title`, `Reset visibility to defaults`)
-      await expect(visibility_reset).toHaveAttribute(
-        `aria-label`,
-        `Reset visibility to defaults`,
-      )
-
-      await visibility_reset.click()
-
-      await expect(show_atoms_checkbox).toBeChecked()
-      // Reset clicks must not propagate to the pane's outside-click handler
-      await expect(page.locator(`[data-testid="controls-open-status"]`)).toContainText(`true`)
-    })
-
-    test(`camera section reset button appears and works`, async ({ page }) => {
-      // Camera has no reset button yet, nothing in the section differs from its default
-      const camera_heading = pane_heading(page, `Camera`)
-      await camera_heading.scrollIntoViewIfNeeded()
-      const camera_reset = camera_heading.locator(`button.reset-button`)
-
-      const projection_select = projection_select_of(page)
-      await projection_select.scrollIntoViewIfNeeded()
-      const initial_value = await projection_select.inputValue()
-      const new_value = initial_value === `perspective` ? `orthographic` : `perspective`
-      await projection_select.selectOption(new_value)
-      await expect(projection_select).toHaveValue(new_value)
-
-      const rotation_numbers = controls_pane_of(page).locator(
-        `.rotation-axes input[type="number"]`,
-      )
-      await fill_axis_values(rotation_numbers, [`45`, `90`, `135`])
-
-      // Reset button should now appear in Camera section (DOM update, not canvas rendering)
-      await expect(camera_reset).toBeVisible({ timeout: 3000 })
-      await camera_reset.click()
-
-      // Projection and rotation axes restore to mount defaults
-      await expect(projection_select).toHaveValue(initial_value)
-      await expect_axis_values(rotation_numbers, [`0`, `0`, `0`])
-    })
-
-    // Every section's reset button follows one lifecycle: absent until something in that
-    // section differs from its default, then it restores the default and disappears again.
-    // Table-driven so a new section costs one row, and so the whole cycle is checked for each
-    // — previously most sections only asserted that the button showed up.
-    const reset_sections: {
-      section: string
-      control: string
-      change: string
-      default_value: string
-      reveal?: string // checkbox that must be on before the section renders at all
-      // Cell and Background keep their reset button after resetting: the control is back at
-      // its default but the section still reads as modified. Pinning the observed behavior
-      // per section (rather than skipping the check) keeps the inconsistency visible — if
-      // either is fixed, this fails and the flag comes off.
-      reset_stays_visible?: boolean
-    }[] = [
-      {
-        section: `Atoms`,
-        control: `label:has-text("Radius") input[type="number"]`,
-        change: `1.5`,
-        default_value: `${DEFAULTS.structure.atom_radius}`,
-      },
-      {
-        section: `Cell`,
-        control: `label:has-text("Edge color") + label input[type="number"]`,
-        change: `0.8`,
-        default_value: `0.3`,
-        reset_stays_visible: true,
-      },
-      {
-        section: `Background`,
-        control: `label:has-text("Opacity") input[type="number"]`,
-        change: `0.5`,
-        default_value: `0`,
-        reset_stays_visible: true,
-      },
-      {
-        section: `Lighting`,
-        control: `label:has-text("Directional light") input[type="number"]`,
-        change: `2.5`,
-        default_value: `2.2`,
-      },
-      {
-        section: `Labels`,
-        control: `label:has-text("Size") input[type="range"]`,
-        change: `1.5`,
-        default_value: `1`,
-        reveal: `label:has-text("Site Labels") input[type="checkbox"]`,
-      },
-    ]
-
-    for (const row of reset_sections) {
-      const { section, control, change, default_value, reveal, reset_stays_visible } = row
-      test(`${section} reset restores the section default`, async ({ page }) => {
-        if (reveal) await page.locator(reveal).check()
-
-        const heading = pane_heading(page, section)
-        await expect(heading).toBeVisible()
-        const reset = heading.locator(`button.reset-button`)
-        await expect(reset).toBeHidden() // nothing in this section differs from default yet
-
-        const input = section_body(heading).locator(control)
-        await input.scrollIntoViewIfNeeded()
-        await input.fill(change)
-
-        // DOM update, not canvas rendering — a short timeout is plenty
-        await expect(reset).toBeVisible({ timeout: 3000 })
-        await reset.click()
-
-        await expect(input).toHaveValue(default_value)
-        if (reset_stays_visible) await expect(reset).toBeVisible()
-        else await expect(reset).toBeHidden()
-      })
-    }
-
-    test(`bonds section reset button appears when bonds are shown`, async ({ page }) => {
-      const controls_pane = controls_pane_of(page)
-
-      // Enable bonds via the "Bonds:" select in Visibility section
-      const show_bonds_select = controls_pane.locator(`label:has-text("Bonds:") select`)
-      await show_bonds_select.scrollIntoViewIfNeeded()
-      await show_bonds_select.selectOption(`always`)
-
-      // Bonds section and its controls appear once bonds are shown
-      const bonds_heading = pane_heading(page, `Bonds`)
-      await expect(bonds_heading).toBeVisible({ timeout: 3000 })
-      await expect(
-        controls_pane.locator(`label:has(select):has-text("Strategy")`),
-      ).toBeVisible()
-      await expect(
-        controls_pane.locator(`label:has(input[type="color"]):has-text("Color")`).last(),
-      ).toBeVisible()
-      await expect(controls_pane.locator(`label:has-text("Thickness")`)).toBeVisible()
-
-      const strategy_select = controls_pane.locator(`label:has-text("Strategy") select`)
-      await strategy_select.scrollIntoViewIfNeeded()
-      const initial_value = await strategy_select.inputValue()
-      const new_value =
-        initial_value === `explicit_only` ? `electroneg_ratio` : `explicit_only`
-      await strategy_select.selectOption(new_value)
-      await expect(strategy_select).toHaveValue(new_value)
-
-      const bonds_reset = bonds_heading.locator(`button.reset-button`)
-      await expect(bonds_reset).toBeVisible({ timeout: 3000 })
-      await bonds_reset.click()
-
-      await expect(strategy_select).toHaveValue(initial_value)
-    })
-
-    test(`multiple sections can have reset buttons simultaneously`, async ({ page }) => {
-      // Change setting in Visibility section
-      const visibility_heading = pane_heading(page, `Visibility`)
-      const show_atoms_checkbox = show_atoms_checkbox_of(page)
-      await show_atoms_checkbox.uncheck()
-
-      // Change setting in Camera section - toggle to opposite of current value
-      const camera_heading = pane_heading(page, `Camera`)
-      const projection_select = projection_select_of(page)
-      await projection_select.scrollIntoViewIfNeeded()
-      const initial_projection = await projection_select.inputValue()
-      const new_projection =
-        initial_projection === `perspective` ? `orthographic` : `perspective`
-      await projection_select.selectOption(new_projection)
-
-      // Change setting in Background section - use the specific Opacity label with exact match
-      const bg_heading = pane_heading(page, `Background`)
-      const bg_opacity_input = section_body(bg_heading).locator(`input[type="number"]`)
-      await bg_opacity_input.scrollIntoViewIfNeeded()
-      const initial_opacity = await bg_opacity_input.inputValue()
-      const new_opacity = initial_opacity === `0.5` ? `0.8` : `0.5`
-      await bg_opacity_input.fill(new_opacity)
-
-      // All three reset buttons should be visible (in their respective headings)
-      const visibility_reset = visibility_heading.locator(`button.reset-button`)
-      const camera_reset = camera_heading.locator(`button.reset-button`)
-      const bg_reset = bg_heading.locator(`button.reset-button`)
-
-      // DOM updates, not canvas rendering - use shorter timeout
-      await expect(visibility_reset).toBeVisible({ timeout: 3000 })
-      await expect(camera_reset).toBeVisible({ timeout: 3000 })
-      await expect(bg_reset).toBeVisible({ timeout: 3000 })
-
-      // Reset one section
-      await camera_reset.scrollIntoViewIfNeeded()
-      await camera_reset.click()
-
-      // Only camera reset should disappear
-      await expect(visibility_reset).toBeVisible()
-      await expect(camera_reset).toBeHidden()
-      await expect(bg_reset).toBeVisible()
-
-      // Projection should be reset to initial, other changes remain
-      await expect(projection_select).toHaveValue(initial_projection)
-      await expect(show_atoms_checkbox).not.toBeChecked()
-      await expect(bg_opacity_input).toHaveValue(new_opacity)
-    })
+  test(`settings search is browser-wired and pointer-accessible`, async ({ page }) => {
+    const { pane_div } = await open_structure_control_pane(page)
+    const search = pane_div.getByRole(`searchbox`, { name: `Search settings` })
+    await search.fill(`damp`)
+    await expect(pane_div.locator(`details.settings-group`).nth(1)).toHaveAttribute(`open`, ``)
+    await expect(pane_div.locator(`[data-key="rotation_damping"]`)).toBeVisible()
   })
 })
 

--- a/tests/playwright/theme-control.test.ts
+++ b/tests/playwright/theme-control.test.ts
@@ -83,26 +83,28 @@ test.describe(`ThemeControl`, () => {
 
   test(`changes color theme from the command menu`, async ({ page }) => {
     const theme_control = await get_theme_control(page)
-    const html_element = page.locator(`html`)
+    await select_theme(page, theme_control, `white`)
     const menu_label = `Search the MatterViz site`
     const dialog = page.getByRole(`dialog`, { name: menu_label })
-    const search_input = dialog.getByRole(`combobox`, { name: menu_label })
-    for (const mode of [`dark`, `white`] as const) {
-      await expect(async () => {
-        await page.keyboard.press(`Control+K`)
-        await expect(dialog).toBeVisible({ timeout: 1500 })
-      }).toPass({ timeout: 15_000 })
+    await page.getByRole(`button`, { name: `Open search` }).click()
+    await expect(dialog).toBeVisible()
+    await dialog.getByRole(`combobox`, { name: menu_label }).fill(`dark colour appearance`)
+    await dialog.getByRole(`option`, { name: /dark color theme/i }).click()
+    await expect(page.locator(`html`)).toHaveAttribute(`data-theme`, `dark`)
+    await expect(theme_control).toHaveValue(`dark`)
+    await expect
+      .poll(() => page.evaluate(() => localStorage.getItem(`matterviz-theme`)))
+      .toBe(`dark`)
 
-      await search_input.fill(`${mode} colour appearance`)
-      await dialog
-        .getByRole(`option`, { name: new RegExp(`${mode} color theme`, `i`) })
-        .click()
-      await expect(html_element).toHaveAttribute(`data-theme`, mode)
-      await expect(theme_control).toHaveValue(mode)
-      await expect
-        .poll(() => page.evaluate(() => localStorage.getItem(`matterviz-theme`)))
-        .toBe(mode)
-    }
+    await page.keyboard.press(`Control+K`)
+    await expect(dialog).toBeVisible()
+    await dialog.getByRole(`combobox`, { name: menu_label }).fill(`white colour appearance`)
+    await dialog.getByRole(`option`, { name: /white color theme/i }).click()
+    await expect(page.locator(`html`)).toHaveAttribute(`data-theme`, `white`)
+    await expect(theme_control).toHaveValue(`white`)
+    await expect
+      .poll(() => page.evaluate(() => localStorage.getItem(`matterviz-theme`)))
+      .toBe(`white`)
   })
 
   test(`syntax highlighting colors follow app theme not OS preference`, async ({ page }) => {

--- a/tests/playwright/theme-control.test.ts
+++ b/tests/playwright/theme-control.test.ts
@@ -81,6 +81,25 @@ test.describe(`ThemeControl`, () => {
     }
   })
 
+  test(`changes color theme from the command menu`, async ({ page }) => {
+    const theme_control = await get_theme_control(page)
+    const html_element = page.locator(`html`)
+    const menu_label = `Search the MatterViz site`
+    const dialog = page.getByRole(`dialog`, { name: menu_label })
+    const search_input = dialog.getByRole(`combobox`, { name: menu_label })
+    const mode = `dark`
+
+    await expect(async () => {
+      await page.keyboard.press(`Control+K`)
+      await expect(dialog).toBeVisible({ timeout: 1500 })
+    }).toPass({ timeout: 15_000 })
+
+    await search_input.fill(`${mode} color mode`)
+    await dialog.getByRole(`option`, { name: new RegExp(`${mode} color theme`, `i`) }).click()
+    await expect(html_element).toHaveAttribute(`data-theme`, mode)
+    await expect(theme_control).toHaveValue(mode)
+  })
+
   test(`syntax highlighting colors follow app theme not OS preference`, async ({ page }) => {
     // Regression: starry-night gates its dark palette behind a prefers-color-scheme
     // media query; starry_night_theme_plugin (vite.config.ts) re-targets it to

--- a/tests/playwright/theme-control.test.ts
+++ b/tests/playwright/theme-control.test.ts
@@ -87,17 +87,22 @@ test.describe(`ThemeControl`, () => {
     const menu_label = `Search the MatterViz site`
     const dialog = page.getByRole(`dialog`, { name: menu_label })
     const search_input = dialog.getByRole(`combobox`, { name: menu_label })
-    const mode = `dark`
+    for (const mode of [`dark`, `white`] as const) {
+      await expect(async () => {
+        await page.keyboard.press(`Control+K`)
+        await expect(dialog).toBeVisible({ timeout: 1500 })
+      }).toPass({ timeout: 15_000 })
 
-    await expect(async () => {
-      await page.keyboard.press(`Control+K`)
-      await expect(dialog).toBeVisible({ timeout: 1500 })
-    }).toPass({ timeout: 15_000 })
-
-    await search_input.fill(`${mode} color mode`)
-    await dialog.getByRole(`option`, { name: new RegExp(`${mode} color theme`, `i`) }).click()
-    await expect(html_element).toHaveAttribute(`data-theme`, mode)
-    await expect(theme_control).toHaveValue(mode)
+      await search_input.fill(`${mode} colour appearance`)
+      await dialog
+        .getByRole(`option`, { name: new RegExp(`${mode} color theme`, `i`) })
+        .click()
+      await expect(html_element).toHaveAttribute(`data-theme`, mode)
+      await expect(theme_control).toHaveValue(mode)
+      await expect
+        .poll(() => page.evaluate(() => localStorage.getItem(`matterviz-theme`)))
+        .toBe(mode)
+    }
   })
 
   test(`syntax highlighting colors follow app theme not OS preference`, async ({ page }) => {

--- a/tests/vitest/BrillouinZoneControls.test.ts
+++ b/tests/vitest/BrillouinZoneControls.test.ts
@@ -1,0 +1,15 @@
+import { BrillouinZoneControls } from '$lib/brillouin'
+import { mount } from 'svelte'
+import { expect, test } from 'vitest'
+
+test(`Brillouin zone edge width readout preserves slider precision`, () => {
+  mount(BrillouinZoneControls, {
+    target: document.body,
+    props: { controls_open: true, edge_width: 0.019 },
+  })
+
+  const width_input = document.querySelector<HTMLInputElement>(
+    `input[type="range"][step="0.001"]`,
+  )
+  expect(width_input?.previousElementSibling?.textContent).toBe(`0.019`)
+})

--- a/tests/vitest/SettingsSection.test.svelte.ts
+++ b/tests/vitest/SettingsSection.test.svelte.ts
@@ -87,6 +87,7 @@ describe(`SettingsSection`, () => {
     ],
     [`equal regexps`, { setting1: /test/gi }, { setting1: /test/gi }, false],
     [`regexp change`, { setting1: /test/gi }, { setting1: /test/g }, true],
+    [`negative zero`, { setting1: 0 }, { setting1: -0 }, false],
     [`key addition`, { setting1: `a` }, { setting1: `a`, setting2: undefined }, true],
     [`key removal`, { setting1: `a`, setting2: undefined }, { setting1: `a` }, true],
   ]
@@ -114,9 +115,10 @@ describe(`SettingsSection`, () => {
   })
 
   test.each([
-    [`Set`, new SvelteSet([`a`])],
-    [`Map`, new SvelteMap([[`key`, `value`]])],
-  ])(`rejects %s-valued settings`, (_name, value) => {
+    [`Set`, new SvelteSet([`a`]), `must not contain Set or Map`],
+    [`Map`, new SvelteMap([[`key`, `value`]]), `must not contain Set or Map`],
+    [`custom-prototype`, Object.create({ inherited: true }), `must be plain objects`],
+  ])(`rejects %s-valued settings`, (_name, value, message) => {
     expect(() =>
       mount(SettingsSection, {
         target: document.body,
@@ -126,7 +128,7 @@ describe(`SettingsSection`, () => {
           children: snippet(`content`),
         },
       }),
-    ).toThrow(`must not contain Set or Map`)
+    ).toThrow(message)
   })
 
   test.each([
@@ -298,6 +300,22 @@ describe(`SettingsSection`, () => {
 
     await click(`.description-toggle`)
     expect(document.querySelectorAll(`.settings-row-description`)).toHaveLength(0)
+  })
+
+  test(`reveals caller-supplied row descriptions`, async () => {
+    mount(SettingsSection, {
+      target: document.body,
+      props: {
+        title: `Atoms`,
+        setting_metadata: {},
+        children: snippet(
+          `<label data-key="radius" data-description="Radius of rendered atoms"><span>Radius</span><input></label>`,
+        ),
+      },
+    })
+    await tick()
+
+    expect(document.querySelector(`.description-toggle`)).not.toBeNull()
   })
 
   test(`only offers descriptions mapped to rows in this section`, async () => {

--- a/tests/vitest/SettingsSection.test.svelte.ts
+++ b/tests/vitest/SettingsSection.test.svelte.ts
@@ -1,11 +1,15 @@
 import { SettingsSection } from '$lib'
-import { createRawSnippet, flushSync, mount, tick } from 'svelte'
+import { createRawSnippet, flushSync, mount, tick, type ComponentProps } from 'svelte'
 import { SvelteMap, SvelteSet } from 'svelte/reactivity'
 import { describe, expect, test } from 'vitest'
 import SettingsSectionRerenderHarness from './SettingsSectionRerenderHarness.svelte'
 
 const snippet = (content: string) => createRawSnippet(() => ({ render: () => content }))
 type SettingValues = Record<string, unknown>
+const mount_section = (
+  props: ComponentProps<typeof SettingsSection>,
+  target: HTMLElement = document.body,
+): void => void mount(SettingsSection, { target, props })
 const element = (selector: string, root: ParentNode = document): HTMLElement => {
   const match = root.querySelector<HTMLElement>(selector)
   if (!match) throw new Error(`Missing element: ${selector}`)
@@ -28,17 +32,14 @@ const mount_atoms = (
   reset_calls: [string, unknown, boolean][] = [],
 ): SettingValues => {
   const current_values = $state<SettingValues>({ ...initial })
-  mount(SettingsSection, {
-    target: document.body,
-    props: {
-      title: `Atoms`,
-      current_values,
-      children: atoms,
-      on_reset_key: (key: string, value: unknown, present: boolean) => {
-        reset_calls.push([key, value, present])
-        if (present) current_values[key] = value
-        else Reflect.deleteProperty(current_values, key)
-      },
+  mount_section({
+    title: `Atoms`,
+    current_values,
+    children: atoms,
+    on_reset_key: (key: string, value: unknown, present: boolean) => {
+      reset_calls.push([key, value, present])
+      if (present) current_values[key] = value
+      else Reflect.deleteProperty(current_values, key)
     },
   })
   return current_values
@@ -50,23 +51,15 @@ describe(`SettingsSection`, () => {
       [`Section A`, `Content A`],
       [`Section B`, `Content B`],
     ]) {
-      mount(SettingsSection, {
-        target: document.body,
-        props: { title, current_values: {}, children: snippet(content) },
-      })
+      mount_section({ title, children: snippet(content) })
     }
     const [heading_a, heading_b] = [...document.querySelectorAll(`h4`)]
     const [section_a, section_b] = [...document.querySelectorAll(`section`)]
-    expect([heading_a.textContent?.trim(), heading_b.textContent?.trim()]).toEqual([
+    expect([heading_a.textContent?.trim(), section_a.textContent?.trim()]).toEqual([
       `Section A`,
-      `Section B`,
-    ])
-    expect([section_a.textContent?.trim(), section_b.textContent?.trim()]).toEqual([
       `Content A`,
-      `Content B`,
     ])
     // ids are non-empty, unique, and each section points at its own heading
-    // (boolean assertion is oxlint-stable; --fix rewrites toBeTruthy() -> toBe(true))
     expect(heading_a.id.startsWith(`settings-section-title-`)).toBe(true)
     expect(heading_a.id).not.toBe(heading_b.id)
     expect(section_a.getAttribute(`aria-labelledby`)).toBe(heading_a.id)
@@ -74,15 +67,8 @@ describe(`SettingsSection`, () => {
   })
 
   const reset_cases: [string, SettingValues, SettingValues, boolean][] = [
-    [`equal arrays`, { setting1: [`a`, `b`] }, { setting1: [`a`, `b`] }, false],
     [`equal nested arrays`, { setting1: [{ key: 1 }] }, { setting1: [{ key: 1 }] }, false],
     [`equal empty arrays`, { setting1: [] }, { setting1: [] }, false],
-    [
-      `equal nullish values`,
-      { setting1: undefined, setting2: null },
-      { setting1: undefined, setting2: null },
-      false,
-    ],
     [`primitive change`, { setting1: `default` }, { setting1: `changed` }, true],
     [
       `object key insertion order`,
@@ -112,15 +98,12 @@ describe(`SettingsSection`, () => {
 
   test.each(reset_cases)(`reset button after %s`, (_name, initial, next, expect_reset) => {
     let current_values = $state<SettingValues>({ ...initial })
-    mount(SettingsSection, {
-      target: document.body,
-      props: {
-        title: `Test Settings`,
-        get current_values() {
-          return current_values
-        },
-        children: snippet(`content`),
+    mount_section({
+      title: `Test Settings`,
+      get current_values() {
+        return current_values
       },
+      children: snippet(`content`),
     })
     expect(document.querySelector(`.reset-button`)).toBeNull()
 
@@ -128,8 +111,7 @@ describe(`SettingsSection`, () => {
       current_values = { ...next }
     })
     const reset_button = document.querySelector<HTMLButtonElement>(`.reset-button`)
-    expect(Boolean(reset_button)).toBe(expect_reset)
-    if (expect_reset) expect(reset_button?.type).toBe(`button`)
+    expect(reset_button?.type).toBe(expect_reset ? `button` : undefined)
   })
 
   test.each([
@@ -138,13 +120,10 @@ describe(`SettingsSection`, () => {
     [`custom-prototype`, Object.create({ inherited: true }), `must be plain objects`],
   ])(`rejects %s-valued settings`, (_name, value, message) => {
     expect(() =>
-      mount(SettingsSection, {
-        target: document.body,
-        props: {
-          title: `Unsupported`,
-          current_values: { value },
-          children: snippet(`content`),
-        },
+      mount_section({
+        title: `Unsupported`,
+        current_values: { value },
+        children: snippet(`content`),
       }),
     ).toThrow(message)
   })
@@ -175,12 +154,10 @@ describe(`SettingsSection`, () => {
       Object.assign(current_values, change)
     })
     await tick()
-    const reset_buttons = document.querySelectorAll(`.setting-reset-button`)
-    expect(reset_buttons).toHaveLength(1)
-    const reset_button = document.querySelector<HTMLButtonElement>(
-      `[data-key="${key}"] .setting-reset-button`,
-    )
-    expect(reset_button?.getAttribute(`aria-label`)).toBe(`Reset ${key} to default`)
+    expect(document.querySelectorAll(`.setting-reset-button`)).toHaveLength(1)
+    expect(
+      element(`[data-key="${key}"] .setting-reset-button`).getAttribute(`aria-label`),
+    ).toBe(`Reset ${key} to default`)
     await click(`[data-key="${key}"] .setting-reset-button`)
 
     expect(reset_calls).toEqual([[key, reference_value, reference_present]])
@@ -201,20 +178,17 @@ describe(`SettingsSection`, () => {
     expect(document.querySelectorAll(`.setting-reset-button`)).toHaveLength(2)
 
     await click(`.reset-button`)
-    // has_changes drives both indicators, so the section button clearing itself is the invariant
     expect(document.querySelector(`.reset-button`)).toBeNull()
     expect(document.querySelector(`.setting-reset-button`)).toBeNull()
     expect(current_values).toEqual({ radius: 1, palette: `warm` })
   })
 
   test(`names unlabelled row controls and leaves author-named ones alone`, async () => {
-    mount(SettingsSection, {
-      target: document.body,
-      props: {
-        title: `Atoms`,
-        current_values: { radius: 1 },
-        setting_metadata: { radius: `Radius of rendered atoms` },
-        children: snippet(`
+    mount_section({
+      title: `Atoms`,
+      current_values: { radius: 1 },
+      setting_metadata: { radius: `Radius of rendered atoms` },
+      children: snippet(`
           <label data-key="radius">
             <span>Radius</span>
             <input type="number">
@@ -223,7 +197,6 @@ describe(`SettingsSection`, () => {
             <select aria-labelledby="somewhere-else"></select>
           </label>
         `),
-      },
     })
     await tick()
 
@@ -241,24 +214,21 @@ describe(`SettingsSection`, () => {
   })
 
   test(`reveals row descriptions and ignores metadata without a row`, async () => {
-    mount(SettingsSection, {
-      target: document.body,
-      props: {
-        title: `Pointer sensitivity`,
-        current_values: { rotate_speed: 1, rotation_damping: 0.1, radius: 1 },
-        setting_metadata: {
-          rotate_speed: { description: `Pointer rotation speed` },
-          rotation_damping: { description: `Motion inertia after releasing the pointer` },
-          unrelated: `Not rendered here`,
-        },
-        children: snippet(`
+    mount_section({
+      title: `Pointer sensitivity`,
+      current_values: { rotate_speed: 1, rotation_damping: 0.1, radius: 1 },
+      setting_metadata: {
+        rotate_speed: { description: `Pointer rotation speed` },
+        rotation_damping: { description: `Motion inertia after releasing the pointer` },
+        unrelated: `Not rendered here`,
+      },
+      children: snippet(`
           <div>
             <label data-key="rotate_speed"><span>Rotate speed</span><input></label>
             <label data-key="rotation_damping"><span>Damping</span><input></label>
             <label data-key="radius" data-description="Radius of rendered atoms"><span>Radius</span><input></label>
           </div>
         `),
-      },
     })
     await tick()
 
@@ -287,15 +257,15 @@ describe(`SettingsSection`, () => {
     expect(document.querySelectorAll(`.settings-row-description`)).toHaveLength(0)
     const unrelated_target = document.createElement(`div`)
     document.body.append(unrelated_target)
-    mount(SettingsSection, {
-      target: unrelated_target,
-      props: {
+    mount_section(
+      {
         title: `Unrelated metadata`,
         current_values: { diameter: 1 },
         setting_metadata: { unrelated: `Not rendered here` },
         children: snippet(`<label data-key="diameter"><span>Diameter</span><input></label>`),
       },
-    })
+      unrelated_target,
+    )
     await tick()
     // Prove the connected row was enhanced before checking that unrelated metadata is ignored.
     expect(element(`input`, unrelated_target).getAttribute(`data-auto-label`)).toBe(`Diameter`)

--- a/tests/vitest/SettingsSection.test.svelte.ts
+++ b/tests/vitest/SettingsSection.test.svelte.ts
@@ -66,32 +66,24 @@ describe(`SettingsSection`, () => {
     expect(section_b.getAttribute(`aria-labelledby`)).toBe(heading_b.id)
   })
 
-  const reset_cases: [string, SettingValues, SettingValues, boolean][] = [
-    [`equal nested arrays`, { setting1: [{ key: 1 }] }, { setting1: [{ key: 1 }] }, false],
-    [`equal empty arrays`, { setting1: [] }, { setting1: [] }, false],
-    [`primitive change`, { setting1: `default` }, { setting1: `changed` }, true],
-    [
-      `object key insertion order`,
-      { setting1: { a: 1, b: 2 } },
-      { setting1: { b: 2, a: 1 } },
-      false,
-    ],
-    [`nested change`, { setting1: { a: 1 } }, { setting1: { a: 2 } }, true],
-    [
-      `equal dates`,
-      { setting1: new Date(`2026-01-01`) },
-      { setting1: new Date(`2026-01-01`) },
-      false,
-    ],
-    [
-      `date change`,
-      { setting1: new Date(`2026-01-01`) },
-      { setting1: new Date(`2026-01-02`) },
-      true,
-    ],
-    [`equal regexps`, { setting1: /test/gi }, { setting1: /test/gi }, false],
-    [`regexp change`, { setting1: /test/gi }, { setting1: /test/g }, true],
-    [`negative zero`, { setting1: 0 }, { setting1: -0 }, false],
+  type ResetCase = [string, SettingValues, SettingValues, boolean]
+  const value_case = (
+    name: string,
+    initial: unknown,
+    next: unknown,
+    expect_reset: boolean,
+  ): ResetCase => [name, { setting1: initial }, { setting1: next }, expect_reset]
+  const reset_cases: ResetCase[] = [
+    value_case(`equal nested arrays`, [{ key: 1 }], [{ key: 1 }], false),
+    value_case(`equal empty arrays`, [], [], false),
+    value_case(`primitive change`, `default`, `changed`, true),
+    value_case(`object key insertion order`, { a: 1, b: 2 }, { b: 2, a: 1 }, false),
+    value_case(`nested change`, { a: 1 }, { a: 2 }, true),
+    value_case(`equal dates`, new Date(`2026-01-01`), new Date(`2026-01-01`), false),
+    value_case(`date change`, new Date(`2026-01-01`), new Date(`2026-01-02`), true),
+    value_case(`equal regexps`, /test/gi, /test/gi, false),
+    value_case(`regexp change`, /test/gi, /test/g, true),
+    value_case(`negative zero`, 0, -0, false),
     [`key addition`, { setting1: `a` }, { setting1: `a`, setting2: undefined }, true],
     [`key removal`, { setting1: `a`, setting2: undefined }, { setting1: `a` }, true],
   ]

--- a/tests/vitest/SettingsSection.test.svelte.ts
+++ b/tests/vitest/SettingsSection.test.svelte.ts
@@ -1,9 +1,30 @@
 import { SettingsSection } from '$lib'
-import { createRawSnippet, flushSync, mount } from 'svelte'
+import { createRawSnippet, flushSync, mount, tick } from 'svelte'
+import { SvelteMap, SvelteSet } from 'svelte/reactivity'
 import { describe, expect, test } from 'vitest'
+import SettingsSectionRerenderHarness from './SettingsSectionRerenderHarness.svelte'
 
 const snippet = (content: string) => createRawSnippet(() => ({ render: () => content }))
 type SettingValues = Record<string, unknown>
+const element = (selector: string, root: ParentNode = document): HTMLElement => {
+  const match = root.querySelector<HTMLElement>(selector)
+  if (!match) throw new Error(`Missing element: ${selector}`)
+  return match
+}
+const click = async (selector: string, root: ParentNode = document): Promise<void> => {
+  const button = element(selector, root)
+  button.click()
+  await tick()
+}
+const restore_key = (
+  values: SettingValues,
+  key: string,
+  value: unknown,
+  present: boolean,
+): SettingValues =>
+  present
+    ? { ...values, [key]: value }
+    : Object.fromEntries(Object.entries(values).filter(([entry_key]) => entry_key !== key))
 
 describe(`SettingsSection`, () => {
   test(`renders content with unique aria-labelledby targets`, () => {
@@ -87,6 +108,266 @@ describe(`SettingsSection`, () => {
     flushSync(() => {
       current_values = { ...next }
     })
-    expect(Boolean(document.querySelector(`.reset-button`))).toBe(expect_reset)
+    const reset_button = document.querySelector<HTMLButtonElement>(`.reset-button`)
+    expect(Boolean(reset_button)).toBe(expect_reset)
+    if (expect_reset) expect(reset_button?.type).toBe(`button`)
+  })
+
+  test.each([
+    [`Set`, new SvelteSet([`a`])],
+    [`Map`, new SvelteMap([[`key`, `value`]])],
+  ])(`rejects %s-valued settings`, (_name, value) => {
+    expect(() =>
+      mount(SettingsSection, {
+        target: document.body,
+        props: {
+          title: `Unsupported`,
+          current_values: { value },
+          children: snippet(`content`),
+        },
+      }),
+    ).toThrow(`must not contain Set or Map`)
+  })
+
+  test.each([
+    {
+      name: `existing key`,
+      initial: { radius: 1, palette: { colors: [`red`, `blue`] } },
+      change: { radius: 2 },
+      key: `radius`,
+      reference_value: 1,
+      reference_present: true,
+    },
+    {
+      name: `new key`,
+      initial: { radius: 1 },
+      change: { temporary: undefined },
+      key: `temporary`,
+      reference_value: undefined,
+      reference_present: false,
+    },
+  ])(`resets $name to its mounted state`, async (test_case) => {
+    const { initial, change, key, reference_value, reference_present } = test_case
+    let current_values = $state<SettingValues>({ ...initial })
+    const read_current_values = (): SettingValues => current_values
+    const reset_calls: [string, unknown, boolean][] = []
+    mount(SettingsSection, {
+      target: document.body,
+      props: {
+        title: `Atoms`,
+        get current_values() {
+          return current_values
+        },
+        children: snippet(`
+          <div>
+            <label data-key="radius"><span>Radius</span><input></label>
+            <label data-key="palette"><span>Palette</span><select></select></label>
+            <label data-key="temporary"><span>Temporary</span><input></label>
+          </div>
+        `),
+        on_reset_key: (reset_key: string, value: unknown, present: boolean) => {
+          reset_calls.push([reset_key, value, present])
+          current_values = restore_key(current_values, reset_key, value, present)
+        },
+      },
+    })
+
+    flushSync(() => {
+      current_values = { ...current_values, ...change }
+    })
+    await tick()
+    const reset_buttons = document.querySelectorAll(`.setting-reset-button`)
+    expect(reset_buttons).toHaveLength(1)
+    const reset_button = document.querySelector<HTMLButtonElement>(
+      `[data-key="${key}"] .setting-reset-button`,
+    )
+    expect(reset_button?.getAttribute(`aria-label`)).toBe(`Reset ${key} to default`)
+    await click(`[data-key="${key}"] .setting-reset-button`)
+
+    expect(reset_calls).toEqual([[key, reference_value, reference_present]])
+    expect(Object.hasOwn(read_current_values(), key)).toBe(reference_present)
+    if (reference_present) expect(read_current_values()[key]).toEqual(reference_value)
+    expect(document.querySelector(`.setting-reset-button`)).toBeNull()
+    expect(document.querySelector(`.reset-button`)).toBeNull()
+  })
+
+  test(`section reset without on_reset replays on_reset_key until nothing is changed`, async () => {
+    let current_values = $state<SettingValues>({ radius: 1, palette: `warm` })
+    const read_current_values = (): SettingValues => current_values
+    mount(SettingsSection, {
+      target: document.body,
+      props: {
+        title: `Atoms`,
+        get current_values() {
+          return current_values
+        },
+        children: snippet(`
+          <div>
+            <label data-key="radius"><span>Radius</span><input></label>
+            <label data-key="palette"><span>Palette</span><select></select></label>
+          </div>
+        `),
+        on_reset_key: (key: string, value: unknown, present: boolean) =>
+          (current_values = restore_key(current_values, key, value, present)),
+      },
+    })
+
+    flushSync(() => {
+      current_values = { radius: 5, palette: `cool`, extra: true }
+    })
+    await tick()
+    // `extra` has no row of its own, so only the two rendered rows get a per-row button
+    expect(document.querySelectorAll(`.setting-reset-button`)).toHaveLength(2)
+
+    await click(`.reset-button`)
+    // has_changes drives both indicators, so the section button clearing itself is the invariant
+    expect(document.querySelector(`.reset-button`)).toBeNull()
+    expect(document.querySelector(`.setting-reset-button`)).toBeNull()
+    expect(read_current_values()).toEqual({ radius: 1, palette: `warm` })
+  })
+
+  test(`names unlabelled row controls and leaves author-named ones alone`, async () => {
+    mount(SettingsSection, {
+      target: document.body,
+      props: {
+        title: `Atoms`,
+        current_values: { radius: 1 },
+        setting_metadata: { radius: `Radius of rendered atoms` },
+        children: snippet(`
+          <label data-key="radius">
+            <span>Radius</span>
+            <input type="number">
+            <input type="range">
+            <input type="text" aria-label="Author named">
+            <select aria-labelledby="somewhere-else"></select>
+          </label>
+        `),
+      },
+    })
+    await tick()
+
+    expect(
+      [...document.querySelectorAll(`input, select`)].map((control) => [
+        control.getAttribute(`aria-label`),
+        control.getAttribute(`data-auto-label`),
+      ]),
+    ).toEqual([
+      [`Radius`, `Radius`],
+      [`Radius`, `Radius`],
+      [`Author named`, null],
+      [null, null],
+    ])
+  })
+
+  test(`reveals mapped row descriptions with an accessible section toggle`, async () => {
+    mount(SettingsSection, {
+      target: document.body,
+      props: {
+        title: `Pointer sensitivity`,
+        current_values: { rotate_speed: 1, rotation_damping: 0.1 },
+        setting_metadata: {
+          rotate_speed: { description: `Pointer rotation speed` },
+          rotation_damping: { description: `Motion inertia after releasing the pointer` },
+        },
+        children: snippet(`
+          <div>
+            <label data-key="rotate_speed"><span>Rotate speed</span><input></label>
+            <label data-key="rotation_damping"><span>Damping</span><input></label>
+          </div>
+        `),
+      },
+    })
+    await tick()
+
+    const toggle = element(`.description-toggle`)
+    expect(toggle.getAttribute(`aria-expanded`)).toBe(`false`)
+    expect(document.querySelectorAll(`.settings-row-description`)).toHaveLength(0)
+    expect(
+      document
+        .querySelector(`[data-key="rotation_damping"]`)
+        ?.getAttribute(`data-description`),
+    ).toBe(`Motion inertia after releasing the pointer`)
+
+    await click(`.description-toggle`)
+    expect(toggle.getAttribute(`aria-expanded`)).toBe(`true`)
+    expect(
+      [...document.querySelectorAll(`.settings-row-description`)].map(
+        (description) => description.textContent,
+      ),
+    ).toEqual([`Pointer rotation speed`, `Motion inertia after releasing the pointer`])
+
+    await click(`.description-toggle`)
+    expect(document.querySelectorAll(`.settings-row-description`)).toHaveLength(0)
+  })
+
+  test(`only offers descriptions mapped to rows in this section`, async () => {
+    mount(SettingsSection, {
+      target: document.body,
+      props: {
+        title: `Atoms`,
+        current_values: { radius: 1 },
+        setting_metadata: { unrelated: `Not rendered here` },
+        children: snippet(`<label data-key="radius"><span>Radius</span><input></label>`),
+      },
+    })
+    await tick()
+    // Prove the connected row was enhanced before checking that unrelated metadata is ignored.
+    expect(element(`input`).getAttribute(`data-auto-label`)).toBe(`Radius`)
+    expect(document.querySelector(`.description-toggle`)).toBeNull()
+  })
+
+  const rerender_row = (): HTMLElement => element(`[data-generation]`)
+  const expect_enhanced_row = (description: string): void => {
+    const row = rerender_row()
+    expect(row.querySelector(`input`)?.getAttribute(`data-auto-label`)).toBe(`Radius`)
+    expect(row.querySelector(`.settings-row-description`)?.textContent).toBe(description)
+    expect(row.querySelectorAll(`.setting-reset-button`)).toHaveLength(1)
+  }
+
+  test(`enhances a replacement control nested in an existing row`, async () => {
+    mount(SettingsSectionRerenderHarness, { target: document.body })
+    await click(`[data-testid="change-dimensions"]`)
+    const reset_button = element(`.setting-reset-button`, rerender_row())
+    reset_button.focus()
+    const palette = element(`select`)
+    if (!(palette instanceof HTMLSelectElement)) throw new Error(`Palette select is missing`)
+    palette.value = `cool`
+    palette.dispatchEvent(new Event(`change`, { bubbles: true }))
+    await tick()
+    expect(document.activeElement).toBe(reset_button)
+    const previous_input = element(`input`, rerender_row())
+
+    await click(`[data-testid="replace-input"]`)
+    expect(element(`input`, rerender_row())).not.toBe(previous_input)
+    expect_enhanced_row(`Radius of rendered atoms`)
+  })
+
+  test(`refreshes dynamic keys and cleans up a remounted row`, async () => {
+    mount(SettingsSectionRerenderHarness, { target: document.body })
+    await click(`[data-testid="change-dimensions"]`)
+    await click(`[data-testid="change-key"]`)
+
+    expect(rerender_row().dataset.key).toBe(`diameter`)
+    expect(element(`.setting-reset-button`, rerender_row()).getAttribute(`aria-label`)).toBe(
+      `Reset diameter to default`,
+    )
+    expect_enhanced_row(`Diameter of rendered atoms`)
+    await click(`.setting-reset-button`, rerender_row())
+    expect(rerender_row().querySelector(`.setting-reset-button`)).toBeNull()
+    expect(document.querySelector(`.reset-button`)).not.toBeNull()
+
+    await click(`[data-testid="change-key"]`)
+    const previous_row = rerender_row()
+    const previous_input = element(`input`, previous_row)
+    await click(`[data-testid="replace-row"]`)
+
+    expect(rerender_row()).not.toBe(previous_row)
+    expect(previous_row.querySelector(`.settings-row-description`)).toBeNull()
+    expect(previous_row.querySelector(`.setting-reset-button`)).toBeNull()
+    expect([
+      previous_input.getAttribute(`aria-label`),
+      previous_input.getAttribute(`data-auto-label`),
+    ]).toEqual([null, null])
+    expect_enhanced_row(`Radius of rendered atoms`)
   })
 })

--- a/tests/vitest/SettingsSection.test.svelte.ts
+++ b/tests/vitest/SettingsSection.test.svelte.ts
@@ -16,15 +16,33 @@ const click = async (selector: string, root: ParentNode = document): Promise<voi
   button.click()
   await tick()
 }
-const restore_key = (
-  values: SettingValues,
-  key: string,
-  value: unknown,
-  present: boolean,
-): SettingValues =>
-  present
-    ? { ...values, [key]: value }
-    : Object.fromEntries(Object.entries(values).filter(([entry_key]) => entry_key !== key))
+const atoms = snippet(`
+  <div>
+    <label data-key="radius"><span>Radius</span><input></label>
+    <label data-key="palette"><span>Palette</span><select></select></label>
+    <label data-key="temporary"><span>Temporary</span><input></label>
+  </div>
+`)
+const mount_atoms = (
+  initial: SettingValues,
+  reset_calls: [string, unknown, boolean][] = [],
+): SettingValues => {
+  const current_values = $state<SettingValues>({ ...initial })
+  mount(SettingsSection, {
+    target: document.body,
+    props: {
+      title: `Atoms`,
+      current_values,
+      children: atoms,
+      on_reset_key: (key: string, value: unknown, present: boolean) => {
+        reset_calls.push([key, value, present])
+        if (present) current_values[key] = value
+        else Reflect.deleteProperty(current_values, key)
+      },
+    },
+  })
+  return current_values
+}
 
 describe(`SettingsSection`, () => {
   test(`renders content with unique aria-labelledby targets`, () => {
@@ -150,32 +168,11 @@ describe(`SettingsSection`, () => {
     },
   ])(`resets $name to its mounted state`, async (test_case) => {
     const { initial, change, key, reference_value, reference_present } = test_case
-    let current_values = $state<SettingValues>({ ...initial })
-    const read_current_values = (): SettingValues => current_values
     const reset_calls: [string, unknown, boolean][] = []
-    mount(SettingsSection, {
-      target: document.body,
-      props: {
-        title: `Atoms`,
-        get current_values() {
-          return current_values
-        },
-        children: snippet(`
-          <div>
-            <label data-key="radius"><span>Radius</span><input></label>
-            <label data-key="palette"><span>Palette</span><select></select></label>
-            <label data-key="temporary"><span>Temporary</span><input></label>
-          </div>
-        `),
-        on_reset_key: (reset_key: string, value: unknown, present: boolean) => {
-          reset_calls.push([reset_key, value, present])
-          current_values = restore_key(current_values, reset_key, value, present)
-        },
-      },
-    })
+    const current_values = mount_atoms(initial, reset_calls)
 
     flushSync(() => {
-      current_values = { ...current_values, ...change }
+      Object.assign(current_values, change)
     })
     await tick()
     const reset_buttons = document.querySelectorAll(`.setting-reset-button`)
@@ -187,35 +184,17 @@ describe(`SettingsSection`, () => {
     await click(`[data-key="${key}"] .setting-reset-button`)
 
     expect(reset_calls).toEqual([[key, reference_value, reference_present]])
-    expect(Object.hasOwn(read_current_values(), key)).toBe(reference_present)
-    if (reference_present) expect(read_current_values()[key]).toEqual(reference_value)
+    expect(Object.hasOwn(current_values, key)).toBe(reference_present)
+    if (reference_present) expect(current_values[key]).toEqual(reference_value)
     expect(document.querySelector(`.setting-reset-button`)).toBeNull()
     expect(document.querySelector(`.reset-button`)).toBeNull()
   })
 
   test(`section reset without on_reset replays on_reset_key until nothing is changed`, async () => {
-    let current_values = $state<SettingValues>({ radius: 1, palette: `warm` })
-    const read_current_values = (): SettingValues => current_values
-    mount(SettingsSection, {
-      target: document.body,
-      props: {
-        title: `Atoms`,
-        get current_values() {
-          return current_values
-        },
-        children: snippet(`
-          <div>
-            <label data-key="radius"><span>Radius</span><input></label>
-            <label data-key="palette"><span>Palette</span><select></select></label>
-          </div>
-        `),
-        on_reset_key: (key: string, value: unknown, present: boolean) =>
-          (current_values = restore_key(current_values, key, value, present)),
-      },
-    })
+    const current_values = mount_atoms({ radius: 1, palette: `warm` })
 
     flushSync(() => {
-      current_values = { radius: 5, palette: `cool`, extra: true }
+      Object.assign(current_values, { radius: 5, palette: `cool`, extra: true })
     })
     await tick()
     // `extra` has no row of its own, so only the two rendered rows get a per-row button
@@ -225,7 +204,7 @@ describe(`SettingsSection`, () => {
     // has_changes drives both indicators, so the section button clearing itself is the invariant
     expect(document.querySelector(`.reset-button`)).toBeNull()
     expect(document.querySelector(`.setting-reset-button`)).toBeNull()
-    expect(read_current_values()).toEqual({ radius: 1, palette: `warm` })
+    expect(current_values).toEqual({ radius: 1, palette: `warm` })
   })
 
   test(`names unlabelled row controls and leaves author-named ones alone`, async () => {
@@ -261,20 +240,22 @@ describe(`SettingsSection`, () => {
     ])
   })
 
-  test(`reveals mapped row descriptions with an accessible section toggle`, async () => {
+  test(`reveals row descriptions and ignores metadata without a row`, async () => {
     mount(SettingsSection, {
       target: document.body,
       props: {
         title: `Pointer sensitivity`,
-        current_values: { rotate_speed: 1, rotation_damping: 0.1 },
+        current_values: { rotate_speed: 1, rotation_damping: 0.1, radius: 1 },
         setting_metadata: {
           rotate_speed: { description: `Pointer rotation speed` },
           rotation_damping: { description: `Motion inertia after releasing the pointer` },
+          unrelated: `Not rendered here`,
         },
         children: snippet(`
           <div>
             <label data-key="rotate_speed"><span>Rotate speed</span><input></label>
             <label data-key="rotation_damping"><span>Damping</span><input></label>
+            <label data-key="radius" data-description="Radius of rendered atoms"><span>Radius</span><input></label>
           </div>
         `),
       },
@@ -296,42 +277,29 @@ describe(`SettingsSection`, () => {
       [...document.querySelectorAll(`.settings-row-description`)].map(
         (description) => description.textContent,
       ),
-    ).toEqual([`Pointer rotation speed`, `Motion inertia after releasing the pointer`])
+    ).toEqual([
+      `Pointer rotation speed`,
+      `Motion inertia after releasing the pointer`,
+      `Radius of rendered atoms`,
+    ])
 
     await click(`.description-toggle`)
     expect(document.querySelectorAll(`.settings-row-description`)).toHaveLength(0)
-  })
-
-  test(`reveals caller-supplied row descriptions`, async () => {
+    const unrelated_target = document.createElement(`div`)
+    document.body.append(unrelated_target)
     mount(SettingsSection, {
-      target: document.body,
+      target: unrelated_target,
       props: {
-        title: `Atoms`,
-        setting_metadata: {},
-        children: snippet(
-          `<label data-key="radius" data-description="Radius of rendered atoms"><span>Radius</span><input></label>`,
-        ),
-      },
-    })
-    await tick()
-
-    expect(document.querySelector(`.description-toggle`)).not.toBeNull()
-  })
-
-  test(`only offers descriptions mapped to rows in this section`, async () => {
-    mount(SettingsSection, {
-      target: document.body,
-      props: {
-        title: `Atoms`,
-        current_values: { radius: 1 },
+        title: `Unrelated metadata`,
+        current_values: { diameter: 1 },
         setting_metadata: { unrelated: `Not rendered here` },
-        children: snippet(`<label data-key="radius"><span>Radius</span><input></label>`),
+        children: snippet(`<label data-key="diameter"><span>Diameter</span><input></label>`),
       },
     })
     await tick()
     // Prove the connected row was enhanced before checking that unrelated metadata is ignored.
-    expect(element(`input`).getAttribute(`data-auto-label`)).toBe(`Radius`)
-    expect(document.querySelector(`.description-toggle`)).toBeNull()
+    expect(element(`input`, unrelated_target).getAttribute(`data-auto-label`)).toBe(`Diameter`)
+    expect(unrelated_target.querySelector(`.description-toggle`)).toBeNull()
   })
 
   const rerender_row = (): HTMLElement => element(`[data-generation]`)

--- a/tests/vitest/SettingsSectionRerenderHarness.svelte
+++ b/tests/vitest/SettingsSectionRerenderHarness.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+  import { SettingsSection } from '$lib'
+
+  let current_values = $state({ radius: 1, diameter: 2, palette: `warm` })
+  let generation = $state(0)
+  let input_generation = $state(0)
+  let row_key = $state<`radius` | `diameter`>(`radius`)
+  let descriptions_open = $state(true)
+</script>
+
+<button
+  type="button"
+  data-testid="change-dimensions"
+  onclick={() => {
+    current_values.radius = 2
+    current_values.diameter = 3
+  }}
+>
+  Change dimensions
+</button>
+<button type="button" data-testid="replace-row" onclick={() => (generation += 1)}>
+  Replace row
+</button>
+<button type="button" data-testid="replace-input" onclick={() => (input_generation += 1)}>
+  Replace input
+</button>
+<button
+  type="button"
+  data-testid="change-key"
+  onclick={() => (row_key = row_key === `radius` ? `diameter` : `radius`)}
+>
+  Change key
+</button>
+
+<SettingsSection
+  title="Atoms"
+  {current_values}
+  on_reset_key={(key, reference_value) => {
+    current_values = { ...current_values, [key]: reference_value }
+  }}
+  setting_metadata={{
+    radius: `Radius of rendered atoms`,
+    diameter: `Diameter of rendered atoms`,
+    palette: `Palette used for rendered atoms`,
+  }}
+  bind:descriptions_open
+  layout="grid"
+>
+  {#key generation}
+    <label data-key={row_key} data-generation={generation}>
+      <span>Radius</span>
+      {#key input_generation}
+        <input type="range" bind:value={current_values.radius} />
+      {/key}
+    </label>
+  {/key}
+  <label data-key="palette">
+    <span>Palette</span>
+    <select bind:value={current_values.palette}>
+      <option value="warm">Warm</option>
+      <option value="cool">Cool</option>
+    </select>
+  </label>
+</SettingsSection>

--- a/tests/vitest/brillouin-compute.test.ts
+++ b/tests/vitest/brillouin-compute.test.ts
@@ -662,21 +662,21 @@ describe(`scene sizing helpers`, () => {
       [`scales with padding`, cube, 2, 4 * Math.sqrt(3)],
       // the default padding must exceed the bare diameter or the zone touches the frame edge
       [
-        `pads to 85% of the shorter edge by default`,
+        `pads to 92% of the shorter edge by default`,
         cube,
         undefined,
-        (2 * Math.sqrt(3)) / 0.85,
+        (2 * Math.sqrt(3)) / 0.92,
       ],
       // Without vertices the zone is framed by the cell it is inscribed in: a cubic lattice of
       // side 4 gives a cell diagonal of 4*sqrt(3). Using 2*k_space_size = 8 instead would frame
-      // the zone at 74% of the edge and then jump 15% the moment the vertices arrive.
+      // the zone too loosely and then jump when the vertices arrive.
       [
         `falls back to the cell without vertices`,
         undefined,
         undefined,
-        (4 * Math.sqrt(3)) / 0.85,
+        (4 * Math.sqrt(3)) / 0.92,
       ],
-      [`falls back on empty vertices too`, [], undefined, (4 * Math.sqrt(3)) / 0.85],
+      [`falls back on empty vertices too`, [], undefined, (4 * Math.sqrt(3)) / 0.92],
     ] as [string, Vec3[] | undefined, number | undefined, number][])(
       `%s`,
       (_desc, vertices, padding, expected) =>
@@ -716,6 +716,6 @@ describe(`scene sizing helpers`, () => {
 
     // k_space_size has its own placeholder |b| when there is no reciprocal lattice either
     test(`falls back twice without a lattice`, () =>
-      expect(bz_fit_extent(undefined, undefined)).toBeCloseTo((Math.sqrt(3) * 10) / 0.85, 10))
+      expect(bz_fit_extent(undefined, undefined)).toBeCloseTo((Math.sqrt(3) * 10) / 0.92, 10))
   })
 })

--- a/tests/vitest/convex-hull/ConvexHullControls.test.ts
+++ b/tests/vitest/convex-hull/ConvexHullControls.test.ts
@@ -106,37 +106,35 @@ describe(`ConvexHullControls category filters (magnetic default)`, () => {
   // camera rows are data-driven per dimensionality: ternary tilts in degrees, quaternary in radians
   test.each([
     [
-      `ternary`,
       { elevation: 30.4, azimuth: -15.6, zoom: 1, center_x: 0, center_y: 0 },
       `Elev°|30|5|false;Azim°|-16|15|false`,
       `elevation`,
     ],
     [
-      `quaternary`,
       { rotation_x: 0.456, rotation_y: -0.123, zoom: 1, center_x: 0, center_y: 0 },
       `φ|0.46|0.1|true;θ|-0.12|0.1|false`,
       `rotation_x`,
     ],
-  ] as const)(`%s camera rows render and write back`, (_desc, camera, expected, key) => {
+  ] as const)(`camera rows render and write back`, (camera, expected, key) => {
     const state = { ...camera }
     mount_controls({ camera: state })
-    const rows = [...document.querySelectorAll<HTMLLabelElement>(`.setting label`)].filter(
-      (row) => expected.includes(row.querySelector(`span`)?.textContent ?? ``),
+    const camera_row = [...document.querySelectorAll<HTMLElement>(`.setting`)].find(
+      (row) => row.querySelector(`.control-label`)?.textContent === `Camera`,
     )
+    const inputs = [...(camera_row?.querySelectorAll<HTMLInputElement>(`input`) ?? [])]
     expect(
-      rows
-        .map((row) => {
-          const input = row.querySelector<HTMLInputElement>(`input[type="number"]`)
-          return [
-            row.textContent?.replaceAll(/\s/g, ``),
-            input?.value,
-            input?.step,
-            input?.hasAttribute(`min`),
-          ].join(`|`)
-        })
+      inputs
+        .map((input) =>
+          [
+            input.closest(`label`)?.textContent?.replaceAll(/\s/g, ``),
+            input.value,
+            input.step,
+            input.hasAttribute(`min`),
+          ].join(`|`),
+        )
         .join(`;`),
     ).toBe(expected)
-    const first_input = rows[0]?.querySelector<HTMLInputElement>(`input[type="number"]`)
+    const [first_input] = inputs
     if (!first_input) throw new Error(`missing ${expected.split(`|`)[0]} camera input`)
     first_input.value = `12`
     first_input.dispatchEvent(new Event(`input`, { bubbles: true }))

--- a/tests/vitest/convex-hull/ConvexHullControls.test.ts
+++ b/tests/vitest/convex-hull/ConvexHullControls.test.ts
@@ -1,10 +1,8 @@
-// Tests for ConvexHullControls category filter toggles (magnetic orderings by default)
 import ConvexHullControls from '$lib/convex-hull/ConvexHullControls.svelte'
 import { default_controls } from '$lib/convex-hull/index'
 import type { ConvexHullEntry } from '$lib/convex-hull/types'
-import type { ComponentProps } from 'svelte'
-import { flushSync, mount } from 'svelte'
-import { beforeEach, describe, expect, test } from 'vitest'
+import { flushSync, mount, type ComponentProps } from 'svelte'
+import { describe, expect, test } from 'vitest'
 
 const mag = (magnetic_ordering?: string): ConvexHullEntry => ({
   composition: { Fe: 1, O: 1 },
@@ -39,10 +37,6 @@ const press = (toggle: HTMLElement, key: string): KeyboardEvent => {
 }
 
 describe(`ConvexHullControls category filters (magnetic default)`, () => {
-  beforeEach(() => {
-    document.body.innerHTML = ``
-  })
-
   test(`hides category row when no entry has magnetic ordering data`, () => {
     mount_controls({ stable_entries: [mag()], unstable_entries: [mag()] })
     expect(document.querySelector(`.category-filters`)).toBeNull()

--- a/tests/vitest/convex-hull/ConvexHullControls.test.ts
+++ b/tests/vitest/convex-hull/ConvexHullControls.test.ts
@@ -103,6 +103,47 @@ describe(`ConvexHullControls category filters (magnetic default)`, () => {
     expect(fm_toggle.classList.contains(`inactive`)).toBe(expect_toggled)
   })
 
+  // camera rows are data-driven per dimensionality: ternary tilts in degrees, quaternary in radians
+  test.each([
+    [
+      `ternary`,
+      { elevation: 30.4, azimuth: -15.6, zoom: 1, center_x: 0, center_y: 0 },
+      `Elev°|30|5|false;Azim°|-16|15|false`,
+      `elevation`,
+    ],
+    [
+      `quaternary`,
+      { rotation_x: 0.456, rotation_y: -0.123, zoom: 1, center_x: 0, center_y: 0 },
+      `φ|0.46|0.1|true;θ|-0.12|0.1|false`,
+      `rotation_x`,
+    ],
+  ] as const)(`%s camera rows render and write back`, (_desc, camera, expected, key) => {
+    const state = { ...camera }
+    mount_controls({ camera: state })
+    const rows = [...document.querySelectorAll<HTMLLabelElement>(`.setting label`)].filter(
+      (row) => expected.includes(row.querySelector(`span`)?.textContent ?? ``),
+    )
+    expect(
+      rows
+        .map((row) => {
+          const input = row.querySelector<HTMLInputElement>(`input[type="number"]`)
+          return [
+            row.textContent?.replaceAll(/\s/g, ``),
+            input?.value,
+            input?.step,
+            input?.hasAttribute(`min`),
+          ].join(`|`)
+        })
+        .join(`;`),
+    ).toBe(expected)
+    const first_input = rows[0]?.querySelector<HTMLInputElement>(`input[type="number"]`)
+    if (!first_input) throw new Error(`missing ${expected.split(`|`)[0]} camera input`)
+    first_input.value = `12`
+    first_input.dispatchEvent(new Event(`input`, { bubbles: true }))
+    flushSync()
+    expect(state).toMatchObject({ [key]: 12 })
+  })
+
   test(`Space key also activates the stable/unstable legend toggles`, () => {
     mount_controls({ stable_entries: [mag()] })
     // Points row (stability mode) renders stable + unstable toggles outside .category-filters

--- a/tests/vitest/convex-hull/ConvexHullControls.test.ts
+++ b/tests/vitest/convex-hull/ConvexHullControls.test.ts
@@ -140,7 +140,9 @@ describe(`ConvexHullControls category filters (magnetic default)`, () => {
     if (!first_input) throw new Error(`missing ${expected.split(`|`)[0]} camera input`)
     first_input.value = `12`
     first_input.dispatchEvent(new Event(`input`, { bubbles: true }))
-    flushSync()
+    expect(state).toMatchObject({ [key]: 12 })
+    first_input.value = ``
+    first_input.dispatchEvent(new Event(`input`, { bubbles: true }))
     expect(state).toMatchObject({ [key]: 12 })
   })
 

--- a/tests/vitest/effects.test.svelte.ts
+++ b/tests/vitest/effects.test.svelte.ts
@@ -1,4 +1,5 @@
 import PulseAnimationHarness from './fixtures/PulseAnimationHarness.svelte'
+import { pulsing_highlight_opacity } from '$lib/effects.svelte'
 import { create_placed_tween } from '$lib/plot/core/placed-tween.svelte'
 import { flushSync, mount, unmount } from 'svelte'
 import { afterEach, describe, expect, test, vi } from 'vitest'
@@ -35,6 +36,14 @@ afterEach(() => {
 })
 
 describe(`create_pulse_animation`, () => {
+  test.each([
+    [0, 0.2],
+    [0.5, 0.275],
+    [1, 0.35],
+  ])(`keeps highlight opacity subtle at unit=%s`, (pulse_unit, expected) => {
+    expect(pulsing_highlight_opacity(pulse_unit)).toBeCloseTo(expected)
+  })
+
   test(`resets time and stops after on_tick deactivates synchronously`, () => {
     install_animation_frame_mock()
     const state = $state({ active: true })

--- a/tests/vitest/fermi-surface/FermiSurfaceControls.svelte.test.ts
+++ b/tests/vitest/fermi-surface/FermiSurfaceControls.svelte.test.ts
@@ -2,7 +2,7 @@ import FermiSurfaceControls from '$lib/fermi-surface/FermiSurfaceControls.svelte
 import type { ColorProperty, FermiSurfaceData } from '$lib/fermi-surface/types'
 import { mount, tick, unmount } from 'svelte'
 import { describe, expect, test } from 'vitest'
-import { bind_props } from '../setup'
+import { bind_props, doc_query } from '../setup'
 
 const make_fermi_data = (band_indices = [0, 1]): FermiSurfaceData => ({
   isosurfaces: band_indices.map((band_index) => ({
@@ -73,9 +73,36 @@ describe(`FermiSurfaceControls`, () => {
         await tick()
         expect(state.selected_bands).toEqual(expected_selected_bands)
         expect(state.color_property).toBe(expected_color_property)
+        if (initial_selected_bands === undefined && expected_selected_bands?.length) {
+          expect(
+            document.querySelector(`button[aria-label="Reset bands to defaults"]`),
+          ).toBeNull()
+        }
       } finally {
         await unmount(component)
       }
     },
   )
+
+  test(`tracks and resets the appearance color scale`, async () => {
+    const state = $state<{ color_property: ColorProperty; color_scale: string }>({
+      color_property: `velocity`,
+      color_scale: `interpolateViridis`,
+    })
+    const component = mount(FermiSurfaceControls, {
+      target: document.body,
+      props: bind_props({ controls_open: true, fermi_data: make_fermi_data() }, state),
+    })
+
+    try {
+      await tick()
+      state.color_scale = `interpolatePlasma`
+      await tick()
+      doc_query<HTMLButtonElement>(`button[aria-label="Reset appearance to defaults"]`).click()
+      await tick()
+      expect([state.color_property, state.color_scale]).toEqual([`band`, `interpolateViridis`])
+    } finally {
+      await unmount(component)
+    }
+  })
 })

--- a/tests/vitest/heatmap-matrix/HeatmapMatrixControls.test.ts
+++ b/tests/vitest/heatmap-matrix/HeatmapMatrixControls.test.ts
@@ -3,7 +3,7 @@ import { HeatmapMatrixControls, ORDERING_LABELS } from '$lib/heatmap-matrix'
 import type { ComponentProps } from 'svelte'
 import { mount, tick } from 'svelte'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
-import { doc_query } from '../setup'
+import { doc_query, expect_labelled_settings_grid } from '../setup'
 
 const mount_controls = (
   props: Partial<ComponentProps<typeof HeatmapMatrixControls>> = {},
@@ -40,6 +40,7 @@ describe(`HeatmapMatrixControls`, () => {
     expect(toggle.style.cssText).toContain(`pointer-events: none`)
     // Pane div has heatmap-controls class
     expect(doc_query(`.draggable-pane.heatmap-controls`)).toBeInstanceOf(HTMLElement)
+    expect_labelled_settings_grid()
     // Ordering select has all ordering options
     const ordering_select = doc_query<HTMLSelectElement>(`.heatmap-controls select`)
     const option_values = Array.from(ordering_select.options).map((opt) => opt.value)

--- a/tests/vitest/heatmap-matrix/HeatmapMatrixControls.test.ts
+++ b/tests/vitest/heatmap-matrix/HeatmapMatrixControls.test.ts
@@ -1,8 +1,7 @@
 import type { ElementAxisOrderingKey } from '$lib/heatmap-matrix'
 import { HeatmapMatrixControls, ORDERING_LABELS } from '$lib/heatmap-matrix'
-import type { ComponentProps } from 'svelte'
-import { mount, tick } from 'svelte'
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { mount, tick, type ComponentProps } from 'svelte'
+import { describe, expect, test, vi } from 'vitest'
 import { doc_query, expect_labelled_settings_grid } from '../setup'
 
 const mount_controls = (
@@ -22,26 +21,19 @@ const get_toggle = () =>
 
 // Find the legend position select by its option values (right/bottom)
 const find_position_select = () =>
-  Array.from(document.querySelectorAll(`.heatmap-controls select`)).find((sel) =>
-    (sel as HTMLSelectElement).querySelector(`option[value="right"]`),
-  ) as HTMLSelectElement | undefined
+  [...document.querySelectorAll<HTMLSelectElement>(`.heatmap-controls select`)].find(
+    (select) => select.querySelector(`option[value="right"]`),
+  )
 
 describe(`HeatmapMatrixControls`, () => {
-  beforeEach(() => {
-    document.body.innerHTML = ``
-  })
-
   test(`renders toggle, ordering options, and pane with correct classes`, () => {
     mount_controls()
-    // Toggle button present and initially hidden
     const toggle = get_toggle()
     expect(toggle).not.toBeNull()
     expect(toggle.style.cssText).toContain(`opacity: 0`)
     expect(toggle.style.cssText).toContain(`pointer-events: none`)
-    // Pane div has heatmap-controls class
     expect(doc_query(`.draggable-pane.heatmap-controls`)).toBeInstanceOf(HTMLElement)
     expect_labelled_settings_grid()
-    // Ordering select has all ordering options
     const ordering_select = doc_query<HTMLSelectElement>(`.heatmap-controls select`)
     const option_values = Array.from(ordering_select.options).map((opt) => opt.value)
     expect(option_values).toHaveLength(Object.keys(ORDERING_LABELS).length)
@@ -101,14 +93,12 @@ describe(`HeatmapMatrixControls`, () => {
 
   test(`normalize and domain selects present with correct options`, () => {
     mount_controls({ normalize: `log`, domain_mode: `robust` })
-    const selects = document.querySelectorAll(`.heatmap-controls select`)
-    const all_options = Array.from(selects).flatMap((sel) =>
-      Array.from((sel as HTMLSelectElement).options).map((opt) => opt.value),
+    const selects = document.querySelectorAll<HTMLSelectElement>(`.heatmap-controls select`)
+    const all_options = [...selects].flatMap((select) =>
+      [...select.options].map((option) => option.value),
     )
-    // Normalize options
     expect(all_options).toContain(`linear`)
     expect(all_options).toContain(`log`)
-    // Domain options
     expect(all_options).toContain(`auto`)
     expect(all_options).toContain(`robust`)
     expect(all_options).toContain(`fixed`)
@@ -119,7 +109,6 @@ describe(`HeatmapMatrixControls`, () => {
     await tick()
     expect(find_position_select()).toBeUndefined()
 
-    // Enable show_legend by clicking the checkbox
     const legend_checkbox = doc_query<HTMLInputElement>(
       `.heatmap-controls input[type="checkbox"]`,
     )
@@ -137,7 +126,6 @@ describe(`HeatmapMatrixControls`, () => {
     expect(buttons).toHaveLength(2)
     expect(buttons[0].textContent?.trim()).toBe(`Export CSV`)
     expect(buttons[1].textContent?.trim()).toBe(`Export JSON`)
-    // Click each and verify correct format passed
     buttons[0].click()
     expect(export_handler).toHaveBeenLastCalledWith(`csv`)
     buttons[1].click()

--- a/tests/vitest/isosurface/IsosurfaceControls.test.svelte.ts
+++ b/tests/vitest/isosurface/IsosurfaceControls.test.svelte.ts
@@ -8,7 +8,12 @@ import type {
 } from '$lib/isosurface/types'
 import { flushSync, mount } from 'svelte'
 import { describe, expect, test } from 'vitest'
-import { doc_query, make_grid, make_volume as make_volume_fixture } from '../setup'
+import {
+  doc_query,
+  expect_labelled_settings_grid,
+  make_grid,
+  make_volume as make_volume_fixture,
+} from '../setup'
 
 // Minimal VolumetricData fixture for testing controls (2x2x2 grid with values 1..8)
 const make_volume = (overrides?: Partial<VolumetricData>): VolumetricData =>
@@ -90,6 +95,9 @@ describe(`IsosurfaceControls`, () => {
       expect(document.querySelectorAll(`input[type="range"]`).length).toBeGreaterThanOrEqual(2)
       expect(doc_query(`.grid-info`).textContent).toContain(`2 × 2 × 2`)
       expect(find_label(`Layers`)?.querySelector(`select`)?.value).toBe(`1`)
+      if (!volumes) {
+        expect_labelled_settings_grid(document, { section_selector: `.isosurface-settings` })
+      }
 
       const vol_select = find_label(`Volume`)?.querySelector<HTMLSelectElement>(`select`)
       const color_by = find_label(`Color by`)?.querySelector<HTMLSelectElement>(`select`)
@@ -226,7 +234,7 @@ describe(`IsosurfaceControls multi-volume`, () => {
       `Color range minimum`,
       `Color range maximum`,
     ])
-    expect(document.querySelector(`.color-range`)?.textContent).toContain(`Range:`)
+    expect(document.querySelector(`.color-range`)?.textContent).toContain(`Range`)
     expect(Number(range_inputs[0].value)).toBe(-1)
     expect(Number(range_inputs[1].value)).toBe(1)
 

--- a/tests/vitest/layout/NumberRangeInput.svelte.test.ts
+++ b/tests/vitest/layout/NumberRangeInput.svelte.test.ts
@@ -48,4 +48,21 @@ describe(`NumberRangeInput`, () => {
     const untitled_range = untitled.querySelector<HTMLInputElement>(`input[type="range"]`)
     expect(untitled_range?.getAttribute(`aria-label`)).toBeNull()
   })
+
+  test(`puts the same explicit bounds on both inputs and forwards rest props`, () => {
+    const target = document.createElement(`div`)
+    mount(NumberRangeInput, {
+      target,
+      props: { min: 0.25, max: 1.25, step: 0.25, value: 0.5, 'data-key': `atom_radius` },
+    })
+
+    const inputs = [...target.querySelectorAll<HTMLInputElement>(`input`)]
+    expect(inputs.map(({ min, max, step }) => ({ min, max, step }))).toEqual([
+      { min: `0.25`, max: `1.25`, step: `0.25` },
+      { min: `0.25`, max: `1.25`, step: `0.25` },
+    ])
+    // a settings pane keys its per-row reset and search off data-key, so it has to land on
+    // the row element rather than being swallowed by the component
+    expect(target.querySelector(`label`)?.dataset.key).toBe(`atom_radius`)
+  })
 })

--- a/tests/vitest/layout/NumberRangeInput.svelte.test.ts
+++ b/tests/vitest/layout/NumberRangeInput.svelte.test.ts
@@ -39,6 +39,12 @@ describe(`NumberRangeInput`, () => {
     expect(state.value).toBe(0.3)
     expect(number.valueAsNumber).toBe(0.3)
 
+    number.value = ``
+    number.dispatchEvent(new Event(`input`, { bubbles: true }))
+    await tick()
+    expect(state.value).toBe(0.3)
+    expect(range.valueAsNumber).toBe(0.3)
+
     // without a title the range slider gets no aria-label (no "undefined"/empty attr)
     const untitled = document.createElement(`div`)
     mount(NumberRangeInput, {

--- a/tests/vitest/layout/SettingsSearch.test.svelte.ts
+++ b/tests/vitest/layout/SettingsSearch.test.svelte.ts
@@ -15,6 +15,12 @@ const set_query = async (input: HTMLInputElement, query: string): Promise<void> 
   await tick()
 }
 const settle_observer = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0))
+const atom_radius = `[data-key="atom_radius"]`
+const color_scheme = `[data-key="color_scheme"]`
+const rotation_damping = `[data-key="rotation_damping"]`
+const zoom_speed = `[data-key="zoom_speed"]`
+const sphere_segments = `[data-testid="sphere-segments"]`
+const nested_sphere_segments = `[data-testid="nested-sphere-segments"]`
 
 const mounted_search = async (): Promise<{
   input: HTMLInputElement
@@ -67,62 +73,32 @@ describe(`SettingsSearch`, () => {
   })
 
   test.each([
-    [
-      `labels`,
-      `radius`,
-      `[data-key="atom_radius"]`,
-      `[data-key="color_scheme"]`,
-      `appearance`,
-    ],
-    [
-      `descriptions`,
-      `motion inertia`,
-      `[data-key="rotation_damping"]`,
-      `[data-key="zoom_speed"]`,
-      `camera`,
-    ],
-    [
-      `unkeyed rows`,
-      `sphere`,
-      `[data-testid="sphere-segments"]`,
-      `[data-key="atom_radius"]`,
-      `appearance`,
-    ],
+    [`labels`, `radius`, atom_radius, color_scheme, `appearance`],
+    [`descriptions`, `motion inertia`, rotation_damping, zoom_speed, `camera`],
+    [`unkeyed rows`, `sphere`, sphere_segments, atom_radius, `appearance`],
     [
       `nested unkeyed rows`,
       `nested sphere`,
-      `[data-testid="nested-sphere-segments"]`,
-      `[data-key="atom_radius"]`,
+      nested_sphere_segments,
+      atom_radius,
       `appearance`,
     ],
     [
       `nested descriptions`,
       `fine tessellation`,
-      `[data-testid="nested-sphere-segments"]`,
-      `[data-key="atom_radius"]`,
+      nested_sphere_segments,
+      atom_radius,
       `appearance`,
     ],
     [
       `matched containers`,
       `nested control collection`,
-      `[data-testid="nested-sphere-segments"]`,
-      `[data-key="atom_radius"]`,
+      nested_sphere_segments,
+      atom_radius,
       `appearance`,
     ],
-    [
-      `section titles`,
-      `pointer sensitivity`,
-      `[data-key="rotation_damping"]`,
-      `[data-key="atom_radius"]`,
-      `camera`,
-    ],
-    [
-      `group titles`,
-      `camera`,
-      `[data-key="rotation_damping"]`,
-      `[data-key="atom_radius"]`,
-      `camera`,
-    ],
+    [`section titles`, `pointer sensitivity`, rotation_damping, atom_radius, `camera`],
+    [`group titles`, `camera`, rotation_damping, atom_radius, `camera`],
   ] as const)(`matches $0`, async (_name, query, matched, hidden_selector, group) => {
     const { input, appearance, camera } = await mounted_search()
     const matching_group = group === `appearance` ? appearance : camera
@@ -176,14 +152,14 @@ describe(`SettingsSearch`, () => {
 
   test(`preserves caller-hidden rows through idle refresh, search, and clear`, async () => {
     const { input, appearance, camera } = await mounted_search()
-    const zoom_speed = element(`[data-key="zoom_speed"]`)
+    const zoom_speed_row = element(zoom_speed)
     element(`[data-testid="hide-zoom-speed"]`).click()
     await tick()
 
     // Trigger the observer while idle: search must not replay a stale visibility baseline.
-    element(`[data-key="rotation_damping"]`).append(document.createComment(``))
+    element(rotation_damping).append(document.createComment(``))
     await settle_observer()
-    expect(zoom_speed.hidden).toBe(true)
+    expect(zoom_speed_row.hidden).toBe(true)
 
     await set_query(input, `zoom speed`)
     expect([hidden(appearance), hidden(camera)]).toEqual([true, true])
@@ -193,7 +169,7 @@ describe(`SettingsSearch`, () => {
     await tick()
     expect(document.querySelector(`input[type="search"]`)).toBeNull()
     expect(document.querySelector(`[role="status"]`)).toBeNull()
-    expect(zoom_speed.hidden).toBe(true)
+    expect(zoom_speed_row.hidden).toBe(true)
   })
 
   test(`refreshes matches when caller visibility or text changes`, async () => {
@@ -211,7 +187,7 @@ describe(`SettingsSearch`, () => {
     expect(hidden(appearance)).toBe(false)
 
     await set_query(input, `renamed radius`)
-    const radius_text = element(`[data-key="atom_radius"] span`).firstChild
+    const radius_text = element(`${atom_radius} span`).firstChild
     if (!radius_text) throw new Error(`Atom radius text node is missing`)
     radius_text.textContent = `Renamed radius`
     await settle_observer()
@@ -220,15 +196,15 @@ describe(`SettingsSearch`, () => {
 
   test(`preserves a caller-hidden row changed during search`, async () => {
     const { input } = await mounted_search()
-    const zoom_speed = element(`[data-key="zoom_speed"]`)
+    const zoom_speed_row = element(zoom_speed)
     await set_query(input, `damping`)
     element(`[data-testid="hide-zoom-speed"]`).click()
     await tick()
 
     await set_query(input, `zoom speed`)
-    expect(zoom_speed.hidden).toBe(true)
+    expect(zoom_speed_row.hidden).toBe(true)
     await set_query(input, ``)
-    expect(zoom_speed.hidden).toBe(true)
+    expect(zoom_speed_row.hidden).toBe(true)
   })
 
   test(`keeps its mutation observer while the query changes`, async () => {

--- a/tests/vitest/layout/SettingsSearch.test.svelte.ts
+++ b/tests/vitest/layout/SettingsSearch.test.svelte.ts
@@ -1,5 +1,5 @@
 import { mount, tick } from 'svelte'
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import SettingsSearchHarness from './SettingsSearchHarness.svelte'
 
 const element = (selector: string): HTMLElement => {
@@ -61,6 +61,27 @@ describe(`SettingsSearch`, () => {
       `[data-key="atom_radius"]`,
       `appearance`,
     ],
+    [
+      `matched containers`,
+      `nested control collection`,
+      `[data-testid="nested-sphere-segments"]`,
+      `[data-key="atom_radius"]`,
+      `appearance`,
+    ],
+    [
+      `section titles`,
+      `pointer sensitivity`,
+      `[data-key="rotation_damping"]`,
+      `[data-key="atom_radius"]`,
+      `camera`,
+    ],
+    [
+      `group titles`,
+      `camera`,
+      `[data-key="rotation_damping"]`,
+      `[data-key="atom_radius"]`,
+      `camera`,
+    ],
   ] as const)(`matches $0`, async (_name, query, matched, hidden_selector, group) => {
     const { input, appearance, camera } = await mounted_search()
     const matching_group = group === `appearance` ? appearance : camera
@@ -72,6 +93,18 @@ describe(`SettingsSearch`, () => {
     if (_name.includes(`unkeyed`))
       expect(element(matched).hasAttribute(`data-key`)).toBe(false)
   })
+
+  // Section headings carry Explain/Reset buttons. Folding a heading into its rows' search text
+  // must not drag those labels along, or either word would match every row in the section.
+  test.each([[`explain`], [`reset`]])(
+    `treats the %s heading button as chrome, not searchable text`,
+    async (query) => {
+      const { input, appearance, camera } = await mounted_search()
+      await set_query(input, query)
+      expect([hidden(appearance), hidden(camera)]).toEqual([true, true])
+      expect(document.body.textContent).toContain(`No settings match`)
+    },
+  )
 
   test.each([
     [`default states via Escape`, true, false, `damping`, `damp`, true],
@@ -133,5 +166,18 @@ describe(`SettingsSearch`, () => {
     expect(zoom_speed.hidden).toBe(true)
     await set_query(input, ``)
     expect(zoom_speed.hidden).toBe(true)
+  })
+
+  test(`keeps its mutation observer while the query changes`, async () => {
+    const { input } = await mounted_search()
+    const disconnect = vi.spyOn(MutationObserver.prototype, `disconnect`)
+    try {
+      await set_query(input, `radius`)
+      await set_query(input, `damping`)
+      await set_query(input, ``)
+      expect(disconnect).not.toHaveBeenCalled()
+    } finally {
+      disconnect.mockRestore()
+    }
   })
 })

--- a/tests/vitest/layout/SettingsSearch.test.svelte.ts
+++ b/tests/vitest/layout/SettingsSearch.test.svelte.ts
@@ -53,6 +53,19 @@ describe(`SettingsSearch`, () => {
     expect(document.activeElement).toBe(element(`.open-search`))
   })
 
+  test(`preserves focus when mounted with a prefilled query`, async () => {
+    const focus_target = document.createElement(`button`)
+    document.body.append(focus_target)
+    focus_target.focus()
+    mount(SettingsSearchHarness, { target: document.body, props: { query: `radius` } })
+    await tick()
+
+    expect(document.querySelector<HTMLInputElement>(`input[type="search"]`)?.value).toBe(
+      `radius`,
+    )
+    expect(document.activeElement).toBe(focus_target)
+  })
+
   test.each([
     [
       `labels`,

--- a/tests/vitest/layout/SettingsSearch.test.svelte.ts
+++ b/tests/vitest/layout/SettingsSearch.test.svelte.ts
@@ -1,0 +1,137 @@
+import { mount, tick } from 'svelte'
+import { describe, expect, test } from 'vitest'
+import SettingsSearchHarness from './SettingsSearchHarness.svelte'
+
+const element = (selector: string): HTMLElement => {
+  const match = document.querySelector<HTMLElement>(selector)
+  if (!match) throw new Error(`Missing element: ${selector}`)
+  return match
+}
+const hidden = (node: HTMLElement): boolean =>
+  Boolean(node.hidden) || node.hasAttribute(`data-search-hidden`)
+const set_query = async (input: HTMLInputElement, query: string): Promise<void> => {
+  input.value = query
+  input.dispatchEvent(new Event(`input`, { bubbles: true }))
+  await tick()
+}
+
+const mounted_search = async (): Promise<{
+  input: HTMLInputElement
+  appearance: HTMLDetailsElement
+  camera: HTMLDetailsElement
+}> => {
+  mount(SettingsSearchHarness, { target: document.body })
+  await tick()
+  const input = document.querySelector<HTMLInputElement>(`input[type="search"]`)
+  const [appearance, camera] = [
+    ...document.querySelectorAll<HTMLDetailsElement>(`details.settings-group`),
+  ]
+  if (!input || !appearance || !camera)
+    throw new Error(`Settings search harness failed to mount`)
+  return { input, appearance, camera }
+}
+
+describe(`SettingsSearch`, () => {
+  test.each([
+    [
+      `labels`,
+      `radius`,
+      `[data-key="atom_radius"]`,
+      `[data-key="color_scheme"]`,
+      `appearance`,
+    ],
+    [
+      `descriptions`,
+      `motion inertia`,
+      `[data-key="rotation_damping"]`,
+      `[data-key="zoom_speed"]`,
+      `camera`,
+    ],
+    [
+      `unkeyed rows`,
+      `sphere`,
+      `[data-testid="sphere-segments"]`,
+      `[data-key="atom_radius"]`,
+      `appearance`,
+    ],
+    [
+      `nested unkeyed rows`,
+      `nested sphere`,
+      `[data-testid="nested-sphere-segments"]`,
+      `[data-key="atom_radius"]`,
+      `appearance`,
+    ],
+  ] as const)(`matches $0`, async (_name, query, matched, hidden_selector, group) => {
+    const { input, appearance, camera } = await mounted_search()
+    const matching_group = group === `appearance` ? appearance : camera
+    const other_group = group === `appearance` ? camera : appearance
+
+    await set_query(input, query)
+    expect([hidden(matching_group), hidden(other_group)]).toEqual([false, true])
+    expect([hidden(element(matched)), hidden(element(hidden_selector))]).toEqual([false, true])
+    if (_name.includes(`unkeyed`))
+      expect(element(matched).hasAttribute(`data-key`)).toBe(false)
+  })
+
+  test.each([
+    [`default states via Escape`, true, false, `damping`, `damp`, true],
+    [`caller choices via query clear`, false, true, `radius`, `radiu`, false],
+  ] as const)(
+    `restores $0`,
+    async (_name, appearance_open, camera_open, query, continued_query, escape) => {
+      const { input, appearance, camera } = await mounted_search()
+      appearance.open = appearance_open
+      camera.open = camera_open
+      const matched_group = query === `damping` ? camera : appearance
+
+      await set_query(input, query)
+      await set_query(input, continued_query)
+      expect(matched_group.open).toBe(true)
+      if (escape) {
+        input.dispatchEvent(
+          new KeyboardEvent(`keydown`, { key: `Escape`, bubbles: true, cancelable: true }),
+        )
+        await tick()
+      } else await set_query(input, ``)
+
+      expect(input.value).toBe(``)
+      expect([appearance.open, camera.open]).toEqual([appearance_open, camera_open])
+      expect([hidden(appearance), hidden(camera)]).toEqual([false, false])
+    },
+  )
+
+  test(`preserves caller-hidden rows through idle refresh, search, and clear`, async () => {
+    const { input, appearance, camera } = await mounted_search()
+    const zoom_speed = element(`[data-key="zoom_speed"]`)
+    element(`[data-testid="hide-zoom-speed"]`).click()
+    await tick()
+
+    // Trigger the observer while idle: search must not replay a stale visibility baseline.
+    element(`[data-key="rotation_damping"]`).append(document.createComment(``))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(zoom_speed.hidden).toBe(true)
+
+    await set_query(input, `zoom speed`)
+    expect([hidden(appearance), hidden(camera)]).toEqual([true, true])
+    expect(element(`[role="status"]`).textContent).toContain(`No settings match “zoom speed”.`)
+
+    element(`.clear-search`).click()
+    await tick()
+    expect(input.value).toBe(``)
+    expect(document.querySelector(`[role="status"]`)).toBeNull()
+    expect(zoom_speed.hidden).toBe(true)
+  })
+
+  test(`preserves a caller-hidden row changed during search`, async () => {
+    const { input } = await mounted_search()
+    const zoom_speed = element(`[data-key="zoom_speed"]`)
+    await set_query(input, `damping`)
+    element(`[data-testid="hide-zoom-speed"]`).click()
+    await tick()
+
+    await set_query(input, `zoom speed`)
+    expect(zoom_speed.hidden).toBe(true)
+    await set_query(input, ``)
+    expect(zoom_speed.hidden).toBe(true)
+  })
+})

--- a/tests/vitest/layout/SettingsSearch.test.svelte.ts
+++ b/tests/vitest/layout/SettingsSearch.test.svelte.ts
@@ -22,6 +22,8 @@ const mounted_search = async (): Promise<{
 }> => {
   mount(SettingsSearchHarness, { target: document.body })
   await tick()
+  element(`.open-search`).click()
+  await tick()
   const input = document.querySelector<HTMLInputElement>(`input[type="search"]`)
   const [appearance, camera] = [
     ...document.querySelectorAll<HTMLDetailsElement>(`details.settings-group`),
@@ -32,6 +34,24 @@ const mounted_search = async (): Promise<{
 }
 
 describe(`SettingsSearch`, () => {
+  test(`expands from an icon, focuses the field, and collapses on Escape`, async () => {
+    mount(SettingsSearchHarness, { target: document.body })
+    await tick()
+    expect(document.querySelector(`input[type="search"]`)).toBeNull()
+
+    element(`.open-search`).click()
+    await tick()
+    const input = document.querySelector<HTMLInputElement>(`input[type="search"]`)
+    expect(document.activeElement).toBe(input)
+
+    input?.dispatchEvent(
+      new KeyboardEvent(`keydown`, { key: `Escape`, bubbles: true, cancelable: true }),
+    )
+    await tick()
+    expect(document.querySelector(`input[type="search"]`)).toBeNull()
+    expect(document.querySelector(`.open-search`)).not.toBeNull()
+  })
+
   test.each([
     [
       `labels`,
@@ -127,7 +147,7 @@ describe(`SettingsSearch`, () => {
         await tick()
       } else await set_query(input, ``)
 
-      expect(input.value).toBe(``)
+      expect(document.querySelector(`.open-search`)).not.toBeNull()
       expect([appearance.open, camera.open]).toEqual([appearance_open, camera_open])
       expect([hidden(appearance), hidden(camera)]).toEqual([false, false])
     },
@@ -150,7 +170,7 @@ describe(`SettingsSearch`, () => {
 
     element(`.clear-search`).click()
     await tick()
-    expect(input.value).toBe(``)
+    expect(document.querySelector(`input[type="search"]`)).toBeNull()
     expect(document.querySelector(`[role="status"]`)).toBeNull()
     expect(zoom_speed.hidden).toBe(true)
   })

--- a/tests/vitest/layout/SettingsSearch.test.svelte.ts
+++ b/tests/vitest/layout/SettingsSearch.test.svelte.ts
@@ -8,12 +8,13 @@ const element = (selector: string): HTMLElement => {
   return match
 }
 const hidden = (node: HTMLElement): boolean =>
-  Boolean(node.hidden) || node.hasAttribute(`data-search-hidden`)
+  Boolean(node.closest(`[hidden], [data-search-hidden]`))
 const set_query = async (input: HTMLInputElement, query: string): Promise<void> => {
   input.value = query
   input.dispatchEvent(new Event(`input`, { bubbles: true }))
   await tick()
 }
+const settle_observer = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0))
 
 const mounted_search = async (): Promise<{
   input: HTMLInputElement
@@ -49,7 +50,7 @@ describe(`SettingsSearch`, () => {
     )
     await tick()
     expect(document.querySelector(`input[type="search"]`)).toBeNull()
-    expect(document.querySelector(`.open-search`)).not.toBeNull()
+    expect(document.activeElement).toBe(element(`.open-search`))
   })
 
   test.each([
@@ -77,6 +78,13 @@ describe(`SettingsSearch`, () => {
     [
       `nested unkeyed rows`,
       `nested sphere`,
+      `[data-testid="nested-sphere-segments"]`,
+      `[data-key="atom_radius"]`,
+      `appearance`,
+    ],
+    [
+      `nested descriptions`,
+      `fine tessellation`,
       `[data-testid="nested-sphere-segments"]`,
       `[data-key="atom_radius"]`,
       `appearance`,
@@ -161,7 +169,7 @@ describe(`SettingsSearch`, () => {
 
     // Trigger the observer while idle: search must not replay a stale visibility baseline.
     element(`[data-key="rotation_damping"]`).append(document.createComment(``))
-    await new Promise((resolve) => setTimeout(resolve, 0))
+    await settle_observer()
     expect(zoom_speed.hidden).toBe(true)
 
     await set_query(input, `zoom speed`)
@@ -173,6 +181,28 @@ describe(`SettingsSearch`, () => {
     expect(document.querySelector(`input[type="search"]`)).toBeNull()
     expect(document.querySelector(`[role="status"]`)).toBeNull()
     expect(zoom_speed.hidden).toBe(true)
+  })
+
+  test(`refreshes matches when caller visibility or text changes`, async () => {
+    const { input, appearance } = await mounted_search()
+    const parent_row = element(`[data-key="sphere-container"]`)
+    await set_query(input, `fine tessellation`)
+
+    parent_row.hidden = true
+    await settle_observer()
+    expect(hidden(appearance)).toBe(true)
+    expect(document.querySelector(`[role="status"]`)).not.toBeNull()
+
+    parent_row.hidden = false
+    await settle_observer()
+    expect(hidden(appearance)).toBe(false)
+
+    await set_query(input, `renamed radius`)
+    const radius_text = element(`[data-key="atom_radius"] span`).firstChild
+    if (!radius_text) throw new Error(`Atom radius text node is missing`)
+    radius_text.textContent = `Renamed radius`
+    await settle_observer()
+    expect(hidden(appearance)).toBe(false)
   })
 
   test(`preserves a caller-hidden row changed during search`, async () => {

--- a/tests/vitest/layout/SettingsSearchHarness.svelte
+++ b/tests/vitest/layout/SettingsSearchHarness.svelte
@@ -27,7 +27,10 @@
         <span>Sphere segments</span><input type="number" />
       </label>
       <div data-key="sphere-container" data-description="Nested control collection">
-        <label data-testid="nested-sphere-segments">
+        <label
+          data-testid="nested-sphere-segments"
+          data-description="Fine tessellation setting"
+        >
           <span>Nested sphere segments</span><input type="number" />
         </label>
       </div>

--- a/tests/vitest/layout/SettingsSearchHarness.svelte
+++ b/tests/vitest/layout/SettingsSearchHarness.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+  import { SettingsGroup, SettingsSearch, SettingsSection } from '$lib'
+
+  let appearance_open = $state(true)
+  let camera_open = $state(false)
+  let zoom_speed_hidden = $state(false)
+</script>
+
+<button type="button" data-testid="hide-zoom-speed" onclick={() => (zoom_speed_hidden = true)}>
+  Hide zoom speed
+</button>
+
+<SettingsSearch>
+  <SettingsGroup title="Appearance" class="appearance-group" bind:open={appearance_open}>
+    <SettingsSection
+      title="Atoms"
+      current_values={{ atom_radius: 1, color_scheme: `Vesta` }}
+      setting_metadata={{
+        atom_radius: { description: `Radius multiplier for rendered atoms` },
+        color_scheme: { description: `Element color palette` },
+      }}
+    >
+      <label data-key="atom_radius"><span>Atom radius</span><input type="range" /></label>
+      <label data-key="color_scheme" hidden><span>Color scheme</span><select></select></label>
+      <!-- no data-key: nothing resets it individually, but search must still find it -->
+      <label data-testid="sphere-segments">
+        <span>Sphere segments</span><input type="number" />
+      </label>
+      <div>
+        <label data-testid="nested-sphere-segments">
+          <span>Nested sphere segments</span><input type="number" />
+        </label>
+      </div>
+    </SettingsSection>
+  </SettingsGroup>
+  <SettingsGroup title="Camera" bind:open={camera_open}>
+    <SettingsSection
+      title="Pointer sensitivity"
+      current_values={{ rotation_damping: 0.1, zoom_speed: 1 }}
+      setting_metadata={{
+        rotation_damping: { description: `Motion inertia after releasing the pointer` },
+        zoom_speed: { description: `Pointer wheel zoom sensitivity` },
+      }}
+    >
+      <label data-key="rotation_damping"><span>Damping</span><input type="range" /></label>
+      <label data-key="zoom_speed" hidden={zoom_speed_hidden}>
+        <span>Zoom speed</span><input type="range" />
+      </label>
+    </SettingsSection>
+  </SettingsGroup>
+</SettingsSearch>

--- a/tests/vitest/layout/SettingsSearchHarness.svelte
+++ b/tests/vitest/layout/SettingsSearchHarness.svelte
@@ -26,7 +26,7 @@
       <label data-testid="sphere-segments">
         <span>Sphere segments</span><input type="number" />
       </label>
-      <div>
+      <div data-key="sphere-container" data-description="Nested control collection">
         <label data-testid="nested-sphere-segments">
           <span>Nested sphere segments</span><input type="number" />
         </label>

--- a/tests/vitest/layout/SettingsSearchHarness.svelte
+++ b/tests/vitest/layout/SettingsSearchHarness.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { SettingsGroup, SettingsSearch, SettingsSection } from '$lib'
 
+  let { query = $bindable(``) }: { query?: string } = $props()
   let appearance_open = $state(true)
   let camera_open = $state(false)
   let zoom_speed_hidden = $state(false)
@@ -10,7 +11,7 @@
   Hide zoom speed
 </button>
 
-<SettingsSearch>
+<SettingsSearch bind:query>
   <SettingsGroup title="Appearance" class="appearance-group" bind:open={appearance_open}>
     <SettingsSection
       title="Atoms"

--- a/tests/vitest/layout/SettingsSearchHarness.svelte
+++ b/tests/vitest/layout/SettingsSearchHarness.svelte
@@ -15,10 +15,9 @@
   <SettingsGroup title="Appearance" class="appearance-group" bind:open={appearance_open}>
     <SettingsSection
       title="Atoms"
-      current_values={{ atom_radius: 1, color_scheme: `Vesta` }}
       setting_metadata={{
-        atom_radius: { description: `Radius multiplier for rendered atoms` },
-        color_scheme: { description: `Element color palette` },
+        atom_radius: `Radius multiplier for rendered atoms`,
+        color_scheme: `Element color palette`,
       }}
     >
       <label data-key="atom_radius"><span>Atom radius</span><input type="range" /></label>
@@ -40,10 +39,9 @@
   <SettingsGroup title="Camera" bind:open={camera_open}>
     <SettingsSection
       title="Pointer sensitivity"
-      current_values={{ rotation_damping: 0.1, zoom_speed: 1 }}
       setting_metadata={{
-        rotation_damping: { description: `Motion inertia after releasing the pointer` },
-        zoom_speed: { description: `Pointer wheel zoom sensitivity` },
+        rotation_damping: `Motion inertia after releasing the pointer`,
+        zoom_speed: `Pointer wheel zoom sensitivity`,
       }}
     >
       <label data-key="rotation_damping"><span>Damping</span><input type="range" /></label>

--- a/tests/vitest/periodic-table/PeriodicTable.test.svelte.ts
+++ b/tests/vitest/periodic-table/PeriodicTable.test.svelte.ts
@@ -1,7 +1,9 @@
 import type { ChemicalElement, ElementCategory } from '$lib'
-import { element_data, PeriodicTable, PropertySelect } from '$lib'
+import { element_data, PeriodicTable, PeriodicTableControls, PropertySelect } from '$lib'
+import { DEFAULT_CATEGORY_COLORS } from '$lib/colors'
 import { CATEGORY_COUNTS, ELEM_HEATMAP_LABELS } from '$lib/labels'
 import type { Vec2 } from '$lib/math'
+import { colors, selected } from '$lib/state.svelte'
 import { createRawSnippet, mount, tick } from 'svelte'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import { doc_query } from '../setup'
@@ -13,6 +15,8 @@ describe(`PeriodicTable`, () => {
   afterEach(() => {
     // Restore console.error if it was mocked
     vi.restoreAllMocks()
+    selected.category = null
+    Object.assign(colors.category, DEFAULT_CATEGORY_COLORS)
   })
   test.each([
     [true, 120],
@@ -34,6 +38,53 @@ describe(`PeriodicTable`, () => {
     element_tile?.dispatchEvent(mouseleave)
     await tick()
     expect(Array.from(element_tile.classList)).not.toContain(`active`)
+  })
+
+  test(`category color input focus updates the selected category`, () => {
+    mount(PeriodicTableControls, { target: document.body })
+    const input = doc_query<HTMLInputElement>(`.category-colors input[type="color"]`)
+    input.focus()
+    expect(selected.category).toBe(input.closest(`label`)?.dataset.key)
+
+    input.blur()
+    expect(selected.category).toBeNull()
+  })
+
+  test(`row and section resets restore shipped periodic-table defaults`, async () => {
+    const category = `noble gas`
+    const mounted_category_color = `#123456`
+    colors.category[category] = mounted_category_color
+    mount(PeriodicTableControls, {
+      target: document.body,
+      props: { tile_border_radius: 2, hover_border_width: 2 },
+    })
+    const number_input = (key: string) =>
+      doc_query<HTMLInputElement>(`[data-key="${key}"] input[type="number"]`)
+    const set_input = (input: HTMLInputElement, value: string | number): void => {
+      input.value = `${value}`
+      input.dispatchEvent(new Event(`input`, { bubbles: true }))
+    }
+    const click_reset = async (selector: string): Promise<void> => {
+      doc_query<HTMLButtonElement>(selector).click()
+      await tick()
+    }
+    const category_input = doc_query<HTMLInputElement>(
+      `[data-key="${category}"] input[type="color"]`,
+    )
+    set_input(number_input(`tile_border_radius`), 5)
+    set_input(number_input(`hover_border_width`), 3)
+    set_input(category_input, `#654321`)
+    await tick()
+
+    await click_reset(`[data-key="tile_border_radius"] .setting-reset-button`)
+    expect(number_input(`tile_border_radius`).valueAsNumber).toBe(1)
+    expect(number_input(`hover_border_width`).valueAsNumber).toBe(3)
+
+    await click_reset(`button[aria-label="Reset element tiles to defaults"]`)
+    expect(number_input(`hover_border_width`).valueAsNumber).toBe(1)
+
+    await click_reset(`button[aria-label="Reset element category colors to defaults"]`)
+    expect(category_input.value).toBe(DEFAULT_CATEGORY_COLORS[category])
   })
 
   test(`shows element photo when hovering element tile`, async () => {

--- a/tests/vitest/periodic-table/PeriodicTable.test.svelte.ts
+++ b/tests/vitest/periodic-table/PeriodicTable.test.svelte.ts
@@ -40,16 +40,6 @@ describe(`PeriodicTable`, () => {
     expect(Array.from(element_tile.classList)).not.toContain(`active`)
   })
 
-  test(`category color input focus updates the selected category`, () => {
-    mount(PeriodicTableControls, { target: document.body })
-    const input = doc_query<HTMLInputElement>(`.category-colors input[type="color"]`)
-    input.focus()
-    expect(selected.category).toBe(input.closest(`label`)?.dataset.key)
-
-    input.blur()
-    expect(selected.category).toBeNull()
-  })
-
   test(`row and section resets restore shipped periodic-table defaults`, async () => {
     const category = `noble gas`
     const mounted_category_color = `#123456`
@@ -71,6 +61,10 @@ describe(`PeriodicTable`, () => {
     const category_input = doc_query<HTMLInputElement>(
       `[data-key="${category}"] input[type="color"]`,
     )
+    category_input.focus()
+    expect(selected.category).toBe(category)
+    category_input.blur()
+    expect(selected.category).toBeNull()
     set_input(number_input(`tile_border_radius`), 5)
     set_input(number_input(`hover_border_width`), 3)
     set_input(category_input, `#654321`)

--- a/tests/vitest/periodic-table/PeriodicTable.test.svelte.ts
+++ b/tests/vitest/periodic-table/PeriodicTable.test.svelte.ts
@@ -81,6 +81,26 @@ describe(`PeriodicTable`, () => {
     expect(category_input.value).toBe(DEFAULT_CATEGORY_COLORS[category])
   })
 
+  test(`rejects an unknown runtime reset key`, async () => {
+    mount(PeriodicTableControls, { target: document.body })
+    const row = doc_query(`[data-key="tile_border_radius"]`)
+    const input = doc_query<HTMLInputElement>(
+      `[data-key="tile_border_radius"] input[type="number"]`,
+    )
+    input.value = `5`
+    input.dispatchEvent(new Event(`input`, { bubbles: true }))
+    await tick()
+
+    const reset_button = doc_query<HTMLButtonElement>(
+      `[data-key="tile_border_radius"] .setting-reset-button`,
+    )
+    row.dataset.key = `unknown-control`
+    reset_button.click()
+    await tick()
+    expect(row.querySelector(`.setting-reset-button`)).toBeNull()
+    expect(input.valueAsNumber).toBe(5)
+  })
+
   test(`shows element photo when hovering element tile`, async () => {
     mount(PeriodicTable, { target: document.body, props: { show_photo: true } })
 

--- a/tests/vitest/phase-diagram/PhaseDiagramControls.test.ts
+++ b/tests/vitest/phase-diagram/PhaseDiagramControls.test.ts
@@ -2,6 +2,7 @@ import type { PhaseDiagramData } from '$lib/phase-diagram'
 import { PhaseDiagramControls } from '$lib/phase-diagram'
 import { type ComponentProps, mount } from 'svelte'
 import { describe, expect, test } from 'vitest'
+import { bind_props } from '../setup'
 
 // Sample phase diagram data for testing
 const sample_data: PhaseDiagramData = {
@@ -63,6 +64,27 @@ describe(`PhaseDiagramControls`, () => {
     const target = mount_controls({ enable_export: false })
     const export_regex = /<h4[^>]*>Export<\/h4>/i
     expect(target.innerHTML).not.toMatch(export_regex)
+  })
+
+  test(`ignores empty axis tick inputs and clamps finite values`, () => {
+    const target = document.createElement(`div`)
+    const state = { x_axis: { ticks: 5 } }
+    mount(PhaseDiagramControls, {
+      target,
+      props: bind_props({ controls_open: true }, state),
+    })
+    const tick_input = [
+      ...target.querySelectorAll<HTMLInputElement>(`input[type="number"]`),
+    ].find((input) => input.closest(`label`)?.textContent?.includes(`X-axis ticks`))
+    if (!tick_input) throw new Error(`X-axis tick input not found`)
+
+    tick_input.value = ``
+    tick_input.dispatchEvent(new Event(`input`, { bubbles: true }))
+    expect(state.x_axis.ticks).toBe(5)
+
+    tick_input.value = `99`
+    tick_input.dispatchEvent(new Event(`input`, { bubbles: true }))
+    expect(state.x_axis.ticks).toBe(15)
   })
 
   test.each([

--- a/tests/vitest/phase-diagram/PhaseDiagramControls.test.ts
+++ b/tests/vitest/phase-diagram/PhaseDiagramControls.test.ts
@@ -97,23 +97,16 @@ describe(`PhaseDiagramControls`, () => {
     expect(visibility_grid?.innerHTML.includes(`Special pts`)).toBe(expected)
   })
 
-  test.each([
-    [`Boundaries`, true],
-    [`Labels`, true],
-    [`Grid`, true],
-    [`Comp. labels`, true],
-  ])(`checkbox "%s" defaults to %s`, (label_text, expected_value) => {
+  test(`visibility checkboxes default to enabled`, () => {
     const target = mount_controls()
-    const checkboxes = target.querySelectorAll(`input[type="checkbox"]`)
-    expect(checkboxes.length).toBeGreaterThan(0)
-
-    const checkbox = Array.from(checkboxes).find((cb) => {
-      const label = cb.closest(`label`)
-      return label?.textContent?.includes(label_text)
-    }) as HTMLInputElement | undefined
-
-    expect(checkbox, `checkbox "${label_text}" not found`).toBeDefined()
-    expect(checkbox?.checked).toBe(expected_value)
+    const checkboxes = [...target.querySelectorAll<HTMLInputElement>(`input[type="checkbox"]`)]
+    for (const label_text of [`Boundaries`, `Labels`, `Grid`, `Comp. labels`]) {
+      const checkbox = checkboxes.find((input) =>
+        input.closest(`label`)?.textContent?.includes(label_text),
+      )
+      expect(checkbox, `checkbox "${label_text}" not found`).toBeDefined()
+      expect(checkbox?.checked).toBe(true)
+    }
   })
 
   test(`renders with custom config values`, () => {
@@ -124,7 +117,6 @@ describe(`PhaseDiagramControls`, () => {
       },
     })
 
-    // The font size input should have the custom value
     const font_size_input = target.querySelector<HTMLInputElement>(
       `input[type="number"][min="8"][max="20"]`,
     )
@@ -142,14 +134,9 @@ describe(`PhaseDiagramControls`, () => {
     expect(readout.style.opacity).toBe(`0.8`)
   })
 
-  test(`uses component names from data in title`, () => {
-    const target = mount_controls({ data: sample_data })
-    expect(target.innerHTML).toContain(`Cu-Ni`)
-  })
-
-  test(`shows generic title when no data provided`, () => {
-    const target = mount_controls()
-    expect(target.innerHTML).toContain(`Phase diagram controls`)
+  test(`renders component-specific and generic titles`, () => {
+    expect(mount_controls({ data: sample_data }).innerHTML).toContain(`Cu-Ni`)
+    expect(mount_controls().innerHTML).toContain(`Phase diagram controls`)
   })
 
   test(`hides pane content when controls_open is false`, () => {

--- a/tests/vitest/phase-diagram/PhaseDiagramControls.test.ts
+++ b/tests/vitest/phase-diagram/PhaseDiagramControls.test.ts
@@ -1,6 +1,6 @@
 import type { PhaseDiagramData } from '$lib/phase-diagram'
 import { PhaseDiagramControls } from '$lib/phase-diagram'
-import { mount } from 'svelte'
+import { type ComponentProps, mount } from 'svelte'
 import { describe, expect, test } from 'vitest'
 
 // Sample phase diagram data for testing
@@ -43,35 +43,24 @@ const sample_data: PhaseDiagramData = {
   ],
 }
 
-describe(`PhaseDiagramControls`, () => {
-  test.each([
-    { section: `Visibility`, labels: [`Boundaries`, `Labels`, `Grid`, `Comp. Labels`] },
-    { section: `Appearance`, labels: [`Font size`] },
-    { section: `Colors`, labels: [`Background`, `Boundaries`] },
-    {
-      section: `Tie-line Display`,
-      labels: [`Line width`, `Endpoint radius`, `Cursor radius`],
-    },
-    { section: `Axes`, labels: [`X-axis ticks`, `Y-axis ticks`] },
-    { section: `Export`, labels: [`PNG DPI`] },
-  ])(`renders $section section with its controls when open`, ({ section, labels }) => {
-    const target = document.createElement(`div`)
-    mount(PhaseDiagramControls, {
-      target,
-      props: { controls_open: true, enable_export: true },
-    })
+const mount_controls = (props: ComponentProps<typeof PhaseDiagramControls> = {}) => {
+  const target = document.createElement(`div`)
+  mount(PhaseDiagramControls, { target, props: { controls_open: true, ...props } })
+  return target
+}
 
-    for (const text of [section, ...labels]) expect(target.innerHTML).toContain(text)
+describe(`PhaseDiagramControls`, () => {
+  test(`renders sections and controls when open`, () => {
+    const target = mount_controls({ enable_export: true })
+    const expected_text =
+      `Visibility|Labels|Grid|Comp. labels|Appearance|Font size|Colors|Background|` +
+      `Boundaries|Tie-line display|Line width|Endpoint radius|Cursor radius|Axes|` +
+      `X-axis ticks|Y-axis ticks|Export|PNG DPI`
+    for (const text of expected_text.split(`|`)) expect(target.textContent).toContain(text)
   })
 
   test(`hides export section when enable_export is false`, () => {
-    const target = document.createElement(`div`)
-    mount(PhaseDiagramControls, {
-      target,
-      props: { controls_open: true, enable_export: false },
-    })
-
-    // Export section header should not be present
+    const target = mount_controls({ enable_export: false })
     const export_regex = /<h4[^>]*>Export<\/h4>/i
     expect(target.innerHTML).not.toMatch(export_regex)
   })
@@ -79,31 +68,20 @@ describe(`PhaseDiagramControls`, () => {
   test.each([
     { data: sample_data, expected: true, desc: `with special_points` },
     { data: { ...sample_data, special_points: [] }, expected: false, desc: `without` },
-  ])(`Special Pts toggle shown=$expected $desc`, ({ data, expected }) => {
-    const target = document.createElement(`div`)
-    mount(PhaseDiagramControls, {
-      target,
-      props: { controls_open: true, data },
-    })
-
+  ])(`Special pts toggle shown=$expected $desc`, ({ data, expected }) => {
+    const target = mount_controls({ data })
     const visibility_grid = target.querySelector(`.visibility-grid`)
     expect(visibility_grid).toBeInstanceOf(HTMLElement)
-    expect(visibility_grid?.innerHTML.includes(`Special Pts`)).toBe(expected)
+    expect(visibility_grid?.innerHTML.includes(`Special pts`)).toBe(expected)
   })
 
   test.each([
     [`Boundaries`, true],
     [`Labels`, true],
     [`Grid`, true],
-    [`Comp. Labels`, true],
+    [`Comp. labels`, true],
   ])(`checkbox "%s" defaults to %s`, (label_text, expected_value) => {
-    const target = document.createElement(`div`)
-    mount(PhaseDiagramControls, {
-      target,
-      props: { controls_open: true },
-    })
-
-    // Find the checkbox by its label text
+    const target = mount_controls()
     const checkboxes = target.querySelectorAll(`input[type="checkbox"]`)
     expect(checkboxes.length).toBeGreaterThan(0)
 
@@ -117,15 +95,10 @@ describe(`PhaseDiagramControls`, () => {
   })
 
   test(`renders with custom config values`, () => {
-    const target = document.createElement(`div`)
-    mount(PhaseDiagramControls, {
-      target,
-      props: {
-        controls_open: true,
-        config: {
-          font_size: 16,
-          special_point_radius: 8,
-        },
+    const target = mount_controls({
+      config: {
+        font_size: 16,
+        special_point_radius: 8,
       },
     })
 
@@ -136,37 +109,29 @@ describe(`PhaseDiagramControls`, () => {
     expect(font_size_input?.value).toBe(`16`)
   })
 
-  test(`uses component names from data in title`, () => {
-    const target = document.createElement(`div`)
-    mount(PhaseDiagramControls, {
-      target,
-      props: {
-        controls_open: true,
-        data: sample_data,
-      },
-    })
+  test(`keeps the DPI input and readout inline while de-emphasizing only the readout`, () => {
+    const target = mount_controls({ enable_export: true })
+    const dpi_value = target.querySelector<HTMLElement>(`.dpi-value`)
+    const input = dpi_value?.querySelector(`input`)
+    const readout = dpi_value?.querySelector(`span`)
+    if (!dpi_value || !input || !readout) throw new Error(`DPI controls are missing`)
+    expect(dpi_value.style.display).toBe(`inline-flex`)
+    expect(input.style.opacity).not.toBe(`0.8`)
+    expect(readout.style.opacity).toBe(`0.8`)
+  })
 
+  test(`uses component names from data in title`, () => {
+    const target = mount_controls({ data: sample_data })
     expect(target.innerHTML).toContain(`Cu-Ni`)
   })
 
   test(`shows generic title when no data provided`, () => {
-    const target = document.createElement(`div`)
-    mount(PhaseDiagramControls, {
-      target,
-      props: { controls_open: true },
-    })
-
-    expect(target.innerHTML).toContain(`Phase Diagram Controls`)
+    const target = mount_controls()
+    expect(target.innerHTML).toContain(`Phase diagram controls`)
   })
 
   test(`hides pane content when controls_open is false`, () => {
-    const target = document.createElement(`div`)
-    mount(PhaseDiagramControls, {
-      target,
-      props: { controls_open: false },
-    })
-
-    // The pane should be hidden (display: none)
+    const target = mount_controls({ controls_open: false })
     const pane = target.querySelector(`.draggable-pane`) as HTMLElement
     expect(pane).toBeInstanceOf(HTMLElement)
     expect(pane?.style.display).toBe(`none`)

--- a/tests/vitest/phase-diagram/PhaseDiagramControls.test.ts
+++ b/tests/vitest/phase-diagram/PhaseDiagramControls.test.ts
@@ -4,44 +4,14 @@ import { type ComponentProps, mount } from 'svelte'
 import { describe, expect, test } from 'vitest'
 import { bind_props } from '../setup'
 
-// Sample phase diagram data for testing
 const sample_data: PhaseDiagramData = {
   components: [`Cu`, `Ni`],
   temperature_range: [300, 1800],
   temperature_unit: `K`,
   composition_unit: `at%`,
-  regions: [
-    {
-      id: `liquid`,
-      name: `Liquid`,
-      vertices: [
-        [0, 1800],
-        [1, 1800],
-        [1, 1400],
-        [0, 1350],
-      ],
-      color: `#6baed6`,
-    },
-  ],
-  boundaries: [
-    {
-      id: `liquidus`,
-      type: `liquidus`,
-      points: [
-        [0, 1350],
-        [0.5, 1400],
-        [1, 1400],
-      ],
-    },
-  ],
-  special_points: [
-    {
-      id: `test-point`,
-      type: `eutectic`,
-      position: [0.5, 1350],
-      label: `E`,
-    },
-  ],
+  regions: [],
+  boundaries: [],
+  special_points: [{ id: `test-point`, type: `eutectic`, position: [0.5, 1350], label: `E` }],
 }
 
 const mount_controls = (props: ComponentProps<typeof PhaseDiagramControls> = {}) => {
@@ -62,8 +32,7 @@ describe(`PhaseDiagramControls`, () => {
 
   test(`hides export section when enable_export is false`, () => {
     const target = mount_controls({ enable_export: false })
-    const export_regex = /<h4[^>]*>Export<\/h4>/i
-    expect(target.innerHTML).not.toMatch(export_regex)
+    expect(target.textContent).not.toContain(`Export`)
   })
 
   test(`ignores empty axis tick inputs and clamps finite values`, () => {
@@ -104,8 +73,7 @@ describe(`PhaseDiagramControls`, () => {
       const checkbox = checkboxes.find((input) =>
         input.closest(`label`)?.textContent?.includes(label_text),
       )
-      expect(checkbox, `checkbox "${label_text}" not found`).toBeDefined()
-      expect(checkbox?.checked).toBe(true)
+      expect(checkbox?.checked, `checkbox "${label_text}" not found`).toBe(true)
     }
   })
 

--- a/tests/vitest/plot/BoxPlotControls.test.ts
+++ b/tests/vitest/plot/BoxPlotControls.test.ts
@@ -11,7 +11,7 @@ describe(`BoxPlotControls`, () => {
       box.parentElement?.textContent?.includes(label),
     )
 
-  test(`Box / Violin reset reverts changed settings to defaults`, async () => {
+  test(`Box / violin reset reverts changed settings to defaults`, async () => {
     const container = document.createElement(`div`)
     document.body.append(container)
     mount(BoxPlotControls, {
@@ -31,7 +31,7 @@ describe(`BoxPlotControls`, () => {
     expect([mean.checked, outliers.checked]).toEqual([true, false])
 
     const heading = [...container.querySelectorAll(`h4`)].find((el) =>
-      el.textContent?.includes(`Box / Violin`),
+      el.textContent?.includes(`Box / violin`),
     )
     const reset_btn = heading?.querySelector<HTMLButtonElement>(`button.reset-button`)
     // a missing/no-op reset (the original bug) would leave the flipped values in place

--- a/tests/vitest/plot/ColorScaleSelect.test.ts
+++ b/tests/vitest/plot/ColorScaleSelect.test.ts
@@ -6,22 +6,15 @@ import { bind_props, doc_query } from '../setup'
 
 describe(`ColorScaleSelect`, () => {
   test(`binds value and selected correctly (initial state)`, () => {
-    // Tests if initial value and selected props are rendered correctly.
-    const selected_value: D3InterpolateName = `interpolateViridis`
-    const selected_array: D3InterpolateName[] = [`interpolateViridis`]
-
-    // Initial mount
     mount(ColorScaleSelect, {
       target: document.body,
       props: {
-        value: selected_value,
-        selected: selected_array,
+        value: `interpolateViridis`,
+        selected: [`interpolateViridis`],
       },
     })
 
-    // Check initial state rendered by svelte-widgets
-    const initial_selection = doc_query(`.selected`)
-    expect(initial_selection?.textContent?.trim()).toBe(`Viridis`)
+    expect(doc_query(`.selected`).textContent?.trim()).toBe(`Viridis`)
   })
 
   // Binding `selected` alongside `value` is optional, so mounting must not treat an unbound
@@ -55,24 +48,13 @@ describe(`ColorScaleSelect`, () => {
       },
     })
 
-    const multiselect_el = doc_query(`.multiselect`)
-    if (multiselect_el) {
-      multiselect_el.dispatchEvent(new MouseEvent(`mousedown`))
-      await vi.waitFor(() => document.body.querySelector(`.options`))
-    }
+    doc_query(`.multiselect`).dispatchEvent(new MouseEvent(`mousedown`))
+    await vi.waitFor(() => document.body.querySelector(`.options`))
 
     const color_bar_wrapper = doc_query(`.colorbar`)
-    expect(color_bar_wrapper).toBeInstanceOf(HTMLElement)
-    // Check wrapper style
     expect(color_bar_wrapper.getAttribute(`style`)).toContain(
       custom_color_bar_props.wrapper_style,
     )
-
-    // Check flex direction based on title_side
     expect(color_bar_wrapper.style.flexDirection).toBe(`row-reverse`)
-
-    // Check for the existence of the inner bar div, but not its specific background style
-    const color_bar_div = doc_query(`.colorbar > div.bar`)
-    expect(color_bar_div).toBeInstanceOf(HTMLElement)
   })
 })

--- a/tests/vitest/plot/ColorScaleSelect.test.ts
+++ b/tests/vitest/plot/ColorScaleSelect.test.ts
@@ -1,8 +1,8 @@
 import { ColorScaleSelect } from '$lib'
 import type { D3InterpolateName } from '$lib/colors'
-import { mount } from 'svelte'
+import { flushSync, mount } from 'svelte'
 import { describe, expect, test, vi } from 'vitest'
-import { doc_query } from '../setup'
+import { bind_props, doc_query } from '../setup'
 
 describe(`ColorScaleSelect`, () => {
   test(`binds value and selected correctly (initial state)`, () => {
@@ -22,6 +22,20 @@ describe(`ColorScaleSelect`, () => {
     // Check initial state rendered by svelte-widgets
     const initial_selection = doc_query(`.selected`)
     expect(initial_selection?.textContent?.trim()).toBe(`Viridis`)
+  })
+
+  // Binding `selected` alongside `value` is optional, so mounting must not treat an unbound
+  // `selected` as "nothing is selected" and write that emptiness back over the caller's value.
+  test(`keeps a bound value when only value is bound`, () => {
+    const controls_state = { value: `interpolateViridis` as D3InterpolateName }
+    mount(ColorScaleSelect, {
+      target: document.body,
+      props: bind_props({}, controls_state),
+    })
+    flushSync()
+
+    expect(controls_state.value).toBe(`interpolateViridis`)
+    expect(doc_query(`.selected`)?.textContent?.trim()).toBe(`Viridis`)
   })
 
   test(`passes color_bar props to ColorBar snippet`, async () => {

--- a/tests/vitest/plot/Histogram.test.ts
+++ b/tests/vitest/plot/Histogram.test.ts
@@ -216,9 +216,18 @@ describe(`Histogram`, () => {
       bins: 5,
       x2_axis: { label: `Mass (lbs)` },
       mode: `overlay`,
+      show_controls: true,
+      controls_open: true,
     })
     await tick()
     expect(document.querySelector(`g.x2-axis`)).toBeInstanceOf(SVGGElement)
+    const scale_type_sections = document.querySelectorAll(`[data-testid="scale-type-section"]`)
+    expect(scale_type_sections).toHaveLength(1)
+    expect(
+      [...scale_type_sections[0].querySelectorAll(`label > span:first-child`)].map(
+        (label) => label.textContent,
+      ),
+    ).toEqual([`X`, `X2`, `Y`])
     const x_ticks = get_tick_numbers(`x`)
     expect(x_ticks.length).toBeGreaterThan(0)
     expect(Math.max(...x_ticks)).toBeLessThan(100)

--- a/tests/vitest/plot/Histogram.test.ts
+++ b/tests/vitest/plot/Histogram.test.ts
@@ -305,6 +305,26 @@ describe(`Histogram`, () => {
     )
   })
 
+  test(`property options allow duplicate and empty series labels`, async () => {
+    mount_histogram({
+      series: [`Repeated`, `Repeated`, ``, undefined].map((label) =>
+        series_of([1], { label }),
+      ),
+      mode: `single`,
+      show_controls: true,
+      controls_open: true,
+    })
+    await tick()
+
+    const property_select = [...document.querySelectorAll<HTMLSelectElement>(`select`)].find(
+      (select) => select.closest(`label`)?.textContent?.includes(`Property`),
+    )
+    const option_labels = [...(property_select?.options ?? [])].map(
+      (option) => option.textContent,
+    )
+    expect(option_labels).toEqual([`All`, `Repeated`, `Repeated`, `Series`, `Series`])
+  })
+
   test(`touch gestures keep finite axis ranges`, async () => {
     // oxfmt-ignore
     for (const events of [

--- a/tests/vitest/plot/PlotControls.test.svelte.ts
+++ b/tests/vitest/plot/PlotControls.test.svelte.ts
@@ -1,15 +1,18 @@
 import { PlotControls } from '$lib/plot'
 import { DEFAULTS } from '$lib/settings'
-import { mount, tick } from 'svelte'
+import { type ComponentProps, flushSync, mount, tick } from 'svelte'
 import { describe, expect, test, vi } from 'vitest'
-import { doc_query } from '../setup'
+import { bind_props, doc_query } from '../setup'
 
 describe(`PlotControls`, () => {
-  const mount_controls = (props = {}) =>
-    mount(PlotControls, {
+  const mount_controls = (props: ComponentProps<typeof PlotControls> = {}) => {
+    props.show_controls ??= true
+    props.controls_open ??= true
+    return mount(PlotControls, {
       target: document.body,
-      props: { show_controls: true, controls_open: true, ...props },
+      props,
     })
+  }
 
   describe(`range input handling`, () => {
     test.each([
@@ -47,6 +50,28 @@ describe(`PlotControls`, () => {
         expect(document.querySelectorAll(`input.range-input`)).toHaveLength(expected)
       },
     )
+
+    test(`resets after a secondary axis disappears`, async () => {
+      let has_x2_points = $state(true)
+      mount_controls({
+        get has_x2_points() {
+          return has_x2_points
+        },
+        auto_x_range: [0, 100],
+        auto_x2_range: [0, 100],
+      })
+      const range_input = doc_query<HTMLInputElement>(`input.range-input`)
+      range_input.value = `10`
+      range_input.dispatchEvent(new Event(`input`, { bubbles: true }))
+      await tick()
+      flushSync(() => (has_x2_points = false))
+
+      expect(() =>
+        doc_query<HTMLButtonElement>(
+          `button[aria-label="Reset axis range to defaults"]`,
+        ).click(),
+      ).not.toThrow()
+    })
   })
 
   describe(`format input validation`, () => {
@@ -89,33 +114,57 @@ describe(`PlotControls`, () => {
     }
 
     test(`renders correct number of grid controls and resets them`, async () => {
-      const display = $state({ x_grid: true, y_grid: true, y2_grid: true })
+      const state = $state({ display: { x_grid: true, y_grid: true, y2_grid: true } })
+      const initial_display = state.display
+      mount_controls(bind_props({ has_y2_points: true }, state))
+      const grids = get_checkboxes_in_group(`grid`)
+      expect(grids).toHaveLength(3)
+      expect(
+        document.querySelector(`button[aria-label="Reset display to defaults"]`),
+      ).toBeNull()
+
+      grids[0].click()
+      await tick()
+      expect(state.display.x_grid).toBe(false)
+
+      doc_query<HTMLButtonElement>(`button[aria-label="Reset display to defaults"]`).click()
+      await tick()
+      expect(state.display).not.toBe(initial_display)
+      expect(state.display).toMatchObject({
+        x_grid: DEFAULTS.plot.show_x_grid,
+        x_zero_line: DEFAULTS.plot.show_x_zero_line,
+        x2_zero_line: false,
+        y_zero_line: DEFAULTS.plot.show_y_zero_line,
+        y2_zero_line: false,
+        y2_grid: true,
+      })
+      expect(
+        document.querySelector(`button[aria-label="Reset display to defaults"]`),
+      ).toBeNull()
+    })
+
+    test(`does not fill missing display keys on mount`, () => {
+      const display = $state({ x_grid: false })
       mount_controls({
-        has_y2_points: true,
         get display() {
           return display
         },
       })
-      const grids = get_checkboxes_in_group(`grid`)
-      expect(grids).toHaveLength(3)
-
-      grids[0].click()
-      await tick()
-      expect(display.x_grid).toBe(false)
-
-      doc_query<HTMLButtonElement>(`button[aria-label="Reset display to defaults"]`).click()
-      await tick()
-      expect(display.x_grid).toBe(DEFAULTS.plot.show_x_grid)
+      expect(display).toEqual({ x_grid: false })
     })
 
-    test.each([
+    test.each<{
+      x_range: [number, number]
+      y_range: [number, number]
+      expected: number
+    }>([
       { x_range: [-10, 10], y_range: [-5, 5], expected: 2 },
       { x_range: [0, 10], y_range: [-5, 5], expected: 2 },
       { x_range: [1, 10], y_range: [-5, 5], expected: 1 },
       { x_range: [-10, 10], y_range: [1, 5], expected: 1 },
       { x_range: [1, 10], y_range: [1, 5], expected: 0 },
     ])(`shows $expected zero line controls for ranges`, ({ x_range, y_range, expected }) => {
-      mount_controls({ x_range, y_range, auto_x_range: x_range, auto_y_range: y_range })
+      mount_controls({ auto_x_range: x_range, auto_y_range: y_range })
       const zero_lines = get_checkboxes_in_group(`zero line`)
       expect(zero_lines).toHaveLength(expected)
     })
@@ -141,6 +190,7 @@ describe(`PlotControls`, () => {
     expect([...tick_inputs].map((input) => input.value)).toEqual(
       [DEFAULTS.plot.x_ticks, DEFAULTS.plot.y_ticks].map(String),
     )
+    expect(document.querySelector(`button[aria-label="Reset ticks to defaults"]`)).toBeNull()
   })
 
   test(`controls visibility toggles`, () => {

--- a/tests/vitest/plot/PlotControls.test.svelte.ts
+++ b/tests/vitest/plot/PlotControls.test.svelte.ts
@@ -105,13 +105,11 @@ describe(`PlotControls`, () => {
   })
 
   describe(`display controls`, () => {
-    // Helper to find checkboxes within a control group by data-label attribute.
-    const get_checkboxes_in_group = (label: string) => {
-      const group = document.querySelector(`.control-group[data-label="${label}"]`)
-      return group
-        ? Array.from(group.querySelectorAll<HTMLInputElement>(`input[type="checkbox"]`))
-        : []
-    }
+    const get_checkboxes_in_group = (label: string): HTMLInputElement[] => [
+      ...(document
+        .querySelector(`.control-group[data-label="${label}"]`)
+        ?.querySelectorAll<HTMLInputElement>(`input[type="checkbox"]`) ?? []),
+    ]
 
     test(`renders correct number of grid controls and resets them`, async () => {
       const state = $state({ display: { x_grid: true, y_grid: true, y2_grid: true } })

--- a/tests/vitest/plot/PlotControls.test.svelte.ts
+++ b/tests/vitest/plot/PlotControls.test.svelte.ts
@@ -1,5 +1,6 @@
 import { PlotControls } from '$lib/plot'
-import { mount } from 'svelte'
+import { DEFAULTS } from '$lib/settings'
+import { mount, tick } from 'svelte'
 import { describe, expect, test, vi } from 'vitest'
 import { doc_query } from '../setup'
 
@@ -67,6 +68,15 @@ describe(`PlotControls`, () => {
       input.dispatchEvent(new Event(`input`, { bubbles: true }))
       expect(input.classList.contains(`invalid`)).toBe(!valid)
     })
+
+    test(`format inputs fill their grid column`, () => {
+      mount_controls({ has_x2_points: true, has_y2_points: true })
+      const inputs = document.querySelectorAll<HTMLInputElement>(
+        `[data-testid="tick-format-section"] input`,
+      )
+      expect(inputs).toHaveLength(4)
+      for (const input of inputs) expect(getComputedStyle(input).width).toBe(`100%`)
+    })
   })
 
   describe(`display controls`, () => {
@@ -78,10 +88,24 @@ describe(`PlotControls`, () => {
         : []
     }
 
-    test(`renders correct number of grid controls`, () => {
-      mount_controls({ has_y2_points: true })
+    test(`renders correct number of grid controls and resets them`, async () => {
+      const display = $state({ x_grid: true, y_grid: true, y2_grid: true })
+      mount_controls({
+        has_y2_points: true,
+        get display() {
+          return display
+        },
+      })
       const grids = get_checkboxes_in_group(`grid`)
       expect(grids).toHaveLength(3)
+
+      grids[0].click()
+      await tick()
+      expect(display.x_grid).toBe(false)
+
+      doc_query<HTMLButtonElement>(`button[aria-label="Reset display to defaults"]`).click()
+      await tick()
+      expect(display.x_grid).toBe(DEFAULTS.plot.show_x_grid)
     })
 
     test.each([
@@ -97,7 +121,7 @@ describe(`PlotControls`, () => {
     })
   })
 
-  test(`tick controls section only renders when show_ticks`, () => {
+  test(`tick controls only render when enabled and use configured defaults`, () => {
     // section titles render in <h4> headers (not inside the <section> itself)
     const has_ticks_section = () =>
       Array.from(document.querySelectorAll(`h4`)).some((header) =>
@@ -107,8 +131,16 @@ describe(`PlotControls`, () => {
     expect(has_ticks_section()).toBe(false)
 
     document.body.innerHTML = ``
-    mount_controls({ show_ticks: true })
+    mount_controls({
+      show_ticks: true,
+      x_axis: { ticks: undefined },
+      y_axis: { ticks: undefined },
+    })
     expect(has_ticks_section()).toBe(true)
+    const tick_inputs = document.querySelectorAll<HTMLInputElement>(`input[min="2"][max="20"]`)
+    expect([...tick_inputs].map((input) => input.value)).toEqual(
+      [DEFAULTS.plot.x_ticks, DEFAULTS.plot.y_ticks].map(String),
+    )
   })
 
   test(`controls visibility toggles`, () => {

--- a/tests/vitest/plot/ScatterPlot.test.svelte.ts
+++ b/tests/vitest/plot/ScatterPlot.test.svelte.ts
@@ -734,7 +734,7 @@ describe(`ScatterPlot`, () => {
     })
     await tick()
 
-    expect(document.querySelector(`.label-text`)?.textContent).toBe(`Fallback`)
+    expect(document.querySelector(`text.label-text`)?.textContent).toBe(`Fallback`)
   })
 
   test(`hides auto labels culled by max_neighbors`, async () => {
@@ -755,7 +755,7 @@ describe(`ScatterPlot`, () => {
     })
 
     expect(
-      [...plot.querySelectorAll(`.label-text`)].map((label) => label.textContent),
+      [...plot.querySelectorAll(`text.label-text`)].map((label) => label.textContent),
     ).toEqual([`Lonely`])
   })
 

--- a/tests/vitest/scene/props.test.ts
+++ b/tests/vitest/scene/props.test.ts
@@ -5,6 +5,7 @@ import {
   GIZMO_DEFAULT_STYLES,
   page_visibility,
 } from '$lib/scene'
+import { DEFAULTS } from '$lib/settings'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 
 describe(`build_gizmo_props`, () => {
@@ -58,6 +59,21 @@ describe(`build_orbit_props`, () => {
       props.onstart()
       props.onend()
     }).not.toThrow()
+  })
+
+  // Rotation feel is easy to regress by nudging one default, and neither number reads as
+  // wrong on its own. OrbitControls turns the camera by 360° * drag_px * rotateSpeed /
+  // canvas_height_px, then pays a released gesture out at dampingFactor per frame — so assert
+  // the drag distance and settle time those defaults produce, not the defaults themselves.
+  test(`default rotation stays controllable on a default-height canvas`, () => {
+    const { rotate_speed, rotation_damping } = DEFAULTS.structure
+    const props = build_orbit_props({ ...opts, rotate_speed, rotation_damping })
+    const deg_per_drag_px = (360 * props.rotateSpeed) / 500 // --struct-height default
+    // a 15° nudge to peek behind an atom must be a deliberate drag, not a trackpad twitch
+    expect(15 / deg_per_drag_px).toBeGreaterThan(30)
+    // the queued tail decays by (1 - dampingFactor) per frame; spend it inside half a second
+    // at 60 fps or the view keeps drifting past wherever the pointer was released
+    expect(Math.log(0.01) / Math.log(1 - props.dampingFactor) / 60).toBeLessThan(0.5)
   })
 
   test(`onstart/onend toggle camera_is_moving and run onstart_extra once`, () => {

--- a/tests/vitest/settings.test.ts
+++ b/tests/vitest/settings.test.ts
@@ -264,6 +264,5 @@ describe(`Structure viewer state serialization`, () => {
     expect(localStorage.getItem(STRUCTURE_VIEW_STATE_STORAGE_KEY)).not.toBeNull()
     expect(clear_structure_view_state()).toBe(true)
     expect(localStorage.getItem(STRUCTURE_VIEW_STATE_STORAGE_KEY)).toBeNull()
-    expect(load_structure_view_state()).toBeNull()
   })
 })

--- a/tests/vitest/settings.test.ts
+++ b/tests/vitest/settings.test.ts
@@ -4,6 +4,16 @@ import {
   merge,
   SETTINGS_CONFIG,
 } from '$lib/settings'
+import {
+  clear_structure_view_state,
+  create_structure_view_state,
+  deserialize_structure_view_state,
+  load_structure_view_state,
+  save_structure_view_state,
+  serialize_structure_view_state,
+  STRUCTURE_VIEW_STATE_STORAGE_KEY,
+  STRUCTURE_VIEW_STATE_VERSION,
+} from '$lib/settings/viewer-state'
 import { describe, expect, test } from 'vitest'
 
 describe(`Settings`, () => {
@@ -88,4 +98,174 @@ test(`settings builder groups structure props`, () => {
   expect(props.scene_props).toMatchObject(DEFAULTS.structure)
   expect(props.scene_props.gizmo).toBe(DEFAULTS.structure.show_gizmo)
   expect(props.lattice_props.cell_edge_width).toBe(DEFAULTS.structure.cell_edge_width)
+})
+
+describe(`Structure viewer state serialization`, () => {
+  test(`keeps themed backgrounds unset and skips non-portable structure state`, () => {
+    const scene_props = {
+      get camera_position(): never {
+        throw new Error(`camera_position must not be read`)
+      },
+    }
+    const state = create_structure_view_state({ scene_props })
+    expect(state.settings.background_color).toBeUndefined()
+    expect(state.settings.structure).not.toHaveProperty(`camera_position`)
+  })
+
+  test(`round-trips validated settings through the shared JSON format`, () => {
+    const state = create_structure_view_state({
+      scene_props: {
+        atom_radius: 1.25,
+        camera_projection: `perspective`,
+        vector_configs: { force: { visible: false } },
+      },
+      lattice_props: { cell_edge_opacity: 0.8 },
+      color_scheme: `Jmol`,
+      background_color: `#123456`,
+      background_opacity: 0.4,
+      show_image_atoms: false,
+      atom_color_config: {
+        mode: `coordination`,
+        scale: `interpolatePlasma`,
+        scale_type: `continuous`,
+      },
+      supercell_scaling: `2x3x1`,
+      cell_type: `conventional`,
+      multi_view: true,
+      controls_pane_size: { width: 520, height: 640 },
+    })
+
+    const result = deserialize_structure_view_state(serialize_structure_view_state(state))
+    if (!result.state) throw new Error(result.error)
+
+    expect(result.state).toMatchObject({
+      version: STRUCTURE_VIEW_STATE_VERSION,
+      settings: {
+        color_scheme: `Jmol`,
+        background_color: `#123456`,
+        background_opacity: 0.4,
+        structure: {
+          atom_radius: 1.25,
+          camera_projection: `perspective`,
+          cell_edge_opacity: 0.8,
+          show_image_atoms: false,
+          atom_color_mode: `coordination`,
+          atom_color_scale: `interpolatePlasma`,
+        },
+      },
+      viewer: {
+        supercell_scaling: `2x3x1`,
+        cell_type: `conventional`,
+        multi_view: true,
+        controls_pane_size: { width: 520, height: 640 },
+      },
+    })
+    expect(result.state.settings.structure).not.toHaveProperty(`vector_configs`)
+  })
+
+  test(`replaces unknown, wrong-type, and out-of-range values with schema defaults`, () => {
+    const result = deserialize_structure_view_state(
+      JSON.stringify({
+        version: STRUCTURE_VIEW_STATE_VERSION,
+        unknown_top_level: true,
+        settings: {
+          color_scheme: 42,
+          background_color: null,
+          background_opacity: 2,
+          unknown_group: { enabled: true },
+          structure: {
+            atom_radius: 99,
+            show_atoms: `yes`,
+            camera_projection: `fisheye`,
+            rotation: [0, `bad`, 0],
+            polyhedra_excluded_elements: [8],
+            unknown_setting: `ignored`,
+          },
+        },
+        viewer: {
+          supercell_scaling: `0x2x2`,
+          cell_type: `derived`,
+          multi_view: `yes`,
+          controls_pane_size: { width: -1, height: `large` },
+          unknown_viewer_setting: true,
+        },
+      }),
+    )
+    if (!result.state) throw new Error(result.error)
+    const { settings, viewer } = result.state
+
+    expect(settings).toMatchObject({
+      color_scheme: DEFAULTS.color_scheme,
+      background_color: DEFAULTS.background_color,
+      background_opacity: DEFAULTS.background_opacity,
+      structure: {
+        atom_radius: DEFAULTS.structure.atom_radius,
+        show_atoms: DEFAULTS.structure.show_atoms,
+        camera_projection: DEFAULTS.structure.camera_projection,
+        rotation: DEFAULTS.structure.rotation,
+        polyhedra_excluded_elements: DEFAULTS.structure.polyhedra_excluded_elements,
+      },
+    })
+    expect(settings.structure).not.toHaveProperty(`unknown_setting`)
+    expect(settings).not.toHaveProperty(`unknown_group`)
+    expect(viewer).toEqual({
+      supercell_scaling: `1x1x1`,
+      cell_type: `original`,
+      multi_view: false,
+    })
+  })
+
+  test.each([
+    [`corrupt JSON`, `{`, `Invalid JSON`],
+    [`non-object JSON`, `[]`, `must be a JSON object`],
+    [
+      `unsupported version`,
+      JSON.stringify({ version: 999 }),
+      `Unsupported view-state version`,
+    ],
+  ])(`rejects %s`, (_description, json, expected_error) => {
+    expect(deserialize_structure_view_state(json)).toEqual({
+      error: expect.stringContaining(expected_error),
+    })
+  })
+
+  test(`handles missing and corrupt localStorage without throwing`, () => {
+    expect(load_structure_view_state()).toBeNull()
+
+    localStorage.setItem(STRUCTURE_VIEW_STATE_STORAGE_KEY, `{bad json`)
+    expect(load_structure_view_state()).toBeNull()
+    expect(localStorage.getItem(STRUCTURE_VIEW_STATE_STORAGE_KEY)).toBeNull()
+  })
+
+  test(`throws on invalid program-created state`, () => {
+    const invalid_state = create_structure_view_state()
+    Reflect.set(invalid_state, `version`, 999)
+
+    expect(() => save_structure_view_state(invalid_state)).toThrow(
+      `Cannot serialize structure view state version 999`,
+    )
+  })
+
+  test(`persists non-default state and removes a restored default state`, () => {
+    const customized = create_structure_view_state({
+      scene_props: { atom_radius: 1.5 },
+    })
+    expect(save_structure_view_state(customized)).toBe(true)
+    expect(load_structure_view_state()?.settings.structure.atom_radius).toBe(1.5)
+
+    expect(save_structure_view_state(create_structure_view_state())).toBe(true)
+    expect(localStorage.getItem(STRUCTURE_VIEW_STATE_STORAGE_KEY)).toBeNull()
+  })
+
+  // backs "Reset all" in the controls pane: the next load must not resurrect the old settings
+  test(`clearing drops persisted state`, () => {
+    save_structure_view_state(
+      create_structure_view_state({ scene_props: { atom_radius: 1.5 } }),
+    )
+    expect(localStorage.getItem(STRUCTURE_VIEW_STATE_STORAGE_KEY)).not.toBeNull()
+
+    expect(clear_structure_view_state()).toBe(true)
+    expect(localStorage.getItem(STRUCTURE_VIEW_STATE_STORAGE_KEY)).toBeNull()
+    expect(load_structure_view_state()).toBeNull()
+  })
 })

--- a/tests/vitest/settings.test.ts
+++ b/tests/vitest/settings.test.ts
@@ -13,6 +13,7 @@ import {
   serialize_structure_view_state,
   STRUCTURE_VIEW_STATE_STORAGE_KEY,
   STRUCTURE_VIEW_STATE_VERSION,
+  type StructureViewState,
 } from '$lib/settings/viewer-state'
 import { describe, expect, test } from 'vitest'
 
@@ -101,6 +102,12 @@ test(`settings builder groups structure props`, () => {
 })
 
 describe(`Structure viewer state serialization`, () => {
+  const parse_or_throw = (json: string): StructureViewState => {
+    const { state, error } = deserialize_structure_view_state(json)
+    if (!state) throw new Error(error)
+    return state
+  }
+
   test(`keeps themed backgrounds unset and skips non-portable structure state`, () => {
     const scene_props = {
       get camera_position(): never {
@@ -135,10 +142,8 @@ describe(`Structure viewer state serialization`, () => {
       controls_pane_size: { width: 520, height: 640 },
     })
 
-    const result = deserialize_structure_view_state(serialize_structure_view_state(state))
-    if (!result.state) throw new Error(result.error)
-
-    expect(result.state).toMatchObject({
+    const round_tripped = parse_or_throw(serialize_structure_view_state(state))
+    expect(round_tripped).toMatchObject({
       version: STRUCTURE_VIEW_STATE_VERSION,
       settings: {
         color_scheme: `Jmol`,
@@ -160,11 +165,11 @@ describe(`Structure viewer state serialization`, () => {
         controls_pane_size: { width: 520, height: 640 },
       },
     })
-    expect(result.state.settings.structure).not.toHaveProperty(`vector_configs`)
+    expect(round_tripped.settings.structure).not.toHaveProperty(`vector_configs`)
   })
 
   test(`replaces unknown, wrong-type, and out-of-range values with schema defaults`, () => {
-    const result = deserialize_structure_view_state(
+    const { settings, viewer } = parse_or_throw(
       JSON.stringify({
         version: STRUCTURE_VIEW_STATE_VERSION,
         unknown_top_level: true,
@@ -191,8 +196,6 @@ describe(`Structure viewer state serialization`, () => {
         },
       }),
     )
-    if (!result.state) throw new Error(result.error)
-    const { settings, viewer } = result.state
 
     expect(settings).toMatchObject({
       color_scheme: DEFAULTS.color_scheme,

--- a/tests/vitest/settings.test.ts
+++ b/tests/vitest/settings.test.ts
@@ -258,15 +258,10 @@ describe(`Structure viewer state serialization`, () => {
 
     expect(save_structure_view_state(create_structure_view_state())).toBe(true)
     expect(localStorage.getItem(STRUCTURE_VIEW_STATE_STORAGE_KEY)).toBeNull()
-  })
 
-  // backs "Reset all" in the controls pane: the next load must not resurrect the old settings
-  test(`clearing drops persisted state`, () => {
-    save_structure_view_state(
-      create_structure_view_state({ scene_props: { atom_radius: 1.5 } }),
-    )
+    // backs "Reset all" in the controls pane: the next load must not resurrect old settings
+    save_structure_view_state(customized)
     expect(localStorage.getItem(STRUCTURE_VIEW_STATE_STORAGE_KEY)).not.toBeNull()
-
     expect(clear_structure_view_state()).toBe(true)
     expect(localStorage.getItem(STRUCTURE_VIEW_STATE_STORAGE_KEY)).toBeNull()
     expect(load_structure_view_state()).toBeNull()

--- a/tests/vitest/setup.ts
+++ b/tests/vitest/setup.ts
@@ -83,6 +83,23 @@ export function doc_query<T extends Element = HTMLElement>(
 
 export const svg_query = (selector: string): SVGElement => doc_query<SVGElement>(selector)
 
+export const expect_labelled_settings_grid = (
+  root: ParentNode = document,
+  {
+    section_selector = `section.settings-section`,
+    row_selector = `:scope > label, :scope > .setting`,
+  }: { section_selector?: string; row_selector?: string } = {},
+): void => {
+  const sections = [...root.querySelectorAll(section_selector)]
+  expect(sections.length).toBeGreaterThan(0)
+  const rows = sections.flatMap((section) => [...section.querySelectorAll(row_selector)])
+  expect(rows.length).toBeGreaterThan(0)
+  for (const section of sections) {
+    expect(section.classList.contains(`grid`)).toBe(true)
+  }
+  for (const row of rows) expect(row.firstElementChild?.tagName).toBe(`SPAN`)
+}
+
 // Extract the rotation pivot-y from an axis label's nearest rotated SVG ancestor.
 // Used to assert y/y2 axis titles share a pivot.
 export const axis_label_pivot_y = (root: ParentNode, selector: string): number => {

--- a/tests/vitest/setup.ts
+++ b/tests/vitest/setup.ts
@@ -92,12 +92,30 @@ export const expect_labelled_settings_grid = (
 ): void => {
   const sections = [...root.querySelectorAll(section_selector)]
   expect(sections.length).toBeGreaterThan(0)
-  const rows = sections.flatMap((section) => [...section.querySelectorAll(row_selector)])
-  expect(rows.length).toBeGreaterThan(0)
+  let row_count = 0
   for (const section of sections) {
-    expect(section.classList.contains(`grid`)).toBe(true)
+    const section_title =
+      section.previousElementSibling?.textContent?.replaceAll(/\s+/g, ` `).trim() ??
+      section.getAttribute(`aria-label`) ??
+      `untitled`
+    expect(
+      section.classList.contains(`grid`),
+      `Settings section "${section_title}" should use grid layout`,
+    ).toBe(true)
+    const rows = [...section.querySelectorAll(row_selector)]
+    row_count += rows.length
+    for (const row of rows) {
+      const row_text =
+        row.textContent?.replaceAll(/\s+/g, ` `).trim() ??
+        row.getAttribute(`data-key`) ??
+        `untitled`
+      expect(
+        row.firstElementChild?.tagName,
+        `Settings row "${row_text}" in section "${section_title}" should start with a span`,
+      ).toBe(`SPAN`)
+    }
   }
-  for (const row of rows) expect(row.firstElementChild?.tagName).toBe(`SPAN`)
+  expect(row_count).toBeGreaterThan(0)
 }
 
 // Extract the rotation pivot-y from an axis label's nearest rotated SVG ancestor.

--- a/tests/vitest/setup.ts
+++ b/tests/vitest/setup.ts
@@ -92,30 +92,16 @@ export const expect_labelled_settings_grid = (
 ): void => {
   const sections = [...root.querySelectorAll(section_selector)]
   expect(sections.length).toBeGreaterThan(0)
-  let row_count = 0
-  for (const section of sections) {
-    const section_title =
-      section.previousElementSibling?.textContent?.replaceAll(/\s+/g, ` `).trim() ??
-      section.getAttribute(`aria-label`) ??
-      `untitled`
-    expect(
-      section.classList.contains(`grid`),
-      `Settings section "${section_title}" should use grid layout`,
-    ).toBe(true)
-    const rows = [...section.querySelectorAll(row_selector)]
-    row_count += rows.length
-    for (const row of rows) {
-      const row_text =
-        row.textContent?.replaceAll(/\s+/g, ` `).trim() ??
-        row.getAttribute(`data-key`) ??
-        `untitled`
-      expect(
-        row.firstElementChild?.tagName,
-        `Settings row "${row_text}" in section "${section_title}" should start with a span`,
-      ).toBe(`SPAN`)
-    }
-  }
-  expect(row_count).toBeGreaterThan(0)
+  expect(
+    sections.every((section) => section.classList.contains(`grid`)),
+    `All settings sections should use grid layout`,
+  ).toBe(true)
+  const rows = sections.flatMap((section) => [...section.querySelectorAll(row_selector)])
+  expect(rows.length).toBeGreaterThan(0)
+  expect(
+    rows.every((row) => row.firstElementChild?.tagName === `SPAN`),
+    `Every settings row should start with a span`,
+  ).toBe(true)
 }
 
 // Extract the rotation pivot-y from an axis label's nearest rotated SVG ancestor.

--- a/tests/vitest/structure/Structure.test.svelte.ts
+++ b/tests/vitest/structure/Structure.test.svelte.ts
@@ -669,10 +669,14 @@ test(`camera projection and auto-rotate controls reflect scene_props`, async () 
     `orthographic`,
   ])
 
-  const auto_rotate_input = document.querySelector(
-    `.controls-pane input[type="number"][max="2"]`,
-  ) as HTMLInputElement
-  expect(Number(auto_rotate_input.value)).toBeCloseTo(0.5, 1)
+  // by label, not by `[max="2"]`: several sliders share that bound, so a positional match
+  // silently follows whichever section the pane happens to render first
+  const auto_rotate_label = [...document.querySelectorAll(`.controls-pane label`)].find(
+    (label) => label.textContent?.includes(`Auto-rotate speed`),
+  )
+  const auto_rotate_input =
+    auto_rotate_label?.querySelector<HTMLInputElement>(`input[type="number"]`)
+  expect(Number(auto_rotate_input?.value)).toBeCloseTo(0.5, 1)
 })
 
 test(`viewer-local setting changes do not mutate defaults or another viewer`, async () => {

--- a/tests/vitest/structure/StructureControls.svelte.test.ts
+++ b/tests/vitest/structure/StructureControls.svelte.test.ts
@@ -13,6 +13,7 @@ import { type ComponentProps, mount, tick } from 'svelte'
 import { describe, expect, test, vi } from 'vitest'
 import {
   bind_props,
+  doc_query,
   expect_labelled_settings_grid,
   make_crystal,
   simple_structure,
@@ -39,6 +40,11 @@ const set_input = (input: HTMLInputElement, value: string): void => {
   input.value = value
   input.dispatchEvent(new Event(`input`, { bubbles: true }))
 }
+// Most rows carry no stable selector, so they are addressed by their visible label text.
+const find_label = (root: ParentNode, text: string, { exact = false } = {}) =>
+  [...root.querySelectorAll(`label`)].find((label) =>
+    exact ? label.textContent?.trim() === text : label.textContent?.includes(text),
+  )
 // jsdom has no file picker, so hand the input a FileList stand-in and fire the change it would.
 // The handler reads the file asynchronously, so settle on the status line it writes at the end
 // rather than on anything it does before awaiting.
@@ -48,10 +54,7 @@ const import_settings_file = async (
   expect_status: RegExp,
   name = `shared-view.json`,
 ): Promise<void> => {
-  const input = target.querySelector<HTMLInputElement>(
-    `input[aria-label="Import viewer settings JSON"]`,
-  )
-  if (!input) throw new Error(`Import viewer settings input is missing`)
+  const input = doc_query<HTMLInputElement>(`input[aria-label="Import viewer settings JSON"]`)
   const file = new File([], name)
   Object.defineProperty(file, `text`, { value: () => Promise.resolve(contents) })
   Object.defineProperty(input, `files`, {
@@ -98,8 +101,7 @@ describe(`StructureControls layout`, () => {
       [`Preferences`, false],
     ])
 
-    const search = target.querySelector<HTMLInputElement>(`input[type="search"]`)
-    if (!search) throw new Error(`Settings search input is missing`)
+    const search = doc_query<HTMLInputElement>(`input[type="search"]`)
     set_input(search, `damp`)
     await tick()
     expect(groups[0]?.hasAttribute(`data-search-hidden`)).toBe(true)
@@ -138,9 +140,7 @@ describe(`StructureControls layout`, () => {
       overrides: { max?: number; step?: number } = {},
     ) => {
       const config = SETTINGS_CONFIG.structure[setting]
-      const label = [...target.querySelectorAll<HTMLLabelElement>(`label`)].find((element) =>
-        element.textContent?.includes(label_text),
-      )
+      const label = find_label(target, label_text)
       if (!label) throw new Error(`${label_text} slider is missing`)
       const inputs = [...label.querySelectorAll<HTMLInputElement>(`input`)]
       expect(inputs).toHaveLength(2)
@@ -200,8 +200,8 @@ const mount_persisted_controls = async () => {
 }
 
 describe(`StructureControls reactive props`, () => {
-  test(`restores persisted settings`, async () => {
-    const { state } = await mount_persisted_controls()
+  test(`restores persisted settings and treats them as the reset snapshot`, async () => {
+    const { state, target } = await mount_persisted_controls()
     expect(state).toMatchObject({
       scene_props: { atom_radius: 1.35, ambient_light: 2.5 },
       lattice_props: { cell_edge_opacity: 0.75 },
@@ -213,20 +213,15 @@ describe(`StructureControls reactive props`, () => {
       supercell_scaling: `2x2x1`,
       multi_view: true,
     })
-  })
-
-  test(`uses restored settings as section reset snapshots`, async () => {
-    const { target } = await mount_persisted_controls()
     // Persisted values define this session's reset snapshot, so they do not immediately
     // masquerade as unsaved changes.
     expect(target.querySelector(`button[aria-label="Reset atoms to defaults"]`)).toBeNull()
   })
 
   test(`persists changed settings and pane size after debounce`, async () => {
-    const { state, target } = await mount_persisted_controls()
+    const { state } = await mount_persisted_controls()
     state.scene_props.atom_radius = 1.6
-    const pane = target.querySelector<HTMLElement>(`.controls-pane`)
-    if (!pane) throw new Error(`Structure controls pane is missing`)
+    const pane = doc_query(`.controls-pane`)
     pane.style.width = `520px`
     pane.style.height = `610px`
     trigger_resize_observer(pane)
@@ -255,13 +250,11 @@ describe(`StructureControls reactive props`, () => {
   })
 
   test(`reset-all restores defaults and clears persisted state`, async () => {
-    const { state, target } = await mount_persisted_controls()
+    const { state } = await mount_persisted_controls()
     state.scene_props.vector_configs = {
       force: { visible: false, color: `#ff0000`, scale: 4 },
     }
-    const reset_button = target.querySelector<HTMLButtonElement>(`button.reset-all-settings`)
-    if (!reset_button) throw new Error(`Reset-all settings button is missing`)
-    reset_button.click()
+    doc_query<HTMLButtonElement>(`button.reset-all-settings`).click()
     await tick()
     expect(state.scene_props.atom_radius).toBe(DEFAULTS.structure.atom_radius)
     expect(state.scene_props.ambient_light).toBe(DEFAULTS.structure.ambient_light)
@@ -281,8 +274,16 @@ describe(`StructureControls reactive props`, () => {
     await mount_bound_controls(state, { persist_settings: false })
 
     expect(state.scene_props.atom_radius).toBe(DEFAULTS.structure.atom_radius)
-    state.scene_props.atom_radius = 2
-    await tick()
+    // Saves are debounced, so asserting after a single tick would hold even with persistence
+    // switched on. Drive the clock past the timer to prove nothing was ever queued.
+    vi.useFakeTimers()
+    try {
+      state.scene_props.atom_radius = 2
+      await tick()
+      await vi.advanceTimersByTimeAsync(1000)
+    } finally {
+      vi.useRealTimers()
+    }
     expect(load_structure_view_state()?.settings.structure.atom_radius).toBe(1.5)
   })
 
@@ -396,10 +397,9 @@ describe(`StructureControls reactive props`, () => {
     }
     await tick()
 
-    const opacity_input = target.querySelector<HTMLInputElement>(
+    const opacity_input = doc_query<HTMLInputElement>(
       `[data-key="site_label_bg_opacity"] input[type="number"]`,
     )
-    if (!opacity_input) throw new Error(`site label background opacity input is missing`)
     expect(
       target.querySelector<HTMLInputElement>(`input[aria-label="Site label color"]`)?.value,
     ).toBe(`#00ff00`)
@@ -462,9 +462,9 @@ describe(`StructureControls reactive props`, () => {
     const target = await mount_bound_controls(state, { polyhedra_rendered_elements: [] })
 
     const center_checkbox = (symbol: string) =>
-      [...target.querySelectorAll(`label`)]
-        .find((label) => label.textContent?.trim() === symbol)
-        ?.querySelector<HTMLInputElement>(`input[type="checkbox"]`)
+      find_label(target, symbol, { exact: true })?.querySelector<HTMLInputElement>(
+        `input[type="checkbox"]`,
+      )
 
     // force-included element shows checked even when not (yet) rendered
     expect(center_checkbox(`O`)?.checked).toBe(true)
@@ -489,10 +489,7 @@ describe(`StructureControls reactive props`, () => {
 
     const target = await mount_bound_controls(state, { structure: fe_oxide })
 
-    const center_label = (symbol: string) =>
-      [...target.querySelectorAll(`label`)].find(
-        (label) => label.textContent?.trim() === symbol,
-      )
+    const center_label = (symbol: string) => find_label(target, symbol, { exact: true })
 
     expect(center_label(`Fe`)).toBeDefined()
     // no split-character artifacts from string iteration
@@ -538,10 +535,9 @@ describe(`StructureControls reactive props`, () => {
     expect(reset_button(`site vectors`)).toBeNull()
     expect(reset_button(`visibility`)).toBeNull()
 
-    const force_scale = target.querySelector<HTMLInputElement>(
+    const force_scale = doc_query<HTMLInputElement>(
       `[data-key="vector_scale:force"] input[type="number"]`,
     )
-    if (!force_scale) throw new Error(`per-key vector scale input is missing`)
     set_input(force_scale, `2.5`)
 
     state.scene_props.displacement_arrow_color = `#123456`
@@ -611,10 +607,7 @@ describe(`StructureControls reactive props`, () => {
       })
       const target = await mount_bound_controls(state)
 
-      const has_toggle = [...target.querySelectorAll(`label`)].some((label) =>
-        label.textContent?.includes(`Show trajectory trails`),
-      )
-      expect(has_toggle).toBe(expect_toggle)
+      expect(Boolean(find_label(target, `Show trajectory trails`))).toBe(expect_toggle)
       expect(target.textContent?.includes(`Trail length`) ?? false).toBe(expect_length)
     },
   )
@@ -630,9 +623,8 @@ describe(`StructureControls reactive props`, () => {
 
     const target = await mount_controls(bind_props({ controls_open: true }, state))
 
-    const multi_view_input = [...target.querySelectorAll<HTMLInputElement>(`input`)].find(
-      (input) => input.closest(`label`)?.textContent?.includes(`Multi-view grid`),
-    )
+    const multi_view_row = find_label(target, `Multi-view grid`)
+    const multi_view_input = multi_view_row?.querySelector<HTMLInputElement>(`input`)
     expect(multi_view_input?.disabled).toBe(true)
     const hint_id = multi_view_input?.getAttribute(`aria-describedby`) ?? ``
     expect(document.querySelector(`#${hint_id}`)?.textContent).toContain(

--- a/tests/vitest/structure/StructureControls.svelte.test.ts
+++ b/tests/vitest/structure/StructureControls.svelte.test.ts
@@ -40,8 +40,7 @@ const set_input = (input: HTMLInputElement, value: string): void => {
   input.value = value
   input.dispatchEvent(new Event(`input`, { bubbles: true }))
 }
-// Most rows carry no stable selector, so they are addressed by their visible label text.
-const find_label = (root: ParentNode, text: string, { exact = false } = {}) =>
+const find_label = (root: ParentNode, text: string, exact = false) =>
   [...root.querySelectorAll(`label`)].find((label) =>
     exact ? label.textContent?.trim() === text : label.textContent?.includes(text),
   )
@@ -57,16 +56,13 @@ const import_settings_file = async (
   const input = doc_query<HTMLInputElement>(`input[aria-label="Import viewer settings JSON"]`)
   const file = new File([], name)
   Object.defineProperty(file, `text`, { value: () => Promise.resolve(contents) })
-  Object.defineProperty(input, `files`, {
-    configurable: true,
-    value: [file],
-  })
+  Object.defineProperty(input, `files`, { configurable: true, value: [file] })
   input.dispatchEvent(new Event(`change`, { bubbles: true }))
-  await vi.waitFor(() =>
-    expect(target.querySelector(`small.settings-import-status`)?.textContent ?? ``).toMatch(
+  await vi.waitFor(() => {
+    expect(target.querySelector(`small.settings-import-status`)?.textContent).toMatch(
       expect_status,
-    ),
-  )
+    )
+  })
 }
 type AtomColorConfigProps = NonNullable<
   ComponentProps<typeof StructureControls>['atom_color_config']
@@ -136,11 +132,13 @@ describe(`StructureControls layout`, () => {
       target.querySelectorAll(`section.grid > label, section.grid > .setting`).length,
     ).toBeGreaterThan(20)
 
-    const expect_slider = (
-      label_text: string,
-      setting: keyof typeof SETTINGS_CONFIG.structure,
-      overrides: { max?: number; step?: number } = {},
-    ) => {
+    const sliders = [
+      [`Radius`, `atom_radius`, undefined, 0.05],
+      [`Auto-rotate speed`, `auto_rotate`, undefined, 0.01],
+      [`Trail length`, `trajectory_line_trail_frames`, stream.n_frames, undefined],
+      [`Frame stride`, `trajectory_line_frame_stride`, undefined, undefined],
+    ] as const
+    for (const [label_text, setting, max, step] of sliders) {
       const config = SETTINGS_CONFIG.structure[setting]
       const label = find_label(target, label_text)
       if (!label) throw new Error(`${label_text} slider is missing`)
@@ -148,17 +146,12 @@ describe(`StructureControls layout`, () => {
       expect(inputs).toHaveLength(2)
       for (const input of inputs) {
         expect(input.min).toBe(`${config.minimum}`)
-        expect(input.max).toBe(`${overrides.max ?? config.maximum}`)
-        const expected_step = overrides.step ?? config.multipleOf
+        expect(input.max).toBe(`${max ?? config.maximum}`)
+        const expected_step = step ?? config.multipleOf
         if (expected_step !== undefined) expect(input.step).toBe(`${expected_step}`)
       }
       expect(label.dataset.originalTitle).toBe(config.description)
     }
-
-    expect_slider(`Radius`, `atom_radius`, { step: 0.05 })
-    expect_slider(`Auto-rotate speed`, `auto_rotate`, { step: 0.01 })
-    expect_slider(`Trail length`, `trajectory_line_trail_frames`, { max: stream.n_frames })
-    expect_slider(`Frame stride`, `trajectory_line_frame_stride`)
   })
 })
 
@@ -293,9 +286,7 @@ describe(`StructureControls reactive props`, () => {
     const state = $state({ scene_props: { ...DEFAULTS.structure } })
     const target = await mount_bound_controls(state, { persist_settings: false })
     vi.mocked(navigator.clipboard.writeText).mockClear()
-    target
-      .querySelector<HTMLButtonElement>(`button[aria-label="Copy viewer settings JSON"]`)
-      ?.click()
+    doc_query<HTMLButtonElement>(`button[aria-label="Copy viewer settings JSON"]`).click()
     const copied = vi.mocked(navigator.clipboard.writeText).mock.lastCall?.[0]
     expect(JSON.parse(copied ?? `{}`)).toMatchObject({
       version: 1,
@@ -358,11 +349,7 @@ describe(`StructureControls reactive props`, () => {
     await tick()
     expect(state.atom_color_config.scale_type).toBe(`categorical`)
 
-    const reset = target.querySelector<HTMLButtonElement>(
-      `[data-key="atom_color_mode"] .setting-reset-button`,
-    )
-    expect(reset).not.toBeNull()
-    reset?.click()
+    doc_query<HTMLButtonElement>(`[data-key="atom_color_mode"] .setting-reset-button`).click()
     await tick()
 
     expect(state.atom_color_config).toMatchObject({
@@ -464,7 +451,7 @@ describe(`StructureControls reactive props`, () => {
     const target = await mount_bound_controls(state, { polyhedra_rendered_elements: [] })
 
     const center_checkbox = (symbol: string) =>
-      find_label(target, symbol, { exact: true })?.querySelector<HTMLInputElement>(
+      find_label(target, symbol, true)?.querySelector<HTMLInputElement>(
         `input[type="checkbox"]`,
       )
 
@@ -491,7 +478,7 @@ describe(`StructureControls reactive props`, () => {
 
     const target = await mount_bound_controls(state, { structure: fe_oxide })
 
-    const center_label = (symbol: string) => find_label(target, symbol, { exact: true })
+    const center_label = (symbol: string) => find_label(target, symbol, true)
 
     expect(center_label(`Fe`)).toBeDefined()
     // no split-character artifacts from string iteration

--- a/tests/vitest/structure/StructureControls.svelte.test.ts
+++ b/tests/vitest/structure/StructureControls.svelte.test.ts
@@ -32,6 +32,32 @@ const set_input = (input: HTMLInputElement, value: string): void => {
   input.value = value
   input.dispatchEvent(new Event(`input`, { bubbles: true }))
 }
+// jsdom has no file picker, so hand the input a FileList stand-in and fire the change it would.
+// The handler reads the file asynchronously, so settle on the status line it writes at the end
+// rather than on anything it does before awaiting.
+const import_settings_file = async (
+  target: HTMLElement,
+  contents: string,
+  expect_status: RegExp,
+  name = `shared-view.json`,
+): Promise<void> => {
+  const input = target.querySelector<HTMLInputElement>(
+    `input[aria-label="Import viewer settings JSON"]`,
+  )
+  if (!input) throw new Error(`Import viewer settings input is missing`)
+  const file = new File([], name)
+  Object.defineProperty(file, `text`, { value: () => Promise.resolve(contents) })
+  Object.defineProperty(input, `files`, {
+    configurable: true,
+    value: [file],
+  })
+  input.dispatchEvent(new Event(`change`, { bubbles: true }))
+  await vi.waitFor(() =>
+    expect(target.querySelector(`small.settings-import-status`)?.textContent ?? ``).toMatch(
+      expect_status,
+    ),
+  )
+}
 type AtomColorConfigProps = NonNullable<
   ComponentProps<typeof StructureControls>['atom_color_config']
 >
@@ -135,49 +161,68 @@ describe(`StructureControls layout`, () => {
   })
 })
 
-describe(`StructureControls reactive props`, () => {
-  test(`restores persisted settings before section reset snapshots and clears all`, async () => {
-    save_structure_view_state(
-      create_structure_view_state({
-        scene_props: {
-          atom_radius: 1.35,
-          ambient_light: 2.5,
-          show_trajectory_lines: true,
-        },
-        lattice_props: { cell_edge_opacity: 0.75 },
-        color_scheme: `Jmol`,
-        background_color: `#123456`,
-        background_opacity: 0.4,
-        show_image_atoms: false,
-        supercell_scaling: `2x2x1`,
-        multi_view: true,
-      }),
-    )
-    const state = $state({
-      scene_props: { ...DEFAULTS.structure },
-      lattice_props: {
-        cell_edge_opacity: DEFAULTS.structure.cell_edge_opacity,
-        cell_surface_opacity: DEFAULTS.structure.cell_surface_opacity,
-        cell_edge_color: DEFAULTS.structure.cell_edge_color,
-        cell_surface_color: DEFAULTS.structure.cell_surface_color,
-        cell_edge_width: DEFAULTS.structure.cell_edge_width,
-        show_cell_vectors: DEFAULTS.structure.show_cell_vectors,
-      },
-      color_scheme: DEFAULTS.color_scheme,
-      background_color: undefined as string | undefined,
-      background_opacity: DEFAULTS.background_opacity,
-      show_image_atoms: DEFAULTS.structure.show_image_atoms,
-      show_trajectory_lines: false,
-      supercell_scaling: `1x1x1`,
-      multi_view: false,
-    })
-    const target = await mount_controls(
-      bind_props(
-        { structure: simple_structure, controls_open: true, persist_settings: true },
-        state,
-      ),
-    )
+type PersistedControlsState = {
+  scene_props: NonNullable<ComponentProps<typeof StructureControls>['scene_props']>
+  lattice_props: NonNullable<ComponentProps<typeof StructureControls>['lattice_props']>
+  color_scheme: string
+  background_color: string | undefined
+  background_opacity: number
+  show_image_atoms: boolean
+  show_trajectory_lines: boolean
+  supercell_scaling: string
+  multi_view: boolean
+}
 
+const mount_persisted_controls = async (): Promise<{
+  target: HTMLElement
+  state: PersistedControlsState
+}> => {
+  save_structure_view_state(
+    create_structure_view_state({
+      scene_props: {
+        atom_radius: 1.35,
+        ambient_light: 2.5,
+        show_trajectory_lines: true,
+      },
+      lattice_props: { cell_edge_opacity: 0.75 },
+      color_scheme: `Jmol`,
+      background_color: `#123456`,
+      background_opacity: 0.4,
+      show_image_atoms: false,
+      supercell_scaling: `2x2x1`,
+      multi_view: true,
+    }),
+  )
+  const state = $state<PersistedControlsState>({
+    scene_props: { ...DEFAULTS.structure },
+    lattice_props: {
+      cell_edge_opacity: DEFAULTS.structure.cell_edge_opacity,
+      cell_surface_opacity: DEFAULTS.structure.cell_surface_opacity,
+      cell_edge_color: DEFAULTS.structure.cell_edge_color,
+      cell_surface_color: DEFAULTS.structure.cell_surface_color,
+      cell_edge_width: DEFAULTS.structure.cell_edge_width,
+      show_cell_vectors: DEFAULTS.structure.show_cell_vectors,
+    },
+    color_scheme: DEFAULTS.color_scheme,
+    background_color: undefined,
+    background_opacity: DEFAULTS.background_opacity,
+    show_image_atoms: DEFAULTS.structure.show_image_atoms,
+    show_trajectory_lines: false,
+    supercell_scaling: `1x1x1`,
+    multi_view: false,
+  })
+  const target = await mount_controls(
+    bind_props(
+      { structure: simple_structure, controls_open: true, persist_settings: true },
+      state,
+    ),
+  )
+  return { target, state }
+}
+
+describe(`StructureControls reactive props`, () => {
+  test(`restores persisted settings`, async () => {
+    const { state } = await mount_persisted_controls()
     expect(state).toMatchObject({
       scene_props: { atom_radius: 1.35, ambient_light: 2.5 },
       lattice_props: { cell_edge_opacity: 0.75 },
@@ -189,10 +234,17 @@ describe(`StructureControls reactive props`, () => {
       supercell_scaling: `2x2x1`,
       multi_view: true,
     })
+  })
+
+  test(`uses restored settings as section reset snapshots`, async () => {
+    const { target } = await mount_persisted_controls()
     // Persisted values define this session's reset snapshot, so they do not immediately
     // masquerade as unsaved changes.
     expect(target.querySelector(`button[aria-label="Reset atoms to defaults"]`)).toBeNull()
+  })
 
+  test(`persists changed settings and pane size after debounce`, async () => {
+    const { state, target } = await mount_persisted_controls()
     state.scene_props.atom_radius = 1.6
     const pane = target.querySelector<HTMLElement>(`.controls-pane`)
     if (!pane) throw new Error(`Structure controls pane is missing`)
@@ -206,10 +258,24 @@ describe(`StructureControls reactive props`, () => {
       }),
     )
 
-    target.querySelector<HTMLButtonElement>(`button.reset-all-settings`)?.click()
+    state.scene_props.atom_radius = 1.35
+    await vi.waitFor(() =>
+      expect(load_structure_view_state()?.settings.structure.atom_radius).toBe(1.35),
+    )
+  })
+
+  test(`reset-all restores defaults and clears persisted state`, async () => {
+    const { state, target } = await mount_persisted_controls()
+    state.scene_props.vector_configs = {
+      force: { visible: false, color: `#ff0000`, scale: 4 },
+    }
+    const reset_button = target.querySelector<HTMLButtonElement>(`button.reset-all-settings`)
+    if (!reset_button) throw new Error(`Reset-all settings button is missing`)
+    reset_button.click()
     await tick()
     expect(state.scene_props.atom_radius).toBe(DEFAULTS.structure.atom_radius)
     expect(state.scene_props.ambient_light).toBe(DEFAULTS.structure.ambient_light)
+    expect(state.scene_props.vector_configs).toEqual({})
     expect(state.color_scheme).toBe(DEFAULTS.color_scheme)
     expect(state.background_color).toBeUndefined()
     expect(state.show_trajectory_lines).toBe(DEFAULTS.structure.show_trajectory_lines)
@@ -247,44 +313,42 @@ describe(`StructureControls reactive props`, () => {
     target
       .querySelector<HTMLButtonElement>(`button[aria-label="Copy viewer settings JSON"]`)
       ?.click()
-    expect(navigator.clipboard.writeText).toHaveBeenCalledOnce()
-    const copied_json = vi.mocked(navigator.clipboard.writeText).mock.calls[0]?.[0]
-    expect(JSON.parse(copied_json ?? `{}`)).toMatchObject({
+    const copied = vi.mocked(navigator.clipboard.writeText).mock.lastCall?.[0]
+    expect(JSON.parse(copied ?? `{}`)).toMatchObject({
       version: 1,
       settings: { structure: { atom_radius: DEFAULTS.structure.atom_radius } },
     })
 
-    const imported = create_structure_view_state({
+    const shared = create_structure_view_state({
       scene_props: { atom_radius: 1.8, camera_projection: `perspective` },
-      color_scheme: `Muted`,
     })
-    const file_input = target.querySelector<HTMLInputElement>(
-      `input[aria-label="Import viewer settings JSON"]`,
+    await import_settings_file(
+      target,
+      serialize_structure_view_state(shared),
+      /Imported shared-view\.json/,
     )
-    if (!file_input) throw new Error(`Import viewer settings input is missing`)
-    Object.defineProperty(file_input, `files`, {
-      configurable: true,
-      value: [
-        new File([serialize_structure_view_state(imported)], `shared-view.json`, {
-          type: `application/json`,
-        }),
-      ],
-    })
-    file_input.dispatchEvent(new Event(`change`, { bubbles: true }))
-    await vi.waitFor(() => expect(state.scene_props.atom_radius).toBe(1.8))
+    expect(state.scene_props.atom_radius).toBe(1.8)
     expect(state.scene_props.camera_projection).toBe(`perspective`)
-    expect(target.textContent).toContain(`Imported shared-view.json`)
+  })
 
-    // "Reset all" has to undo an import wholesale, not just the rows the user touched by hand
-    target
-      .querySelector<HTMLButtonElement>(
-        `button[aria-label="Reset all viewer settings to defaults"]`,
-      )
-      ?.click()
-    await vi.waitFor(() =>
-      expect(state.scene_props.atom_radius).toBe(DEFAULTS.structure.atom_radius),
+  test.each([
+    [`malformed JSON`, `{"nope":`, /Invalid JSON/],
+    [
+      `unsupported version`,
+      JSON.stringify({ version: 999 }),
+      /Unsupported view-state version 999; expected 1/,
+    ],
+  ])(`import rejects %s and leaves settings untouched`, async (_label, payload, status) => {
+    const state = $state({ scene_props: { ...DEFAULTS.structure, atom_radius: 1.4 } })
+    const target = await mount_controls(
+      bind_props(
+        { structure: simple_structure, controls_open: true, persist_settings: false },
+        state,
+      ),
     )
-    expect(state.scene_props.camera_projection).toBe(DEFAULTS.structure.camera_projection)
+    await import_settings_file(target, payload, status)
+    expect(target.querySelector(`small.settings-import-status[role="alert"]`)).not.toBeNull()
+    expect(state.scene_props.atom_radius).toBe(1.4)
   })
 
   test(`fills a missing atom color scale at mount and after prop replacement`, async () => {
@@ -549,6 +613,29 @@ describe(`StructureControls reactive props`, () => {
     )
     expect(state.scene_props.polyhedra_excluded_elements).toEqual([])
     expect(state.scene_props.vector_configs?.force?.scale).toBeNull()
+  })
+
+  test(`refreshes site-vector reset snapshots when vector keys change`, async () => {
+    const structure_with_vector = (key: string) => ({
+      ...simple_structure,
+      sites: simple_structure.sites.map((site) => ({
+        ...site,
+        properties: { ...site.properties, [key]: [0.1, 0.2, 0.3] },
+      })),
+    })
+    const state = $state({
+      structure: structure_with_vector(`force`),
+      scene_props: { ...DEFAULTS.structure },
+    })
+    const target = await mount_controls(
+      bind_props({ controls_open: true, persist_settings: false }, state),
+    )
+
+    state.structure = structure_with_vector(`magmom`)
+    await tick()
+    expect(
+      target.querySelector(`button[aria-label="Reset site vectors to defaults"]`),
+    ).toBeNull()
   })
 
   test(`section reset restores mount-time values, not shipped defaults`, async () => {

--- a/tests/vitest/structure/StructureControls.svelte.test.ts
+++ b/tests/vitest/structure/StructureControls.svelte.test.ts
@@ -28,6 +28,13 @@ const mount_controls = async (
   await tick()
   return target
 }
+const mount_bound_controls = (
+  state: Record<string, unknown>,
+  props: ComponentProps<typeof StructureControls> = {},
+): Promise<HTMLElement> =>
+  mount_controls(
+    bind_props({ structure: simple_structure, controls_open: true, ...props }, state),
+  )
 const set_input = (input: HTMLInputElement, value: string): void => {
   input.value = value
   input.dispatchEvent(new Event(`input`, { bubbles: true }))
@@ -106,32 +113,24 @@ describe(`StructureControls layout`, () => {
     ).toBe(false)
   })
 
-  test(`uses labelled settings grids throughout the pane`, async () => {
-    const target = await mount_controls({
-      structure: simple_structure,
-      controls_open: true,
-      scene_props: {
-        show_bonds: `always`,
-        show_polyhedra: `always`,
-        show_site_labels: true,
-      },
-      displacement_summary: { rmsd: 0.1, max_displacement: 0.2, error: null },
-    })
-
-    expect_labelled_settings_grid(target)
-    expect(
-      target.querySelectorAll(`section.grid > label, section.grid > .setting`).length,
-    ).toBeGreaterThan(20)
-  })
-
-  test(`derives structure slider metadata from the settings schema`, async () => {
+  test(`uses labelled grids and schema-backed sliders`, async () => {
     const stream = trail_stream()
     const target = await mount_controls({
       structure: simple_structure,
       controls_open: true,
       show_trajectory_lines: true,
-      scene_props: { trajectory_position_stream: stream },
+      scene_props: {
+        show_bonds: `always`,
+        show_polyhedra: `always`,
+        show_site_labels: true,
+        trajectory_position_stream: stream,
+      },
+      displacement_summary: { rmsd: 0.1, max_displacement: 0.2, error: null },
     })
+    expect_labelled_settings_grid(target)
+    expect(
+      target.querySelectorAll(`section.grid > label, section.grid > .setting`).length,
+    ).toBeGreaterThan(20)
 
     const expect_slider = (
       label_text: string,
@@ -161,22 +160,7 @@ describe(`StructureControls layout`, () => {
   })
 })
 
-type PersistedControlsState = {
-  scene_props: NonNullable<ComponentProps<typeof StructureControls>['scene_props']>
-  lattice_props: NonNullable<ComponentProps<typeof StructureControls>['lattice_props']>
-  color_scheme: string
-  background_color: string | undefined
-  background_opacity: number
-  show_image_atoms: boolean
-  show_trajectory_lines: boolean
-  supercell_scaling: string
-  multi_view: boolean
-}
-
-const mount_persisted_controls = async (): Promise<{
-  target: HTMLElement
-  state: PersistedControlsState
-}> => {
+const mount_persisted_controls = async () => {
   save_structure_view_state(
     create_structure_view_state({
       scene_props: {
@@ -193,7 +177,7 @@ const mount_persisted_controls = async (): Promise<{
       multi_view: true,
     }),
   )
-  const state = $state<PersistedControlsState>({
+  const state = $state({
     scene_props: { ...DEFAULTS.structure },
     lattice_props: {
       cell_edge_opacity: DEFAULTS.structure.cell_edge_opacity,
@@ -211,12 +195,7 @@ const mount_persisted_controls = async (): Promise<{
     supercell_scaling: `1x1x1`,
     multi_view: false,
   })
-  const target = await mount_controls(
-    bind_props(
-      { structure: simple_structure, controls_open: true, persist_settings: true },
-      state,
-    ),
-  )
+  const target = await mount_bound_controls(state, { persist_settings: true })
   return { target, state }
 }
 
@@ -257,6 +236,17 @@ describe(`StructureControls reactive props`, () => {
         viewer: { controls_pane_size: { width: 520, height: 610 } },
       }),
     )
+  })
+
+  // Nothing else may change alongside it: comparing against the mount baseline rather than the
+  // last save would leave 1.6 on disk, and a second moving part would mask that by making the
+  // serialized state differ from the baseline anyway.
+  test(`re-saves a setting driven away from and back to its restored value`, async () => {
+    const { state } = await mount_persisted_controls()
+    state.scene_props.atom_radius = 1.6
+    await vi.waitFor(() =>
+      expect(load_structure_view_state()?.settings.structure.atom_radius).toBe(1.6),
+    )
 
     state.scene_props.atom_radius = 1.35
     await vi.waitFor(() =>
@@ -288,12 +278,7 @@ describe(`StructureControls reactive props`, () => {
       create_structure_view_state({ scene_props: { atom_radius: 1.5 } }),
     )
     const state = $state({ scene_props: { ...DEFAULTS.structure } })
-    await mount_controls(
-      bind_props(
-        { structure: simple_structure, controls_open: true, persist_settings: false },
-        state,
-      ),
-    )
+    await mount_bound_controls(state, { persist_settings: false })
 
     expect(state.scene_props.atom_radius).toBe(DEFAULTS.structure.atom_radius)
     state.scene_props.atom_radius = 2
@@ -303,12 +288,7 @@ describe(`StructureControls reactive props`, () => {
 
   test(`copies and imports viewer settings through the visible actions`, async () => {
     const state = $state({ scene_props: { ...DEFAULTS.structure } })
-    const target = await mount_controls(
-      bind_props(
-        { structure: simple_structure, controls_open: true, persist_settings: false },
-        state,
-      ),
-    )
+    const target = await mount_bound_controls(state, { persist_settings: false })
     vi.mocked(navigator.clipboard.writeText).mockClear()
     target
       .querySelector<HTMLButtonElement>(`button[aria-label="Copy viewer settings JSON"]`)
@@ -340,12 +320,7 @@ describe(`StructureControls reactive props`, () => {
     ],
   ])(`import rejects %s and leaves settings untouched`, async (_label, payload, status) => {
     const state = $state({ scene_props: { ...DEFAULTS.structure, atom_radius: 1.4 } })
-    const target = await mount_controls(
-      bind_props(
-        { structure: simple_structure, controls_open: true, persist_settings: false },
-        state,
-      ),
-    )
+    const target = await mount_bound_controls(state, { persist_settings: false })
     await import_settings_file(target, payload, status)
     expect(target.querySelector(`small.settings-import-status[role="alert"]`)).not.toBeNull()
     expect(state.scene_props.atom_radius).toBe(1.4)
@@ -356,9 +331,7 @@ describe(`StructureControls reactive props`, () => {
       atom_color_config: { mode: `coordination`, scale_type: `continuous` },
     })
 
-    const target = await mount_controls(
-      bind_props({ structure: simple_structure, controls_open: true }, state),
-    )
+    const target = await mount_bound_controls(state)
 
     expect(state.atom_color_config.scale).toBe(DEFAULTS.structure.atom_color_scale)
     expect(target.querySelector(`button[aria-label="Reset atoms to defaults"]`)).toBeNull()
@@ -376,9 +349,7 @@ describe(`StructureControls reactive props`, () => {
         scale_type: DEFAULTS.structure.atom_color_scale_type,
       },
     })
-    const target = await mount_controls(
-      bind_props({ structure: simple_structure, controls_open: true }, state),
-    )
+    const target = await mount_bound_controls(state)
 
     state.atom_color_config.mode = `wyckoff`
     await tick()
@@ -413,9 +384,7 @@ describe(`StructureControls reactive props`, () => {
       },
     })
 
-    const target = await mount_controls(
-      bind_props({ structure: simple_structure, controls_open: true }, state),
-    )
+    const target = await mount_bound_controls(state)
     // mounting the pane reads those strings, it does not rewrite them
     expect(state.scene_props.site_label_color).toBe(`#111111`)
     expect(state.scene_props.site_label_bg_color).toBe(bg_color)
@@ -468,7 +437,7 @@ describe(`StructureControls reactive props`, () => {
         scale_type: `continuous` as const,
       },
     })
-    await mount_controls(bind_props({ structure, controls_open: true }, state))
+    await mount_bound_controls(state, { structure })
 
     // The native property dropdown performs this same nested mutation through bind:value.
     state.atom_color_config.property_key = CNA_TYPE_PROPERTY
@@ -489,13 +458,8 @@ describe(`StructureControls reactive props`, () => {
       },
     })
 
-    const target = await mount_controls(
-      bind_props(
-        // nothing rendered yet (e.g. O blocked by CN cap), but O is force-included
-        { structure: simple_structure, controls_open: true, polyhedra_rendered_elements: [] },
-        state,
-      ),
-    )
+    // nothing rendered yet (e.g. O blocked by CN cap), but O is force-included
+    const target = await mount_bound_controls(state, { polyhedra_rendered_elements: [] })
 
     const center_checkbox = (symbol: string) =>
       [...target.querySelectorAll(`label`)]
@@ -523,9 +487,7 @@ describe(`StructureControls reactive props`, () => {
     ])
     const state = $state({ scene_props: { show_polyhedra: `crystals` as const } })
 
-    const target = await mount_controls(
-      bind_props({ structure: fe_oxide, controls_open: true }, state),
-    )
+    const target = await mount_bound_controls(state, { structure: fe_oxide })
 
     const center_label = (symbol: string) =>
       [...target.querySelectorAll(`label`)].find(
@@ -553,18 +515,14 @@ describe(`StructureControls reactive props`, () => {
     }
     // every key defined at its default, so the mount-time snapshot the reset offer compares
     // against isn't perturbed by `bind:` writing back into an undefined prop
-    const state = $state({ scene_props: { ...DEFAULTS.structure } })
+    const state = $state({
+      scene_props: { ...DEFAULTS.structure, atom_radius: 1.4 },
+    })
 
-    const target = await mount_controls(
-      bind_props(
-        {
-          structure: vector_structure,
-          controls_open: true,
-          displacement_summary: { rmsd: 0.12, max_displacement: 0.34, error: null },
-        },
-        state,
-      ),
-    )
+    const target = await mount_bound_controls(state, {
+      structure: vector_structure,
+      displacement_summary: { rmsd: 0.12, max_displacement: 0.34, error: null },
+    })
     const vector_defaults = default_vector_configs([`force`, `magmom`])
     state.scene_props.vector_configs = vector_defaults
     await tick()
@@ -574,6 +532,7 @@ describe(`StructureControls reactive props`, () => {
         `button[aria-label="Reset ${section} to defaults"]`,
       )
     // nothing differs from the mount-time snapshot yet, so no section offers a reset
+    expect(reset_button(`atoms`)).toBeNull()
     expect(reset_button(`displacement overlay`)).toBeNull()
     expect(reset_button(`polyhedra`)).toBeNull()
     expect(reset_button(`site vectors`)).toBeNull()
@@ -586,6 +545,7 @@ describe(`StructureControls reactive props`, () => {
     set_input(force_scale, `2.5`)
 
     state.scene_props.displacement_arrow_color = `#123456`
+    state.scene_props.atom_radius = 2.2
     state.scene_props.polyhedra_excluded_elements = [`O`]
     await tick()
     const force_config = state.scene_props.vector_configs?.force
@@ -603,14 +563,15 @@ describe(`StructureControls reactive props`, () => {
       scale: 2.5,
     })
 
-    reset_button(`displacement overlay`)?.click()
-    reset_button(`polyhedra`)?.click()
-    reset_button(`site vectors`)?.click()
+    for (const section of [`displacement overlay`, `atoms`, `polyhedra`, `site vectors`]) {
+      reset_button(section)?.click()
+    }
     await tick()
 
     expect(state.scene_props.displacement_arrow_color).toBe(
       DEFAULTS.structure.displacement_arrow_color,
     )
+    expect(state.scene_props.atom_radius).toBe(1.4)
     expect(state.scene_props.polyhedra_excluded_elements).toEqual([])
     expect(state.scene_props.vector_configs?.force?.scale).toBeNull()
   })
@@ -627,36 +588,13 @@ describe(`StructureControls reactive props`, () => {
       structure: structure_with_vector(`force`),
       scene_props: { ...DEFAULTS.structure },
     })
-    const target = await mount_controls(
-      bind_props({ controls_open: true, persist_settings: false }, state),
-    )
+    const target = await mount_bound_controls(state, { persist_settings: false })
 
     state.structure = structure_with_vector(`magmom`)
     await tick()
     expect(
       target.querySelector(`button[aria-label="Reset site vectors to defaults"]`),
     ).toBeNull()
-  })
-
-  test(`section reset restores mount-time values, not shipped defaults`, async () => {
-    const state = $state({ scene_props: { ...DEFAULTS.structure, atom_radius: 1.4 } })
-    const target = await mount_controls(
-      bind_props(
-        { structure: simple_structure, controls_open: true, persist_settings: false },
-        state,
-      ),
-    )
-    const reset_button = (section: string) =>
-      target.querySelector<HTMLButtonElement>(
-        `button[aria-label="Reset ${section} to defaults"]`,
-      )
-
-    expect(reset_button(`atoms`)).toBeNull()
-    state.scene_props.atom_radius = 2.2
-    await tick()
-    reset_button(`atoms`)?.click()
-    await tick()
-    expect(state.scene_props.atom_radius).toBe(1.4)
   })
 
   test.each<[string, TrajectoryPositionStream | null | undefined, boolean, boolean, boolean]>([
@@ -671,9 +609,7 @@ describe(`StructureControls reactive props`, () => {
         show_trajectory_lines: show_trails,
         scene_props: { trajectory_position_stream: stream },
       })
-      const target = await mount_controls(
-        bind_props({ structure: simple_structure, controls_open: true }, state),
-      )
+      const target = await mount_bound_controls(state)
 
       const has_toggle = [...target.querySelectorAll(`label`)].some((label) =>
         label.textContent?.includes(`Show trajectory trails`),

--- a/tests/vitest/structure/StructureControls.svelte.test.ts
+++ b/tests/vitest/structure/StructureControls.svelte.test.ts
@@ -268,12 +268,12 @@ describe(`StructureControls reactive props`, () => {
     expect(localStorage.getItem(STRUCTURE_VIEW_STATE_STORAGE_KEY)).toBeNull()
   })
 
-  test(`persist_settings=false neither restores nor overwrites saved preferences`, async () => {
+  test(`persistence is opt-in and disabled by default`, async () => {
     save_structure_view_state(
       create_structure_view_state({ scene_props: { atom_radius: 1.5 } }),
     )
     const state = $state({ scene_props: { ...DEFAULTS.structure } })
-    await mount_bound_controls(state, { persist_settings: false })
+    await mount_bound_controls(state)
 
     expect(state.scene_props.atom_radius).toBe(DEFAULTS.structure.atom_radius)
     // Saves are debounced, so asserting after a single tick would hold even with persistence

--- a/tests/vitest/structure/StructureControls.svelte.test.ts
+++ b/tests/vitest/structure/StructureControls.svelte.test.ts
@@ -1,10 +1,23 @@
-import { DEFAULTS } from '$lib/settings'
-import { StructureControls } from '$lib/structure'
+import { DEFAULTS, SETTINGS_CONFIG } from '$lib/settings'
+import {
+  create_structure_view_state,
+  load_structure_view_state,
+  save_structure_view_state,
+  serialize_structure_view_state,
+  STRUCTURE_VIEW_STATE_STORAGE_KEY,
+} from '$lib/settings/viewer-state'
+import { default_vector_configs, StructureControls } from '$lib/structure'
 import { CNA_TYPE_PROPERTY } from '$lib/structure-id'
 import type { TrajectoryPositionStream } from '$lib/trajectory'
 import { type ComponentProps, mount, tick } from 'svelte'
-import { describe, expect, test } from 'vitest'
-import { bind_props, make_crystal, simple_structure } from '../setup'
+import { describe, expect, test, vi } from 'vitest'
+import {
+  bind_props,
+  expect_labelled_settings_grid,
+  make_crystal,
+  simple_structure,
+  trigger_resize_observer,
+} from '../setup'
 
 const mount_controls = async (
   props: ComponentProps<typeof StructureControls>,
@@ -15,6 +28,13 @@ const mount_controls = async (
   await tick()
   return target
 }
+const set_input = (input: HTMLInputElement, value: string): void => {
+  input.value = value
+  input.dispatchEvent(new Event(`input`, { bubbles: true }))
+}
+type AtomColorConfigProps = NonNullable<
+  ComponentProps<typeof StructureControls>['atom_color_config']
+>
 
 const trail_stream = (): TrajectoryPositionStream => ({
   positions: new Float64Array(9),
@@ -32,19 +52,309 @@ const trail_stream = (): TrajectoryPositionStream => ({
   steps: [0, 1, 2],
 })
 
+describe(`StructureControls layout`, () => {
+  test(`integrates topic groups and settings search`, async () => {
+    const target = await mount_controls({ structure: simple_structure, controls_open: true })
+    const groups = [...target.querySelectorAll<HTMLDetailsElement>(`details.settings-group`)]
+    expect(
+      groups.map((group) => [group.querySelector(`.group-title`)?.textContent, group.open]),
+    ).toEqual([
+      [`Appearance`, true],
+      [`Camera`, false],
+      [`Scene`, false],
+      [`Preferences`, false],
+    ])
+
+    const search = target.querySelector<HTMLInputElement>(`input[type="search"]`)
+    if (!search) throw new Error(`Settings search input is missing`)
+    set_input(search, `damp`)
+    await tick()
+    expect(groups[0]?.hasAttribute(`data-search-hidden`)).toBe(true)
+    expect(groups[1]?.hasAttribute(`data-search-hidden`)).toBe(false)
+    expect(groups[1]?.open).toBe(true)
+    expect(groups[2]?.hasAttribute(`data-search-hidden`)).toBe(true)
+    expect(
+      target
+        .querySelector<HTMLElement>(`[data-key="rotation_damping"]`)
+        ?.hasAttribute(`data-search-hidden`),
+    ).toBe(false)
+  })
+
+  test(`uses labelled settings grids throughout the pane`, async () => {
+    const target = await mount_controls({
+      structure: simple_structure,
+      controls_open: true,
+      scene_props: {
+        show_bonds: `always`,
+        show_polyhedra: `always`,
+        show_site_labels: true,
+      },
+      displacement_summary: { rmsd: 0.1, max_displacement: 0.2, error: null },
+    })
+
+    expect_labelled_settings_grid(target)
+    expect(
+      target.querySelectorAll(`section.grid > label, section.grid > .setting`).length,
+    ).toBeGreaterThan(20)
+  })
+
+  test(`derives structure slider metadata from the settings schema`, async () => {
+    const stream = trail_stream()
+    const target = await mount_controls({
+      structure: simple_structure,
+      controls_open: true,
+      show_trajectory_lines: true,
+      scene_props: { trajectory_position_stream: stream },
+    })
+
+    const expect_slider = (
+      label_text: string,
+      setting: keyof typeof SETTINGS_CONFIG.structure,
+      overrides: { max?: number; step?: number } = {},
+    ) => {
+      const config = SETTINGS_CONFIG.structure[setting]
+      const label = [...target.querySelectorAll<HTMLLabelElement>(`label`)].find((element) =>
+        element.textContent?.includes(label_text),
+      )
+      if (!label) throw new Error(`${label_text} slider is missing`)
+      const inputs = [...label.querySelectorAll<HTMLInputElement>(`input`)]
+      expect(inputs).toHaveLength(2)
+      for (const input of inputs) {
+        expect(input.min).toBe(`${config.minimum}`)
+        expect(input.max).toBe(`${overrides.max ?? config.maximum}`)
+        const expected_step = overrides.step ?? config.multipleOf
+        if (expected_step !== undefined) expect(input.step).toBe(`${expected_step}`)
+      }
+      expect(label.dataset.originalTitle).toBe(config.description)
+    }
+
+    expect_slider(`Radius`, `atom_radius`, { step: 0.05 })
+    expect_slider(`Auto-rotate speed`, `auto_rotate`, { step: 0.01 })
+    expect_slider(`Trail length`, `trajectory_line_trail_frames`, { max: stream.n_frames })
+    expect_slider(`Frame stride`, `trajectory_line_frame_stride`)
+  })
+})
+
 describe(`StructureControls reactive props`, () => {
-  test(`syncs site label controls from external scene prop updates`, async () => {
+  test(`restores persisted settings before section reset snapshots and clears all`, async () => {
+    save_structure_view_state(
+      create_structure_view_state({
+        scene_props: {
+          atom_radius: 1.35,
+          ambient_light: 2.5,
+          show_trajectory_lines: true,
+        },
+        lattice_props: { cell_edge_opacity: 0.75 },
+        color_scheme: `Jmol`,
+        background_color: `#123456`,
+        background_opacity: 0.4,
+        show_image_atoms: false,
+        supercell_scaling: `2x2x1`,
+        multi_view: true,
+      }),
+    )
+    const state = $state({
+      scene_props: { ...DEFAULTS.structure },
+      lattice_props: {
+        cell_edge_opacity: DEFAULTS.structure.cell_edge_opacity,
+        cell_surface_opacity: DEFAULTS.structure.cell_surface_opacity,
+        cell_edge_color: DEFAULTS.structure.cell_edge_color,
+        cell_surface_color: DEFAULTS.structure.cell_surface_color,
+        cell_edge_width: DEFAULTS.structure.cell_edge_width,
+        show_cell_vectors: DEFAULTS.structure.show_cell_vectors,
+      },
+      color_scheme: DEFAULTS.color_scheme,
+      background_color: undefined as string | undefined,
+      background_opacity: DEFAULTS.background_opacity,
+      show_image_atoms: DEFAULTS.structure.show_image_atoms,
+      show_trajectory_lines: false,
+      supercell_scaling: `1x1x1`,
+      multi_view: false,
+    })
+    const target = await mount_controls(
+      bind_props(
+        { structure: simple_structure, controls_open: true, persist_settings: true },
+        state,
+      ),
+    )
+
+    expect(state).toMatchObject({
+      scene_props: { atom_radius: 1.35, ambient_light: 2.5 },
+      lattice_props: { cell_edge_opacity: 0.75 },
+      color_scheme: `Jmol`,
+      background_color: `#123456`,
+      background_opacity: 0.4,
+      show_image_atoms: false,
+      show_trajectory_lines: true,
+      supercell_scaling: `2x2x1`,
+      multi_view: true,
+    })
+    // Persisted values define this session's reset snapshot, so they do not immediately
+    // masquerade as unsaved changes.
+    expect(target.querySelector(`button[aria-label="Reset atoms to defaults"]`)).toBeNull()
+
+    state.scene_props.atom_radius = 1.6
+    const pane = target.querySelector<HTMLElement>(`.controls-pane`)
+    if (!pane) throw new Error(`Structure controls pane is missing`)
+    pane.style.width = `520px`
+    pane.style.height = `610px`
+    trigger_resize_observer(pane)
+    await vi.waitFor(() =>
+      expect(load_structure_view_state()).toMatchObject({
+        settings: { structure: { atom_radius: 1.6 } },
+        viewer: { controls_pane_size: { width: 520, height: 610 } },
+      }),
+    )
+
+    target.querySelector<HTMLButtonElement>(`button.reset-all-settings`)?.click()
+    await tick()
+    expect(state.scene_props.atom_radius).toBe(DEFAULTS.structure.atom_radius)
+    expect(state.scene_props.ambient_light).toBe(DEFAULTS.structure.ambient_light)
+    expect(state.color_scheme).toBe(DEFAULTS.color_scheme)
+    expect(state.background_color).toBeUndefined()
+    expect(state.show_trajectory_lines).toBe(DEFAULTS.structure.show_trajectory_lines)
+    expect(state.supercell_scaling).toBe(`1x1x1`)
+    expect(localStorage.getItem(STRUCTURE_VIEW_STATE_STORAGE_KEY)).toBeNull()
+  })
+
+  test(`persist_settings=false neither restores nor overwrites saved preferences`, async () => {
+    save_structure_view_state(
+      create_structure_view_state({ scene_props: { atom_radius: 1.5 } }),
+    )
+    const state = $state({ scene_props: { ...DEFAULTS.structure } })
+    await mount_controls(
+      bind_props(
+        { structure: simple_structure, controls_open: true, persist_settings: false },
+        state,
+      ),
+    )
+
+    expect(state.scene_props.atom_radius).toBe(DEFAULTS.structure.atom_radius)
+    state.scene_props.atom_radius = 2
+    await tick()
+    expect(load_structure_view_state()?.settings.structure.atom_radius).toBe(1.5)
+  })
+
+  test(`copies and imports viewer settings through the visible actions`, async () => {
+    const state = $state({ scene_props: { ...DEFAULTS.structure } })
+    const target = await mount_controls(
+      bind_props(
+        { structure: simple_structure, controls_open: true, persist_settings: false },
+        state,
+      ),
+    )
+    vi.mocked(navigator.clipboard.writeText).mockClear()
+    target
+      .querySelector<HTMLButtonElement>(`button[aria-label="Copy viewer settings JSON"]`)
+      ?.click()
+    expect(navigator.clipboard.writeText).toHaveBeenCalledOnce()
+    const copied_json = vi.mocked(navigator.clipboard.writeText).mock.calls[0]?.[0]
+    expect(JSON.parse(copied_json ?? `{}`)).toMatchObject({
+      version: 1,
+      settings: { structure: { atom_radius: DEFAULTS.structure.atom_radius } },
+    })
+
+    const imported = create_structure_view_state({
+      scene_props: { atom_radius: 1.8, camera_projection: `perspective` },
+      color_scheme: `Muted`,
+    })
+    const file_input = target.querySelector<HTMLInputElement>(
+      `input[aria-label="Import viewer settings JSON"]`,
+    )
+    if (!file_input) throw new Error(`Import viewer settings input is missing`)
+    Object.defineProperty(file_input, `files`, {
+      configurable: true,
+      value: [
+        new File([serialize_structure_view_state(imported)], `shared-view.json`, {
+          type: `application/json`,
+        }),
+      ],
+    })
+    file_input.dispatchEvent(new Event(`change`, { bubbles: true }))
+    await vi.waitFor(() => expect(state.scene_props.atom_radius).toBe(1.8))
+    expect(state.scene_props.camera_projection).toBe(`perspective`)
+    expect(target.textContent).toContain(`Imported shared-view.json`)
+
+    // "Reset all" has to undo an import wholesale, not just the rows the user touched by hand
+    target
+      .querySelector<HTMLButtonElement>(
+        `button[aria-label="Reset all viewer settings to defaults"]`,
+      )
+      ?.click()
+    await vi.waitFor(() =>
+      expect(state.scene_props.atom_radius).toBe(DEFAULTS.structure.atom_radius),
+    )
+    expect(state.scene_props.camera_projection).toBe(DEFAULTS.structure.camera_projection)
+  })
+
+  test(`fills a missing atom color scale at mount and after prop replacement`, async () => {
+    const state = $state<{ atom_color_config: AtomColorConfigProps }>({
+      atom_color_config: { mode: `coordination`, scale_type: `continuous` },
+    })
+
+    const target = await mount_controls(
+      bind_props({ structure: simple_structure, controls_open: true }, state),
+    )
+
+    expect(state.atom_color_config.scale).toBe(DEFAULTS.structure.atom_color_scale)
+    expect(target.querySelector(`button[aria-label="Reset atoms to defaults"]`)).toBeNull()
+
+    state.atom_color_config = { mode: `coordination` }
+    await tick()
+    expect(state.atom_color_config.scale).toBe(DEFAULTS.structure.atom_color_scale)
+  })
+
+  test(`atom color mode row reset restores its derived scale type`, async () => {
+    const state = $state<{ atom_color_config: AtomColorConfigProps }>({
+      atom_color_config: {
+        mode: DEFAULTS.structure.atom_color_mode,
+        scale: DEFAULTS.structure.atom_color_scale,
+        scale_type: DEFAULTS.structure.atom_color_scale_type,
+      },
+    })
+    const target = await mount_controls(
+      bind_props({ structure: simple_structure, controls_open: true }, state),
+    )
+
+    state.atom_color_config.mode = `wyckoff`
+    await tick()
+    expect(state.atom_color_config.scale_type).toBe(`categorical`)
+
+    const reset = target.querySelector<HTMLButtonElement>(
+      `[data-key="atom_color_mode"] .setting-reset-button`,
+    )
+    expect(reset).not.toBeNull()
+    reset?.click()
+    await tick()
+
+    expect(state.atom_color_config).toMatchObject({
+      mode: DEFAULTS.structure.atom_color_mode,
+      scale_type: DEFAULTS.structure.atom_color_scale_type,
+    })
+    expect(
+      target.querySelector(`[data-key="atom_color_mode"] .setting-reset-button`),
+    ).toBeNull()
+  })
+
+  // The label colors are CSS strings the scene owns, read through derived bindings rather than
+  // mirrored into local state. Only the hex behind a fully transparent background has nowhere
+  // in that string to live, so that one value is remembered here.
+  test(`site label colors round-trip through scene props`, async () => {
+    const bg_color = `color-mix(in srgb, #000000 20%, transparent)`
     const state = $state({
       scene_props: {
         show_site_labels: true,
         site_label_color: `#111111`,
-        site_label_bg_color: `color-mix(in srgb, #000000 20%, transparent)`,
+        site_label_bg_color: bg_color,
       },
     })
 
     const target = await mount_controls(
       bind_props({ structure: simple_structure, controls_open: true }, state),
     )
+    // mounting the pane reads those strings, it does not rewrite them
+    expect(state.scene_props.site_label_color).toBe(`#111111`)
+    expect(state.scene_props.site_label_bg_color).toBe(bg_color)
 
     state.scene_props = {
       ...state.scene_props,
@@ -53,18 +363,29 @@ describe(`StructureControls reactive props`, () => {
     }
     await tick()
 
-    const label_color_input = target.querySelector<HTMLInputElement>(
-      `input[aria-label="Site label color"]`,
+    const opacity_input = target.querySelector<HTMLInputElement>(
+      `[data-key="site_label_bg_opacity"] input[type="number"]`,
     )
-    const label_bg_color_input = target.querySelector<HTMLInputElement>(
-      `input[aria-label="Site label background color"]`,
+    if (!opacity_input) throw new Error(`site label background opacity input is missing`)
+    expect(
+      target.querySelector<HTMLInputElement>(`input[aria-label="Site label color"]`)?.value,
+    ).toBe(`#00ff00`)
+    expect(
+      target.querySelector<HTMLInputElement>(`input[aria-label="Site label background color"]`)
+        ?.value,
+    ).toBe(`#123456`)
+    expect(opacity_input.valueAsNumber).toBe(0.7)
+
+    // zero opacity collapses to `transparent` rather than an equivalent color-mix, and the
+    // swatch keeps the hex so raising the slider again brings the same color back
+    set_input(opacity_input, `0`)
+    await tick()
+    expect(state.scene_props.site_label_bg_color).toBe(`transparent`)
+    set_input(opacity_input, `0.5`)
+    await tick()
+    expect(state.scene_props.site_label_bg_color).toBe(
+      `color-mix(in srgb, #123456 50%, transparent)`,
     )
-    const label_bg_opacity_input = target.querySelector<HTMLInputElement>(
-      `input[aria-label="Site label background opacity"]`,
-    )
-    expect(label_color_input?.value).toBe(`#00ff00`)
-    expect(label_bg_color_input?.value).toBe(`#123456`)
-    expect(label_bg_opacity_input?.valueAsNumber).toBe(0.7)
   })
 
   test(`updates the scale type when the selected property changes`, async () => {
@@ -153,9 +474,19 @@ describe(`StructureControls reactive props`, () => {
     expect(center_label(`e`)).toBeUndefined()
   })
 
-  // Sections wire `current_values` and `on_reset` from one shared key list. Check two
-  // scene_props-driven sections to ensure changes reveal their reset and restore defaults.
+  // Sections wire `current_values` and their reset from one shared key list. Check three
+  // sections to ensure changes reveal their reset and restore defaults — including Site
+  // vectors, whose per-key scales live in vector_configs rather than under a scene_props key
+  // and so have to be tracked by hand.
   test(`offers section resets only after changes and restores defaults`, async () => {
+    // two vector keys so the per-key scale inputs render at all
+    const vector_structure = {
+      ...simple_structure,
+      sites: simple_structure.sites.map((site) => ({
+        ...site,
+        properties: { ...site.properties, force: [0.1, 0, 0], magmom: [0, 0.2, 0] },
+      })),
+    }
     // every key defined at its default, so the mount-time snapshot the reset offer compares
     // against isn't perturbed by `bind:` writing back into an undefined prop
     const state = $state({ scene_props: { ...DEFAULTS.structure } })
@@ -163,33 +494,82 @@ describe(`StructureControls reactive props`, () => {
     const target = await mount_controls(
       bind_props(
         {
-          structure: simple_structure,
+          structure: vector_structure,
           controls_open: true,
           displacement_summary: { rmsd: 0.12, max_displacement: 0.34, error: null },
         },
         state,
       ),
     )
+    const vector_defaults = default_vector_configs([`force`, `magmom`])
+    state.scene_props.vector_configs = vector_defaults
+    await tick()
 
     const reset_button = (section: string) =>
       target.querySelector<HTMLButtonElement>(
         `button[aria-label="Reset ${section} to defaults"]`,
       )
-    // nothing differs from the mount-time snapshot yet, so neither section offers a reset
+    // nothing differs from the mount-time snapshot yet, so no section offers a reset
     expect(reset_button(`displacement overlay`)).toBeNull()
     expect(reset_button(`polyhedra`)).toBeNull()
+    expect(reset_button(`site vectors`)).toBeNull()
+    expect(reset_button(`visibility`)).toBeNull()
+
+    const force_scale = target.querySelector<HTMLInputElement>(
+      `[data-key="vector_scale:force"] input[type="number"]`,
+    )
+    if (!force_scale) throw new Error(`per-key vector scale input is missing`)
+    set_input(force_scale, `2.5`)
 
     state.scene_props.displacement_arrow_color = `#123456`
     state.scene_props.polyhedra_excluded_elements = [`O`]
     await tick()
+    const force_config = state.scene_props.vector_configs?.force
+    if (!force_config) throw new Error(`force vector config is missing`)
+    expect(force_config.scale).toBe(2.5)
+    expect(reset_button(`visibility`)).toBeNull()
+
+    force_config.color = `#ff0000`
+    await tick()
+    expect(reset_button(`visibility`)).not.toBeNull()
+    reset_button(`visibility`)?.click()
+    await tick()
+    expect(state.scene_props.vector_configs?.force).toMatchObject({
+      color: vector_defaults.force?.color,
+      scale: 2.5,
+    })
+
     reset_button(`displacement overlay`)?.click()
     reset_button(`polyhedra`)?.click()
+    reset_button(`site vectors`)?.click()
     await tick()
 
     expect(state.scene_props.displacement_arrow_color).toBe(
       DEFAULTS.structure.displacement_arrow_color,
     )
     expect(state.scene_props.polyhedra_excluded_elements).toEqual([])
+    expect(state.scene_props.vector_configs?.force?.scale).toBeNull()
+  })
+
+  test(`section reset restores mount-time values, not shipped defaults`, async () => {
+    const state = $state({ scene_props: { ...DEFAULTS.structure, atom_radius: 1.4 } })
+    const target = await mount_controls(
+      bind_props(
+        { structure: simple_structure, controls_open: true, persist_settings: false },
+        state,
+      ),
+    )
+    const reset_button = (section: string) =>
+      target.querySelector<HTMLButtonElement>(
+        `button[aria-label="Reset ${section} to defaults"]`,
+      )
+
+    expect(reset_button(`atoms`)).toBeNull()
+    state.scene_props.atom_radius = 2.2
+    await tick()
+    reset_button(`atoms`)?.click()
+    await tick()
+    expect(state.scene_props.atom_radius).toBe(1.4)
   })
 
   test.each<[string, TrajectoryPositionStream | null | undefined, boolean, boolean, boolean]>([

--- a/tests/vitest/structure/StructureControls.svelte.test.ts
+++ b/tests/vitest/structure/StructureControls.svelte.test.ts
@@ -101,6 +101,8 @@ describe(`StructureControls layout`, () => {
       [`Preferences`, false],
     ])
 
+    doc_query<HTMLButtonElement>(`.open-search`).click()
+    await tick()
     const search = doc_query<HTMLInputElement>(`input[type="search"]`)
     set_input(search, `damp`)
     await tick()

--- a/tests/vitest/structure/StructureControls.test.ts
+++ b/tests/vitest/structure/StructureControls.test.ts
@@ -143,7 +143,7 @@ describe(`StructureControls`, () => {
         `input[aria-label="Site label background color"]`,
       )
       const opacity_input = doc_query<HTMLInputElement>(
-        `input[aria-label="Site label background opacity"]`,
+        `[data-key="site_label_bg_opacity"] input[type="number"]`,
       )
       expect(bg_color_input.value).toBe(expected_hex_color)
       expect(opacity_input.valueAsNumber).toBe(expected_opacity)
@@ -157,8 +157,10 @@ describe(`StructureControls`, () => {
       doc_query<HTMLButtonElement>(`button[aria-label="Reset labels to defaults"]`).click()
       await tick()
 
-      expect(bg_color_input.value).toBe(`#000000`)
-      expect(opacity_input.valueAsNumber).toBe(0)
+      // reset restores what the pane mounted with, so the two halves of the one bg string come
+      // back together even though a separate row drives each
+      expect(bg_color_input.value).toBe(expected_hex_color)
+      expect(opacity_input.valueAsNumber).toBe(expected_opacity)
     },
   )
 })

--- a/tests/vitest/structure/index.test.ts
+++ b/tests/vitest/structure/index.test.ts
@@ -2,6 +2,7 @@ import type { AnyStructure, ElementSymbol, Site, Species, Vec3 } from '$lib'
 import * as struct_utils from '$lib/structure'
 import type { StructureFitOpts } from '$lib/structure'
 import {
+  camera_needs_fit,
   camera_position_for_target,
   DEFAULT_FIT_PADDING,
   DEFAULT_STRUCTURE_VIEWS,
@@ -199,11 +200,11 @@ describe(`structure_fit_frame`, () => {
   })
 
   test(`molecule / cell framing`, () => {
-    expect(DEFAULT_FIT_PADDING).toBeGreaterThan(1)
+    expect(DEFAULT_FIT_PADDING).toBeCloseTo(1 / 0.92, 10)
     const diatomic = { sites: [site(`H`, [-1, 0, 0]), site(`H`, [1, 0, 0])] }
     const { center, extent: fit } = structure_fit_frame(diatomic)
     center.forEach((coord) => expect(coord).toBeCloseTo(0, 10))
-    expect(extent(diatomic, { atom_radius_scale: 0 })).toBeCloseTo(2 / 0.85, 10)
+    expect(extent(diatomic, { atom_radius_scale: 0 })).toBeCloseTo(2 * DEFAULT_FIT_PADDING, 10)
     expect(fit).toBeCloseTo(2 * (1 + 0.25 * 0.7) * DEFAULT_FIT_PADDING, 10)
     expect(
       structure_fit_frame(
@@ -270,6 +271,18 @@ describe(`structure_fit_frame`, () => {
 })
 
 describe(`camera helpers`, () => {
+  test(`fits zero poses and re-fits changed camera views`, () => {
+    expect(camera_needs_fit([0, 0, 0], undefined, `orthographic:`)).toBe(true)
+    expect(camera_needs_fit([10, 3, 8], undefined, `orthographic:`)).toBe(false)
+    expect(camera_needs_fit([10, 3, 8], `orthographic:`, `perspective:1,0.3,0.8`)).toBe(true)
+    expect(
+      camera_needs_fit([10, 3, 8], `perspective:1,0.3,0.8`, `perspective:1,0.3,0.8`),
+    ).toBe(false)
+    expect(camera_needs_fit([10, 3, 8], `perspective:1,0.3,0.8`, `perspective:0,0,1`)).toBe(
+      true,
+    )
+  })
+
   test.each([
     [`default`, undefined, [10, 3, 8]],
     [`zero → default`, [0, 0, 0] as Vec3, [10, 3, 8]],


### PR DESCRIPTION
- unify visualization controls around searchable groups, aligned grid rows, inline explanations, and per-setting resets
- persist validated structure-viewer preferences with JSON import/export, full reset, and consistent web/VS Code bounds
- simplify repeated plot, camera, vector, and range controls while preserving accessible labels and mounted reset state
- expose theme switching in the command menu and harden dynamic settings against stale visibility, focus, and structure state