### PR TITLE
test: protect parent-owned fullscreen from viewer mounts

### DIFF
--- a/tests/vitest/layout/FullscreenButton.test.svelte.ts
+++ b/tests/vitest/layout/FullscreenButton.test.svelte.ts
@@ -73,4 +73,21 @@ describe(`FullscreenButton`, () => {
     expect(state.fullscreen).toBe(false)
     expect(on_change.mock.calls).toEqual([[true], [false]])
   })
+
+  test(`preserves fullscreen owned by a parent when mounted`, async () => {
+    const parent = document.createElement(`div`)
+    const wrapper = document.createElement(`div`)
+    parent.append(wrapper)
+    document.body.append(parent)
+    await parent.requestFullscreen()
+    const exit_fullscreen = vi.spyOn(document, `exitFullscreen`)
+
+    const { state, on_change } = mount_button(wrapper)
+    await tick()
+
+    expect(document.fullscreenElement).toBe(parent)
+    expect(exit_fullscreen).not.toHaveBeenCalled()
+    expect(state.fullscreen).toBe(false)
+    expect(on_change).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

Mounting a materials viewer must not disturb fullscreen owned by a parent application. This matters for integrations such as presentation tools, where a viewer can mount while the surrounding slide deck is already fullscreen.

MatterViz now scopes fullscreen state to each viewer wrapper through the shared `FullscreenButton`. This adds focused regression coverage for the missing case: a different parent owns fullscreen when the control mounts. The test verifies that MatterViz neither exits the parent nor reports its own viewer as fullscreen.

> Written by GPT-5.6 on Codex
