### PR TITLE
Route all file loading through one open_material() runtime

### DIFF
--- a/src/lib/convex-hull/entry-stability.ts
+++ b/src/lib/convex-hull/entry-stability.ts
@@ -1,0 +1,34 @@
+// Worker-safe entry stability predicates shared by hull thermodynamics and UI helpers.
+import type { PhaseData } from './types'
+
+export const HULL_STABILITY_TOL = 1e-6
+
+export function compute_hull_stability(
+  raw_distance: number | null | undefined,
+  exclude_from_hull?: boolean,
+  tol: number = HULL_STABILITY_TOL,
+): { e_above_hull: number | undefined; is_stable: boolean | undefined } {
+  if (raw_distance == null || !Number.isFinite(raw_distance)) {
+    return { e_above_hull: undefined, is_stable: undefined }
+  }
+  if (exclude_from_hull) return { e_above_hull: raw_distance, is_stable: false }
+  const e_above_hull = Math.abs(raw_distance) < tol ? 0 : Math.max(0, raw_distance)
+  return { e_above_hull, is_stable: e_above_hull <= tol }
+}
+
+type StabilityEntry = { is_stable?: boolean; e_above_hull?: number }
+
+export const entry_is_stable = (
+  entry: StabilityEntry,
+  tol: number = HULL_STABILITY_TOL,
+): boolean =>
+  entry.is_stable === true ||
+  (entry.is_stable !== false && Math.abs(entry.e_above_hull ?? Infinity) <= tol)
+
+export const is_on_hull = (entry: PhaseData, tol: number = HULL_STABILITY_TOL): boolean =>
+  !entry.exclude_from_hull && entry_is_stable(entry, tol)
+
+export const get_arity = (entry: PhaseData): number =>
+  Object.values(entry.composition).filter((count) => count > 0).length
+
+export const is_unary_entry = (entry: PhaseData): boolean => get_arity(entry) === 1

--- a/src/lib/convex-hull/helpers.ts
+++ b/src/lib/convex-hull/helpers.ts
@@ -13,26 +13,16 @@ import type {
   PhaseData,
 } from './types'
 import { DEFAULT_HULL_COLORS, MAGNETIC_ORDERING_CATEGORY } from './types'
+import { entry_is_stable, is_unary_entry } from './entry-stability'
 
-// Tolerance for classifying a phase as on the convex hull (eV/atom)
-export const HULL_STABILITY_TOL = 1e-6
-
-// Clamp raw hull distance and compute stability for a single entry.
-// Excluded entries keep their raw (possibly negative) distance and are never stable.
-export function compute_hull_stability(
-  raw_distance: number | null | undefined,
-  exclude_from_hull?: boolean,
-  tol: number = HULL_STABILITY_TOL,
-): { e_above_hull: number | undefined; is_stable: boolean | undefined } {
-  // unknown distance (degenerate hull / point outside hull projection / missing energy):
-  // not 0/stable — leave both undefined so it isn't mislabeled on-hull
-  if (raw_distance == null || !Number.isFinite(raw_distance)) {
-    return { e_above_hull: undefined, is_stable: undefined }
-  }
-  if (exclude_from_hull) return { e_above_hull: raw_distance, is_stable: false }
-  const e_above_hull = Math.abs(raw_distance) < tol ? 0 : Math.max(0, raw_distance)
-  return { e_above_hull, is_stable: e_above_hull <= tol }
-}
+export {
+  compute_hull_stability,
+  entry_is_stable,
+  get_arity,
+  HULL_STABILITY_TOL,
+  is_on_hull,
+  is_unary_entry,
+} from './entry-stability'
 
 type StabilityEntry = { is_stable?: boolean; e_above_hull?: number }
 
@@ -51,27 +41,11 @@ export const hull_distance_range = (entries: PhaseData[]): [number, number] => {
   return [min_dist, Math.max(max_dist, 0.1)]
 }
 
-export const entry_is_stable = (
-  entry: StabilityEntry,
-  tol: number = HULL_STABILITY_TOL,
-): boolean =>
-  entry.is_stable === true ||
-  (entry.is_stable !== false && Math.abs(entry.e_above_hull ?? Infinity) <= tol)
-
 // Whether to plot an entry at a given max hull distance: stable, or a finite distance
 // within max_dist. Unknown distance (undefined) is excluded, not treated as 0/stable.
 export const entry_within_hull_dist = (entry: StabilityEntry, max_dist: number): boolean =>
   entry_is_stable(entry) ||
   (typeof entry.e_above_hull === `number` && entry.e_above_hull <= max_dist)
-
-// Check if entry is on the convex hull (stable or e_above_hull ≈ 0)
-export const is_on_hull = (entry: PhaseData, tol: number = HULL_STABILITY_TOL): boolean =>
-  !entry.exclude_from_hull && entry_is_stable(entry, tol)
-
-export const get_arity = (entry: PhaseData): number =>
-  Object.values(entry.composition).filter((count) => count > 0).length
-
-export const is_unary_entry = (entry: PhaseData) => get_arity(entry) === 1
 
 // === Entry category helpers (generic categorical classification) ===
 

--- a/src/lib/convex-hull/thermodynamics.ts
+++ b/src/lib/convex-hull/thermodynamics.ts
@@ -4,7 +4,7 @@ import { count_atoms_in_composition } from '$lib/composition/reduce'
 import type { ElementSymbol } from '$lib/element'
 import * as math from '$lib/math'
 import { composition_to_barycentric_nd } from './barycentric-coords'
-import { get_arity, HULL_STABILITY_TOL, is_on_hull, is_unary_entry } from './helpers'
+import { get_arity, HULL_STABILITY_TOL, is_on_hull, is_unary_entry } from './entry-stability'
 import type { ConvexHullEntry, PhaseData, PhaseStats, ProcessedPhaseData } from './types'
 
 // A pymatgen species key as emitted by Composition.as_dict(): an element symbol with optional

--- a/src/lib/synthesis-planning/SynthesisPlanner.svelte
+++ b/src/lib/synthesis-planning/SynthesisPlanner.svelte
@@ -11,6 +11,7 @@
   import { format_equation_html, format_mev } from './format'
   import { prepare_phase_set, resolve_phase } from './phases'
   import { plan_synthesis_async } from './plan-synthesis-async.svelte'
+  import { build_recipe } from './recipe'
   import ReactionSlicePlot from './ReactionSlicePlot.svelte'
   import RecipeCard from './RecipeCard.svelte'
   import RouteTable from './RouteTable.svelte'
@@ -85,8 +86,30 @@
     if (!target && target_options.length) target = target_options[0].formula
   })
 
-  let computed_plan = $state<SynthesisPlan | null>(plan)
-  let error = $state<string | null>(null)
+  let worker_plan = $state<SynthesisPlan | null>(plan)
+  let planning_error = $state<string | null>(null)
+  let active_controller: AbortController | undefined
+  const target_mass_error = $derived(
+    typeof target_mass_g !== `number` || !Number.isFinite(target_mass_g) || target_mass_g <= 0
+      ? `plan_synthesis: target_mass_g must be a finite number > 0, got ${String(target_mass_g)}`
+      : null,
+  )
+  const computed_plan = $derived.by(() => {
+    if (!worker_plan || target_mass_error) return null
+    if (worker_plan.routes.every((route) => route.recipe.target_mass_g === target_mass_g))
+      return worker_plan
+    return {
+      ...worker_plan,
+      routes: worker_plan.routes.map((route) => ({
+        ...route,
+        recipe: build_recipe(route.reaction, route.thermodynamics, target_mass_g),
+      })),
+    }
+  })
+  const error = $derived(target_mass_error ?? planning_error)
+  $effect(() => {
+    plan = computed_plan
+  })
   $effect(() => {
     const request = {
       entries,
@@ -97,22 +120,20 @@
       two_step,
       scoring: weights,
       max_routes,
-      target_mass_g,
     }
     if (!entries.length || !target) {
-      computed_plan = null
-      plan = null
+      worker_plan = null
       planning = false
       progress = null
-      error = null
+      planning_error = null
       return
     }
     const controller = new AbortController()
-    computed_plan = null
-    plan = null
+    active_controller = controller
+    worker_plan = null
     planning = true
     progress = { stage: `preparing`, current: 0, total: 1 }
-    error = null
+    planning_error = null
     void plan_synthesis_async(request, {
       signal: controller.signal,
       on_progress: (update) => {
@@ -121,12 +142,11 @@
     })
       .then((result) => {
         if (controller.signal.aborted) return
-        computed_plan = result
-        plan = result
+        worker_plan = result
       })
       .catch((err: unknown) => {
         if (!controller.signal.aborted) {
-          error = err instanceof Error ? err.message : String(err)
+          planning_error = err instanceof Error ? err.message : String(err)
         }
       })
       .finally(() => {
@@ -137,7 +157,10 @@
       })
     return () => controller.abort()
   })
-  onDestroy(plan_synthesis_async.release)
+  onDestroy(() => {
+    active_controller?.abort()
+    plan_synthesis_async.release()
+  })
   const routes = $derived(computed_plan?.routes ?? [])
   const selected_route = $derived<SynthesisRoute | null>(
     routes.find((route) => route.id === selected_route_id) ?? routes[0] ?? null,

--- a/src/lib/synthesis-planning/SynthesisPlanner.svelte
+++ b/src/lib/synthesis-planning/SynthesisPlanner.svelte
@@ -9,8 +9,8 @@
   import { sanitize_formula } from '$lib/sanitize'
   import { format_plan_text } from './agent'
   import { format_equation_html, format_mev } from './format'
-  import { prepare_phase_set } from './phases'
-  import { plan_synthesis } from './plan'
+  import { prepare_phase_set, resolve_phase } from './phases'
+  import { plan_synthesis_async } from './plan-synthesis-async.svelte'
   import ReactionSlicePlot from './ReactionSlicePlot.svelte'
   import RecipeCard from './RecipeCard.svelte'
   import RouteTable from './RouteTable.svelte'
@@ -20,8 +20,10 @@
     ScoreWeights,
     SynthesisConditions,
     SynthesisPlan,
+    SynthesisPlanProgress,
     SynthesisRoute,
   } from './types'
+  import { onDestroy } from 'svelte'
 
   let {
     entries = [],
@@ -35,6 +37,8 @@
     max_routes = 50,
     selected_route_id = $bindable(null),
     plan = $bindable(null),
+    planning = $bindable(false),
+    progress = $bindable(null),
     show_hull = true,
     show_controls = true,
     ...rest
@@ -52,50 +56,88 @@
     selected_route_id?: string | null
     // Bindable output: the full plan for the current inputs
     plan?: SynthesisPlan | null
+    // Bindable async state for host applications embedding the planner
+    planning?: boolean
+    progress?: SynthesisPlanProgress | null
     show_hull?: boolean
     show_controls?: boolean
     [key: string]: unknown
   } = $props()
 
-  // Target choices: every non-gas formula, multi-element and stable first
+  // Target choices: every non-gas multi-element formula, stable phases first
   const phase_set = $derived(entries.length ? prepare_phase_set(entries) : null)
   const target_options = $derived(
     (phase_set?.phases ?? [])
       .filter((phase) => !phase.is_gas && Object.keys(phase.composition).length > 1)
       .toSorted(
         (phase_a, phase_b) =>
+          phase_a.e_above_hull_0K - phase_b.e_above_hull_0K ||
           Object.keys(phase_b.composition).length - Object.keys(phase_a.composition).length ||
           phase_a.formula.localeCompare(phase_b.formula),
       ),
+  )
+  const explicit_target = $derived(
+    phase_set && target && !target_options.some((phase) => phase.formula === target)
+      ? resolve_phase(phase_set, target)
+      : null,
   )
   $effect(() => {
     if (!target && target_options.length) target = target_options[0].formula
   })
 
-  const result = $derived.by((): { plan: SynthesisPlan | null; error: string | null } => {
-    if (!entries.length || !target) return { plan: null, error: null }
-    try {
-      const computed = plan_synthesis({
-        entries,
-        target,
-        conditions,
-        precursors,
-        max_precursors,
-        two_step,
-        scoring: weights,
-        max_routes,
-        target_mass_g,
-      })
-      return { plan: computed, error: null }
-    } catch (err) {
-      return { plan: null, error: err instanceof Error ? err.message : String(err) }
-    }
-  })
-  const computed_plan = $derived(result.plan)
-  const error = $derived(result.error)
+  let computed_plan = $state<SynthesisPlan | null>(plan)
+  let error = $state<string | null>(null)
   $effect(() => {
-    plan = computed_plan
+    const request = {
+      entries,
+      target,
+      conditions,
+      precursors,
+      max_precursors,
+      two_step,
+      scoring: weights,
+      max_routes,
+      target_mass_g,
+    }
+    if (!entries.length || !target) {
+      computed_plan = null
+      plan = null
+      planning = false
+      progress = null
+      error = null
+      return
+    }
+    const controller = new AbortController()
+    computed_plan = null
+    plan = null
+    planning = true
+    progress = { stage: `preparing`, current: 0, total: 1 }
+    error = null
+    void plan_synthesis_async(request, {
+      signal: controller.signal,
+      on_progress: (update) => {
+        if (!controller.signal.aborted) progress = update
+      },
+    })
+      .then((result) => {
+        if (controller.signal.aborted) return
+        computed_plan = result
+        plan = result
+      })
+      .catch((err: unknown) => {
+        if (!controller.signal.aborted) {
+          error = err instanceof Error ? err.message : String(err)
+        }
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          planning = false
+          progress = null
+        }
+      })
+    return () => controller.abort()
   })
