### PR TITLE
Make the docs site and components work on phone-width screens

### DIFF
--- a/src/lib/app.css
+++ b/src/lib/app.css
@@ -83,6 +83,15 @@
   opacity: 1;
   pointer-events: auto;
 }
+/* Touch devices have no hover, so viewer controls that only fade in while the pointer is over
+   the viewer would never appear. Keep them shown there; !important beats the hashed
+   component selectors that hide them. */
+@media (hover: none) {
+  .hover-visible {
+    opacity: 1 !important;
+    pointer-events: auto !important;
+  }
+}
 body.fullscreen .draggable-pane {
   position: fixed !important; /* In fullscreen, we want viewport-relative positioning */
   top: 3.3em !important;

--- a/src/lib/chempot-diagram/ChemPotDiagram.svelte
+++ b/src/lib/chempot-diagram/ChemPotDiagram.svelte
@@ -120,8 +120,12 @@
   }
   .projection-grid {
     display: grid;
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 0.4em;
+    /* two 280px sub-diagrams need ~600px; below that stack them */
+    @media (max-width: 640px) {
+      grid-template-columns: minmax(0, 1fr);
+    }
   }
   .projection-label {
     margin: 0 0 0.3em;

--- a/src/lib/chempot-diagram/ChemPotDiagram.svelte
+++ b/src/lib/chempot-diagram/ChemPotDiagram.svelte
@@ -120,11 +120,12 @@
   }
   .projection-grid {
     display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    /* as many 280px sub-diagrams per row as the component's own width allows (a 500px
+       diagram inside a desktop layout stacks too), never more than two */
+    grid-template-columns: repeat(auto-fit, minmax(min(280px, 100%), 1fr));
     gap: 0.4em;
-    /* two 280px sub-diagrams need ~600px; below that stack them */
-    @media (max-width: 640px) {
-      grid-template-columns: minmax(0, 1fr);
+    > div {
+      max-width: calc(50% - 0.2em);
     }
   }
   .projection-label {

--- a/src/lib/chempot-diagram/ChemPotDiagram2D.svelte
+++ b/src/lib/chempot-diagram/ChemPotDiagram2D.svelte
@@ -203,7 +203,7 @@
   // Axis label text
   function axis_label(element: string): string {
     const prefix = formal_chempots ? `\u0394` : ``
-    return `${prefix}\u03BC<sub>${element}</sub> <span style="font-weight:300;opacity:0.7">(eV)</span>`
+    return `${prefix}\u03BC<sub>${element}</sub> (eV)`
   }
 
   let x_axis = $state({ label: ``, label_shift: { y: -45 } })

--- a/src/lib/chempot-diagram/ChemPotDiagram3D.svelte
+++ b/src/lib/chempot-diagram/ChemPotDiagram3D.svelte
@@ -2065,7 +2065,9 @@
     bottom: 16px;
     left: 1em;
     display: flex;
-    gap: 10px;
+    flex-wrap: wrap;
+    gap: 2px 10px;
+    max-width: calc(100% - 2em);
     font-size: 12px;
     z-index: 10;
     pointer-events: none;

--- a/src/lib/composition/FormulaFilter.svelte
+++ b/src/lib/composition/FormulaFilter.svelte
@@ -706,197 +706,208 @@
   class:warning={validation.state === `warning`}
   {...rest}
 >
-  <input
-    bind:this={input_element}
-    bind:value={input_value}
-    onblur={() => {
-      // mousedown preventDefault on history items prevents blur, so this only
-      // fires when focus genuinely leaves (tab out, click outside, etc.)
-      // sync_value → set_value → close_history, so no separate close needed
-      sync_value()
-    }}
-    onfocus={open_history}
-    {oninput}
-    onpaste={() => {
-      requestAnimationFrame(() => {
-        input_value = normalize_formula_unicode(input_value)
-        oninput()
-      })
-    }}
-    {onkeydown}
-    {placeholder}
-    {disabled}
-    aria-label="Formula filter"
-  />
-  {#if history_open && visible_history.length > 0}
-    <div class="history-dropdown" role="listbox" aria-label="Recent searches">
-      <div class="history-header-row">
-        <span class="history-header">Recent</span>
-        <button
-          type="button"
-          class="history-clear-all"
-          title="Clear history"
-          aria-label="Clear all history"
-          onmousedown={(event) => {
-            event.preventDefault()
-            clear_history()
-          }}
-        >
-          Clear
-        </button>
-      </div>
-      {#each visible_history as entry, idx (entry)}
-        <div class="history-item" class:focused={idx === focused_history_idx}>
+  <!-- Chips and validation live inside the root: as siblings they became separate grid/flex
+       items in any host that lays filters out side by side -->
+  <div class="filter-row">
+    <input
+      bind:this={input_element}
+      bind:value={input_value}
+      onblur={() => {
+        // mousedown preventDefault on history items prevents blur, so this only
+        // fires when focus genuinely leaves (tab out, click outside, etc.)
+        // sync_value → set_value → close_history, so no separate close needed
+        sync_value()
+      }}
+      onfocus={open_history}
+      {oninput}
+      onpaste={() => {
+        requestAnimationFrame(() => {
+          input_value = normalize_formula_unicode(input_value)
+          oninput()
+        })
+      }}
+      {onkeydown}
+      {placeholder}
+      {disabled}
+      aria-label="Formula filter"
+    />
+    {#if history_open && visible_history.length > 0}
+      <div class="history-dropdown" role="listbox" aria-label="Recent searches">
+        <div class="history-header-row">
+          <span class="history-header">Recent</span>
           <button
             type="button"
-            class="history-value"
-            role="option"
-            aria-selected={idx === focused_history_idx}
+            class="history-clear-all"
+            title="Clear history"
+            aria-label="Clear all history"
             onmousedown={(event) => {
               event.preventDefault()
-              set_value(entry)
+              clear_history()
             }}
           >
-            {entry}
-          </button>
-          <button
-            type="button"
-            class="history-pin"
-            title={is_pinned(entry) ? `Unpin entry` : `Pin entry`}
-            aria-label={is_pinned(entry) ? `Unpin ${entry}` : `Pin ${entry}`}
-            onmousedown={(event) => {
-              event.preventDefault()
-              toggle_pin_history(entry)
-            }}
-          >
-            <Icon
-              icon={is_pinned(entry) ? Star : Circle}
-              style="width: 0.8em; height: 0.8em"
-            />
-          </button>
-          <button
-            type="button"
-            class="history-remove"
-            title="Remove from history"
-            aria-label="Remove {entry} from history"
-            onmousedown={(event) => {
-              event.preventDefault()
-              remove_from_history(entry)
-            }}
-          >
-            <Icon icon={Close} style="width: 0.7em; height: 0.7em" />
+            Clear
           </button>
         </div>
+        {#each visible_history as entry, idx (entry)}
+          <div class="history-item" class:focused={idx === focused_history_idx}>
+            <button
+              type="button"
+              class="history-value"
+              role="option"
+              aria-selected={idx === focused_history_idx}
+              onmousedown={(event) => {
+                event.preventDefault()
+                set_value(entry)
+              }}
+            >
+              {entry}
+            </button>
+            <button
+              type="button"
+              class="history-pin"
+              title={is_pinned(entry) ? `Unpin entry` : `Pin entry`}
+              aria-label={is_pinned(entry) ? `Unpin ${entry}` : `Pin ${entry}`}
+              onmousedown={(event) => {
+                event.preventDefault()
+                toggle_pin_history(entry)
+              }}
+            >
+              <Icon
+                icon={is_pinned(entry) ? Star : Circle}
+                style="width: 0.8em; height: 0.8em"
+              />
+            </button>
+            <button
+              type="button"
+              class="history-remove"
+              title="Remove from history"
+              aria-label="Remove {entry} from history"
+              onmousedown={(event) => {
+                event.preventDefault()
+                remove_from_history(entry)
+              }}
+            >
+              <Icon icon={Close} style="width: 0.7em; height: 0.7em" />
+            </button>
+          </div>
+        {/each}
+      </div>
+    {/if}
+    {#if input_value}
+      <button
+        type="button"
+        class={['mode-hint clickable', { locked: mode_locked }]}
+        onclick={cycle_mode}
+        title={mode_locked
+          ? `Mode is locked`
+          : `Click to switch to '${next_mode.mode}' → ${next_mode.value}`}
+        {@attach tooltip()}
+        aria-label="Change search mode"
+      >
+        {mode_hint}
+      </button>
+    {/if}
+    {#if show_mode_lock && !disabled}
+      <button
+        type="button"
+        class={['icon-btn lock-btn', { active: mode_locked }]}
+        onclick={toggle_mode_lock}
+        title={mode_locked ? `Unlock mode inference` : `Lock current mode`}
+        {@attach tooltip()}
+        aria-label={mode_locked ? `Unlock mode` : `Lock mode`}
+      >
+        <Icon icon={mode_locked ? Lock : Unlock} style="width: 1em; height: 1em" />
+      </button>
+    {/if}
+    {#if show_clear_button && value && !disabled}
+      <button
+        type="button"
+        class="icon-btn clear-btn"
+        onclick={clear_filter}
+        title="Clear (Escape)"
+        {@attach tooltip()}
+        aria-label="Clear filter"
+      >
+        <Icon icon={Close} style="width: 1em; height: 1em" />
+      </button>
+    {/if}
+    {#if show_examples && !disabled}
+      <div bind:this={examples_wrapper} style="position: relative">
+        <button
+          type="button"
+          class={['icon-btn help-btn', { active: examples_open }]}
+          onclick={toggle_examples}
+          title="Show search examples"
+          aria-label="Show search examples"
+          aria-expanded={examples_open}
+          aria-haspopup="menu"
+        >
+          <Icon icon={Info} style="width: 1.1em; height: 1.1em" />
+        </button>
+        {#if examples_open}
+          <div
+            class={['examples-dropdown', { 'anchor-left': anchor_left }]}
+            role="menu"
+            tabindex="-1"
+            onkeydown={handle_menu_keydown}
+          >
+            {#each examples as category (category.label)}
+              <div class="example-category">
+                <div class="category-label">{category.label}:</div>
+                {#each category.examples as example (example)}
+                  <button
+                    type="button"
+                    class="example-tag"
+                    data-example-item
+                    onclick={() => apply_example(example)}
+                    title={category.description}
+                    role="menuitem"
+                    tabindex="-1"
+                  >
+                    {example}
+                  </button>
+                {/each}
+              </div>
+            {/each}
+          </div>
+        {/if}
+      </div>
+    {/if}
+  </div>
+  {#if show_chip_row}
+    <div class="token-chip-row">
+      {#each parsed_tokens as token, idx (`${token.operator}:${token.element}:${token.constraint ?? ``}:${idx}`)}
+        <button
+          type="button"
+          class="token-chip"
+          class:exclude={token.operator === `exclude`}
+          class:invalid={!token.is_valid}
+          onclick={() => remove_token(idx)}
+          title="Click to remove token"
+          aria-label="Remove token {token.raw}"
+        >
+          {token_chip_label(token)}
+        </button>
       {/each}
     </div>
   {/if}
-  {#if input_value}
-    <button
-      type="button"
-      class={['mode-hint clickable', { locked: mode_locked }]}
-      onclick={cycle_mode}
-      title={mode_locked
-        ? `Mode is locked`
-        : `Click to switch to '${next_mode.mode}' → ${next_mode.value}`}
-      {@attach tooltip()}
-      aria-label="Change search mode"
-    >
-      {mode_hint}
-    </button>
-  {/if}
-  {#if show_mode_lock && !disabled}
-    <button
-      type="button"
-      class={['icon-btn lock-btn', { active: mode_locked }]}
-      onclick={toggle_mode_lock}
-      title={mode_locked ? `Unlock mode inference` : `Lock current mode`}
-      {@attach tooltip()}
-      aria-label={mode_locked ? `Unlock mode` : `Lock mode`}
-    >
-      <Icon icon={mode_locked ? Lock : Unlock} style="width: 1em; height: 1em" />
-    </button>
-  {/if}
-  {#if show_clear_button && value && !disabled}
-    <button
-      type="button"
-      class="icon-btn clear-btn"
-      onclick={clear_filter}
-      title="Clear (Escape)"
-      {@attach tooltip()}
-      aria-label="Clear filter"
-    >
-      <Icon icon={Close} style="width: 1em; height: 1em" />
-    </button>
-  {/if}
-  {#if show_examples && !disabled}
-    <div bind:this={examples_wrapper} style="position: relative">
-      <button
-        type="button"
-        class={['icon-btn help-btn', { active: examples_open }]}
-        onclick={toggle_examples}
-        title="Show search examples"
-        aria-label="Show search examples"
-        aria-expanded={examples_open}
-        aria-haspopup="menu"
-      >
-        <Icon icon={Info} style="width: 1.1em; height: 1.1em" />
-      </button>
-      {#if examples_open}
-        <div
-          class={['examples-dropdown', { 'anchor-left': anchor_left }]}
-          role="menu"
-          tabindex="-1"
-          onkeydown={handle_menu_keydown}
-        >
-          {#each examples as category (category.label)}
-            <div class="example-category">
-              <div class="category-label">{category.label}:</div>
-              {#each category.examples as example (example)}
-                <button
-                  type="button"
-                  class="example-tag"
-                  data-example-item
-                  onclick={() => apply_example(example)}
-                  title={category.description}
-                  role="menuitem"
-                  tabindex="-1"
-                >
-                  {example}
-                </button>
-              {/each}
-            </div>
-          {/each}
-        </div>
-      {/if}
+  {#if validation.message}
+    <div class="validation-message" class:invalid={validation.state === `invalid`}>
+      {validation.message}
     </div>
   {/if}
 </div>
-{#if show_chip_row}
-  <div class="token-chip-row">
-    {#each parsed_tokens as token, idx (`${token.operator}:${token.element}:${token.constraint ?? ``}:${idx}`)}
-      <button
-        type="button"
-        class="token-chip"
-        class:exclude={token.operator === `exclude`}
-        class:invalid={!token.is_valid}
-        onclick={() => remove_token(idx)}
-        title="Click to remove token"
-        aria-label="Remove token {token.raw}"
-      >
-        {token_chip_label(token)}
-      </button>
-    {/each}
-  </div>
-{/if}
-{#if validation.message}
-  <div class="validation-message" class:invalid={validation.state === `invalid`}>
-    {validation.message}
-  </div>
-{/if}
 
 <style>
   .formula-filter {
-    position: relative;
+    min-width: 0;
+    &.disabled {
+      opacity: 0.5;
+      pointer-events: none;
+    }
+  }
+  .filter-row {
+    position: relative; /* anchors the history dropdown to the input row, not the chips */
     display: flex;
     align-items: center;
     gap: var(--formula-filter-gap, 1pt);
@@ -904,20 +915,16 @@
     border-radius: var(--formula-filter-border-radius, var(--border-radius, 3pt));
     background: var(--formula-filter-bg, rgba(128, 128, 128, 0.05));
     transition: background 0.15s;
-    &.invalid {
+    .invalid > & {
       outline: 1px solid rgba(239, 68, 68, 0.65);
       background: rgba(239, 68, 68, 0.08);
     }
-    &.warning {
+    .warning > & {
       outline: 1px solid rgba(245, 158, 11, 0.6);
       background: rgba(245, 158, 11, 0.08);
     }
     &:focus-within {
       background: rgba(77, 182, 255, 0.08);
-    }
-    &.disabled {
-      opacity: 0.5;
-      pointer-events: none;
     }
   }
   input {

--- a/src/lib/convex-hull/ConvexHullCanvas.svelte
+++ b/src/lib/convex-hull/ConvexHullCanvas.svelte
@@ -326,7 +326,7 @@
         title="Energy above hull (eV/atom)"
         range={hull_distance_range(plot_entries)}
         scale={color_scale}
-        wrapper_style="position: absolute; bottom: 1em; left: 1em; width: 200px;"
+        wrapper_style="position: absolute; bottom: 1em; left: 1em; width: min(200px, 50cqw - 1.5em);"
         bar_style="height: 12px;"
         title_style="margin-bottom: 4px;"
       />
@@ -337,7 +337,7 @@
         title="Formation energy (eV/atom)"
         scale={{ fn: e_form_color_scale_fn, domain: e_form_range }}
         range={e_form_range}
-        wrapper_style="position: absolute; bottom: 1em; right: 1em; width: 200px;"
+        wrapper_style="position: absolute; bottom: 1em; right: 1em; width: min(200px, 50cqw - 1.5em);"
         bar_style="height: 12px;"
         title_style="margin-bottom: 4px;"
       />

--- a/src/lib/convex-hull/ConvexHullStats.svelte
+++ b/src/lib/convex-hull/ConvexHullStats.svelte
@@ -427,6 +427,8 @@
   }
   .convex-hull-stats.side-by-side {
     display: flex;
+    /* the table drops below the stats once the host is too narrow for both */
+    flex-wrap: wrap;
     gap: var(--hull-stats-gap, 1.5em);
     align-items: stretch;
     width: fit-content;
@@ -440,7 +442,7 @@
     max-width: var(--hull-stats-pane-max-width, 320px);
   }
   .table-pane {
-    flex: 1 1 0;
+    flex: 1 1 var(--hull-stats-table-min-width, 300px);
     max-width: 100%;
     min-width: 0;
     overflow: auto;

--- a/src/lib/layout/SequenceControls.svelte
+++ b/src/lib/layout/SequenceControls.svelte
@@ -179,6 +179,12 @@
     align-items: center;
     gap: clamp(0.25rem, 1.5cqw, 0.5rem);
     min-width: 0;
+    /* SequenceControlBar wraps at this width, but flex: 1 shrinks the slider to nothing
+       instead of wrapping, so claim a whole row below the nav/fps/pane buttons */
+    @container (max-width: 520px) {
+      flex-basis: 100%;
+      order: 1;
+    }
     > span {
       opacity: 0.75;
       font-variant-numeric: tabular-nums;

--- a/src/lib/periodic-table/TableInset.svelte
+++ b/src/lib/periodic-table/TableInset.svelte
@@ -41,4 +41,17 @@
     --scatter-font-size: var(--ptable-inset-font-size, 12px);
     --scatter-fullscreen-font-size: var(--ptable-inset-fullscreen-font-size, 16px);
   }
+  /* On phone-width tables the inset area is ~200px wide by ~60px tall, so controls, stats
+     and headings spill over the tiles. Drop custom insets into their own full-width row below
+     the table instead (.periodic-table is the inline-size container). The built-in colorbar
+     is compact enough to stay put. 380px catches 360-393px phones (table = 94vw) while the
+     384px tables of a two-column grid in a 50em main column keep their inset. */
+  @container (max-width: 380px) {
+    .table-inset:not(.auto-colorbar-inset) {
+      position: static;
+      grid-row: 11;
+      grid-column: 1 / -1;
+      margin-top: 1em;
+    }
+  }
 </style>

--- a/src/lib/plot/bar/SpacegroupBarPlot.svelte
+++ b/src/lib/plot/bar/SpacegroupBarPlot.svelte
@@ -312,12 +312,15 @@
   {orientation}
   mode="overlay"
   padding={{
-    // room above the plot area for the stacked count annotations
-    t:
+    ...padding,
+    // room above the plot area for the stacked count annotations: the caller's top padding is
+    // a floor, never a cap, or the rows it was computed for would overlap the bars
+    t: Math.max(
+      padding.t ?? 0,
       show_counts && orientation === `vertical`
         ? DEFAULT_PLOT_PADDING.t + COUNT_LABEL_ROW_PX * (n_count_rows - 1)
         : DEFAULT_PLOT_PADDING.t,
-    ...padding,
+    ),
   }}
   x_axis={x_axis_config}
   y_axis={y_axis_config}

--- a/src/lib/plot/bar/SpacegroupBarPlot.svelte
+++ b/src/lib/plot/bar/SpacegroupBarPlot.svelte
@@ -75,7 +75,13 @@
   // frame padding; the real scale only enters in user_content. Worst case the estimate
   // is off by a few px per label, which the collision gap absorbs.
   const sg_per_px = $derived(
-    MAX_SPACEGROUP / Math.max(plot_width - DEFAULT_PLOT_PADDING.l - DEFAULT_PLOT_PADDING.r, 1),
+    MAX_SPACEGROUP /
+      Math.max(
+        plot_width -
+          (padding.l ?? DEFAULT_PLOT_PADDING.l) -
+          (padding.r ?? DEFAULT_PLOT_PADDING.r),
+        1,
+      ),
   )
 
   // Smart tick selection: thin out ticks for dense data

--- a/src/lib/plot/bar/SpacegroupBarPlot.svelte
+++ b/src/lib/plot/bar/SpacegroupBarPlot.svelte
@@ -3,6 +3,7 @@
   import type { Vec2 } from '$lib/math'
   import type { BarHandlerProps, BarSeries, TickConfig } from '$lib/plot'
   import { BarPlot } from '$lib/plot'
+  import { DEFAULT_PLOT_PADDING } from '$lib/plot/core/layout'
   import type { CrystalSystem } from '$lib/symmetry'
   import * as symmetry from '$lib/symmetry'
   import * as spg from '$lib/symmetry/spacegroups'
@@ -16,6 +17,10 @@
   })
 
   const MAX_SPACEGROUP = 230
+  const TICK_LABEL_HEIGHT_PX = 14 // 12px rotated tick label plus breathing room
+  const COUNT_LABEL_CHAR_PX = 6.4 // mean glyph advance of the 12px count annotation
+  const COUNT_LABEL_ROW_PX = 14
+  const COUNT_LABEL_MAX_ROWS = 3
   let {
     data,
     show_counts = true,
@@ -23,6 +28,7 @@
     orientation = `vertical`,
     x_axis = {},
     y_axis = {},
+    padding = {},
     ...rest
   }: ComponentProps<typeof BarPlot> & {
     data: (number | string)[]
@@ -54,6 +60,24 @@
   // Create sorted list of space groups for x-axis
   const sorted_spacegroups = $derived(Array.from(histogram.keys()).toSorted((a, b) => a - b))
 
+  // Always show full space group range (1-230)
+  const x_range: Vec2 = [0.5, MAX_SPACEGROUP + 0.5]
+
+  // Rendered width of the plot, observed on the root element. Tick thinning and count
+  // annotation rows depend on pixel spacing, which the data alone can't tell us.
+  let plot_width = $state(0)
+  const observe_width = (node: HTMLElement) => {
+    const observer = new ResizeObserver(() => (plot_width = node.clientWidth))
+    observer.observe(node)
+    return () => observer.disconnect()
+  }
+  // Approximate data-space width of one px along the spacegroup axis, from the default
+  // frame padding; the real scale only enters in user_content. Worst case the estimate
+  // is off by a few px per label, which the collision gap absorbs.
+  const sg_per_px = $derived(
+    MAX_SPACEGROUP / Math.max(plot_width - DEFAULT_PLOT_PADDING.l - DEFAULT_PLOT_PADDING.r, 1),
+  )
+
   // Smart tick selection: thin out ticks for dense data
   const x_axis_ticks = $derived.by(() => {
     const non_zero_count = sorted_spacegroups.filter(
@@ -61,9 +85,21 @@
     ).length
 
     // If data is dense (>40 space groups with data), show only multiples of 5
-    return non_zero_count > 40
-      ? sorted_spacegroups.filter((sg) => sg % 5 === 0)
-      : sorted_spacegroups
+    const candidates =
+      non_zero_count > 40
+        ? sorted_spacegroups.filter((sg) => sg % 5 === 0)
+        : sorted_spacegroups
+    // Vertical ticks are rotated 90°, so each label needs ~one line height along the
+    // axis. Greedily drop ticks that would land on the previous kept label. (Horizontal
+    // puts spacegroups on the y axis, whose length we don't observe.)
+    const min_gap =
+      orientation === `vertical` && plot_width ? TICK_LABEL_HEIGHT_PX * sg_per_px : 0
+    let last_kept = -Infinity
+    return candidates.filter((sg) => {
+      if (sg - last_kept < min_gap) return false
+      last_kept = sg
+      return true
+    })
   })
 
   // Build BarSeries - one series per crystal system for proper coloring
@@ -89,9 +125,6 @@
     })
   })
 
-  // Always show full space group range (1-230)
-  const x_range: Vec2 = [0.5, MAX_SPACEGROUP + 0.5]
-
   // Calculate crystal system region boundaries using full theoretical ranges
   const crystal_system_regions = $derived.by(() => {
     const [range_min, range_max] = x_range
@@ -107,6 +140,29 @@
   })
 
   const total_count = $derived(normalized_data.length)
+  const count_label = (count: number) =>
+    `${format_num(count, `,~`)} (${format_num(count / total_count, `.1~%`)})`
+
+  // Count annotations sit above their crystal-system band. Narrow bands (triclinic is
+  // 2 of 230 spacegroups) and narrow plots make neighbouring labels overlap, so each
+  // label is bumped to the first of a few stacked rows where it doesn't collide with
+  // the labels already placed. Returns system -> row, omitting labels that fit nowhere.
+  const count_label_rows = $derived.by(() => {
+    const rows = new SvelteMap<CrystalSystem, number>()
+    if (orientation !== `vertical`) return rows
+    const row_right_edges: number[] = Array(COUNT_LABEL_MAX_ROWS).fill(-Infinity)
+    for (const region of crystal_system_regions) {
+      const label = count_label(region.count)
+      const half_width = (label.length * COUNT_LABEL_CHAR_PX) / 2
+      const center = (region.sg_start + region.sg_end) / 2 / sg_per_px
+      const row = row_right_edges.findIndex((right) => center - half_width > right)
+      if (row === -1) continue
+      row_right_edges[row] = center + half_width
+      rows.set(region.system, row)
+    }
+    return rows
+  })
+  const n_count_rows = $derived(Math.max(0, ...count_label_rows.values()) + 1)
 
   // Build axis configurations based on orientation
   const x_axis_config = $derived(
@@ -188,17 +244,18 @@
         >
           {region.system}
         </text>
-        <!-- Count annotation at top -->
-        {#if show_counts && total_count > 0}
-          {@const y_offset = region.system === `triclinic` ? -20 : -5}
+        <!-- Count annotation at top, stacked into rows where neighbours would overlap -->
+        {#if show_counts && total_count > 0 && count_label_rows.has(region.system)}
+          {@const label = count_label(region.count)}
+          {@const half_width = (label.length * COUNT_LABEL_CHAR_PX) / 2}
           <text
-            x={x_center}
-            y={pad.t + y_offset}
+            x={Math.min(Math.max(x_center, half_width), width - half_width)}
+            y={pad.t - 5 - COUNT_LABEL_ROW_PX * (count_label_rows.get(region.system) ?? 0)}
             text-anchor="middle"
             font-size="12"
             fill="var(--text-color, black)"
           >
-            {format_num(region.count, `,~`)} ({format_num(region.count / total_count, `.1~%`)})
+            {label}
           </text>
         {/if}
       {:else}
@@ -240,7 +297,7 @@
             font-size="12"
             fill="var(--text-color, black)"
           >
-            {format_num(region.count, `,~`)} ({format_num(region.count / total_count, `.1~%`)})
+            {count_label(region.count)}
           </text>
         {/if}
       {/if}
@@ -249,10 +306,19 @@
 {/snippet}
 
 <BarPlot
+  {@attach observe_width}
   {...rest}
   series={bar_series}
   {orientation}
   mode="overlay"
+  padding={{
+    // room above the plot area for the stacked count annotations
+    t:
+      show_counts && orientation === `vertical`
+        ? DEFAULT_PLOT_PADDING.t + COUNT_LABEL_ROW_PX * (n_count_rows - 1)
+        : DEFAULT_PLOT_PADDING.t,
+    ...padding,
+  }}
   x_axis={x_axis_config}
   y_axis={y_axis_config}
   {show_legend}

--- a/src/lib/plot/core/components/ColorBar.svelte
+++ b/src/lib/plot/core/components/ColorBar.svelte
@@ -191,8 +191,13 @@
       Math.max(...base.map((tick) => measure_text_line(format_tick(tick), bar_font).width)) + 8 // breathing room between neighbours
     const max_fit = Math.floor(bar_px / label_px) + 1
     if (base.length <= max_fit) return base
-    const stride = Math.ceil((base.length - 1) / Math.max(max_fit - 1, 1))
-    return base.filter((_, idx) => idx % stride === 0)
+    // evenly spaced picks that always include both ends, so the range stays readable
+    const n_keep = Math.max(max_fit, 2)
+    const last = base.length - 1
+    const picks = new Set(
+      Array.from({ length: n_keep }, (_, idx) => Math.round((idx * last) / (n_keep - 1))),
+    )
+    return base.filter((_, idx) => picks.has(idx))
   })
 
   const wrapper_flex_dir = $derived(

--- a/src/lib/plot/core/components/ColorBar.svelte
+++ b/src/lib/plot/core/components/ColorBar.svelte
@@ -10,6 +10,11 @@
   } from '$lib/plot/core/color-ramp'
   import PortalSelect from '$lib/plot/core/components/PortalSelect.svelte'
   import { generate_arcsinh_ticks } from '$lib/plot/core/scales'
+  import {
+    DEFAULT_FONT_SPEC,
+    measure_text_line,
+    resolve_font_spec,
+  } from '$lib/plot/core/text-metrics'
   import type {
     AxisOption,
     ColorBarDataLoaderFn,
@@ -138,8 +143,6 @@
     }
     return tick_scale.ticks(n_ticks)
   })
-  // Tick values are unique (deduped above, or generated), so they key the rendered labels
-  const visible_ticks = $derived(tick_side === `inside` ? ticks.slice(1, -1) : ticks)
   $effect.pre(() => {
     const [lo, hi] = tick_scale.domain()
     nice_range = snap_ticks && !Array.isArray(tick_labels) ? [lo, hi] : range
@@ -163,6 +166,34 @@
     if (tick_format.startsWith(`%`)) return timeFormat(tick_format)(new Date(value))
     return format(tick_format)(value)
   }
+
+  // Rendered bar length and font, so generated tick labels can be thinned once a narrow
+  // host squeezes the bar below the width its labels need. Width stays 0 until measured
+  // (and in environments without layout), which leaves the tick list untouched.
+  let bar_px = $state(0)
+  let bar_font = $state(DEFAULT_FONT_SPEC)
+  const observe_bar = (node: HTMLDivElement) => {
+    const observer = new ResizeObserver(() => {
+      bar_px = node.clientWidth
+      bar_font = resolve_font_spec(node)
+    })
+    observer.observe(node)
+    return () => observer.disconnect()
+  }
+  // Tick values are unique (deduped above, or generated), so they key the rendered labels
+  const visible_ticks = $derived.by(() => {
+    const base = tick_side === `inside` ? ticks.slice(1, -1) : ticks
+    // explicit tick arrays are the caller's choice; vertical labels stack and never collide
+    if (Array.isArray(tick_labels) || orientation !== `horizontal` || !bar_px) return base
+    if (base.length < 3) return base
+    // labels are centered on their tick, so n labels need ~(n - 1) label widths of bar
+    const label_px =
+      Math.max(...base.map((tick) => measure_text_line(format_tick(tick), bar_font).width)) + 8 // breathing room between neighbours
+    const max_fit = Math.floor(bar_px / label_px) + 1
+    if (base.length <= max_fit) return base
+    const stride = Math.ceil((base.length - 1) / Math.max(max_fit - 1, 1))
+    return base.filter((_, idx) => idx % stride === 0)
+  })
 
   const wrapper_flex_dir = $derived(
     { left: `row`, right: `row-reverse`, top: `column`, bottom: `column-reverse` }[
@@ -287,6 +318,7 @@
     </div>
   {/if}
   <div
+    {@attach observe_bar}
     style={final_bar_style}
     class={[
       `bar`,
@@ -318,6 +350,9 @@
     margin: var(--cbar-margin);
     padding: var(--cbar-padding);
     width: var(--cbar-width, auto);
+    /* a fixed --cbar-width/bar_style must shrink to narrow hosts instead of widening them */
+    max-width: 100%;
+    min-width: 0;
     font-size: var(--cbar-font-size, 9pt);
     /* align-items based on title side for vertical layout */
     align-items: var(--cbar-wrapper-align-items);
@@ -329,6 +364,8 @@
     /* Use CSS variables set inline */
     width: var(--cbar-width);
     height: var(--cbar-height);
+    /* column layouts (title top/bottom) don't flex-shrink the bar, so cap it explicitly */
+    max-width: 100%;
   }
   /* Tick labels are `position: absolute` and otherwise overflow the bar. */
   div.bar.horizontal.tick-primary {
@@ -410,9 +447,15 @@
     gap: var(--cbar-select-gap, 0.3em);
     white-space: nowrap;
     width: auto;
+    max-width: 100%;
     &:is(.left, .right) {
       flex-direction: column;
       justify-content: center; /* center title vertically along the bar height */
+    }
+    /* long horizontal titles wrap rather than overflow; the row itself stays nowrap so
+       the property/color-scale selects keep sitting on one line */
+    &:is(.top, .bottom) .label {
+      white-space: normal;
     }
     /* Rotate only the label element, not the entire row (keeps selects usable) */
     /* Only rotate when orientation is vertical AND title is on left/right side */

--- a/src/lib/plot/core/decorations/outside.ts
+++ b/src/lib/plot/core/decorations/outside.ts
@@ -77,11 +77,22 @@ const standard_items = (
 }
 
 // Horizontal colorbar -> top; vertical colorbar -> right; legend -> right or bottom.
+// A legend spanning more than this fraction of the plot's width or height (a phone-width
+// frame, a long series list) covers too much data to sit inside whatever the obstacle test
+// says. A too-wide one also cannot take the right margin without leaving no plot width, so
+// it goes below; a too-tall one is placed by the usual right/bottom economy.
+export const LEGEND_MAX_INTERIOR_FRACTION = 0.45
+
 export function place_outside_decorations(scene: DecorationScene): OutsideLayout {
   const { base_pad, width, height, obstacles_norm, gap = DEFAULT_DECORATION_GAP } = scene
   const { legend, colorbar } = standard_items(scene.items)
   const base_w = width - base_pad.l - base_pad.r
   const base_h = height - base_pad.t - base_pad.b
+  const { width: legend_width = 0, height: legend_height = 0 } = legend?.footprint ?? {}
+  // (unless the caller's right padding already has room for it, which costs no plot width)
+  const too_wide =
+    legend_width > LEGEND_MAX_INTERIOR_FRACTION * base_w && legend_width + 2 * gap > base_pad.r
+  const too_tall = legend_height > LEGEND_MAX_INTERIOR_FRACTION * base_h
 
   const colorbar_outside =
     colorbar != null &&
@@ -92,12 +103,17 @@ export function place_outside_decorations(scene: DecorationScene): OutsideLayout
 
   const legend_outside =
     legend != null &&
-    is_crowded(obstacles_norm, legend.footprint, base_w, base_h, legend.clearance ?? 12)
-  const { width: legend_width = 0, height: legend_height = 0 } = legend?.footprint ?? {}
+    (too_wide ||
+      too_tall ||
+      is_crowded(obstacles_norm, legend.footprint, base_w, base_h, legend.clearance ?? 12))
   // Put a narrow/tall legend on the right (wastes less reserved margin than a wide bottom strip);
-  // a wide/short legend goes below. Skip the right side if a vertical colorbar already took it.
+  // a wide/short legend goes below. Skip the right side if a vertical colorbar already took it
+  // or the frame is too narrow to give any width away.
   const legend_right =
-    legend_outside && !colorbar_takes_right && legend_height * base_w > legend_width * base_h
+    legend_outside &&
+    !too_wide &&
+    !colorbar_takes_right &&
+    legend_height * base_w > legend_width * base_h
   const legend_bottom = legend_outside && !legend_right
 
   const pad: Required<Sides> = {

--- a/src/lib/plot/core/decorations/solve.ts
+++ b/src/lib/plot/core/decorations/solve.ts
@@ -74,14 +74,23 @@ const with_auto_legend_tracks = (
 ): DecorationPlacement => {
   if (item.kind !== `legend` || !item.auto_tracks) return placement
   const { available_edge_length, ...track_config } = item.auto_tracks
+  // A strip below/above the plot fills its width with columns, one beside it fills the height
+  // with rows, whatever layout the legend would use inside the plot
+  const orientation =
+    placement.location === `outside` && placement.side
+      ? [`top`, `bottom`].includes(placement.side)
+        ? `horizontal`
+        : `vertical`
+      : track_config.orientation
   const base_edge_length =
-    track_config.orientation === `horizontal`
+    orientation === `horizontal`
       ? scene.width - scene.base_pad.l - scene.base_pad.r
       : scene.height - scene.base_pad.t - scene.base_pad.b
   return {
     ...placement,
     layout_tracks: suggest_legend_tracks({
       ...track_config,
+      orientation,
       available_edge_length: available_edge_length ?? Math.max(0, base_edge_length),
     }),
   }

--- a/src/lib/plot/sankey/Sankey.svelte
+++ b/src/lib/plot/sankey/Sankey.svelte
@@ -591,6 +591,13 @@
     fill: var(--text-color);
     font-size: var(--sankey-font-size, 11px);
   }
+  /* .sankey is a size container; node labels sit beside nodes and collide fast when a
+     multi-column diagram is squeezed into a phone-width host */
+  @container (max-width: 480px) {
+    svg {
+      font-size: var(--sankey-font-size, 9px);
+    }
+  }
   .links path {
     transition: stroke-opacity 0.15s ease;
   }

--- a/src/lib/spectral/Bands.svelte
+++ b/src/lib/spectral/Bands.svelte
@@ -644,7 +644,7 @@
       </SettingsSection>
     {/snippet}
 
-    {#snippet user_content({ height, x_scale_fn, y_scale_fn, pad })}
+    {#snippet user_content({ height, width, x_scale_fn, y_scale_fn, pad })}
       <!-- Fat band ribbons (rendered behind band lines) -->
       {#each ribbon_data as ribbon (ribbon.key)}
         {@const path_d = helpers.generate_ribbon_path(
@@ -781,11 +781,15 @@
             opacity="0.7"
           />
         {/each}
+        <!-- The ~60px label only fits in the right margin when the caller padded for it;
+             otherwise anchor it inside the plot so it is not clipped by the SVG edge -->
+        {@const gap_label_fits_right = width - bands_x_end >= 70}
         <text
-          x={bands_x_end + 4}
+          x={gap_label_fits_right ? bands_x_end + 4 : bands_x_end - 4}
           y={gap_mid_y}
           dy="0.35em"
           font-size="10"
+          text-anchor={gap_label_fits_right ? `start` : `end`}
           fill="var(--text-color)"
         >
           E<tspan dy="2" font-size="8">g:</tspan>

--- a/src/lib/spectral/BandsAndDos.svelte
+++ b/src/lib/spectral/BandsAndDos.svelte
@@ -28,18 +28,28 @@
     children?: Snippet<[HoveredData]>
   } = $props()
 
+  // Below this container width the 200px DOS column would leave the bands too narrow to read,
+  // so the DOS turns vertical and stacks underneath. Measured on the wrapper (not the
+  // viewport) because the component is embedded at arbitrary sizes in notebooks and IDEs.
+  const stack_below_width = 520
+  let clientWidth = $state(800)
+  let stacked = $derived(clientWidth < stack_below_width)
+
   let shared_frequency_range = $derived(
     shared_y_axis ? compute_frequency_range(band_structs, doses) : undefined,
   )
   let fermi_level = $derived(extract_efermi(band_structs) ?? extract_efermi(doses))
 
-  const default_y_axes = (): AxisConfig[] =>
+  // A vertical DOS puts density on y, so the shared frequency range only binds both y axes
+  // in the side-by-side layout
+  const default_y_axes = (): AxisConfig[] => [
     shared_y_axis
-      ? [
-          axis_with_range(bands_props.y_axis, shared_frequency_range),
-          axis_with_range(dos_props.y_axis, shared_frequency_range, ``),
-        ]
-      : [{ ...bands_props.y_axis }, { label: ``, ...dos_props.y_axis }]
+      ? axis_with_range(bands_props.y_axis, shared_frequency_range)
+      : { ...bands_props.y_axis },
+    shared_y_axis && !stacked
+      ? axis_with_range(dos_props.y_axis, shared_frequency_range, ``)
+      : { ...(stacked ? {} : { label: `` }), ...dos_props.y_axis },
+  ]
 
   const synced = create_synced_y_axes({
     default_axes: default_y_axes,
@@ -47,10 +57,12 @@
       band_structs,
       doses,
       shared_y_axis,
+      stacked,
       JSON.stringify({ bands: bands_props.y_axis, dos: dos_props.y_axis }),
     ],
     shared_range: () => shared_frequency_range,
     sync_zoom: () => sync_y_zoom,
+    linked_count: () => (stacked ? 1 : 2),
   })
 
   let hovered_frequency = $state<number | null>(null)
@@ -59,12 +71,14 @@
   let shared_tb_padding = $derived(
     max_side_padding([{ t: 20, b: 50 }, bands_props.padding, dos_props.padding], [`t`, `b`]),
   )
+  let side_by_side_padding = $derived(stacked ? {} : shared_tb_padding)
 </script>
 
 <div
   {...rest}
-  class={[`bands-and-dos`, rest.class]}
-  style={`display: grid; grid-template-columns: 1fr 200px; gap: 0;` + (rest.style ?? ``)}
+  class={[`bands-and-dos`, { stacked }, rest.class]}
+  style={`display: grid; gap: 0;` + (rest.style ?? ``)}
+  bind:clientWidth
 >
   {@render children?.({ hovered_frequency })}
   <Bands
@@ -73,17 +87,34 @@
     {fermi_level}
     bind:y_axis={synced.y_axes[0]}
     reference_frequency={hovered_frequency}
-    padding={{ r: 15, ...bands_props.padding, ...shared_tb_padding }}
+    padding={{ r: 15, ...bands_props.padding, ...side_by_side_padding }}
   />
 
   <Dos
     {...dos_props}
     {doses}
     {fermi_level}
-    orientation="horizontal"
+    orientation={stacked ? `vertical` : `horizontal`}
+    x_axis={{
+      ...axis_with_range(undefined, stacked ? shared_frequency_range : undefined),
+      ...dos_props.x_axis,
+    }}
     bind:y_axis={synced.y_axes[1]}
     bind:hovered_frequency
     reference_frequency={hovered_frequency}
-    padding={{ l: 15, ...dos_props.padding, ...shared_tb_padding }}
+    padding={{
+      ...(stacked ? {} : { l: 15 }),
+      ...dos_props.padding,
+      ...side_by_side_padding,
+    }}
   />
 </div>
+
+<style>
+  .bands-and-dos {
+    grid-template-columns: minmax(0, 1fr) 200px;
+  }
+  .bands-and-dos.stacked {
+    grid-template-columns: minmax(0, 1fr);
+  }
+</style>

--- a/src/lib/spectral/BandsAndDos.svelte
+++ b/src/lib/spectral/BandsAndDos.svelte
@@ -96,6 +96,8 @@
     {fermi_level}
     orientation={stacked ? `vertical` : `horizontal`}
     x_axis={{
+      // a vertical Dos plots frequency along x (density along y), so the shared frequency
+      // range belongs on x when stacked and on y (synced above) side by side
       ...axis_with_range(undefined, stacked ? shared_frequency_range : undefined),
       ...dos_props.x_axis,
     }}

--- a/src/lib/structure/AtomLegend.svelte
+++ b/src/lib/structure/AtomLegend.svelte
@@ -605,8 +605,11 @@
     opacity: 0;
     position: absolute;
     visibility: hidden;
-    top: 7pt;
-    left: 0;
+    /* cover the chip instead of protruding past it: a hidden input still widens the
+       page's scrollable overflow when the legend sits at the viewer's right edge */
+    inset: 0;
+    width: 100%;
+    height: 100%;
   }
   /* Toggle visibility button - shared between element and property legends */
   .atom-legend button.toggle-visibility {

--- a/src/lib/symmetry/SymmetryStats.svelte
+++ b/src/lib/symmetry/SymmetryStats.svelte
@@ -229,6 +229,7 @@
 <style>
   .controls {
     display: flex;
+    flex-wrap: wrap;
     gap: var(--sym-stats-controls-gap, 1em);
     background: var(--sym-stats-controls-bg, var(--surface-bg));
     padding: var(--sym-stats-controls-padding, 4pt 6pt);
@@ -247,7 +248,10 @@
   }
   .stats-grid {
     display: var(--sym-stats-display, grid);
-    grid-template-columns: var(--sym-stats-grid-columns, repeat(auto-fit, minmax(275px, 1fr)));
+    grid-template-columns: var(
+      --sym-stats-grid-columns,
+      repeat(auto-fit, minmax(min(275px, 100%), 1fr))
+    );
     gap: var(--sym-stats-grid-gap, 1ex 1em);
     margin-block: var(--sym-stats-grid-margin-block, 1ex);
     align-items: var(--sym-stats-grid-align, start);
@@ -257,6 +261,7 @@
   }
   .settings-explorer {
     margin-block: var(--sym-stats-grid-margin-block, 1ex);
+    overflow-x: auto;
   }
   .settings-explorer summary {
     cursor: pointer;

--- a/src/lib/symmetry/WyckoffTable.svelte
+++ b/src/lib/symmetry/WyckoffTable.svelte
@@ -141,6 +141,9 @@
 
 <style>
   .wyckoff-table {
+    display: block; /* lets the table scroll sideways in narrow hosts instead of widening them */
+    max-width: 100%;
+    overflow-x: auto;
     margin-top: 0.5em;
     border-collapse: collapse;
   }

--- a/src/lib/theme/ThemeControl.svelte
+++ b/src/lib/theme/ThemeControl.svelte
@@ -48,6 +48,8 @@
     color: var(--text-color);
     border-radius: var(--theme-control-border-radius, var(--border-radius, 3pt));
     padding: var(--theme-control-padding, 1pt 2pt);
+    /* a finger-sized target; the fixed corner otherwise lands on viewer toolbars on phones */
+    min-height: 2em;
     backdrop-filter: blur(10px);
     transition: all 0.2s ease;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
@@ -59,5 +61,11 @@
   }
   .theme-control:focus {
     outline: 0.5px solid var(--accent-color);
+  }
+  @media (max-width: 600px) {
+    .theme-control {
+      bottom: 0.5em;
+      left: 0.5em;
+    }
   }
 </style>

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -532,7 +532,17 @@
   )
   // Keep plot configuration referentially stable while only the active frame changes:
   // recreating these objects would invalidate ScatterPlot's scales and hover index per frame
-  let trajectory_scatter_padding = $derived({ t: 20, b: 60, r: has_y2_series ? 100 : 20 })
+  // Caller padding is honoured as a floor: the y2 axis needs its right margin whatever the
+  // caller asked for, and a caller cannot know whether a y2 series is currently visible
+  let trajectory_scatter_padding = $derived.by(() => {
+    const user = scatter_props.padding ?? {}
+    return {
+      ...user,
+      t: user.t ?? 20,
+      b: user.b ?? 60,
+      r: Math.max(user.r ?? 0, has_y2_series ? 100 : 20),
+    }
+  })
   let trajectory_scatter_legend = $derived({
     ...scatter_props.legend,
     on_toggle: (series_idx: number) => {
@@ -952,10 +962,10 @@
           bind:controls_open={scatter_controls_open}
           current_x_value={x_map.to_x(settled_plot_step_idx)}
           on_plot_click={plot_skimming ? handle_plot_click : undefined}
-          padding={trajectory_scatter_padding}
           range_padding={0}
           style="height: 100%"
           {...scatter_props}
+          padding={trajectory_scatter_padding}
           hover_config={trajectory_hover_config}
           legend={trajectory_scatter_legend}
         >

--- a/src/routes/(demos)/(hide)/bohr-atoms/+page.svelte
+++ b/src/routes/(demos)/(hide)/bohr-atoms/+page.svelte
@@ -66,6 +66,13 @@
     margin: 1ex;
     border-radius: 1ex;
   }
+  /* phones: the largest atoms are ~300px wide, so a single one per row makes a very long
+     page; the SVG scales to its <li>, so cap that at two per row */
+  @container (max-width: 600px) {
+    li {
+      width: calc(50% - 2ex);
+    }
+  }
   strong {
     position: absolute;
     margin: 0;

--- a/src/routes/(demos)/composition/formula-filter/+page.md
+++ b/src/routes/(demos)/composition/formula-filter/+page.md
@@ -293,7 +293,9 @@ Additional features in `FormulaFilter`:
   })
 </script>
 
-<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1em; margin-bottom: 1em">
+<div
+  style="display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 14em), 1fr)); gap: 1em; margin-bottom: 1em"
+>
   <FormulaFilter bind:value={include} history_key="formula-filter-include" />
   <FormulaFilter
     bind:value={exclude}

--- a/src/routes/(demos)/periodic-table/+page.svelte
+++ b/src/routes/(demos)/periodic-table/+page.svelte
@@ -286,7 +286,7 @@
 
 <h2>2×2 Grid Layout</h2>
 
-<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 2em">
+<div class="two-by-two-grid">
   {#each [{ title: `Atomic Mass`, property: `atomic_mass`, color_scale: `interpolateBlues` }, { title: `Density`, property: `density`, color_scale: `interpolateReds` }, { title: `Melting Point`, property: `melting_point`, color_scale: `interpolateOranges` }, { title: `Boiling Point`, property: `boiling_point`, color_scale: `interpolateGreens` }] as const as { title, property, color_scale } (title)}
     <PeriodicTable
       tile_props={{ show_name: false, show_number: false }}
@@ -308,5 +308,11 @@
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
     gap: 1.5em;
+  }
+  /* two columns on desktop (main is 50em wide), one below ~640px */
+  .two-by-two-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 300px), 1fr));
+    gap: 2em;
   }
 </style>

--- a/src/routes/(demos)/periodic-table/element-colors/+page.md
+++ b/src/routes/(demos)/periodic-table/element-colors/+page.md
@@ -123,6 +123,15 @@
     max-width: 50cqw;
     margin: auto;
   }
+  /* narrow screens: no inset gap to center into, so stack the heading above the table */
+  @container (max-width: 600px) {
+    section {
+      margin: 2em 0 0;
+    }
+    .subtitle {
+      max-width: none;
+    }
+  }
 </style>
 ```
 

--- a/src/routes/(demos)/plot/color-bar/+page.md
+++ b/src/routes/(demos)/plot/color-bar/+page.md
@@ -75,6 +75,7 @@ You can make fat and skinny bars:
 <style>
   form {
     display: flex;
+    flex-wrap: wrap;
     place-items: center;
     place-content: center;
     gap: 1em;
@@ -190,19 +191,21 @@ You can format tick labels for date/time ranges by providing a D3 format string 
   ]
 </script>
 
-<div style="display: flex; column; gap: 2em; align-items: center;">
+<div
+  style="display: flex; flex-wrap: wrap; justify-content: center; gap: 2em 4em; align-items: center; padding-inline: 1.5em"
+>
   <ColorBar
     title="YYYY-MM-DD"
     range={date_range}
     tick_format="%Y-%m-%d"
-    bar_style="width: 200px; margin-left: 3em;"
+    bar_style="width: 200px"
     tick_labels={2}
   />
 
   <ColorBar
     title="Month Day"
     range={date_range}
-    bar_style="width: 500px; margin-left: 3em;"
+    bar_style="width: 500px"
     tick_format="%b %d"
     tick_labels={7}
   />
@@ -338,7 +341,9 @@ Vertical orientation with the title on different sides:
   }
 </script>
 
-<div style="display: flex; gap: 4em; justify-content: center; align-items: center">
+<div
+  style="display: flex; flex-wrap: wrap; gap: 4em; justify-content: center; align-items: center"
+>
   <ColorBar
     title="Energy"
     range={range_left}
@@ -377,7 +382,7 @@ Large numeric ranges on linear and log scales (`scale_type='log'`). Log needs a 
 </script>
 
 <div
-  style="display: grid; grid-template-columns: 1fr 1fr; gap: 4em; place-items: center; margin: 2em 0"
+  style="display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 20em), 1fr)); gap: 4em; place-items: center; margin: 2em 0; padding-inline: 1em"
 >
   <ColorBar
     title="Large Linear Range (0 to 1e6)"
@@ -450,7 +455,7 @@ Large numeric ranges on linear and log scales (`scale_type='log'`). Log needs a 
 </div>
 
 <div
-  style="display: grid; grid-template-columns: 1fr 1fr; gap: 3em; place-items: center; margin: 1em 0"
+  style="display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 20em), 1fr)); gap: 3em; place-items: center; margin: 1em 0; padding-inline: 1em"
 >
   <ColorBar
     title="Symmetric Range (-1000 to 1000)"

--- a/src/routes/(demos)/plot/color-scales/+page.md
+++ b/src/routes/(demos)/plot/color-scales/+page.md
@@ -13,7 +13,32 @@
   )
   let total = $derived(heatmap_values.reduce((sum, val) => sum + val, 0))
   let nice_range = $state([])
+  // the table inset is only ~10 element cells wide; below this width the controls no
+  // longer fit inside it and spill over the heading, so they move below the table
+  let demo_width = $state(1000)
+  let controls_in_inset = $derived(demo_width >= 700)
 </script>
+
+{#snippet controls()}
+  <section>
+    <span>
+      Data set &ensp;
+      {#each [`MP`, `WBM`] as data_set (data_set)}
+        <input type="radio" bind:group={data_name} value={data_set} /> {data_set}
+      {/each}
+    </span>
+    <span>Log color scale <input type="checkbox" bind:checked={log_scale} /></span>
+    <ColorScaleSelect bind:value={color_scale} selected={[color_scale]} />
+    <ColorBar
+      range={[1, Math.max(...heatmap_values)]}
+      scale={color_scale}
+      bind:nice_range
+      scale_type={log_scale ? `log` : `linear`}
+      wrapper_style="width: 80%; --cbar-padding: 0.4em 0.8em 0;"
+      bar_style="width: 100%;"
+    />
+  </section>
+{/snippet}
 
 <h1 style="text-align: center">Color Scales</h1>
 
@@ -21,45 +46,35 @@
   {{ MP: `Materials Project` }[data_name] ?? data_name} Element Occurrence Counts
 </h2>
 
-<PeriodicTable
-  {heatmap_values}
-  log={log_scale}
-  {color_scale}
-  bind:color_scale_range={nice_range}
->
-  {#snippet inset({ active_element })}
-    <TableInset style="align-content: center; --ptable-inset-padding: 0.25em 0.5em 1.4em">
-      <section>
-        <span>
-          Data set &ensp;
-          {#each [`MP`, `WBM`] as data_set (data_set)}
-            <input type="radio" bind:group={data_name} value={data_set} /> {data_set}
-          {/each}
-        </span>
-        <span>Log color scale <input type="checkbox" bind:checked={log_scale} /></span>
-        <ColorScaleSelect bind:value={color_scale} selected={[color_scale]} />
-        <ColorBar
-          range={[1, Math.max(...heatmap_values)]}
-          scale={color_scale}
-          bind:nice_range
-          scale_type={log_scale ? `log` : `linear`}
-          wrapper_style="width: 80%; --cbar-padding: 0.4em 0.8em 0;"
-          bar_style="width: 100%;"
-        />
-      </section>
-      <strong style="height: 25pt">
-        {#if active_element?.name}
-          {@const elem_counts = data_name == `WBM` ? wbm_elem_counts : mp_elem_counts}
-          {active_element?.name}: {format_num(elem_counts[active_element?.symbol])}
-          <!-- compute percent of total -->
-          {#if elem_counts[active_element?.symbol] > 0}
-            ({format_num(elem_counts[active_element?.symbol] / total, `.2~%`)})
-          {/if}
+<div bind:clientWidth={demo_width}>
+  <PeriodicTable
+    {heatmap_values}
+    log={log_scale}
+    {color_scale}
+    bind:color_scale_range={nice_range}
+  >
+    {#snippet inset({ active_element })}
+      <TableInset style="align-content: center; --ptable-inset-padding: 0.25em 0.5em 1.4em">
+        {#if controls_in_inset}
+          {@render controls()}
         {/if}
-      </strong>
-    </TableInset>
-  {/snippet}
-</PeriodicTable>
+        <strong style="height: 25pt">
+          {#if active_element?.name}
+            {@const elem_counts = data_name == `WBM` ? wbm_elem_counts : mp_elem_counts}
+            {active_element?.name}: {format_num(elem_counts[active_element?.symbol])}
+            <!-- compute percent of total -->
+            {#if elem_counts[active_element?.symbol] > 0}
+              ({format_num(elem_counts[active_element?.symbol] / total, `.2~%`)})
+            {/if}
+          {/if}
+        </strong>
+      </TableInset>
+    {/snippet}
+  </PeriodicTable>
+  {#if !controls_in_inset}
+    {@render controls()}
+  {/if}
+</div>
 
 <style>
   section {

--- a/src/routes/(demos)/plot/facet-grid/+page.svelte
+++ b/src/routes/(demos)/plot/facet-grid/+page.svelte
@@ -57,6 +57,10 @@
   }
 
   let point_radius = $state(4)
+  // below this width two side-by-side panels leave no room for axis titles; stack them
+  // and move the shared legend from its side band to below the grid
+  let demo_width = $state(1000)
+  const columns = $derived(demo_width < 640 ? 1 : 2)
   let plot_type = $state<keyof typeof plot_configs>(`scatter`)
   let panels = $derived(
     panel_specs.map(({ key, title, offset, curvature }, panel_idx) => ({
@@ -119,31 +123,38 @@
   {/if}
 </div>
 
-<div data-testid="facet-grid-demo" style="height: 720px; min-width: 0">
+{#snippet shared_legend()}
+  <div class={[`shared-legend`, { below: columns === 1 }]} aria-label="Shared method legend">
+    <strong>Method</strong>
+    {#each method_configs as { label, color } (label)}
+      <span><i style:background={color}></i>{label}</span>
+    {/each}
+    <small style="opacity: 0.7"
+      >Drag to zoom; focus and Shift+wheel to pan; double-click to reset all linked panels.</small
+    >
+  </div>
+{/snippet}
+
+<div
+  data-testid="facet-grid-demo"
+  style:height="{columns === 1 ? 1100 : 720}px"
+  style="min-width: 0; display: grid; grid-template-rows: minmax(0, 1fr) auto; gap: 1em"
+  bind:clientWidth={demo_width}
+>
   <FacetGrid
     {panels}
-    columns={2}
+    {columns}
     gap={8}
     axis_modes={{ x: `shared`, y: `shared` }}
     axis_visibility={{ x: `outer`, x2: `none`, y: `outer`, y2: `none` }}
     shared_bands={{ title_height: 62, legend_width: 126, gap: 10 }}
+    legend={columns === 1 ? undefined : shared_legend}
   >
     {#snippet title()}
       <div class="shared-title">
         <strong style="font-size: 1.15em">Equation-of-state comparison · {plot_type}</strong>
         <span style="opacity: 0.7"
           >Shared x/y ranges, padding, and linked zoom across four materials</span
-        >
-      </div>
-    {/snippet}
-    {#snippet legend()}
-      <div class="shared-legend" aria-label="Shared method legend">
-        <strong>Method</strong>
-        {#each method_configs as { label, color } (label)}
-          <span><i style:background={color}></i>{label}</span>
-        {/each}
-        <small style="opacity: 0.7"
-          >Drag to zoom; focus and Shift+wheel to pan; double-click to reset all linked panels.</small
         >
       </div>
     {/snippet}
@@ -161,6 +172,9 @@
       </div>
     {/snippet}
   </FacetGrid>
+  {#if columns === 1}
+    {@render shared_legend()}
+  {/if}
 </div>
 
 <style>
@@ -187,6 +201,12 @@
     gap: 0.7em;
     height: 100%;
     padding-inline: 0.3em;
+  }
+  .shared-legend.below {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.5em 1.5em;
   }
   .shared-legend span {
     display: flex;

--- a/src/routes/(demos)/plot/histogram/+page.md
+++ b/src/routes/(demos)/plot/histogram/+page.md
@@ -350,7 +350,7 @@ Bins are uniform in the x axis's own space: `bins` equal-width bins on a linear 
 </script>
 
 <div
-  style="display: flex; align-items: center; gap: 1em; margin-bottom: 1em; white-space: nowrap; font-size: 0.9em"
+  style="display: flex; flex-wrap: wrap; align-items: center; gap: 1em; margin-bottom: 1em; font-size: 0.9em"
 >
   <fieldset>
     <legend>X-axis Scale</legend>

--- a/src/routes/(demos)/plot/scatter-plot/+page.md
+++ b/src/routes/(demos)/plot/scatter-plot/+page.md
@@ -598,7 +598,7 @@ Categorized data with color coding, custom tick intervals, and negative values:
 </ScatterPlot>
 
 <!-- Legend -->
-<div style="display: flex; justify-content: center; margin: 1em; gap: 3ex;">
+<div style="display: flex; flex-wrap: wrap; justify-content: center; margin: 1em; gap: 3ex;">
   {#each categories as category, idx (category)}
     <div style="display: flex; align-items: center;">
       <span
@@ -967,7 +967,9 @@ Log scales for data spanning many orders of magnitude. Use the checkboxes to swi
 </script>
 
 <div>
-  <div style="display: flex; justify-content: center; gap: 2em; margin-bottom: 1em">
+  <div
+    style="display: flex; flex-wrap: wrap; justify-content: center; gap: 2em; margin-bottom: 1em"
+  >
     <label>
       <input type="checkbox" bind:checked={x_is_log} />
       Log X-Axis
@@ -978,7 +980,9 @@ Log scales for data spanning many orders of magnitude. Use the checkboxes to swi
     </label>
   </div>
 
-  <div style="display: flex; justify-content: center; gap: 2em; margin-bottom: 1em">
+  <div
+    style="display: flex; flex-wrap: wrap; justify-content: center; gap: 2em; margin-bottom: 1em"
+  >
     <label>
       Min Size (px):
       <input
@@ -1432,12 +1436,14 @@ Mixed display modes, markers, hover styling, and independent X/Y grid controls. 
     x_axis={{ label: axis_labels.x, range: [-15, 15], ticks: ticks.x }}
     y_axis={{ label: axis_labels.y, range: [-15, 15], ticks: ticks.y }}
     bind:display
+    class="external-legend-plot"
     style="height: 400px; position: relative;"
     legend={{
       style: `
         position: absolute;
         top: 3pt;
-        left: 100%;
+        left: var(--legend-left, 100%);
+        right: var(--legend-right, auto);
         background: rgba(255, 255, 255, 0.1);
         padding: 5px 5px 5px 0;
         border-radius: 3px;
@@ -1452,6 +1458,17 @@ Mixed display modes, markers, hover styling, and independent X/Y grid controls. 
     {/snippet}
   </ScatterPlot>
 </div>
+
+<style>
+  /* the legend hangs off the chart's right edge into the page margin, which only exists
+     on wide viewports; below that it tucks into the top-right corner of the chart */
+  @media (max-width: 1000px) {
+    :global(.external-legend-plot .legend) {
+      --legend-left: auto;
+      --legend-right: 4px;
+    }
+  }
+</style>
 ```
 
 ## Automatic Color Bar Placement
@@ -1542,7 +1559,7 @@ The color bar picks the corner with the least data density (top-left, top-right,
 </script>
 
 <div
-  style="display: grid; grid-template-columns: repeat(2, max-content); gap: 1em 2em; place-content: center; margin: 1em"
+  style="display: flex; flex-wrap: wrap; gap: 1em 2em; justify-content: center; margin: 1em"
 >
   {#each [['top_left', 'Top Left'], ['top_right', 'Top Right'], ['bottom_left', 'Bottom Left'], ['bottom_right', 'Bottom Right']] as [quadrant, label] (quadrant)}
     <label

--- a/src/routes/(demos)/reciprocal/brillouin-zone/+page.svelte
+++ b/src/routes/(demos)/reciprocal/brillouin-zone/+page.svelte
@@ -180,7 +180,8 @@
   .grid {
     text-align: center;
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+    /* min(400px, 100%) keeps a single column from forcing horizontal page scroll on phones */
+    grid-template-columns: repeat(auto-fit, minmax(min(400px, 100%), 1fr));
     gap: 2em;
     margin-block: 2em;
   }

--- a/src/routes/(demos)/structure/+page.md
+++ b/src/routes/(demos)/structure/+page.md
@@ -275,7 +275,7 @@ the RMSD through the bindable `displacement_rmsd` prop.
 <style>
   ul.crystal-systems {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(500px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(min(500px, 100%), 1fr));
     gap: 1.5em;
     list-style: none;
     padding: 0;

--- a/src/routes/(demos)/structure/symmetry/+page.svelte
+++ b/src/routes/(demos)/structure/symmetry/+page.svelte
@@ -213,6 +213,15 @@
     grid-template-columns: auto 1fr;
     gap: 2em;
     margin-block: 2em;
+    > * {
+      min-width: 0;
+    }
+  }
+  /* nested so it outranks the base rule regardless of declaration order */
+  @media (max-width: 900px) {
+    .symmetry-grid {
+      grid-template-columns: minmax(0, 1fr);
+    }
   }
   .loading-placeholder {
     display: flex;
@@ -246,6 +255,9 @@
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 2em;
+    @media (max-width: 900px) {
+      grid-template-columns: minmax(0, 1fr);
+    }
   }
   .stacked-layout {
     max-width: 900px;

--- a/src/routes/(demos)/structure/vectors/+page.md
+++ b/src/routes/(demos)/structure/vectors/+page.md
@@ -359,7 +359,7 @@ Structures can carry per-site vector data in their `properties` dict. Recognized
 <style>
   ul.vector-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(500px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(min(500px, 100%), 1fr));
     gap: 1.5em;
     list-style: none;
     padding: 0;

--- a/src/routes/(demos)/structure/xrd/+page.svelte
+++ b/src/routes/(demos)/structure/xrd/+page.svelte
@@ -342,12 +342,16 @@
   }
   .bleed-1400 > section {
     display: grid;
-    grid-template-columns: minmax(300px, 1fr) minmax(300px, 1fr);
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 1em;
+    /* Structure has a 300px floor, so two columns overflow phone widths */
+    @media (max-width: 700px) {
+      grid-template-columns: minmax(0, 1fr);
+    }
   }
   .selected-structures-grid {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: repeat(auto-fill, minmax(min(300px, 100%), 1fr));
     gap: 0.5em;
     align-content: start;
   }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -95,7 +95,9 @@
   )
 </script>
 
-<!-- z-index: above nav dropdown and Structure control toggles -->
+<!-- z-index: above nav dropdown and Structure control toggles.
+     --text: svelte-widgets paints the mobile burger bars with var(--text), which matterviz
+     does not define (it uses --text-color), leaving the burger invisible on phones. -->
 <CommandMenu
   bind:open={cmd_palette_open}
   {actions}
@@ -109,7 +111,11 @@
     style: `left: 50%; margin: 0; transform: translateX(-50%); z-index: var(--z-index-overlay-dialog); --sms-width: min(42em, 90vw); --sms-options-li-padding: 2pt 1ex`,
   }}
 />
-<GitHubCorner href={pkg.repository} --github-corner-bg-hover="var(--github-corner-bg-hover)" />
+<GitHubCorner
+  id="github-corner"
+  href={pkg.repository}
+  --github-corner-bg-hover="var(--github-corner-bg-hover)"
+/>
 <CopyButton
   global
   style="top: 9pt; inset-inline-end: 9pt; background: var(--btn-bg); color: var(--btn-color)"
@@ -137,6 +143,7 @@
   aria-label="Main navigation"
   {page}
   --nav-dropdown-z-index="var(--z-index-overlay-nav)"
+  --text="var(--text-color)"
 >
   <!-- Nav dropdown uses --z-index-overlay-nav to sit above overlay controls. -->
   <button
@@ -165,6 +172,32 @@
 <Footer />
 
 <style>
+  /* Mobile nav: svelte-widgets ships a 1.4rem burger and 2pt-tall menu rows, both well under
+     the ~32px touch-target floor. Padding grows the hit area without moving the bars. */
+  :global(nav.mobile .burger) {
+    box-sizing: content-box;
+    padding: 0.5rem;
+    top: 0.5rem;
+    inset-inline-start: 0.5rem;
+  }
+  :global(nav.mobile .menu > span > a),
+  :global(nav.mobile .dropdown > div:first-child > :is(a, span)) {
+    padding-block: 5pt;
+  }
+  /* The fixed corner sits exactly where viewers put their fullscreen/controls toggles; on a
+     phone a tap there opens GitHub instead. The footer still links to the repo. */
+  @media (max-width: 600px) {
+    :global(#github-corner) {
+      display: none;
+    }
+  }
+  /* On phones the fixed theme select covers demo content (treemap tiles, hover readouts);
+     `auto` follows the OS there and the control returns on wider screens */
+  @media (max-width: 480px) {
+    :global(.theme-control) {
+      display: none;
+    }
+  }
   :global(dialog.site-search-dialog :is(.cmd-label, .cmd-description)) {
     min-width: 0;
     overflow: hidden;

--- a/src/site/FermiSurfaceDemo.svelte
+++ b/src/site/FermiSurfaceDemo.svelte
@@ -137,6 +137,15 @@
     border-radius: 6px;
     position: relative;
     margin-block: 1.5rem;
+    container-type: inline-size;
+  }
+  /* The floating header covers the slice once it wraps to several lines, so put it in flow
+     above the plot in narrow embeds */
+  @container (max-width: 480px) {
+    section.slice-section header {
+      position: static;
+      padding: 1ex 1em 0;
+    }
   }
   section.slice-section header {
     display: flex;

--- a/src/site/FermiSurfaceDemo.svelte
+++ b/src/site/FermiSurfaceDemo.svelte
@@ -139,14 +139,6 @@
     margin-block: 1.5rem;
     container-type: inline-size;
   }
-  /* The floating header covers the slice once it wraps to several lines, so put it in flow
-     above the plot in narrow embeds */
-  @container (max-width: 480px) {
-    section.slice-section header {
-      position: static;
-      padding: 1ex 1em 0;
-    }
-  }
   section.slice-section header {
     display: flex;
     position: absolute;
@@ -157,6 +149,14 @@
     gap: 1rem;
     z-index: 10;
     pointer-events: auto;
+  }
+  /* The floating header covers the slice once it wraps to several lines, so put it in flow
+     above the plot in narrow embeds (after the base rule: same specificity, later wins) */
+  @container (max-width: 480px) {
+    section.slice-section header {
+      position: static;
+      padding: 1ex 1em 0;
+    }
   }
   section.slice-section label {
     display: flex;

--- a/tests/vitest/plot/decorations/outside.test.ts
+++ b/tests/vitest/plot/decorations/outside.test.ts
@@ -44,6 +44,18 @@ const place = ({
   })
 }
 
+// A legend wider than ~45% of the plot (a phone-width frame) goes below the plot even when
+// nothing is crowded: inside it would cover most of the data, on the right it would leave no
+// plot width
+test(`a legend too wide for its frame always goes below the plot`, () => {
+  const legend = { footprint: { width: 140, height: 40 } }
+  const roomy = place({ legend, obstacles_norm: [] }) // 140 / 330 = 42%: stays interior
+  expect(roomy.pad).toEqual(base_pad)
+  const narrow = place({ legend, obstacles_norm: [], width: 360 }) // 140 / 290 = 48%
+  expect(narrow.pad.b).toBeGreaterThan(base_pad.b)
+  expect(narrow.pad.r).toBe(base_pad.r)
+})
+
 describe(`place_outside_decorations`, () => {
   test.each([
     { horizontal: true, edge: `top` },


### PR DESCRIPTION
Every demo route was audited at 360 / 390 / 768 px with Playwright (horizontal overflow, elements past the viewport, clipped or overlapping controls, touch-target size, screenshots) and the causes fixed in the components and pages. After the fixes no page in the site has horizontal overflow at any of the three widths; desktop (1400 px) was re-checked per changed component.

## Site chrome
- Mobile burger was **invisible**: svelte-widgets paints it with `var(--text)`, which this site never defined (it uses `--text-color`) — phones had no navigation. Its hit area and the menu rows were also under the ~32 px touch floor.
- GitHub corner hidden ≤600 px (it sat exactly on every viewer's fullscreen/controls toggle); the fixed theme `<select>` hidden ≤480 px (it covered demo content; `auto` follows the OS there) and given a finger-sized target.
- Hover-revealed viewer controls (`.hover-visible`) are always shown on `(hover: none)` devices — they never appeared on touch before.

## Components (embedded-friendly: container queries where a component owns its size)
- `SequenceControls`: the step slider wraps to its own row in containers ≤520 px instead of collapsing to a zero-width thumb over the FPS input (Trajectory, NEB, PhononModeExplorer).
- `AtomLegend`: the hidden colour input widened every Structure viewer by 2–4 px.
- `ConvexHullCanvas`/`Stats`: colorbars `min(200px, 50cqw − 1.5em)`, stats wrap so the table drops below. `ChemPotDiagram`: legend wraps, projection grid stacks ≤640 px, and a desktop bug where 2D axis labels rendered raw `<span style=…>` text.
- `SymmetryStats`/`WyckoffTable`: wrap/shrink/scroll instead of widening the host. `FormulaFilter`: one root element so hosts can put it in a grid (the three-root version also broke the desktop 2-column layout). `TableInset`: custom insets stack below tables ≤380 px.
- `ColorBar`: shrinks into narrow hosts and thins colliding generated tick labels (measured). `SpacegroupBarPlot`: rotated x-ticks de-collided, count annotations stacked into rows (also fixes desktop overlap). `Sankey`: smaller labels ≤480 px.
- `Bands`: gap label anchored inside the plot. `BandsAndDos`: stacks with a vertical DOS below 520 px container width. `FermiSurfaceDemo`: slice header in flow ≤480 px.
- Plot legends: a legend wider than 45 % of the plot (or crowded) moves to a strip below it, and outside strips lay auto tracks along the edge they sit on (columns below/above, rows beside) instead of the legend's interior layout — a 7-series legend no longer eats a third of a phone-width plot as a single column.

## Demo pages
Grids use `min(Npx, 100%)` / `auto-fit` floors so a single column can never exceed the page; fixed pixel widths, `nowrap` control rows and negative-margin hacks replaced; side-by-side examples stack. Pages touched: structure, vectors, xrd, symmetry, periodic-table (+ element-colors), formula-filter, bohr-atoms, facet-grid, color-bar, scatter-plot, histogram, color-scales, brillouin-zone.

## Not in this PR
- Upstream fixes made locally in `../svelte-widgets` (uncommitted, for review there): `Nav` burger bars fall back to `currentColor`, get a ~2.4 rem hit area, and start from the real `innerWidth` so hydration doesn't flash the desktop nav on phones; `CodeExample` gets `min-width: 0`. This PR carries equivalent `:global` patches for the burger until a release is consumed.
- Periodic-table tile text is ~7 px at 390 px (18 columns in 367 px) — would need a horizontal-scroll min-width on the component, which changes every narrow embed; left as is.
- DraggablePane default `--pane-max-height: 80vh` lets tall control panes spill below 400–500 px-tall viewers on phones; a viewer-height clamp also shortens panes on desktop, so it's a product decision (one-line change in `ViewerPane.svelte` if wanted).
