### PR TITLE
Read the element column of a LAMMPS dump that also has a type column

### DIFF
--- a/src/lib/trajectory/parse/lammps.ts
+++ b/src/lib/trajectory/parse/lammps.ts
@@ -114,9 +114,9 @@ export function parse_lammps_trajectory(
   }
 
   // LAMMPS atom types are bare integers whose meaning lives in the input script, not the
-  // dump. Unmapped types fall back to atomic number N like ASE's read_lammps_dump and the
-  // LAMMPS data parser, since most dumps carry no element column; warn once per file so a
-  // Si/O dump showing up as H/He is traceable.
+  // dump. With no element column and no mapping they fall back to atomic number N like
+  // ASE's read_lammps_dump and the LAMMPS data parser; warn once per file so a Si/O dump
+  // showing up as H/He is traceable.
   // Types are validated to be >= 1 before lookup; the clamp keeps the lookup total (H rather
   // than `ELEM_SYMBOLS[-1]` = undefined) should a future column path skip that check.
   const guessed_types = new Set<number>()
@@ -252,7 +252,7 @@ export function parse_lammps_trajectory(
       const xyz: Vec3 = frac_to_cart
         ? frac_to_cart(coords)
         : [coords[0] - box_origin[0], coords[1] - box_origin[1], coords[2] - box_origin[2]]
-      let element_symbol: ElementSymbol
+      let element_symbol: ElementSymbol | undefined
       if (type_col !== undefined) {
         const raw_atom_type = parts[type_col]
         const atom_type = Number(raw_atom_type)
@@ -262,8 +262,10 @@ export function parse_lammps_trajectory(
           )
         }
         atom_types_found.add(atom_type)
-        element_symbol = get_element(atom_type)
-      } else {
+        element_symbol =
+          element_col === undefined ? get_element(atom_type) : atom_type_mapping?.[atom_type]
+      }
+      if (!element_symbol) {
         const raw_symbol = parts[element_col]
         const coerced =
           coerce_elem_symbol(raw_symbol) ?? coerce_elem_symbol(capitalize_symbol(raw_symbol))

--- a/tests/vitest/trajectory/parsers.test.ts
+++ b/tests/vitest/trajectory/parsers.test.ts
@@ -359,6 +359,19 @@ describe(`LAMMPS`, () => {
     expect(run.time_step).toBeUndefined()
   })
 
+  // A dump written by `dump_modify element` names its species, so those names beat guessing
+  // an element from the type number
+  it(`reads the element column when a type column is also present`, async () => {
+    const run = await open(
+      lammps_frame(`id type element x y z`, [`1 1 Si 0 0 0`, `2 2 O 1 1 1`]),
+      `t.lammpstrj`,
+      { atom_type_mapping: undefined },
+    )
+    expect(elements_of(run.preview)).toEqual([`Si`, `O`])
+    expect(run.metadata).toMatchObject({ atom_types: [1, 2], element_counts: { Si: 1, O: 1 } })
+    expect(run.warnings).toEqual([])
+  })
+
   // Corruption inside a frame is an error naming its line and timestep; it used to skip the
   // atom or frame silently and surface only as "No valid frames found"
   // oxfmt-ignore


### PR DESCRIPTION
`dump custom ... id type element x y z` with `dump_modify ... element Si O` is the normal way to write a dump that names its species, and the parser drops those names whenver a `type` column is there as well. A Si/O dump comes back as H and He, so the colours, radii and `element_counts` are all wrong, and the warning it prints says the dump has no element column - about a file that plainly has one.

Resolution order is now `atom_type_mapping`, then the element column, then the atomic-number guess. Left the mapping on top becuase that's where it already sat and it's the documented way to name types; all that changes is the guess no longer beats names the file already carries, which is what the LAMMPS data parser does with its `Masses` comments too. New test fails on `main` with `expected [ 'H', 'He' ] to deeply equal [ 'Si', 'O' ]`.