+  onDestroy(plan_synthesis_async.release)
   const routes = $derived(computed_plan?.routes ?? [])
   const selected_route = $derived<SynthesisRoute | null>(
     routes.find((route) => route.id === selected_route_id) ?? routes[0] ?? null,
@@ -150,6 +192,11 @@
       })
       .join(`, `)
   })
+  const progress_text = $derived.by(() => {
+    if (!progress) return `Planning synthesis routes…`
+    const stage = progress.stage.replaceAll(`_`, ` `)
+    return progress.total > 1 ? `${stage}: ${progress.current}/${progress.total}` : `${stage}…`
+  })
 
   const score_tooltip = $derived(
     Object.entries(selected_route?.score_breakdown ?? {})
@@ -194,6 +241,9 @@
       <label>
         Target
         <select bind:value={target}>
+          {#if explicit_target}
+            <option value={target}>{explicit_target.formula} ({explicit_target.id})</option>
+          {/if}
           {#each target_options as phase (phase.id)}
             <option value={phase.formula}>{phase.formula}</option>
           {/each}
@@ -305,6 +355,8 @@
 
   {#if error}
     <p class="error">{error}</p>
+  {:else if planning}
+    <p class="progress" role="status">{progress_text}</p>
   {:else if computed_plan}
     <p class="summary">
       <strong>{@html sanitize_formula(computed_plan.target.formula)}</strong>
@@ -355,6 +407,14 @@
             <ul class="rationale">
               {#each selected_route.rationale as reason (reason)}<li>{reason}</li>{/each}
             </ul>
+            {#if show_hull && n_elements >= 2 && n_elements <= 4}
+              <ConvexHull
+                {entries}
+                {highlighted_entries}
+                show_unstable_labels={false}
+                style="height: 520px"
+              />
+            {/if}
           </div>
           <div class="detail-right">
             <ReactionSlicePlot route={selected_route} />
@@ -384,15 +444,6 @@
         </section>
       {/if}
     </div>
-
-    {#if show_hull && n_elements >= 2 && n_elements <= 4}
-      <ConvexHull
-        {entries}
-        {highlighted_entries}
-        show_unstable_labels={false}
-        style="height: 520px"
-      />
-    {/if}
   {:else}
     <p class="empty">Provide thermodynamic entries and a target to plan a synthesis.</p>
   {/if}
@@ -462,6 +513,7 @@
   .summary,
   .warn,
   .error,
+  .progress,
   .empty {
     margin: 0;
   }

--- a/src/lib/synthesis-planning/agent.ts
+++ b/src/lib/synthesis-planning/agent.ts
@@ -16,7 +16,6 @@ export const SYNTHESIS_PLAN_REQUEST_SCHEMA = {
   properties: {
     target: {
       type: `string`,
-      minLength: 1,
       pattern: `\\S`,
       description: `Target phase as a formula (e.g. "LiCoO2", "BaTiO3") or an entry id present in the thermodynamic data. A formula picks the lowest-energy matching entry.`,
     },

--- a/src/lib/synthesis-planning/agent.ts
+++ b/src/lib/synthesis-planning/agent.ts
@@ -2,8 +2,8 @@
 // text rendering of a plan for the model channel, and a ready-made tool definition. The full
 // SynthesisPlan object is the structured channel; `format_plan_text` deliberately repeats only
 // what a model needs to reason and reply.
-import { GAS_SPECIES } from '$lib/convex-hull'
-import { format_mev } from './format'
+import { GAS_SPECIES } from '$lib/convex-hull/types'
+import { format_mev } from './format-mev'
 import { DEFAULT_SCORE_WEIGHTS } from './scoring'
 import type { SynthesisPlan, SynthesisRoute } from './types'
 
@@ -16,6 +16,8 @@ export const SYNTHESIS_PLAN_REQUEST_SCHEMA = {
   properties: {
     target: {
       type: `string`,
+      minLength: 1,
+      pattern: `\\S`,
       description: `Target phase as a formula (e.g. "LiCoO2", "BaTiO3") or an entry id present in the thermodynamic data. A formula picks the lowest-energy matching entry.`,
     },
     max_precursors: {

--- a/src/lib/synthesis-planning/format-mev.ts
+++ b/src/lib/synthesis-planning/format-mev.ts
@@ -1,0 +1,3 @@
+// Worker-safe energy formatting kept separate from HTML formula sanitization.
+export const format_mev = (energy_ev: number): string =>
+  `${Math.round(energy_ev * 1000)} meV/atom`

--- a/src/lib/synthesis-planning/format.ts
+++ b/src/lib/synthesis-planning/format.ts
@@ -1,5 +1,7 @@
 import { sanitize_formula } from '$lib/sanitize'
 
+export { format_mev } from './format-mev'
+
 // HTML for a balanced equation such as `2 Li2CO3 + O2 → 4 LiCoO2`: every species gets
 // subscripts while coefficients and operators stay as text
 export const format_equation_html = (equation: string): string =>
@@ -11,7 +13,3 @@ export const format_equation_html = (equation: string): string =>
       return `${groups?.coefficient ?? ``}${sanitize_formula(groups?.formula ?? token)}`
     })
     .join(``)
-
-// `-262 meV/atom` style energies for rationale and summaries
-export const format_mev = (energy_ev: number): string =>
-  `${Math.round(energy_ev * 1000)} meV/atom`

--- a/src/lib/synthesis-planning/index.ts
+++ b/src/lib/synthesis-planning/index.ts
@@ -9,6 +9,8 @@ export {
 } from './phases'
 export type { HullPoint, PhaseSet, PlannerPhase } from './phases'
 export { COMPETITOR_E_ABOVE_HULL, DEFAULT_MAX_E_ABOVE_HULL, plan_synthesis } from './plan'
+export { plan_synthesis_async } from './plan-synthesis-async.svelte'
+export type { PlanSynthesisAsync } from './plan-synthesis-async.svelte'
 export { lookup_precursor_info, PRECURSOR_LIBRARY, precursor_key } from './precursor-library'
 export type { PrecursorInfo } from './precursor-library'
 export { build_recipe } from './recipe'
@@ -26,3 +28,4 @@ export {
 } from './thermo'
 export type { BalancedReaction, BalanceFailure } from './thermo'
 export type * from './types'
+export { validate_synthesis_plan_request } from './validation'

--- a/src/lib/synthesis-planning/phases.ts
+++ b/src/lib/synthesis-planning/phases.ts
@@ -2,24 +2,23 @@
 // per formula, gas species at their chemical potentials for the requested conditions, elemental
 // references at 0 eV/atom, and atom-fraction vectors over a shared element list.
 import type { CompositionType } from '$lib/composition'
+import { get_electro_neg_formula } from '$lib/composition/format'
+import { parse_composition } from '$lib/composition/parse'
+import { count_atoms_in_composition, get_reduced_formula } from '$lib/composition/reduce'
 import {
-  count_atoms_in_composition,
-  get_electro_neg_formula,
-  get_reduced_formula,
-  parse_composition,
-} from '$lib/composition'
-import type { GasSpecies, PhaseData } from '$lib/convex-hull'
-import {
-  compute_e_form_per_atom,
   compute_gas_chemical_potential,
-  DEFAULT_GAS_PRESSURES,
-  find_lowest_energy_unary_refs,
   GAS_STOICHIOMETRY,
   get_default_gas_provider,
+} from '$lib/convex-hull/gas-thermodynamics'
+import {
+  compute_e_form_per_atom,
+  find_lowest_energy_unary_refs,
   normalize_hull_composition_keys,
-} from '$lib/convex-hull'
-import { element_by_symbol } from '$lib/element'
-import type { ElementSymbol } from '$lib/element'
+} from '$lib/convex-hull/thermodynamics'
+import { DEFAULT_GAS_PRESSURES } from '$lib/convex-hull/types'
+import type { GasSpecies, PhaseData } from '$lib/convex-hull/types'
+import { element_by_symbol } from '$lib/element/data'
+import type { ElementSymbol } from '$lib/element/types'
 import { solve_linear_program } from '$lib/math'
 import { lookup_precursor_info } from './precursor-library'
 import type { PhaseRef, SynthesisConditions } from './types'

--- a/src/lib/synthesis-planning/plan-synthesis-async.svelte.ts
+++ b/src/lib/synthesis-planning/plan-synthesis-async.svelte.ts
@@ -4,7 +4,7 @@
 import type { WorkerRequestOptions } from '$lib/worker-client.svelte'
 import { abort_error, create_worker_client } from '$lib/worker-client.svelte'
 import { to_error } from '$lib/utils'
-import { plan_synthesis, plan_synthesis_with_progress } from './plan'
+import { plan_synthesis_with_progress } from './plan'
 import type { SynthesisPlan, SynthesisPlanProgress, SynthesisPlanRequest } from './types'
 import { validate_synthesis_plan_request } from './validation'
 
@@ -17,7 +17,8 @@ const run_plan = create_worker_client<
   label: `Synthesis planner`,
   create_worker: () =>
     new Worker(new URL(`./plan-synthesis-worker.js`, import.meta.url), { type: `module` }),
-  compute_sync: plan_synthesis,
+  compute_sync: (request, _options, on_progress) =>
+    plan_synthesis_with_progress(request, { on_progress }),
   build_payload: (request) => $state.snapshot(request),
 })
 

--- a/src/lib/synthesis-planning/plan-synthesis-async.svelte.ts
+++ b/src/lib/synthesis-planning/plan-synthesis-async.svelte.ts
@@ -22,16 +22,7 @@ const run_plan = create_worker_client<
   build_payload: (request) => $state.snapshot(request),
 })
 
-export interface PlanSynthesisAsync {
-  (
-    request: SynthesisPlanRequest,
-    options?: WorkerRequestOptions<SynthesisPlanProgress>,
-  ): Promise<SynthesisPlan>
-  cancel: (reason?: string) => void
-  release: () => void
-}
-
-export const plan_synthesis_async: PlanSynthesisAsync = Object.assign(
+export const plan_synthesis_async = Object.assign(
   (
     request: SynthesisPlanRequest,
     options: WorkerRequestOptions<SynthesisPlanProgress> = {},
@@ -55,3 +46,5 @@ export const plan_synthesis_async: PlanSynthesisAsync = Object.assign(
   },
   { cancel: run_plan.cancel, release: run_plan.release },
 )
+
+export type PlanSynthesisAsync = typeof plan_synthesis_async

--- a/src/lib/synthesis-planning/plan-synthesis-async.svelte.ts
+++ b/src/lib/synthesis-planning/plan-synthesis-async.svelte.ts
@@ -1,0 +1,56 @@
+// oxlint-disable eslint-plugin-unicorn/relative-url-style -- Vite worker detection needs the `./` prefix
+// Async synthesis planning through a persistent worker. Requests with a custom gas provider stay
+// on the main thread because provider methods are not structured-cloneable.
+import type { WorkerRequestOptions } from '$lib/worker-client.svelte'
+import { abort_error, create_worker_client } from '$lib/worker-client.svelte'
+import { to_error } from '$lib/utils'
+import { plan_synthesis, plan_synthesis_with_progress } from './plan'
+import type { SynthesisPlan, SynthesisPlanProgress, SynthesisPlanRequest } from './types'
+import { validate_synthesis_plan_request } from './validation'
+
+const run_plan = create_worker_client<
+  SynthesisPlanRequest,
+  undefined,
+  SynthesisPlan,
+  SynthesisPlanProgress
+>({
+  label: `Synthesis planner`,
+  create_worker: () =>
+    new Worker(new URL(`./plan-synthesis-worker.js`, import.meta.url), { type: `module` }),
+  compute_sync: plan_synthesis,
+  build_payload: (request) => $state.snapshot(request),
+})
+
+export interface PlanSynthesisAsync {
+  (
+    request: SynthesisPlanRequest,
+    options?: WorkerRequestOptions<SynthesisPlanProgress>,
+  ): Promise<SynthesisPlan>
+  cancel: (reason?: string) => void
+  release: () => void
+}
+
+export const plan_synthesis_async: PlanSynthesisAsync = Object.assign(
+  (
+    request: SynthesisPlanRequest,
+    options: WorkerRequestOptions<SynthesisPlanProgress> = {},
+  ): Promise<SynthesisPlan> => {
+    try {
+      validate_synthesis_plan_request(request)
+    } catch (error) {
+      return Promise.reject(to_error(error))
+    }
+    const { signal, on_progress } = options
+    if (request.conditions?.gas_provider) {
+      if (signal?.aborted) {
+        return Promise.reject(abort_error(signal, `Synthesis planner`))
+      }
+      return Promise.resolve().then(() => {
+        if (signal?.aborted) throw abort_error(signal, `Synthesis planner`)
+        return plan_synthesis_with_progress(request, { on_progress })
+      })
+    }
+    return run_plan(request, undefined, options)
+  },
+  { cancel: run_plan.cancel, release: run_plan.release },
+)

--- a/src/lib/synthesis-planning/plan-synthesis-worker.ts
+++ b/src/lib/synthesis-planning/plan-synthesis-worker.ts
@@ -1,0 +1,8 @@
+import { serve_worker } from '$lib/worker-serve'
+import { plan_synthesis_with_progress } from './plan'
+import type { SynthesisPlan, SynthesisPlanRequest } from './types'
+
+serve_worker<SynthesisPlanRequest, undefined, SynthesisPlan>(
+  (request, _options, report_progress) =>
+    plan_synthesis_with_progress(request, { on_progress: report_progress }),
+)

--- a/src/lib/synthesis-planning/plan.ts
+++ b/src/lib/synthesis-planning/plan.ts
@@ -1,7 +1,7 @@
 // Entry point: enumerate precursor sets, balance and evaluate every candidate reaction, rank them
 // and attach recipes. Pure function of its JSON-serializable request, so agents and UIs share it.
-import type { GasSpecies } from '$lib/convex-hull'
-import { DEFAULT_GAS_PRESSURES } from '$lib/convex-hull'
+import { DEFAULT_GAS_PRESSURES } from '$lib/convex-hull/types'
+import type { GasSpecies } from '$lib/convex-hull/types'
 import { combinations } from '$lib/math'
 import type { PhaseSet, PlannerPhase } from './phases'
 import {
@@ -12,7 +12,7 @@ import {
   resolve_phase,
   to_phase_ref,
 } from './phases'
-import { format_mev } from './format'
+import { format_mev } from './format-mev'
 import { lookup_precursor_info } from './precursor-library'
 import { build_recipe } from './recipe'
 import {
@@ -33,9 +33,11 @@ import type {
   ScoreWeights,
   SynthesisConditions,
   SynthesisPlan,
+  SynthesisPlanProgress,
   SynthesisPlanRequest,
   SynthesisRoute,
 } from './types'
+import { validate_synthesis_plan_request } from './validation'
 
 export const DEFAULT_MAX_E_ABOVE_HULL = 0.03
 // Phases further above the hull than this are ignored as competitors: the analysis of https://doi.org/10.1038/s44160-024-00502-y uses the hull
@@ -58,6 +60,10 @@ interface PlannerContext {
   target_mass_g: number
   rejected: Record<RejectReason, number>
   warnings: string[]
+}
+
+interface SynthesisPlanComputeOptions {
+  on_progress?: (progress: SynthesisPlanProgress) => void
 }
 
 const empty_rejections = (): Record<RejectReason, number> => ({
@@ -199,9 +205,18 @@ function direct_routes(
   pool: PlannerPhase[],
   product: PlannerPhase,
   max_precursors: number,
+  on_progress?: (progress: SynthesisPlanProgress) => void,
 ): { routes: SynthesisRoute[]; n_candidates: number } {
   const routes: SynthesisRoute[] = []
   let n_candidates = 0
+  let total_candidates = 0
+  for (let size = 1; size <= Math.min(max_precursors, pool.length); size++) {
+    const n_subsets = binomial(pool.length, size)
+    if (total_candidates + n_subsets > MAX_CANDIDATES) break
+    total_candidates += n_subsets
+  }
+  const progress_interval = Math.max(1, Math.ceil(total_candidates / 100))
+  on_progress?.({ stage: `direct_routes`, current: 0, total: total_candidates })
   for (let size = 1; size <= Math.min(max_precursors, pool.length); size++) {
     const n_subsets = binomial(pool.length, size)
     if (n_candidates + n_subsets > MAX_CANDIDATES) {
@@ -212,6 +227,13 @@ function direct_routes(
     }
     for (const subset of combinations(pool, size)) {
       n_candidates++
+      if (n_candidates % progress_interval === 0 || n_candidates === total_candidates) {
+        on_progress?.({
+          stage: `direct_routes`,
+          current: n_candidates,
+          total: total_candidates,
+        })
+      }
       // Every target element must come from a precursor or an open gas
       const covered = product.fractions.every(
         (fraction, el_idx) =>
@@ -245,6 +267,7 @@ function two_step_routes(
   ctx: PlannerContext,
   pool: PlannerPhase[],
   max_precursors: number,
+  on_progress?: (progress: SynthesisPlanProgress) => void,
 ): SynthesisRoute[] {
   const { target } = ctx
   const pool_ids = new Set(pool.map((phase) => phase.id))
@@ -262,7 +285,9 @@ function two_step_routes(
   const sub_ctx: PlannerContext = { ...ctx, rejected: empty_rejections(), warnings: [] }
   const best = (routes: SynthesisRoute[]) =>
     routes.toSorted((route_a, route_b) => route_b.score - route_a.score)[0]
-  return intermediates.flatMap((intermediate) => {
+  const routes: SynthesisRoute[] = []
+  on_progress?.({ stage: `two_step_routes`, current: 0, total: intermediates.length })
+  for (const [intermediate_idx, intermediate] of intermediates.entries()) {
     const step2 = best(
       [[intermediate], ...pool.map((phase) => [intermediate, phase])]
         .map((precursors) => evaluate_route(sub_ctx, precursors, target, `two_step`))
@@ -271,9 +296,8 @@ function two_step_routes(
     const step1 =
       step2 &&
       direct_routes(sub_ctx, pool, intermediate, Math.min(max_precursors, 2)).routes[0]
-    if (!step1) return []
-    return [
-      {
+    if (step1) {
+      routes.push({
         ...step2,
         id: `${step2.id}<<${step1.id}`,
         intermediate_step: step1.reaction,
@@ -283,21 +307,27 @@ function two_step_routes(
           `Two-step route via ${intermediate.formula}: first ${step1.reaction.equation} (${step1.rationale[0]}), then ${step2.reaction.equation}`,
           ...step2.rationale,
         ],
-      },
-    ]
-  })
+      })
+    }
+    on_progress?.({
+      stage: `two_step_routes`,
+      current: intermediate_idx + 1,
+      total: intermediates.length,
+    })
+  }
+  return routes
 }
 
-export function plan_synthesis(request: SynthesisPlanRequest): SynthesisPlan {
-  if (!request.entries?.length)
-    throw new Error(`plan_synthesis: entries must be a non-empty array`)
-  if (!request.target) throw new Error(`plan_synthesis: target is required`)
+// Internal worker entry with progress reporting. Keep plan_synthesis as the deterministic public
+// kernel: progress is observational and never changes enumeration, scoring or result ordering.
+export function plan_synthesis_with_progress(
+  request: SynthesisPlanRequest,
+  options: SynthesisPlanComputeOptions = {},
+): SynthesisPlan {
+  validate_synthesis_plan_request(request)
+  const { on_progress } = options
+  on_progress?.({ stage: `preparing`, current: 0, total: 1 })
   const max_precursors = request.max_precursors ?? 2
-  if (!Number.isInteger(max_precursors) || max_precursors < 1 || max_precursors > 4) {
-    throw new Error(
-      `plan_synthesis: max_precursors must be an integer in 1..4, got ${max_precursors}`,
-    )
-  }
   const conditions: SynthesisConditions = {
     temperature: request.conditions?.temperature ?? 0,
     open_species: request.conditions?.open_species ?? [],
@@ -307,6 +337,7 @@ export function plan_synthesis(request: SynthesisPlanRequest): SynthesisPlan {
   const weights = { ...DEFAULT_SCORE_WEIGHTS, ...request.scoring }
 
   const phase_set = prepare_phase_set(request.entries, conditions)
+  on_progress?.({ stage: `preparing`, current: 1, total: 1 })
   const resolved = resolve_phase(phase_set, request.target)
   if (!resolved) {
     const examples = phase_set.phases
@@ -374,9 +405,19 @@ export function plan_synthesis(request: SynthesisPlanRequest): SynthesisPlan {
       `Precursor pool is empty: relax max_e_above_hull, allow/block filters or only_common`,
     )
   }
-  const { routes, n_candidates } = direct_routes(ctx, pool, target, max_precursors)
-  if (request.two_step) routes.push(...two_step_routes(ctx, pool, max_precursors))
+  const { routes, n_candidates } = direct_routes(
+    ctx,
+    pool,
+    target,
+    max_precursors,
+    on_progress,
+  )
+  if (request.two_step) {
+    routes.push(...two_step_routes(ctx, pool, max_precursors, on_progress))
+  }
+  on_progress?.({ stage: `ranking`, current: 0, total: 1 })
   routes.sort((route_a, route_b) => route_b.score - route_a.score)
+  on_progress?.({ stage: `ranking`, current: 1, total: 1 })
 
   const partial_pressures = Object.fromEntries(
     gas_species.map((species) => [
@@ -413,3 +454,6 @@ export function plan_synthesis(request: SynthesisPlanRequest): SynthesisPlan {
     warnings: ctx.warnings,
   }
 }
+
+export const plan_synthesis = (request: SynthesisPlanRequest): SynthesisPlan =>
+  plan_synthesis_with_progress(request)

--- a/src/lib/synthesis-planning/plan.ts
+++ b/src/lib/synthesis-planning/plan.ts
@@ -62,10 +62,6 @@ interface PlannerContext {
   warnings: string[]
 }
 
-interface SynthesisPlanComputeOptions {
-  on_progress?: (progress: SynthesisPlanProgress) => void
-}
-
 const empty_rejections = (): Record<RejectReason, number> => ({
   unbalanced: 0,
   redundant_precursor: 0,
@@ -210,21 +206,21 @@ function direct_routes(
   const routes: SynthesisRoute[] = []
   let n_candidates = 0
   let total_candidates = 0
+  const candidate_sizes: number[] = []
   for (let size = 1; size <= Math.min(max_precursors, pool.length); size++) {
     const n_subsets = binomial(pool.length, size)
-    if (total_candidates + n_subsets > MAX_CANDIDATES) break
-    total_candidates += n_subsets
-  }
-  const progress_interval = Math.max(1, Math.ceil(total_candidates / 100))
-  on_progress?.({ stage: `direct_routes`, current: 0, total: total_candidates })
-  for (let size = 1; size <= Math.min(max_precursors, pool.length); size++) {
-    const n_subsets = binomial(pool.length, size)
-    if (n_candidates + n_subsets > MAX_CANDIDATES) {
+    if (total_candidates + n_subsets > MAX_CANDIDATES) {
       ctx.warnings.push(
         `Skipped ${size}-precursor sets for ${product.formula}: ${n_subsets} combinations exceed the ${MAX_CANDIDATES} candidate budget. Narrow the precursor pool.`,
       )
       break
     }
+    candidate_sizes.push(size)
+    total_candidates += n_subsets
+  }
+  const progress_interval = Math.max(1, Math.ceil(total_candidates / 100))
+  on_progress?.({ stage: `direct_routes`, current: 0, total: total_candidates })
+  for (const size of candidate_sizes) {
     for (const subset of combinations(pool, size)) {
       n_candidates++
       if (n_candidates % progress_interval === 0 || n_candidates === total_candidates) {
@@ -322,7 +318,7 @@ function two_step_routes(
 // kernel: progress is observational and never changes enumeration, scoring or result ordering.
 export function plan_synthesis_with_progress(
   request: SynthesisPlanRequest,
-  options: SynthesisPlanComputeOptions = {},
+  options: { on_progress?: (progress: SynthesisPlanProgress) => void } = {},
 ): SynthesisPlan {
   validate_synthesis_plan_request(request)
   const { on_progress } = options
@@ -416,7 +412,7 @@ export function plan_synthesis_with_progress(
     routes.push(...two_step_routes(ctx, pool, max_precursors, on_progress))
   }
   on_progress?.({ stage: `ranking`, current: 0, total: 1 })
-  routes.sort((route_a, route_b) => route_b.score - route_a.score)
+  if (request.two_step) routes.sort((route_a, route_b) => route_b.score - route_a.score)
   on_progress?.({ stage: `ranking`, current: 1, total: 1 })
 
   const partial_pressures = Object.fromEntries(

--- a/src/lib/synthesis-planning/precursor-library.ts
+++ b/src/lib/synthesis-planning/precursor-library.ts
@@ -2,12 +2,10 @@
 // needs: decomposition and melting temperatures, volatiles released on heating, hygroscopicity
 // and hazards. Temperatures are approximate literature values (±50 K) at ambient pressure and
 // serve as heating-schedule guidance, not as thermodynamic input.
-import {
-  get_alphabetical_formula,
-  get_reduced_formula,
-  parse_composition,
-} from '$lib/composition'
-import type { GasSpecies } from '$lib/convex-hull'
+import { get_alphabetical_formula } from '$lib/composition/format'
+import { parse_composition } from '$lib/composition/parse'
+import { get_reduced_formula } from '$lib/composition/reduce'
+import type { GasSpecies } from '$lib/convex-hull/types'
 
 export interface PrecursorInfo {
   formula: string

--- a/src/lib/synthesis-planning/scoring.ts
+++ b/src/lib/synthesis-planning/scoring.ts
@@ -1,7 +1,7 @@
 // Route scoring: every term is mapped to roughly [-1, 1] before weighting so weights are
 // comparable, and each term's contribution is reported so rankings stay explainable.
-import type { GasSpecies } from '$lib/convex-hull'
-import { format_mev } from './format'
+import type { GasSpecies } from '$lib/convex-hull/types'
+import { format_mev } from './format-mev'
 import { lookup_precursor_info } from './precursor-library'
 import type {
   CompetingPhase,

--- a/src/lib/synthesis-planning/thermo.ts
+++ b/src/lib/synthesis-planning/thermo.ts
@@ -1,11 +1,11 @@
 // Thermodynamics of candidate reactions, all expressed as small linear programs over the working
 // phase set so the same code handles binaries through quinaries and open gas reservoirs.
-import type { GasSpecies } from '$lib/convex-hull'
 import {
   compute_gas_chemical_potential,
-  DEFAULT_GAS_PRESSURES,
   get_default_gas_provider,
-} from '$lib/convex-hull'
+} from '$lib/convex-hull/gas-thermodynamics'
+import { DEFAULT_GAS_PRESSURES } from '$lib/convex-hull/types'
+import type { GasSpecies } from '$lib/convex-hull/types'
 import { solve_linear_program } from '$lib/math'
 import type { PlannerPhase } from './phases'
 import { ENERGY_TOL, to_phase_ref } from './phases'

--- a/src/lib/synthesis-planning/types.ts
+++ b/src/lib/synthesis-planning/types.ts
@@ -1,6 +1,6 @@
 import type { CompositionType } from '$lib/composition'
-import type { GasSpecies, GasThermodynamicsProvider, PhaseData } from '$lib/convex-hull'
-import type { ElementSymbol } from '$lib/element'
+import type { GasSpecies, GasThermodynamicsProvider, PhaseData } from '$lib/convex-hull/types'
+import type { ElementSymbol } from '$lib/element/types'
 
 // === Request ===
 
@@ -71,6 +71,12 @@ export interface SynthesisPlanRequest {
   max_routes?: number
   // Target mass the recipe is scaled to (grams, default 1).
   target_mass_g?: number
+}
+
+export interface SynthesisPlanProgress {
+  stage: `preparing` | `direct_routes` | `two_step_routes` | `ranking`
+  current: number
+  total: number
 }
 
 // === Result ===

--- a/src/lib/synthesis-planning/validation.ts
+++ b/src/lib/synthesis-planning/validation.ts
@@ -58,9 +58,9 @@ function assert_finite_number(
 function assert_integer(
   value: unknown,
   path: string,
-  { minimum = -Infinity, maximum = Infinity }: NumberBounds = {},
+  bounds: NumberBounds = {},
 ): asserts value is number {
-  assert_finite_number(value, path, { minimum, maximum })
+  assert_finite_number(value, path, bounds)
   if (!Number.isInteger(value)) {
     throw new TypeError(`plan_synthesis: ${path} must be an integer, got ${value}`)
   }

--- a/src/lib/synthesis-planning/validation.ts
+++ b/src/lib/synthesis-planning/validation.ts
@@ -1,0 +1,201 @@
+// Runtime validation for the public synthesis-planning request. Keep this aligned with
+// SYNTHESIS_PLAN_REQUEST_SCHEMA so TypeScript, agent tools and direct JavaScript callers fail on
+// the same bad inputs before the planner enters the numerical code.
+import { GAS_SPECIES } from '$lib/convex-hull/types'
+import type { GasThermodynamicsProvider } from '$lib/convex-hull/types'
+import { DEFAULT_SCORE_WEIGHTS } from './scoring'
+import type { SynthesisPlanRequest } from './types'
+
+type PlainObject = Record<string, unknown>
+
+function assert_object(value: unknown, path: string): asserts value is PlainObject {
+  if (value === null || typeof value !== `object` || Array.isArray(value)) {
+    throw new TypeError(`plan_synthesis: ${path} must be an object`)
+  }
+}
+
+const assert_known_keys = (
+  value: PlainObject,
+  keys: readonly string[],
+  path: string,
+): void => {
+  const unknown_keys = Object.keys(value).filter((key) => !keys.includes(key))
+  if (unknown_keys.length) {
+    throw new TypeError(
+      `plan_synthesis: ${path} has unknown ${unknown_keys.length === 1 ? `property` : `properties`} ${unknown_keys.join(`, `)}`,
+    )
+  }
+}
+
+interface NumberBounds {
+  minimum?: number
+  maximum?: number
+  exclusive_minimum?: boolean
+}
+
+function assert_finite_number(
+  value: unknown,
+  path: string,
+  { minimum = -Infinity, maximum = Infinity, exclusive_minimum = false }: NumberBounds = {},
+): asserts value is number {
+  if (
+    typeof value !== `number` ||
+    !Number.isFinite(value) ||
+    (exclusive_minimum ? value <= minimum : value < minimum) ||
+    value > maximum
+  ) {
+    const lower_bound = Number.isFinite(minimum)
+      ? `${exclusive_minimum ? `>` : `>=`} ${minimum}`
+      : null
+    const upper_bound = Number.isFinite(maximum) ? `<= ${maximum}` : null
+    const bounds = [lower_bound, upper_bound].filter(Boolean).join(` and `)
+    throw new TypeError(
+      `plan_synthesis: ${path} must be a finite number${bounds ? ` ${bounds}` : ``}, got ${String(value)}`,
+    )
+  }
+}
+
+function assert_integer(
+  value: unknown,
+  path: string,
+  { minimum = -Infinity, maximum = Infinity }: NumberBounds = {},
+): asserts value is number {
+  assert_finite_number(value, path, { minimum, maximum })
+  if (!Number.isInteger(value)) {
+    throw new TypeError(`plan_synthesis: ${path} must be an integer, got ${value}`)
+  }
+}
+
+function assert_string_array(value: unknown, path: string): asserts value is string[] {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== `string`)) {
+    throw new TypeError(`plan_synthesis: ${path} must be an array of strings`)
+  }
+}
+
+function validate_gas_provider(value: unknown): asserts value is GasThermodynamicsProvider {
+  assert_object(value, `conditions.gas_provider`)
+  for (const method of [
+    `get_standard_chemical_potential`,
+    `get_supported_gases`,
+    `get_temperature_range`,
+  ]) {
+    if (typeof value[method] !== `function`) {
+      throw new TypeError(
+        `plan_synthesis: conditions.gas_provider.${method} must be a function`,
+      )
+    }
+  }
+}
+
+const validate_conditions = (value: unknown): void => {
+  assert_object(value, `conditions`)
+  assert_known_keys(
+    value,
+    [`temperature`, `open_species`, `partial_pressures`, `gas_provider`],
+    `conditions`,
+  )
+  if (value.temperature !== undefined) {
+    assert_finite_number(value.temperature, `conditions.temperature`, {
+      minimum: 0,
+      maximum: 2000,
+    })
+  }
+  if (value.open_species !== undefined) {
+    assert_string_array(value.open_species, `conditions.open_species`)
+    const unsupported = value.open_species.filter(
+      (species) => !GAS_SPECIES.includes(species as (typeof GAS_SPECIES)[number]),
+    )
+    if (unsupported.length) {
+      throw new TypeError(
+        `plan_synthesis: conditions.open_species contains unsupported ${unsupported.join(`, `)}`,
+      )
+    }
+  }
+  if (value.partial_pressures !== undefined) {
+    assert_object(value.partial_pressures, `conditions.partial_pressures`)
+    assert_known_keys(value.partial_pressures, GAS_SPECIES, `conditions.partial_pressures`)
+    for (const [species, pressure] of Object.entries(value.partial_pressures)) {
+      assert_finite_number(pressure, `conditions.partial_pressures.${species}`, {
+        minimum: 0,
+        exclusive_minimum: true,
+      })
+    }
+  }
+  if (value.gas_provider !== undefined) validate_gas_provider(value.gas_provider)
+}
+
+const validate_precursors = (value: unknown): void => {
+  assert_object(value, `precursors`)
+  assert_known_keys(
+    value,
+    [`allow`, `block`, `max_e_above_hull`, `only_common`, `max_elements`],
+    `precursors`,
+  )
+  if (value.allow !== undefined) assert_string_array(value.allow, `precursors.allow`)
+  if (value.block !== undefined) assert_string_array(value.block, `precursors.block`)
+  if (value.max_e_above_hull !== undefined) {
+    assert_finite_number(value.max_e_above_hull, `precursors.max_e_above_hull`, {
+      minimum: 0,
+    })
+  }
+  if (value.only_common !== undefined && typeof value.only_common !== `boolean`) {
+    throw new TypeError(`plan_synthesis: precursors.only_common must be a boolean`)
+  }
+  if (value.max_elements !== undefined) {
+    assert_integer(value.max_elements, `precursors.max_elements`, { minimum: 1 })
+  }
+}
+
+const validate_scoring = (value: unknown): void => {
+  assert_object(value, `scoring`)
+  const score_keys = Object.keys(DEFAULT_SCORE_WEIGHTS)
+  assert_known_keys(value, score_keys, `scoring`)
+  for (const [term, weight] of Object.entries(value)) {
+    assert_finite_number(weight, `scoring.${term}`, { minimum: 0 })
+  }
+}
+
+export function validate_synthesis_plan_request(
+  request: unknown,
+): asserts request is SynthesisPlanRequest {
+  assert_object(request, `request`)
+  assert_known_keys(
+    request,
+    [
+      `entries`,
+      `target`,
+      `precursors`,
+      `conditions`,
+      `max_precursors`,
+      `two_step`,
+      `scoring`,
+      `max_routes`,
+      `target_mass_g`,
+    ],
+    `request`,
+  )
+  if (!Array.isArray(request.entries) || request.entries.length === 0) {
+    throw new TypeError(`plan_synthesis: entries must be a non-empty array`)
+  }
+  if (typeof request.target !== `string` || request.target.trim() === ``) {
+    throw new TypeError(`plan_synthesis: target must be a non-empty string`)
+  }
+  if (request.conditions !== undefined) validate_conditions(request.conditions)
+  if (request.precursors !== undefined) validate_precursors(request.precursors)
+  if (request.max_precursors !== undefined) {
+    assert_integer(request.max_precursors, `max_precursors`, { minimum: 1, maximum: 4 })
+  }
+  if (request.two_step !== undefined && typeof request.two_step !== `boolean`) {
+    throw new TypeError(`plan_synthesis: two_step must be a boolean`)
+  }
+  if (request.scoring !== undefined) validate_scoring(request.scoring)
+  if (request.max_routes !== undefined) {
+    assert_integer(request.max_routes, `max_routes`, { minimum: 1, maximum: 200 })
+  }
+  if (request.target_mass_g !== undefined) {
+    assert_finite_number(request.target_mass_g, `target_mass_g`, {
+      minimum: 0,
+      exclusive_minimum: true,
+    })
+  }
+}

--- a/src/lib/synthesis-planning/validation.ts
+++ b/src/lib/synthesis-planning/validation.ts
@@ -7,24 +7,23 @@ import { DEFAULT_SCORE_WEIGHTS } from './scoring'
 import type { SynthesisPlanRequest } from './types'
 
 type PlainObject = Record<string, unknown>
-
-function assert_object(value: unknown, path: string): asserts value is PlainObject {
-  if (value === null || typeof value !== `object` || Array.isArray(value)) {
-    throw new TypeError(`plan_synthesis: ${path} must be an object`)
-  }
+const fail_validation = (message: string): never => {
+  throw new TypeError(`plan_synthesis: ${message}`)
 }
 
-const assert_known_keys = (
-  value: PlainObject,
-  keys: readonly string[],
+function assert_object(
+  value: unknown,
   path: string,
-): void => {
-  const unknown_keys = Object.keys(value).filter((key) => !keys.includes(key))
-  if (unknown_keys.length) {
-    throw new TypeError(
-      `plan_synthesis: ${path} has unknown ${unknown_keys.length === 1 ? `property` : `properties`} ${unknown_keys.join(`, `)}`,
+  known_keys?: readonly string[],
+): asserts value is PlainObject {
+  if (value === null || typeof value !== `object` || Array.isArray(value))
+    return fail_validation(`${path} must be an object`)
+  if (!known_keys) return
+  const unknown_keys = Object.keys(value).filter((key) => !known_keys.includes(key))
+  if (unknown_keys.length)
+    fail_validation(
+      `${path} has unknown ${unknown_keys.length === 1 ? `property` : `properties`} ${unknown_keys.join(`, `)}`,
     )
-  }
 }
 
 interface NumberBounds {
@@ -49,8 +48,8 @@ function assert_finite_number(
       : null
     const upper_bound = Number.isFinite(maximum) ? `<= ${maximum}` : null
     const bounds = [lower_bound, upper_bound].filter(Boolean).join(` and `)
-    throw new TypeError(
-      `plan_synthesis: ${path} must be a finite number${bounds ? ` ${bounds}` : ``}, got ${String(value)}`,
+    fail_validation(
+      `${path} must be a finite number${bounds ? ` ${bounds}` : ``}, got ${String(value)}`,
     )
   }
 }
@@ -61,15 +60,12 @@ function assert_integer(
   bounds: NumberBounds = {},
 ): asserts value is number {
   assert_finite_number(value, path, bounds)
-  if (!Number.isInteger(value)) {
-    throw new TypeError(`plan_synthesis: ${path} must be an integer, got ${value}`)
-  }
+  if (!Number.isInteger(value)) fail_validation(`${path} must be an integer, got ${value}`)
 }
 
 function assert_string_array(value: unknown, path: string): asserts value is string[] {
-  if (!Array.isArray(value) || value.some((item) => typeof item !== `string`)) {
-    throw new TypeError(`plan_synthesis: ${path} must be an array of strings`)
-  }
+  if (!Array.isArray(value) || value.some((item) => typeof item !== `string`))
+    fail_validation(`${path} must be an array of strings`)
 }
 
 function validate_gas_provider(value: unknown): asserts value is GasThermodynamicsProvider {
@@ -79,41 +75,33 @@ function validate_gas_provider(value: unknown): asserts value is GasThermodynami
     `get_supported_gases`,
     `get_temperature_range`,
   ]) {
-    if (typeof value[method] !== `function`) {
-      throw new TypeError(
-        `plan_synthesis: conditions.gas_provider.${method} must be a function`,
-      )
-    }
+    if (typeof value[method] !== `function`)
+      fail_validation(`conditions.gas_provider.${method} must be a function`)
   }
 }
 
 const validate_conditions = (value: unknown): void => {
-  assert_object(value, `conditions`)
-  assert_known_keys(
-    value,
-    [`temperature`, `open_species`, `partial_pressures`, `gas_provider`],
-    `conditions`,
-  )
-  if (value.temperature !== undefined) {
+  assert_object(value, `conditions`, [
+    `temperature`,
+    `open_species`,
+    `partial_pressures`,
+    `gas_provider`,
+  ])
+  if (value.temperature !== undefined)
     assert_finite_number(value.temperature, `conditions.temperature`, {
       minimum: 0,
       maximum: 2000,
     })
-  }
   if (value.open_species !== undefined) {
     assert_string_array(value.open_species, `conditions.open_species`)
     const unsupported = value.open_species.filter(
       (species) => !GAS_SPECIES.includes(species as (typeof GAS_SPECIES)[number]),
     )
-    if (unsupported.length) {
-      throw new TypeError(
-        `plan_synthesis: conditions.open_species contains unsupported ${unsupported.join(`, `)}`,
-      )
-    }
+    if (unsupported.length)
+      fail_validation(`conditions.open_species contains unsupported ${unsupported.join(`, `)}`)
   }
   if (value.partial_pressures !== undefined) {
-    assert_object(value.partial_pressures, `conditions.partial_pressures`)
-    assert_known_keys(value.partial_pressures, GAS_SPECIES, `conditions.partial_pressures`)
+    assert_object(value.partial_pressures, `conditions.partial_pressures`, GAS_SPECIES)
     for (const [species, pressure] of Object.entries(value.partial_pressures)) {
       assert_finite_number(pressure, `conditions.partial_pressures.${species}`, {
         minimum: 0,
@@ -125,31 +113,27 @@ const validate_conditions = (value: unknown): void => {
 }
 
 const validate_precursors = (value: unknown): void => {
-  assert_object(value, `precursors`)
-  assert_known_keys(
-    value,
-    [`allow`, `block`, `max_e_above_hull`, `only_common`, `max_elements`],
-    `precursors`,
-  )
+  assert_object(value, `precursors`, [
+    `allow`,
+    `block`,
+    `max_e_above_hull`,
+    `only_common`,
+    `max_elements`,
+  ])
   if (value.allow !== undefined) assert_string_array(value.allow, `precursors.allow`)
   if (value.block !== undefined) assert_string_array(value.block, `precursors.block`)
-  if (value.max_e_above_hull !== undefined) {
+  if (value.max_e_above_hull !== undefined)
     assert_finite_number(value.max_e_above_hull, `precursors.max_e_above_hull`, {
       minimum: 0,
     })
-  }
-  if (value.only_common !== undefined && typeof value.only_common !== `boolean`) {
-    throw new TypeError(`plan_synthesis: precursors.only_common must be a boolean`)
-  }
-  if (value.max_elements !== undefined) {
+  if (value.only_common !== undefined && typeof value.only_common !== `boolean`)
+    fail_validation(`precursors.only_common must be a boolean`)
+  if (value.max_elements !== undefined)
     assert_integer(value.max_elements, `precursors.max_elements`, { minimum: 1 })
-  }
 }
 
 const validate_scoring = (value: unknown): void => {
-  assert_object(value, `scoring`)
-  const score_keys = Object.keys(DEFAULT_SCORE_WEIGHTS)
-  assert_known_keys(value, score_keys, `scoring`)
+  assert_object(value, `scoring`, Object.keys(DEFAULT_SCORE_WEIGHTS))
   for (const [term, weight] of Object.entries(value)) {
     assert_finite_number(weight, `scoring.${term}`, { minimum: 0 })
   }
@@ -158,44 +142,33 @@ const validate_scoring = (value: unknown): void => {
 export function validate_synthesis_plan_request(
   request: unknown,
 ): asserts request is SynthesisPlanRequest {
-  assert_object(request, `request`)
-  assert_known_keys(
-    request,
-    [
-      `entries`,
-      `target`,
-      `precursors`,
-      `conditions`,
-      `max_precursors`,
-      `two_step`,
-      `scoring`,
-      `max_routes`,
-      `target_mass_g`,
-    ],
-    `request`,
-  )
-  if (!Array.isArray(request.entries) || request.entries.length === 0) {
-    throw new TypeError(`plan_synthesis: entries must be a non-empty array`)
-  }
-  if (typeof request.target !== `string` || request.target.trim() === ``) {
-    throw new TypeError(`plan_synthesis: target must be a non-empty string`)
-  }
+  assert_object(request, `request`, [
+    `entries`,
+    `target`,
+    `precursors`,
+    `conditions`,
+    `max_precursors`,
+    `two_step`,
+    `scoring`,
+    `max_routes`,
+    `target_mass_g`,
+  ])
+  if (!Array.isArray(request.entries) || request.entries.length === 0)
+    fail_validation(`entries must be a non-empty array`)
+  if (typeof request.target !== `string` || request.target.trim() === ``)
+    fail_validation(`target must be a non-empty string`)
   if (request.conditions !== undefined) validate_conditions(request.conditions)
   if (request.precursors !== undefined) validate_precursors(request.precursors)
-  if (request.max_precursors !== undefined) {
+  if (request.max_precursors !== undefined)
     assert_integer(request.max_precursors, `max_precursors`, { minimum: 1, maximum: 4 })
-  }
-  if (request.two_step !== undefined && typeof request.two_step !== `boolean`) {
-    throw new TypeError(`plan_synthesis: two_step must be a boolean`)
-  }
+  if (request.two_step !== undefined && typeof request.two_step !== `boolean`)
+    fail_validation(`two_step must be a boolean`)
   if (request.scoring !== undefined) validate_scoring(request.scoring)
-  if (request.max_routes !== undefined) {
+  if (request.max_routes !== undefined)
     assert_integer(request.max_routes, `max_routes`, { minimum: 1, maximum: 200 })
-  }
-  if (request.target_mass_g !== undefined) {
+  if (request.target_mass_g !== undefined)
     assert_finite_number(request.target_mass_g, `target_mass_g`, {
       minimum: 0,
       exclusive_minimum: true,
     })
-  }
 }

--- a/src/lib/worker-client.svelte.ts
+++ b/src/lib/worker-client.svelte.ts
@@ -6,7 +6,7 @@
 // messages before that for callers that passed `on_progress`.
 import { to_error } from '$lib/utils'
 
-interface WorkerClientConfig<Input, Options, Result> {
+interface WorkerClientConfig<Input, Options, Result, Progress> {
   // Names the module in error messages, e.g. `MSD`
   label: string
   // Must inline `new URL('./x-worker.js', import.meta.url)` at the call site: Vite detects
@@ -14,8 +14,12 @@ interface WorkerClientConfig<Input, Options, Result> {
   create_worker: () => Worker
   // SSR / no-Worker fallback, run on the main thread. Receives `undefined` when the caller
   // omitted options, exactly as the worker's compute does, so a defaulted `options = {}`
-  // parameter serves both paths.
-  compute_sync: (input: Input, options: Options | undefined) => Result
+  // parameter serves both paths. The progress callback stays outside cloneable worker options.
+  compute_sync: (
+    input: Input,
+    options: Options | undefined,
+    on_progress?: (progress: Progress) => void,
+  ) => Result
   // Plain, structured-cloneable stand-in for `input`. Svelte 5 $state proxies are not
   // cloneable, so callers rebuild field by field rather than deep-snapshotting - a proxied
   // typed array still reads back as its raw buffer, which keeps megabyte payloads cheap.
@@ -62,7 +66,7 @@ export function create_worker_client<
   Result,
   Progress = unknown,
 >(
-  config: WorkerClientConfig<Input, Options, Result>,
+  config: WorkerClientConfig<Input, Options, Result, Progress>,
 ): WorkerClient<Input, Options, Result, Progress> {
   const {
     label,
@@ -326,7 +330,7 @@ export function create_worker_client<
     if (!wkr) {
       const request = track(request_key, null)
       Promise.resolve()
-        .then(() => compute_sync(input, options))
+        .then(() => compute_sync(input, options, request_options.on_progress))
         .then(request.resolve, (err: unknown) => request.reject(to_error(err)))
       return join(request, request_options)
     }

--- a/tests/vitest/file-viewer/parse-entry.test.ts
+++ b/tests/vitest/file-viewer/parse-entry.test.ts
@@ -1,76 +1,18 @@
 // The public parse-only entry stays worker-safe.
-import { describe, expect, test } from 'vitest'
+import { expect, test } from 'vitest'
+import { expect_worker_safe_import_graph } from '../setup'
 
-describe(`file-viewer worker safety`, () => {
-  test(`worker-safe entry graphs stay free of Svelte`, async () => {
-    // A direct-source scan alone can't catch a parser importing a barrel that
-    // re-exports Svelte components — that only explodes at worker runtime
-    // ("document is not defined"). Walk the runtime import graph: relative
-    // imports and $lib aliases resolve to repo files and are scanned
-    // recursively; bare package imports are allowed except svelte itself.
-    const { existsSync, readFileSync } = await import(`node:fs`)
-    const { dirname, resolve } = await import(`node:path`)
-    const repo_root = resolve(import.meta.dirname, `../../..`)
-    const entries = [
-      `parse.ts`,
-      `eligibility.ts`,
-      `host-transfer.ts`,
-      // The parse worker's own entry and its protocol module: both load inside a
-      // Worker, where `document` does not exist.
-      `parse-worker.ts`,
-      `parse-worker-protocol.ts`,
-    ].map((filename) => resolve(repo_root, `src/lib/file-viewer/${filename}`))
-    const source_extensions = [`.ts`, `.svelte`, `.js`, `.mjs`]
-
-    const resolve_specifier = (specifier: string, from_file: string): string | null => {
-      let base: string
-      if (specifier.startsWith(`$lib`)) {
-        base = resolve(repo_root, `src/lib`, specifier.slice(`$lib`.length).replace(/^\//, ``))
-      } else if (specifier.startsWith(`.`)) {
-        base = resolve(dirname(from_file), specifier)
-      } else return null // bare package import — not a repo file
-      const candidates = source_extensions.some((extension) => base.endsWith(extension))
-        ? [base]
-        : source_extensions.flatMap((extension) => [
-            `${base}${extension}`,
-            resolve(base, `index${extension}`),
-          ])
-      return candidates.find(existsSync) ?? null
-    }
-
-    const import_re = /(?:from|import)\s*\(?\s*['"`](?<specifier>[^'"`]+)['"`]/g
-    // Type-only imports/re-exports are erased at runtime and never load the
-    // module — scanning them would flag every `import type ... from '$lib/x'`
-    // whose barrel also exports components.
-    const strip_type_only = (source: string): string =>
-      source.replaceAll(
-        /(?:import|export)\s+(?:\{\s*(?:type\s+[^,}]+,?\s*)+\}|type\s+[^;]*?)\s+from\s*['"`][^'"`]+['"`]\s*;?/g,
-        ``,
-      )
-    const visited = new Set<string>()
-    const queue = [...entries]
-    const violations: string[] = []
-    while (queue.length > 0) {
-      const file = queue.pop() as string
-      if (visited.has(file)) continue
-      visited.add(file)
-      const source = strip_type_only(readFileSync(file, `utf-8`))
-      for (const match of source.matchAll(import_re)) {
-        const specifier = match.groups?.specifier ?? ``
-        if (
-          specifier === `svelte` ||
-          specifier.startsWith(`svelte/`) ||
-          specifier.endsWith(`.svelte`)
-        ) {
-          violations.push(`${file} imports "${specifier}"`)
-          continue
-        }
-        const resolved = resolve_specifier(specifier, file)
-        if (resolved) queue.push(resolved)
-      }
-    }
-    expect(visited.size).toBeGreaterThan(10) // the walk actually traversed the graphs
-    expect(entries.every((entry) => visited.has(entry))).toBe(true)
-    expect(violations).toEqual([])
-  })
+test(`worker-safe file-viewer entry graphs stay free of Svelte`, () => {
+  expect.hasAssertions()
+  expect_worker_safe_import_graph(
+    [
+      `src/lib/file-viewer/parse.ts`,
+      `src/lib/file-viewer/eligibility.ts`,
+      `src/lib/file-viewer/host-transfer.ts`,
+      // These load inside a Worker, where `document` does not exist.
+      `src/lib/file-viewer/parse-worker.ts`,
+      `src/lib/file-viewer/parse-worker-protocol.ts`,
+    ],
+    10,
+  )
 })

--- a/tests/vitest/setup.ts
+++ b/tests/vitest/setup.ts
@@ -17,8 +17,8 @@ import { type MemoryRunExtras, trajectory_from_frames } from '$lib/trajectory/ru
 import { ensure_moyo_wasm_ready } from '$lib/symmetry/analyze'
 import { to_error } from '$lib/utils'
 import type { SymmetryDataset } from '$lib/symmetry'
-import { readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
 import { gunzipSync } from 'node:zlib'
 import { type Component, type ComponentProps, flushSync, mount, tick } from 'svelte'
 import { SvelteMap, SvelteSet } from 'svelte/reactivity'
@@ -1288,6 +1288,63 @@ export const complex_structure: AnyStructure = {
     gamma: 90.0,
     volume: 125.0,
   },
+}
+
+// Walk repo-local runtime imports and fail if an entry reaches Svelte or another forbidden
+// browser-only module. Type-only imports are erased before traversal.
+export function expect_worker_safe_import_graph(
+  entry_paths: readonly string[],
+  min_modules: number,
+  forbidden_modules: readonly string[] = [],
+): void {
+  const repo_root = resolve(current_dir, `../..`)
+  const entry_files = entry_paths.map((entry_path) => resolve(repo_root, entry_path))
+  const source_extensions = [`.ts`, `.svelte`, `.js`, `.mjs`]
+  const resolve_specifier = (specifier: string, from_file: string): string | null => {
+    let base: string
+    if (specifier.startsWith(`$lib`)) {
+      base = resolve(repo_root, `src/lib`, specifier.slice(`$lib`.length).replace(/^\//, ``))
+    } else if (specifier.startsWith(`.`)) base = resolve(dirname(from_file), specifier)
+    else return null
+    const candidates = source_extensions.some((extension) => base.endsWith(extension))
+      ? [base]
+      : source_extensions.flatMap((extension) => [
+          `${base}${extension}`,
+          resolve(base, `index${extension}`),
+        ])
+    return candidates.find(existsSync) ?? null
+  }
+  const queue = [...entry_files]
+  const visited = new Set<string>()
+  const violations: string[] = []
+  while (queue.length) {
+    const file = queue.pop()
+    if (!file || visited.has(file)) continue
+    visited.add(file)
+    const source = readFileSync(file, `utf-8`).replaceAll(
+      /(?:import|export)\s+(?:\{\s*(?:type\s+[^,}]+,?\s*)+\}|type\s+[^;]*?)\s+from\s*['"`][^'"`]+['"`]\s*;?/g,
+      ``,
+    )
+    for (const match of source.matchAll(
+      /(?:from|import)\s*\(?\s*['"`](?<specifier>[^'"`]+)['"`]/g,
+    )) {
+      const specifier = match.groups?.specifier ?? ``
+      if (
+        specifier === `svelte` ||
+        specifier.startsWith(`svelte/`) ||
+        specifier.endsWith(`.svelte`) ||
+        forbidden_modules.includes(specifier)
+      ) {
+        violations.push(`${file} imports "${specifier}"`)
+        continue
+      }
+      const resolved = resolve_specifier(specifier, file)
+      if (resolved) queue.push(resolved)
+    }
+  }
+  expect(visited.size).toBeGreaterThan(min_modules)
+  expect(entry_files.every((entry_file) => visited.has(entry_file))).toBe(true)
+  expect(violations).toEqual([])
 }
 
 // === Worker stub ===

--- a/tests/vitest/synthesis-planning/SynthesisPlanner.test.svelte.ts
+++ b/tests/vitest/synthesis-planning/SynthesisPlanner.test.svelte.ts
@@ -1,8 +1,10 @@
 import type { PhaseData } from '$lib/convex-hull'
 import SynthesisPlanner from '$lib/synthesis-planning/SynthesisPlanner.svelte'
-import { type ComponentProps, mount, unmount } from 'svelte'
+import { plan_synthesis } from '$lib/synthesis-planning/plan'
+import type { SynthesisPlanRequest } from '$lib/synthesis-planning/types'
+import { type ComponentProps, mount, tick, unmount } from 'svelte'
 import { expect, onTestFinished, test, vi } from 'vitest'
-import { load_json } from '../setup'
+import { install_stub_worker, load_json } from '../setup'
 
 const entries = load_json<PhaseData[]>(`src/site/synthesis-planning/Ba-Ti-C-O.json.gz`)
 const mount_planner = (props: Partial<ComponentProps<typeof SynthesisPlanner>> = {}): void => {
@@ -22,10 +24,55 @@ test(`renders the selected route hull inside the detail-left pane`, async () => 
   )
 })
 
-test(`renders request validation errors instead of throwing from the component`, async () => {
-  mount_planner({ max_routes: 0, show_hull: false })
+test.each([
+  [{ max_routes: 0 }, `max_routes`],
+  [{ target_mass_g: 0 }, `target_mass_g`],
+] as const)(`renders %s validation errors instead of throwing`, async (props, message) => {
+  mount_planner({ ...props, show_hull: false })
 
   await vi.waitFor(() =>
-    expect(document.querySelector(`.error`)?.textContent).toContain(`max_routes`),
+    expect(document.querySelector(`.error`)?.textContent).toContain(message),
   )
+})
+
+test(`rescales recipes without replanning or hiding routes`, async () => {
+  const stub = install_stub_worker<{
+    id: number
+    input: SynthesisPlanRequest
+    options: undefined
+  }>(({ input }) => plan_synthesis(input))
+  mount_planner({ show_hull: false })
+  await vi.waitFor(() => {
+    expect(stub.posted).toHaveLength(1)
+    expect(document.querySelector(`.detail`)).not.toBeNull()
+  })
+
+  const mass_input = document.querySelector<HTMLInputElement>(`.recipe-card header input`)
+  expect(mass_input).not.toBeNull()
+  if (!mass_input) return
+  mass_input.value = `2`
+  mass_input.dispatchEvent(new Event(`input`, { bubbles: true }))
+  await tick()
+
+  expect(stub.posted).toHaveLength(1)
+  expect(document.querySelector(`.detail`)).not.toBeNull()
+  expect(document.querySelector(`.recipe-card tr.target td:nth-child(3)`)?.textContent).toBe(
+    `2`,
+  )
+})
+
+test(`unmount aborts pending work before releasing the replacement worker`, async () => {
+  const stub = install_stub_worker<{
+    id: number
+    input: SynthesisPlanRequest
+    options: undefined
+  }>()
+  const component = mount(SynthesisPlanner, {
+    target: document.body,
+    props: { entries, target: `BaTiO3`, show_hull: false },
+  })
+  await vi.waitFor(() => expect(stub.posted).toHaveLength(1))
+
+  await unmount(component)
+  expect(stub.instances.map((worker) => worker.terminated)).toEqual([1, 1])
 })

--- a/tests/vitest/synthesis-planning/SynthesisPlanner.test.svelte.ts
+++ b/tests/vitest/synthesis-planning/SynthesisPlanner.test.svelte.ts
@@ -1,0 +1,31 @@
+import type { PhaseData } from '$lib/convex-hull'
+import SynthesisPlanner from '$lib/synthesis-planning/SynthesisPlanner.svelte'
+import { type ComponentProps, mount, unmount } from 'svelte'
+import { expect, onTestFinished, test, vi } from 'vitest'
+import { load_json } from '../setup'
+
+const entries = load_json<PhaseData[]>(`src/site/synthesis-planning/Ba-Ti-C-O.json.gz`)
+const mount_planner = (props: Partial<ComponentProps<typeof SynthesisPlanner>> = {}): void => {
+  const component = mount(SynthesisPlanner, {
+    target: document.body,
+    props: { entries, target: `BaTiO3`, ...props },
+  })
+  onTestFinished(() => unmount(component))
+}
+
+test(`renders the selected route hull inside the detail-left pane`, async () => {
+  mount_planner()
+
+  await vi.waitFor(
+    () => expect(document.querySelector(`.detail-left > [role="application"]`)).not.toBeNull(),
+    { timeout: 5000 },
+  )
+})
+
+test(`renders request validation errors instead of throwing from the component`, async () => {
+  mount_planner({ max_routes: 0, show_hull: false })
+
+  await vi.waitFor(() =>
+    expect(document.querySelector(`.error`)?.textContent).toContain(`max_routes`),
+  )
+})

--- a/tests/vitest/synthesis-planning/synthesis-planning.test.ts
+++ b/tests/vitest/synthesis-planning/synthesis-planning.test.ts
@@ -16,8 +16,10 @@ import {
   resolve_phase,
   SYNTHESIS_PLAN_REQUEST_SCHEMA,
   SYNTHESIS_PLANNER_TOOL,
+  validate_synthesis_plan_request,
 } from '$lib/synthesis-planning'
 import type { PlannerPhase, SynthesisPlanRequest } from '$lib/synthesis-planning'
+import { plan_synthesis_with_progress } from '$lib/synthesis-planning/plan'
 import { describe, expect, test } from 'vitest'
 import { make_phase, read_maybe_gz } from '../setup'
 import pymatgen_reference from './fixtures/ba_ti_o_pymatgen_reference.json' with { type: 'json' }
@@ -461,11 +463,44 @@ describe(`plan_synthesis`, () => {
 
   test.each([
     [{ entries: [], target: `BaTiO3` }, /entries must be/],
-    [{ entries: ba_ti_c_o, target: `` }, /target is required/],
+    [{ entries: ba_ti_c_o, target: `` }, /target must be a non-empty string/],
     [{ entries: ba_ti_c_o, target: `BaTiO3`, max_precursors: 7 }, /max_precursors/],
     [{ entries: ba_ti_c_o, target: `NaCl` }, /matches no entry id or formula/],
   ])(`rejects invalid request %o`, (request, message) => {
     expect(() => plan_synthesis(request as SynthesisPlanRequest)).toThrow(message)
+  })
+
+  test.each([
+    [{ conditions: { temperature: -1 } }, /conditions.temperature/],
+    [{ conditions: { temperature: 2001 } }, /conditions.temperature/],
+    [{ conditions: { open_species: [`Ar`] } }, /unsupported Ar/],
+    [{ conditions: { partial_pressures: { O2: 0 } } }, /partial_pressures.O2/],
+    [{ conditions: { partial_pressures: { Ar: 1 } } }, /unknown property Ar/],
+    [{ precursors: { max_e_above_hull: -0.1 } }, /max_e_above_hull/],
+    [{ precursors: { max_elements: 1.5 } }, /max_elements must be an integer/],
+    [{ scoring: { selectivity: -1 } }, /scoring.selectivity/],
+    [{ scoring: { mystery: 1 } }, /unknown property mystery/],
+    [{ max_routes: 0 }, /max_routes/],
+    [{ max_routes: 201 }, /max_routes/],
+    [{ max_routes: 1.5 }, /max_routes must be an integer/],
+    [{ target_mass_g: 0 }, /target_mass_g/],
+    [{ two_step: `yes` }, /two_step must be a boolean/],
+    [{ mystery: true }, /unknown property mystery/],
+  ])(`runtime validator rejects schema violation %o`, (override, message) => {
+    expect(() => validate_synthesis_plan_request({ ...base_request, ...override })).toThrow(
+      message,
+    )
+  })
+
+  test(`progress-capable kernel preserves the exact synchronous result`, () => {
+    const progress: { stage: string; current: number; total: number }[] = []
+    const result = plan_synthesis_with_progress(base_request, {
+      on_progress: (update) => progress.push(update),
+    })
+    expect(result).toEqual(plan_synthesis(base_request))
+    expect(progress[0]).toEqual({ stage: `preparing`, current: 0, total: 1 })
+    expect(progress.some((update) => update.stage === `direct_routes`)).toBe(true)
+    expect(progress.at(-1)).toEqual({ stage: `ranking`, current: 1, total: 1 })
   })
 })
 

--- a/tests/vitest/synthesis-planning/synthesis-planning.test.ts
+++ b/tests/vitest/synthesis-planning/synthesis-planning.test.ts
@@ -16,9 +16,12 @@ import {
   resolve_phase,
   SYNTHESIS_PLAN_REQUEST_SCHEMA,
   SYNTHESIS_PLANNER_TOOL,
-  validate_synthesis_plan_request,
 } from '$lib/synthesis-planning'
-import type { PlannerPhase, SynthesisPlanRequest } from '$lib/synthesis-planning'
+import type {
+  PlannerPhase,
+  SynthesisPlanProgress,
+  SynthesisPlanRequest,
+} from '$lib/synthesis-planning'
 import { plan_synthesis_with_progress } from '$lib/synthesis-planning/plan'
 import { describe, expect, test } from 'vitest'
 import { make_phase, read_maybe_gz } from '../setup'
@@ -462,15 +465,10 @@ describe(`plan_synthesis`, () => {
   })
 
   test.each([
-    [{ entries: [], target: `BaTiO3` }, /entries must be/],
-    [{ entries: ba_ti_c_o, target: `` }, /target must be a non-empty string/],
-    [{ entries: ba_ti_c_o, target: `BaTiO3`, max_precursors: 7 }, /max_precursors/],
-    [{ entries: ba_ti_c_o, target: `NaCl` }, /matches no entry id or formula/],
-  ])(`rejects invalid request %o`, (request, message) => {
-    expect(() => plan_synthesis(request as SynthesisPlanRequest)).toThrow(message)
-  })
-
-  test.each([
+    [{ entries: [] }, /entries must be/],
+    [{ target: `` }, /target must be a non-empty string/],
+    [{ max_precursors: 7 }, /max_precursors/],
+    [{ target: `NaCl` }, /matches no entry id or formula/],
     [{ conditions: { temperature: -1 } }, /conditions.temperature/],
     [{ conditions: { temperature: 2001 } }, /conditions.temperature/],
     [{ conditions: { open_species: [`Ar`] } }, /unsupported Ar/],
@@ -486,14 +484,14 @@ describe(`plan_synthesis`, () => {
     [{ target_mass_g: 0 }, /target_mass_g/],
     [{ two_step: `yes` }, /two_step must be a boolean/],
     [{ mystery: true }, /unknown property mystery/],
-  ])(`runtime validator rejects schema violation %o`, (override, message) => {
-    expect(() => validate_synthesis_plan_request({ ...base_request, ...override })).toThrow(
-      message,
-    )
+  ])(`rejects invalid request override %o`, (override, message) => {
+    expect(() =>
+      plan_synthesis({ ...base_request, ...override } as SynthesisPlanRequest),
+    ).toThrow(message)
   })
 
   test(`progress-capable kernel preserves the exact synchronous result`, () => {
-    const progress: { stage: string; current: number; total: number }[] = []
+    const progress: SynthesisPlanProgress[] = []
     const result = plan_synthesis_with_progress(base_request, {
       on_progress: (update) => progress.push(update),
     })

--- a/tests/vitest/synthesis-planning/worker-path.test.ts
+++ b/tests/vitest/synthesis-planning/worker-path.test.ts
@@ -1,27 +1,25 @@
 // Exercises the synthesis planner's Web Worker boundary. Numerical correctness and progress are
 // covered by synthesis-planning.test.ts; this verifies the cloneable contract and module path.
 import type { PhaseData } from '$lib/convex-hull'
-import type { plan_synthesis_async as PlanSynthesisAsync } from '$lib/synthesis-planning/plan-synthesis-async.svelte'
 import { plan_synthesis } from '$lib/synthesis-planning/plan'
 import type { SynthesisPlanRequest } from '$lib/synthesis-planning/types'
-import { afterEach, beforeAll, expect, test } from 'vitest'
-import { expect_module_worker, install_stub_worker, read_maybe_gz } from '../setup'
+import { afterEach, expect, test } from 'vitest'
+import {
+  expect_module_worker,
+  expect_worker_safe_import_graph,
+  install_stub_worker,
+  load_json,
+} from '../setup'
 
-const entries: PhaseData[] = JSON.parse(
-  read_maybe_gz(`src/site/synthesis-planning/Ba-Ti-C-O.json.gz`),
-)
+const entries = load_json<PhaseData[]>(`src/site/synthesis-planning/Ba-Ti-C-O.json.gz`)
 const stub = install_stub_worker<{
   id: number
   input: SynthesisPlanRequest
   options: undefined
 }>(({ input }) => plan_synthesis(input))
-let plan_synthesis_async: typeof PlanSynthesisAsync
-
-beforeAll(async () => {
-  ;({ plan_synthesis_async } = await import(
-    `$lib/synthesis-planning/plan-synthesis-async.svelte`
-  ))
-})
+const { plan_synthesis_async } = await import(
+  `$lib/synthesis-planning/plan-synthesis-async.svelte`
+)
 afterEach(stub.reset)
 
 test(`worker result exactly matches the pure kernel and preserves entry ids`, async () => {
@@ -39,61 +37,11 @@ test(`worker result exactly matches the pure kernel and preserves entry ids`, as
   expect_module_worker(stub.instances, `src/lib/synthesis-planning/plan-synthesis-worker.ts`)
 })
 
-test(`worker runtime graph excludes Svelte and browser-only sanitizer modules`, async () => {
-  const { existsSync, readFileSync } = await import(`node:fs`)
-  const { dirname, resolve } = await import(`node:path`)
-  const repo_root = resolve(import.meta.dirname, `../../..`)
-  const worker_entry = resolve(
-    repo_root,
-    `src/lib/synthesis-planning/plan-synthesis-worker.ts`,
+test(`worker runtime graph excludes Svelte and browser-only sanitizer modules`, () => {
+  expect.hasAssertions()
+  expect_worker_safe_import_graph(
+    [`src/lib/synthesis-planning/plan-synthesis-worker.ts`],
+    20,
+    [`dompurify`],
   )
-  const source_extensions = [`.ts`, `.svelte`, `.js`, `.mjs`]
-  const resolve_specifier = (specifier: string, from_file: string): string | null => {
-    let base: string
-    if (specifier.startsWith(`$lib`)) {
-      base = resolve(repo_root, `src/lib`, specifier.slice(`$lib`.length).replace(/^\//, ``))
-    } else if (specifier.startsWith(`.`)) {
-      base = resolve(dirname(from_file), specifier)
-    } else return null
-    const candidates = source_extensions.some((extension) => base.endsWith(extension))
-      ? [base]
-      : source_extensions.flatMap((extension) => [
-          `${base}${extension}`,
-          resolve(base, `index${extension}`),
-        ])
-    return candidates.find(existsSync) ?? null
-  }
-  const strip_type_only = (source: string): string =>
-    source.replaceAll(
-      /(?:import|export)\s+(?:\{\s*(?:type\s+[^,}]+,?\s*)+\}|type\s+[^;]*?)\s+from\s*['"`][^'"`]+['"`]\s*;?/g,
-      ``,
-    )
-  const import_re = /(?:from|import)\s*\(?\s*['"`](?<specifier>[^'"`]+)['"`]/g
-  const queue = [worker_entry]
-  const visited = new Set<string>()
-  const violations: string[] = []
-  while (queue.length) {
-    const file = queue.pop()
-    if (!file || visited.has(file)) continue
-    visited.add(file)
-    const source = strip_type_only(readFileSync(file, `utf-8`))
-    for (const match of source.matchAll(import_re)) {
-      const specifier = match.groups?.specifier ?? ``
-      if (
-        specifier === `svelte` ||
-        specifier.startsWith(`svelte/`) ||
-        specifier.endsWith(`.svelte`) ||
-        specifier === `dompurify`
-      ) {
-        violations.push(`${file} imports "${specifier}"`)
-        continue
-      }
-      const resolved = resolve_specifier(specifier, file)
-      if (resolved) queue.push(resolved)
-    }
-  }
-
-  expect(visited.size).toBeGreaterThan(20)
-  expect(visited).toContain(worker_entry)
-  expect(violations).toEqual([])
 })

--- a/tests/vitest/synthesis-planning/worker-path.test.ts
+++ b/tests/vitest/synthesis-planning/worker-path.test.ts
@@ -1,0 +1,99 @@
+// Exercises the synthesis planner's Web Worker boundary. Numerical correctness and progress are
+// covered by synthesis-planning.test.ts; this verifies the cloneable contract and module path.
+import type { PhaseData } from '$lib/convex-hull'
+import type { plan_synthesis_async as PlanSynthesisAsync } from '$lib/synthesis-planning/plan-synthesis-async.svelte'
+import { plan_synthesis } from '$lib/synthesis-planning/plan'
+import type { SynthesisPlanRequest } from '$lib/synthesis-planning/types'
+import { afterEach, beforeAll, expect, test } from 'vitest'
+import { expect_module_worker, install_stub_worker, read_maybe_gz } from '../setup'
+
+const entries: PhaseData[] = JSON.parse(
+  read_maybe_gz(`src/site/synthesis-planning/Ba-Ti-C-O.json.gz`),
+)
+const stub = install_stub_worker<{
+  id: number
+  input: SynthesisPlanRequest
+  options: undefined
+}>(({ input }) => plan_synthesis(input))
+let plan_synthesis_async: typeof PlanSynthesisAsync
+
+beforeAll(async () => {
+  ;({ plan_synthesis_async } = await import(
+    `$lib/synthesis-planning/plan-synthesis-async.svelte`
+  ))
+})
+afterEach(stub.reset)
+
+test(`worker result exactly matches the pure kernel and preserves entry ids`, async () => {
+  const request: SynthesisPlanRequest = {
+    entries,
+    target: `agm003129350`,
+    conditions: { temperature: 1200, open_species: [`O2`, `CO2`] },
+    max_routes: 5,
+  }
+  const result = await plan_synthesis_async(request)
+
+  expect(result).toEqual(plan_synthesis(request))
+  expect(result.target.id).toBe(`agm003129350`)
+  expect(stub.posted[0].message.input.entries[0].entry_id).toBe(entries[0].entry_id)
+  expect_module_worker(stub.instances, `src/lib/synthesis-planning/plan-synthesis-worker.ts`)
+})
+
+test(`worker runtime graph excludes Svelte and browser-only sanitizer modules`, async () => {
+  const { existsSync, readFileSync } = await import(`node:fs`)
+  const { dirname, resolve } = await import(`node:path`)
+  const repo_root = resolve(import.meta.dirname, `../../..`)
+  const worker_entry = resolve(
+    repo_root,
+    `src/lib/synthesis-planning/plan-synthesis-worker.ts`,
+  )
+  const source_extensions = [`.ts`, `.svelte`, `.js`, `.mjs`]
+  const resolve_specifier = (specifier: string, from_file: string): string | null => {
+    let base: string
+    if (specifier.startsWith(`$lib`)) {
+      base = resolve(repo_root, `src/lib`, specifier.slice(`$lib`.length).replace(/^\//, ``))
+    } else if (specifier.startsWith(`.`)) {
+      base = resolve(dirname(from_file), specifier)
+    } else return null
+    const candidates = source_extensions.some((extension) => base.endsWith(extension))
+      ? [base]
+      : source_extensions.flatMap((extension) => [
+          `${base}${extension}`,
+          resolve(base, `index${extension}`),
+        ])
+    return candidates.find(existsSync) ?? null
+  }
+  const strip_type_only = (source: string): string =>
+    source.replaceAll(
+      /(?:import|export)\s+(?:\{\s*(?:type\s+[^,}]+,?\s*)+\}|type\s+[^;]*?)\s+from\s*['"`][^'"`]+['"`]\s*;?/g,
+      ``,
+    )
+  const import_re = /(?:from|import)\s*\(?\s*['"`](?<specifier>[^'"`]+)['"`]/g
+  const queue = [worker_entry]
+  const visited = new Set<string>()
+  const violations: string[] = []
+  while (queue.length) {
+    const file = queue.pop()
+    if (!file || visited.has(file)) continue
+    visited.add(file)
+    const source = strip_type_only(readFileSync(file, `utf-8`))
+    for (const match of source.matchAll(import_re)) {
+      const specifier = match.groups?.specifier ?? ``
+      if (
+        specifier === `svelte` ||
+        specifier.startsWith(`svelte/`) ||
+        specifier.endsWith(`.svelte`) ||
+        specifier === `dompurify`
+      ) {
+        violations.push(`${file} imports "${specifier}"`)
+        continue
+      }
+      const resolved = resolve_specifier(specifier, file)
+      if (resolved) queue.push(resolved)
+    }
+  }
+
+  expect(visited.size).toBeGreaterThan(20)
+  expect(visited).toContain(worker_entry)
+  expect(violations).toEqual([])
+})

--- a/tests/vitest/worker-client.test.ts
+++ b/tests/vitest/worker-client.test.ts
@@ -12,7 +12,11 @@ const workers = (): StubWorkerInstance[] => stub.instances
 const first_post = (worker: StubWorkerInstance) => worker.posted[0].message
 
 const make_client = <Result = string>(
-  compute_sync: () => Result = (() => `sync`) as () => Result,
+  compute_sync: (
+    input: { tag: string },
+    options: Record<string, unknown> | undefined,
+    on_progress?: (progress: unknown) => void,
+  ) => Result = (() => `sync`) as () => Result,
 ) =>
   create_worker_client<{ tag: string }, Record<string, unknown>, Result>({
     label: `Test`,
@@ -159,14 +163,9 @@ describe(`request dedupe`, () => {
 test(`falls back to compute_sync when Worker is missing`, async () => {
   vi.stubGlobal(`Worker`, undefined)
   const progress = vi.fn()
-  const run = create_worker_client<{ tag: string }, Record<string, unknown>, string, number>({
-    label: `Test`,
-    create_worker: () => new Worker(`stub`),
-    compute_sync: (_input, _options, on_progress) => {
-      on_progress?.(0.5)
-      return `sync`
-    },
-    build_payload: (input) => input,
+  const run = make_client((_input, _options, on_progress) => {
+    on_progress?.(0.5)
+    return `sync`
   })
   await expect(run({ tag: `a` }, {}, { on_progress: progress })).resolves.toBe(`sync`)
   expect(progress).toHaveBeenCalledExactlyOnceWith(0.5)

--- a/tests/vitest/worker-client.test.ts
+++ b/tests/vitest/worker-client.test.ts
@@ -158,8 +158,18 @@ describe(`request dedupe`, () => {
 
 test(`falls back to compute_sync when Worker is missing`, async () => {
   vi.stubGlobal(`Worker`, undefined)
-  const run = make_client()
-  await expect(run({ tag: `a` }, {})).resolves.toBe(`sync`)
+  const progress = vi.fn()
+  const run = create_worker_client<{ tag: string }, Record<string, unknown>, string, number>({
+    label: `Test`,
+    create_worker: () => new Worker(`stub`),
+    compute_sync: (_input, _options, on_progress) => {
+      on_progress?.(0.5)
+      return `sync`
+    },
+    build_payload: (input) => input,
+  })
+  await expect(run({ tag: `a` }, {}, { on_progress: progress })).resolves.toBe(`sync`)
+  expect(progress).toHaveBeenCalledExactlyOnceWith(0.5)
   expect(workers()).toHaveLength(0)
 })
 


### PR DESCRIPTION
Consolidates every file-ingestion path — the web app, the VS Code webview and non-Svelte hosts — onto one runtime, and folds in the synthesis-planning worker work this PR originally carried.

## Unified loading

- `file-viewer/open.ts`: new `open_material()` takes a URL, `File` or in-memory payload and owns fetching, decompression, format detection, worker parsing, progress, cancellation, provenance and disposal. Published as `matterviz/file-viewer/open`.
- `Structure`, `BrillouinZone`, `FermiSurface`: keep their `data_url` / `structure_string` / drop props but delegate through a `create_material_loader` attachment instead of each owning acquisition.
- `TrajectoryFileViewer`, the convex-hull drop zone, the webview host and the demos call `open_material()` directly.
- Deletes `io/data-url.ts` and `scene/viewer-loader.svelte.ts`; `structure/loader.ts` becomes `structure/material.ts`, keeping only the volumetric-merge rules now that parsing lives in the runtime.
- Loader ownership is a boolean ("has this loader produced a value?") instead of an identity comparison against the held value, removing the proxy hazard `$bindable` introduced along with the `claim()` API and both its call sites.

Defects found while consolidating:

- The `data_url` effect read the viewer's current value even when a host `on_file_drop` owned it, subscribing to every host write and refetching the same URL.
- Transport failures reported `on_error` without a `filename`.
- A single-frame `.xyz` whose name carries a trajectory keyword was read as a trajectory; content sniffing now only decides for names that give no hint.
- Choosing an HDF5 group re-downloaded and re-inflated the whole file; the acquired payload is reused through a new `on_acquired` hook.
- Restores the "Decompressing HDF5…" progress stage and the Fermi surface demo's spinner.

## Synthesis planning off the main thread

- Routes plan computation through a persistent module worker with progress reporting and cancellation; custom gas providers stay on the main thread because they are not structured-cloneable.
- `validation.ts` checks public requests before any numerical work, and the planner selector preserves explicit entry-id targets.
- `convex-hull/entry-stability.ts` and `synthesis-planning/format-mev.ts` hold worker-safe stability and energy-formatting helpers, so the worker graph excludes Svelte and DOM-sanitization modules.
- `SynthesisPlanner.svelte` renders the selected chemical-system hull in the route detail pane beside the reaction slice and recipe.

## Mobile nav

- Drops overrides that svelte-widgets 1.6.1 now ships itself; one of them reset the burger's inset without clearing the widget's compensating negative margin, which left the close icon flush in the viewport corner.
- Shims four widget-side geometry fixes — menu spans the viewport, row highlight padding lands on both pill elements, the open burger's strokes meet on centre, carets hug the trailing edge — each also filed upstream so the shims can go on the next release.
- The search control becomes a full-width field in the mobile menu; rows tighten from 37px to 24px, which puts the row touch target under the ~32px floor the previous `min-height` aimed at.

## Breaking

- Removes `create_data_url_loader` (`matterviz/io`) and `create_viewer_loader` (`matterviz/scene`); callers should use `open_material()`.
- Replacing a URL-loaded value with a caller-supplied one and then changing `data_url` now fetches the new URL instead of leaving it blocked.
