### PR TITLE
Unify viewer keyboard shortcuts and fix VS Code webview dark theming

### DIFF
--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -297,9 +297,14 @@ export const create_html = (
   const moyo_wasm_url = wasm_filename && dist_uri(`assets`, wasm_filename)
 
   const webview_data = { ...data, moyo_wasm_url }
+  // Set color-scheme before main-*.css loads, or its light-dark() tokens flash white/light
+  // until JS applies the theme. Must be a style attribute, not a <style> rule: it needs to
+  // outrank main-*.css's own same-specificity `:root, :host { color-scheme: light dark }`.
+  const color_scheme = data.theme === `dark` || data.theme === `black` ? `dark` : `light`
+  const root_style = `color-scheme: ${color_scheme}; background-color: var(--vscode-editor-background, Canvas);`
 
   return `<!DOCTYPE html>
-<html>
+<html style="${root_style}">
   <head>
     <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'nonce-${nonce}' 'unsafe-eval' 'wasm-unsafe-eval' ${webview.cspSource}; style-src 'unsafe-inline' ${webview.cspSource}; img-src ${webview.cspSource} data:; connect-src ${webview.cspSource}; worker-src blob:;">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -16,7 +16,13 @@ import type {
 import { format_bytes, is_plain_object, to_error } from '$lib/utils'
 import type { DefaultSettings, SettingType } from '$lib/settings'
 import { is_valid_setting_value, merge, SETTINGS_CONFIG } from '$lib/settings'
-import { AUTO_THEME, COLOR_THEMES, is_valid_theme_mode, type ThemeName } from '$lib/theme'
+import {
+  AUTO_THEME,
+  COLOR_THEMES,
+  is_valid_theme_mode,
+  THEME_TYPE,
+  type ThemeName,
+} from '$lib/theme'
 // Deep imports: the $lib/trajectory barrel re-exports Svelte components and worker-backed
 // modules, none of which belong in the Node host bundle
 import { open_trajectory } from '$lib/trajectory/open'
@@ -300,7 +306,9 @@ export const create_html = (
   // Set color-scheme before main-*.css loads, or its light-dark() tokens flash white/light
   // until JS applies the theme. Must be a style attribute, not a <style> rule: it needs to
   // outrank main-*.css's own same-specificity `:root, :host { color-scheme: light dark }`.
-  const color_scheme = data.theme === `dark` || data.theme === `black` ? `dark` : `light`
+  // THEME_TYPE, not a ternary: it is a Record over ThemeName, so a new theme is a type
+  // error there rather than silently rendering light here.
+  const color_scheme = THEME_TYPE[data.theme]
   const root_style = `color-scheme: ${color_scheme}; background-color: var(--vscode-editor-background, Canvas);`
 
   return `<!DOCTYPE html>

--- a/extensions/vscode/tests/extension.test.ts
+++ b/extensions/vscode/tests/extension.test.ts
@@ -665,6 +665,23 @@ describe(`MatterViz Extension`, () => {
     expect(html).toContain(`matterviz-app`)
   })
 
+  // Guards against the white-flash/wrong-theme regression: color-scheme must be set as a
+  // style attribute (outranks main-*.css's own color-scheme rule) before the CSS link.
+  test.each([
+    [`dark`, `dark`],
+    [`black`, `dark`],
+    [`light`, `light`],
+    [`white`, `light`],
+  ] as const)(`HTML declares color-scheme before CSS loads: theme=%s`, (theme, scheme) => {
+    const html = create_html(mock_webview, mock_context, {
+      data: { filename: `test.cif`, content: `content`, is_base64: false },
+      theme,
+    })
+    expect(html).toMatch(/^<!DOCTYPE html>\s*<html style="/)
+    expect(html).toContain(`color-scheme: ${scheme};`)
+    expect(html).toContain(`background-color: var(--vscode-editor-background, Canvas);`)
+  })
+
   // `error` stays a toast; `info` (one per successful render, so every auto-save) goes to the
   // MatterViz output channel instead of a notification
   test.each([

--- a/extensions/vscode/tests/vite-config.test.ts
+++ b/extensions/vscode/tests/vite-config.test.ts
@@ -1,15 +1,12 @@
-import { readFileSync } from 'node:fs'
-import { fileURLToPath } from 'node:url'
+import { make_config } from 'svelte-widgets/vite-config'
 import { expect, test } from 'vitest'
 
-// Checked as source text, not by importing vite.config.ts: that file sits outside
-// tsconfig.json's `include` glob, and importing it here would pull its (pre-existing,
-// unrelated) top-level `.ts`-extension imports into this project's type-check.
-//
-// Without esnext, LightningCSS downlevels light-dark() into an OS-preference polyfill
-// that ignores the webview's declared color-scheme (see create_html in extension.ts).
-test(`webview build targets esnext so LightningCSS keeps native light-dark()`, () => {
-  const config_path = fileURLToPath(new URL(`../vite.config.ts`, import.meta.url))
-  const config_source = readFileSync(config_path, `utf8`)
-  expect(config_source).toMatch(/^\s*cssTarget:\s*`esnext`,$/m)
+// vite.config.ts takes its cssTarget from this shared config, so the two builds cannot drift
+// apart again — what is left to guard is the shared value itself. A target without native
+// light-dark() makes LightningCSS downlevel app.css's theme tokens into an OS-preference
+// polyfill that ignores the color-scheme the webview declares from VS Code's theme.
+// (vite.config.ts is not imported here: it sits outside tsconfig's `include` and its
+// pre-existing `.ts`-extension imports would fail `tsc --noEmit` from this file.)
+test(`shared cssTarget keeps native light-dark()`, () => {
+  expect(make_config().build.cssTarget).toBe(`esnext`)
 })

--- a/extensions/vscode/tests/vite-config.test.ts
+++ b/extensions/vscode/tests/vite-config.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { expect, test } from 'vitest'
+
+// Checked as source text, not by importing vite.config.ts: that file sits outside
+// tsconfig.json's `include` glob, and importing it here would pull its (pre-existing,
+// unrelated) top-level `.ts`-extension imports into this project's type-check.
+//
+// Without esnext, LightningCSS downlevels light-dark() into an OS-preference polyfill
+// that ignores the webview's declared color-scheme (see create_html in extension.ts).
+test(`webview build targets esnext so LightningCSS keeps native light-dark()`, () => {
+  const config_path = fileURLToPath(new URL(`../vite.config.ts`, import.meta.url))
+  const config_source = readFileSync(config_path, `utf8`)
+  expect(config_source).toMatch(/^\s*cssTarget:\s*`esnext`,$/m)
+})

--- a/extensions/vscode/vite.config.ts
+++ b/extensions/vscode/vite.config.ts
@@ -1,5 +1,6 @@
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 import { resolve } from 'node:path'
+import { make_config } from 'svelte-widgets/vite-config'
 import { defineConfig, type PluginOption } from 'vite'
 import {
   json_gz_worker_plugins,
@@ -38,11 +39,11 @@ export default defineConfig(({ mode }) => ({
     },
     emptyOutDir: false,
     chunkSizeWarningLimit: 6000,
-    // Without this, LightningCSS downlevels light-dark() into an OS-prefers-color-scheme
-    // polyfill, ignoring the color-scheme the webview sets from VS Code's theme. VS Code's
-    // Electron/Chromium supports light-dark() natively, so esnext is safe (matches the root
-    // build's `svelte-widgets/vite-config` cssTarget).
-    cssTarget: `esnext`,
+    // Taken from the shared config rather than repeated: vite's default target lacks
+    // light-dark(), so LightningCSS downlevels app.css's tokens into an OS-prefers-color-scheme
+    // polyfill that ignores the color-scheme the webview sets from VS Code's theme. This build
+    // drifted from the root's precisely because the value was declared in two places.
+    cssTarget: make_config().build.cssTarget,
   },
   resolve: { alias: lib_aliases },
 }))

--- a/extensions/vscode/vite.config.ts
+++ b/extensions/vscode/vite.config.ts
@@ -38,6 +38,11 @@ export default defineConfig(({ mode }) => ({
     },
     emptyOutDir: false,
     chunkSizeWarningLimit: 6000,
+    // Without this, LightningCSS downlevels light-dark() into an OS-prefers-color-scheme
+    // polyfill, ignoring the color-scheme the webview sets from VS Code's theme. VS Code's
+    // Electron/Chromium supports light-dark() natively, so esnext is safe (matches the root
+    // build's `svelte-widgets/vite-config` cssTarget).
+    cssTarget: `esnext`,
   },
   resolve: { alias: lib_aliases },
 }))

--- a/src/lib/brillouin/BrillouinZone.svelte
+++ b/src/lib/brillouin/BrillouinZone.svelte
@@ -251,6 +251,7 @@
   function onkeydown(event: KeyboardEvent) {
     // `f` is owned by FullscreenButton; chords stay the browser's (Cmd/Ctrl+F = find)
     if (is_editable_event_target(event.target) || is_modifier_chord(event)) return
+    if (event.repeat) return // holding `i` would flicker the pane
 
     if (event.key === `i`) info_pane_open = !info_pane_open
     else if (event.key === `Escape`) {

--- a/src/lib/brillouin/BrillouinZone.svelte
+++ b/src/lib/brillouin/BrillouinZone.svelte
@@ -31,7 +31,7 @@
   } from './compute'
   import { clamp, reciprocal_lattice } from '$lib/math'
   import { to_error } from '$lib/utils'
-  import { is_editable_event_target } from 'svelte-widgets/utils'
+  import { is_editable_event_target, is_modifier_chord } from 'svelte-widgets/utils'
   import type {
     BrillouinZoneData,
     BrillouinZoneSettings,
@@ -249,10 +249,10 @@
   })
 
   function onkeydown(event: KeyboardEvent) {
-    if (is_editable_event_target(event.target)) return
+    // `f` is owned by FullscreenButton; chords stay the browser's (Cmd/Ctrl+F = find)
+    if (is_editable_event_target(event.target) || is_modifier_chord(event)) return
 
-    if (event.key === `f` && fullscreen_toggle) fullscreen = !fullscreen
-    else if (event.key === `i`) info_pane_open = !info_pane_open
+    if (event.key === `i`) info_pane_open = !info_pane_open
     else if (event.key === `Escape`) {
       if (info_pane_open) info_pane_open = false
       else controls_open = false

--- a/src/lib/chempot-diagram/ChemPotDiagram2D.svelte
+++ b/src/lib/chempot-diagram/ChemPotDiagram2D.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { get_electro_neg_formula } from '$lib/composition/format'
+  import { is_editable_event_target } from 'svelte-widgets/utils'
   import TemperatureSlider from '$lib/convex-hull/TemperatureSlider.svelte'
   import type { PhaseData } from '$lib/convex-hull/types'
   import Spinner from '$lib/feedback/Spinner.svelte'
@@ -294,6 +295,8 @@
     role="application"
     tabindex="0"
     onkeydown={(event) => {
+      // Escape inside a pane input belongs to that input, as in the 3D sibling
+      if (is_editable_event_target(event.target)) return
       if (event.key === `Escape`) clear_hover_lock()
     }}
     onpointerdown={(event) => {

--- a/src/lib/chempot-diagram/ChemPotDiagram3D.svelte
+++ b/src/lib/chempot-diagram/ChemPotDiagram3D.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { DEFAULT_PNG_DPI } from '$lib/constants'
-  import { is_editable_event_target } from 'svelte-widgets/utils'
+  import { is_editable_event_target, is_modifier_chord } from 'svelte-widgets/utils'
   import { Filter } from 'svelte-widgets/icons'
   import { get_electro_neg_formula, get_formula_label_segments } from '$lib/composition/format'
   import type { FormulaLabelSegment } from '$lib/composition/format'
@@ -1381,10 +1381,10 @@
   role="application"
   tabindex="0"
   onkeydown={(event) => {
-    if (is_editable_event_target(event.target)) return
+    // `f` is owned by FullscreenButton; chords stay the browser's (Cmd/Ctrl+F = find)
+    if (is_editable_event_target(event.target) || is_modifier_chord(event)) return
     if (event.key === `Escape`) clear_hover_lock()
     else if (event.key === `c`) cycle_color_mode()
-    else if (event.key === `f`) fullscreen = !fullscreen
   }}
   onpointerdown={(event) => {
     const target = event.target

--- a/src/lib/chempot-diagram/ChemPotDiagram3D.svelte
+++ b/src/lib/chempot-diagram/ChemPotDiagram3D.svelte
@@ -1383,6 +1383,7 @@
   onkeydown={(event) => {
     // `f` is owned by FullscreenButton; chords stay the browser's (Cmd/Ctrl+F = find)
     if (is_editable_event_target(event.target) || is_modifier_chord(event)) return
+    if (event.repeat) return // holding `c` would spin through color modes
     if (event.key === `Escape`) clear_hover_lock()
     else if (event.key === `c`) cycle_color_mode()
   }}

--- a/src/lib/composition/FormulaFilter.svelte
+++ b/src/lib/composition/FormulaFilter.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { Icon } from 'svelte-widgets'
+  import { is_modifier_chord } from 'svelte-widgets/utils'
   import { Circle, Close, Info, Lock, Star, Unlock } from 'svelte-widgets/icons'
   import { is_elem_symbol, type ElementSymbol } from '$lib/element'
   import { tooltip } from 'svelte-widgets/attachments'
@@ -500,7 +501,8 @@
       if (history_open) close_history()
       else if (examples_open) examples_open = false
       else if (input_value) clear_filter()
-    } else if (history_open && visible_history.length > 0) {
+      // Cmd/Ctrl+Arrow jumps within the input's text; only bare arrows walk history
+    } else if (history_open && visible_history.length > 0 && !is_modifier_chord(event)) {
       const len = visible_history.length
       if (event.key === `ArrowDown`) {
         event.preventDefault()

--- a/src/lib/convex-hull/canvas-interactions.svelte.ts
+++ b/src/lib/convex-hull/canvas-interactions.svelte.ts
@@ -131,7 +131,9 @@ export function create_hull_selection(inputs: HullSelectionInputs) {
   }
 
   const handle_keydown = (event: KeyboardEvent) => {
-    if (is_editable_event_target(event.target)) return
+    // Chords stay the browser's and the host's, Cmd+Enter and Cmd/Ctrl+S/R/B/L/U alike.
+    // Guarded up front like the other viewers, so no branch below can claim one first.
+    if (is_editable_event_target(event.target) || is_modifier_chord(event)) return
 
     let handled = true
     if (event.key === `Escape`) {
@@ -142,8 +144,6 @@ export function create_hull_selection(inputs: HullSelectionInputs) {
       if (entry) select_entry(entry)
       else if (modal_open) close_structure_popup()
       else handled = false
-    } else if (is_modifier_chord(event)) {
-      handled = false // Cmd+S/R/B/L/U and friends stay the browser's
     } else {
       const action = inputs.actions()[event.key.toLowerCase()]
       if (action) action()

--- a/src/lib/convex-hull/canvas-interactions.svelte.ts
+++ b/src/lib/convex-hull/canvas-interactions.svelte.ts
@@ -134,6 +134,7 @@ export function create_hull_selection(inputs: HullSelectionInputs) {
     // Chords stay the browser's and the host's, Cmd+Enter and Cmd/Ctrl+S/R/B/L/U alike.
     // Guarded up front like the other viewers, so no branch below can claim one first.
     if (is_editable_event_target(event.target) || is_modifier_chord(event)) return
+    if (event.repeat) return // every hull action is a toggle; holding one would flicker it
 
     let handled = true
     if (event.key === `Escape`) {

--- a/src/lib/convex-hull/canvas-interactions.svelte.ts
+++ b/src/lib/convex-hull/canvas-interactions.svelte.ts
@@ -10,7 +10,7 @@ import { open_material } from '$lib/file-viewer/open'
 import { raw_file_drop_zone } from '$lib/io'
 import { clamp } from '$lib/math'
 import type { AnyStructure } from '$lib/structure'
-import { is_editable_event_target } from 'svelte-widgets/utils'
+import { is_editable_event_target, is_modifier_chord } from 'svelte-widgets/utils'
 import { createAttachmentKey } from 'svelte/attachments'
 import * as draw from './canvas-draw'
 import {
@@ -132,17 +132,26 @@ export function create_hull_selection(inputs: HullSelectionInputs) {
 
   const handle_keydown = (event: KeyboardEvent) => {
     if (is_editable_event_target(event.target)) return
-    // A canvas-originated keydown bubbles to the wrapper (both listen); handle it once
-    if (event.target !== inputs.wrapper()) event.stopPropagation()
 
-    if (event.key === `Escape` && modal_open) return close_structure_popup()
-    if (event.key === `Enter`) {
+    let handled = true
+    if (event.key === `Escape`) {
+      if (modal_open) close_structure_popup()
+      else handled = false
+    } else if (event.key === `Enter`) {
       const entry = hover_data?.entry
       if (entry) select_entry(entry)
       else if (modal_open) close_structure_popup()
-      return
+      else handled = false
+    } else if (is_modifier_chord(event)) {
+      handled = false // Cmd+S/R/B/L/U and friends stay the browser's
+    } else {
+      const action = inputs.actions()[event.key.toLowerCase()]
+      if (action) action()
+      else handled = false
     }
-    inputs.actions()[event.key.toLowerCase()]?.()
+    // A canvas-originated keydown bubbles to the wrapper (both listen); swallow it once we
+    // handled it so it runs once, but let keys we ignore through to the host
+    if (handled && event.target !== inputs.wrapper()) event.stopPropagation()
   }
 
   const drop_zone = {

--- a/src/lib/fermi-surface/FermiSurface.svelte
+++ b/src/lib/fermi-surface/FermiSurface.svelte
@@ -289,8 +289,8 @@
     // Only handle shortcuts when component is focused/hovered or contains focus
     if (!wrapper?.contains(document.activeElement) && !hovered) return
 
-    if (event.key === `f` && fullscreen_toggle) fullscreen = !fullscreen
-    else if (event.key === `Escape`) controls_open = false
+    // `f` is owned by FullscreenButton, which arbitrates it between nested viewers
+    if (event.key === `Escape`) controls_open = false
   }
 </script>
 

--- a/src/lib/heatmap-matrix/HeatmapMatrix.svelte
+++ b/src/lib/heatmap-matrix/HeatmapMatrix.svelte
@@ -688,7 +688,7 @@
     // `e` downloads a file, so typing must never reach it. Chords stay the browser's:
     // guarded up front, or Cmd+Arrow would move a cell instead of scrolling the page.
     if (is_editable_event_target(event.target) || is_modifier_chord(event)) return
-    if (event.key.toLowerCase() === `e`) {
+    if (event.key.toLowerCase() === `e` && !event.repeat) {
       const format = export_formats[0]
       if (format && on_export) on_export(format, build_export_payload(format))
       return

--- a/src/lib/heatmap-matrix/HeatmapMatrix.svelte
+++ b/src/lib/heatmap-matrix/HeatmapMatrix.svelte
@@ -685,9 +685,10 @@
     ArrowUp: [0, -1],
   }
   function handle_keydown(event: KeyboardEvent): void {
-    // `e` downloads a file, so typing must never reach it. Chords stay the browser's.
-    if (is_editable_event_target(event.target)) return
-    if (event.key.toLowerCase() === `e` && !is_modifier_chord(event)) {
+    // `e` downloads a file, so typing must never reach it. Chords stay the browser's:
+    // guarded up front, or Cmd+Arrow would move a cell instead of scrolling the page.
+    if (is_editable_event_target(event.target) || is_modifier_chord(event)) return
+    if (event.key.toLowerCase() === `e`) {
       const format = export_formats[0]
       if (format && on_export) on_export(format, build_export_payload(format))
       return

--- a/src/lib/heatmap-matrix/HeatmapMatrix.svelte
+++ b/src/lib/heatmap-matrix/HeatmapMatrix.svelte
@@ -8,6 +8,7 @@
   import ColorBar from '$lib/plot/core/components/ColorBar.svelte'
   import { virtual_window } from '$lib/table/virtual'
   import { rows_to_csv } from '$lib/utils'
+  import { is_editable_event_target, is_modifier_chord } from 'svelte-widgets/utils'
   import { type ComponentProps, onDestroy, onMount, type Snippet, tick } from 'svelte'
   import type { HTMLAttributes } from 'svelte/elements'
   import { SvelteMap, SvelteSet } from 'svelte/reactivity'
@@ -684,7 +685,9 @@
     ArrowUp: [0, -1],
   }
   function handle_keydown(event: KeyboardEvent): void {
-    if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === `e`) {
+    // `e` downloads a file, so typing must never reach it. Chords stay the browser's.
+    if (is_editable_event_target(event.target)) return
+    if (event.key.toLowerCase() === `e` && !is_modifier_chord(event)) {
       const format = export_formats[0]
       if (format && on_export) on_export(format, build_export_payload(format))
       return

--- a/src/lib/layout/FullscreenButton.svelte
+++ b/src/lib/layout/FullscreenButton.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import type { ComponentProps } from 'svelte'
   import { FullscreenButton } from 'svelte-widgets'
+  import { forward_window_keydown } from 'svelte-widgets/attachments'
+  import { is_editable_event_target, is_modifier_chord } from 'svelte-widgets/utils'
 
   // svelte-widgets' button flips the bound flag on click and reports only browser-initiated
   // transitions (Esc, F11) through `on_change`. Viewers forward every real transition to
@@ -12,6 +14,9 @@
     on_change,
     ...rest
   }: ComponentProps<typeof FullscreenButton> = $props()
+
+  // marks a wrapper as a fullscreen root so nested viewers can spot an outer owner
+  const VIEWER_ATTR = `data-mv-fullscreen-root`
 
   let reported = fullscreen
   const report = (next: boolean) => {
@@ -28,6 +33,31 @@
     const handle_change = () => report(document.fullscreenElement === wrapper)
     document.addEventListener(`fullscreenchange`, handle_change)
     return () => document.removeEventListener(`fullscreenchange`, handle_change)
+  })
+
+  // Plain `f` fullscreens the viewer under the pointer. Every viewer renders one of these
+  // buttons for its own root, so owning the key here keeps one binding across all of them,
+  // and hosts that pass fullscreen_toggle={false} never render us and so never get the key.
+  // Chords stay with the browser (Cmd/Ctrl+F is find-in-page) and typing is left alone.
+  $effect(() => {
+    const root = wrapper
+    if (!root) return
+    root.setAttribute(VIEWER_ATTR, ``)
+    const handle = (event: KeyboardEvent) => {
+      if (event.key !== `f` || event.repeat || is_modifier_chord(event)) return false
+      if (is_editable_event_target(event.target)) return false
+      // Nested viewers (a Structure inside a Trajectory) leave the key to the outer one:
+      // both are hovered at once and would each fullscreen their own root on one press.
+      // Only the keyboard defers — the nested viewer's own button still works.
+      if (root.parentElement?.closest(`[${VIEWER_ATTR}]`)) return false
+      fullscreen = !fullscreen
+      return true
+    }
+    const detach = forward_window_keydown({ handle })(root)
+    return () => {
+      root.removeAttribute(VIEWER_ATTR)
+      detach?.()
+    }
   })
 </script>
 

--- a/src/lib/layout/PaneDivider.svelte
+++ b/src/lib/layout/PaneDivider.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { clamp } from '$lib/math'
+  import { is_modifier_chord } from 'svelte-widgets/utils'
 
   type Orientation = `horizontal` | `vertical`
   const min_ratio = 0.15
@@ -149,6 +150,7 @@
     const [decrease_key, increase_key] =
       orientation === `horizontal` ? horizontal_keys : [`ArrowUp`, `ArrowDown`]
     if (event.key !== decrease_key && event.key !== increase_key) return
+    if (is_modifier_chord(event)) return // Cmd/Ctrl+Arrow scrolls the page
     event.preventDefault()
     const direction = event.key === decrease_key ? -1 : 1
     if (px_mode) {

--- a/src/lib/layout/json-tree/JsonTree.svelte
+++ b/src/lib/layout/json-tree/JsonTree.svelte
@@ -11,6 +11,7 @@
     Search,
   } from 'svelte-widgets/icons'
   import { download } from '$lib/io/fetch'
+  import { is_modifier_chord } from 'svelte-widgets/utils'
   import { make_change_detector } from '$lib/utils'
   import { tick } from 'svelte'
   import { highlight_matches, tooltip } from 'svelte-widgets/attachments'
@@ -384,7 +385,7 @@
     }
     // Any arrow key focuses the first node (index -1 clamps to 0); afterwards Up/Down step
     // (clamped) and Left/Right are left to the focused node's own fold/unfold handler
-    if (!ARROW_KEYS.has(event.key)) return
+    if (!ARROW_KEYS.has(event.key) || is_modifier_chord(event)) return
     const paths = rendered_paths()
     const current_index = focused_path === null ? -1 : paths.indexOf(focused_path)
     const step = event.key === `ArrowDown` ? 1 : event.key === `ArrowUp` ? -1 : 0

--- a/src/lib/periodic-table/PeriodicTable.svelte
+++ b/src/lib/periodic-table/PeriodicTable.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { D3InterpolateName } from '$lib/colors'
+  import { is_modifier_chord } from 'svelte-widgets/utils'
   import {
     is_color,
     is_dark_mode,
@@ -210,7 +211,8 @@
     on_table_keydown?.(event)
     if (disabled || event.defaultPrevented) return
     const arrow_keys = [`ArrowUp`, `ArrowDown`, `ArrowLeft`, `ArrowRight`]
-    if (!arrow_keys.includes(event.key)) return
+    // Cmd/Ctrl+Arrow scrolls the page; only bare arrows walk tiles
+    if (!arrow_keys.includes(event.key) || is_modifier_chord(event)) return
 
     const event_target = event.target
     const tile =

--- a/src/lib/phase-diagram/IsobaricBinaryPhaseDiagram.svelte
+++ b/src/lib/phase-diagram/IsobaricBinaryPhaseDiagram.svelte
@@ -10,7 +10,7 @@
   import { array_extent, compute_bounding_box_2d, polygon_centroid } from '$lib/math'
   import { type AxisConfig, PlotTooltip } from '$lib/plot'
   import { unique_id } from '$lib/plot/core/utils'
-  import { to_error } from '$lib/utils'
+  import { handle_and_prevent, to_error } from '$lib/utils'
   import { forward_window_keydown } from 'svelte-widgets/attachments'
   import { is_editable_event_target, is_modifier_chord } from 'svelte-widgets/utils'
   import { scaleLinear } from 'd3-scale'
@@ -386,9 +386,13 @@
     clear_hover()
   }
 
-  // Plain letters like every other viewer, scoped to this one by the hover/focus forwarder
-  // below rather than the whole document, which is what forced a chord here before.
+  // Plain letters like every other viewer, scoped to this one rather than the whole
+  // document, which is what forced a chord here before. Bound twice: on the root for keys
+  // from a focused descendant (clicking a region focuses the SVG, and the window forwarder
+  // ignores those), and on the window for the hover-without-focus case. The root fires
+  // first and prevents the default, so the forwarder's pass is a no-op.
   function handle_keydown(event: KeyboardEvent): boolean {
+    if (event.defaultPrevented) return false
     if (is_editable_event_target(event.target) || is_modifier_chord(event)) return false
     if (event.key === `e` && !event.repeat) {
       export_pane_open = !export_pane_open
@@ -446,6 +450,7 @@
   {...rest}
   class={[`binary-phase-diagram`, rest.class, { fullscreen }]}
   bind:this={wrapper}
+  onkeydown={handle_and_prevent(handle_keydown)}
   {@attach forward_window_keydown({ handle: handle_keydown })}
   bind:clientWidth={width}
   bind:clientHeight={height}

--- a/src/lib/phase-diagram/IsobaricBinaryPhaseDiagram.svelte
+++ b/src/lib/phase-diagram/IsobaricBinaryPhaseDiagram.svelte
@@ -11,6 +11,8 @@
   import { type AxisConfig, PlotTooltip } from '$lib/plot'
   import { unique_id } from '$lib/plot/core/utils'
   import { to_error } from '$lib/utils'
+  import { forward_window_keydown } from 'svelte-widgets/attachments'
+  import { is_editable_event_target, is_modifier_chord } from 'svelte-widgets/utils'
   import { scaleLinear } from 'd3-scale'
   import { type Snippet, untrack } from 'svelte'
   import type { HTMLAttributes } from 'svelte/elements'
@@ -384,13 +386,19 @@
     clear_hover()
   }
 
-  function handle_doc_keydown(event: KeyboardEvent) {
-    if ((event.ctrlKey || event.metaKey) && event.shiftKey && event.key === `E`) {
-      event.preventDefault()
+  // Plain letters like every other viewer, scoped to this one by the hover/focus forwarder
+  // below rather than the whole document, which is what forced a chord here before.
+  function handle_keydown(event: KeyboardEvent): boolean {
+    if (is_editable_event_target(event.target) || is_modifier_chord(event)) return false
+    if (event.key === `e`) {
       export_pane_open = !export_pane_open
-    } else if (event.key === `Escape` && locked_hover_info) {
-      locked_hover_info = null
+      return true
     }
+    if (event.key === `Escape` && locked_hover_info) {
+      locked_hover_info = null
+      return true
+    }
+    return false
   }
 
   function handle_svg_keydown(event: KeyboardEvent) {
@@ -434,12 +442,11 @@
   {/each}
 {/snippet}
 
-<svelte:document onkeydown={handle_doc_keydown} />
-
 <div
   {...rest}
   class={[`binary-phase-diagram`, rest.class, { fullscreen }]}
   bind:this={wrapper}
+  {@attach forward_window_keydown({ handle: handle_keydown })}
   bind:clientWidth={width}
   bind:clientHeight={height}
   role="img"

--- a/src/lib/phase-diagram/IsobaricBinaryPhaseDiagram.svelte
+++ b/src/lib/phase-diagram/IsobaricBinaryPhaseDiagram.svelte
@@ -390,7 +390,7 @@
   // below rather than the whole document, which is what forced a chord here before.
   function handle_keydown(event: KeyboardEvent): boolean {
     if (is_editable_event_target(event.target) || is_modifier_chord(event)) return false
-    if (event.key === `e`) {
+    if (event.key === `e` && !event.repeat) {
       export_pane_open = !export_pane_open
       return true
     }

--- a/src/lib/phase-diagram/ternary/IsobaricTernaryPhaseDiagram.svelte
+++ b/src/lib/phase-diagram/ternary/IsobaricTernaryPhaseDiagram.svelte
@@ -21,6 +21,7 @@
   import { sanitize_html } from '$lib/sanitize'
   import { create_renderer, webgpu_available } from '$lib/scene'
   import { to_error } from '$lib/utils'
+  import { is_modifier_chord } from 'svelte-widgets/utils'
   import { Canvas } from '@threlte/core'
   import type { Snippet } from 'svelte'
   import { onMount, untrack } from 'svelte'
@@ -282,6 +283,8 @@
   function handle_keydown(event: KeyboardEvent): void {
     // Focused controls keep their own keys (space activates a button, arrows move a slider)
     if ((event.target as Element).closest(`button, input, textarea, select`)) return
+    // Shift+arrow jumps between transitions; Cmd/Ctrl/Alt chords stay the browser's
+    if (is_modifier_chord(event)) return
     const dir = { ArrowRight: 1, ArrowLeft: -1 }[event.key]
     if (dir) {
       const target = dir > 0 ? next_event : prev_event

--- a/src/lib/phase-diagram/ternary/IsobaricTernaryPhaseDiagram.svelte
+++ b/src/lib/phase-diagram/ternary/IsobaricTernaryPhaseDiagram.svelte
@@ -288,7 +288,8 @@
       if (!event.shiftKey) set_temperature(current_t + dir * (t_max - t_min) * 0.01)
       else if (target) set_temperature(target.temperature + dir)
     } else if (event.key === ` `) toggle_play()
-    else if (event.key === `Escape`) selected_phase = null
+    // only claim Escape when there is a selection to clear, else the host keeps the key
+    else if (event.key === `Escape` && selected_phase !== null) selected_phase = null
     else return
     event.preventDefault()
   }

--- a/src/lib/phase-diagram/ternary/PhaseStabilityMap.svelte
+++ b/src/lib/phase-diagram/ternary/PhaseStabilityMap.svelte
@@ -6,6 +6,7 @@
   import { add_alpha, get_d3_interpolator } from '$lib/colors'
   import { get_formula_label_segments } from '$lib/composition/format'
   import { clamp } from '$lib/math'
+  import { is_modifier_chord } from 'svelte-widgets/utils'
   import { clamp01 } from '$lib/utils'
   import { ticks as d3_ticks } from 'd3-array'
   import type { HTMLAttributes } from 'svelte/elements'
@@ -313,7 +314,7 @@
     onkeydown={(event) => {
       // Plain arrows step here; shift+arrows bubble to a host that jumps between transitions
       const dir = { ArrowRight: 1, ArrowLeft: -1, ArrowUp: 1, ArrowDown: -1 }[event.key]
-      if (!dir || event.shiftKey) return
+      if (!dir || event.shiftKey || is_modifier_chord(event)) return
       temperature = Math.min(
         t_max,
         Math.max(t_min, temperature + (dir * (t_max - t_min)) / 100),

--- a/src/lib/plot/core/components/PortalSelect.svelte
+++ b/src/lib/plot/core/components/PortalSelect.svelte
@@ -5,6 +5,7 @@
 
 <script lang="ts">
   import { sanitize_html } from '$lib/sanitize'
+  import { is_modifier_chord } from 'svelte-widgets/utils'
   import { click_outside, float, portal } from 'svelte-widgets/attachments'
   import type { HTMLButtonAttributes } from 'svelte/elements'
 
@@ -62,7 +63,8 @@
   // Arrow/Enter stay on window (focus may be on the trigger, outside the portalled list).
   // Escape is handled by click_outside({ escape: true }) below — not duplicated here.
   function handle_keydown(evt: KeyboardEvent) {
-    if (!dropdown_el) return
+    // Cmd/Ctrl+Arrow scrolls the page; the list only answers bare keys
+    if (!dropdown_el || is_modifier_chord(evt)) return
     const buttons = [...dropdown_el.querySelectorAll(`button`)]
     const idx = buttons.indexOf(document.activeElement as HTMLButtonElement)
     const len = buttons.length

--- a/src/lib/plot/core/utils/hierarchy-state.svelte.ts
+++ b/src/lib/plot/core/utils/hierarchy-state.svelte.ts
@@ -7,6 +7,7 @@
 
 import type { D3InterpolateName } from '$lib/colors'
 import type { Vec2 } from '$lib/math'
+import { is_modifier_chord } from 'svelte-widgets/utils'
 import type ColorBar from '$lib/plot/core/components/ColorBar.svelte'
 import { closest_data_idx, is_activation_key, pointer_pos } from '$lib/plot/core/interactions'
 import type { Sides } from '$lib/plot/core/layout'
@@ -377,6 +378,7 @@ export class HierarchyChartState<
   // lives in hierarchy-chart.ts (arrow_nav_target); this supplies the event's
   // node and the chart's current screen-space visibility.
   handle_keydown = (event: KeyboardEvent): void => {
+    if (is_modifier_chord(event)) return // Cmd/Ctrl+Arrow scrolls the page
     const current_idx = this.#node_idx_from_event(event)
     const navigation_target =
       current_idx == null

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -668,23 +668,16 @@
       session.reset_all_cameras()
       return true
     }
-    // Interface shortcuts need Ctrl/Cmd so typing cannot trigger them
-    if (event.key === `f` && has_modifier && fullscreen_toggle) {
-      fullscreen = !fullscreen
-      return true
-    }
-    if (
-      event.key === `i` &&
-      has_modifier &&
-      display_mode === `structure` &&
-      enable_info_pane
-    ) {
+    // View toggles are plain letters everywhere; typing is already excluded by the editable
+    // guard above. `f` is owned by FullscreenButton, which arbitrates it between nested
+    // viewers. Chords stay the browser's and the host's.
+    if (key === `i` && plain && display_mode === `structure` && enable_info_pane) {
       set_pane_open(`info`, !is_pane_open(`info`))
       return true
     }
     if (
-      event.key === `g` &&
-      has_modifier &&
+      key === `g` &&
+      plain &&
       display_mode === `structure` &&
       controls_config.visible(`multi-view`) &&
       (multi_view_available || multi_view)
@@ -775,8 +768,8 @@
               <button
                 type="button"
                 class={['view-mode-option', { selected: current_layout.mode === mode }]}
-                title={mode === `multi` ? `${label} (Cmd/Ctrl+G)` : label}
-                aria-keyshortcuts={mode === `multi` ? `Control+G Meta+G` : undefined}
+                title={mode === `multi` ? `${label} (G)` : label}
+                aria-keyshortcuts={mode === `multi` ? `G` : undefined}
                 aria-pressed={current_layout.mode === mode}
                 onclick={() => select_structure_layout(mode)}
               >

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -617,6 +617,8 @@
     const key = event.key.toLowerCase()
     const has_modifier = event.ctrlKey || event.metaKey
     const plain = !has_modifier && !event.altKey
+    // autorepeat must not flip a toggle over and over while a key is held down
+    const plain_press = plain && !event.repeat
     const is_undo = has_modifier && key === `z` && !event.shiftKey
     const is_redo = has_modifier && (key === `y` || (key === `z` && event.shiftKey))
     const editing_bonds = measure_mode === `edit-bonds`
@@ -641,11 +643,11 @@
     }
     if (editing_atoms) {
       if (event.key === `Delete` || event.key === `Backspace`) return session.delete_selected()
-      if (key === `a` && plain) {
+      if (key === `a` && plain_press) {
         session.add_atom_mode = !session.add_atom_mode
         return true
       }
-      if (key === `e` && plain && selected_sites.length > 0) {
+      if (key === `e` && plain_press && selected_sites.length > 0) {
         session.change_element_mode = !session.change_element_mode
         return true
       }
@@ -671,13 +673,13 @@
     // View toggles are plain letters everywhere; typing is already excluded by the editable
     // guard above. `f` is owned by FullscreenButton, which arbitrates it between nested
     // viewers. Chords stay the browser's and the host's.
-    if (key === `i` && plain && display_mode === `structure` && enable_info_pane) {
+    if (key === `i` && plain_press && display_mode === `structure` && enable_info_pane) {
       set_pane_open(`info`, !is_pane_open(`info`))
       return true
     }
     if (
       key === `g` &&
-      plain &&
+      plain_press &&
       display_mode === `structure` &&
       controls_config.visible(`multi-view`) &&
       (multi_view_available || multi_view)

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -607,6 +607,10 @@
   // === keyboard ===
   // Returns true when the key was handled so the caller can suppress the browser default
   function handle_keydown(event: KeyboardEvent): boolean {
+    // Bound on the root and on the window: a click leaves the viewer focused *and*
+    // hovered, so both would run and a toggle would cancel itself out. The root fires
+    // first and prevents the default, which makes the window pass a no-op.
+    if (event.defaultPrevented) return false
     const is_input_focused = is_editable_event_target(event.target)
     // Escape leaves add-atom mode even from its element input
     if (event.key === `Escape` && measure_mode === `edit-atoms` && session.add_atom_mode) {

--- a/src/lib/structure/StructureCarousel.svelte
+++ b/src/lib/structure/StructureCarousel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { clamp } from '$lib/math'
+  import { is_modifier_chord } from 'svelte-widgets/utils'
   import type { StructureCarouselItem } from '$lib/structure'
   import GlassChip from '$lib/overlays/GlassChip.svelte'
   import { portal } from 'svelte-widgets/attachments'
@@ -301,7 +302,7 @@
   // (e.g. the info pane's site table) and must not be hijacked. Boundary no-ops
   // fall through to the page, matching the wheel handler.
   const on_track_keydown = (event: KeyboardEvent): void => {
-    if (!track || event.target !== track) return
+    if (!track || event.target !== track || is_modifier_chord(event)) return
     const [back_key, fwd_key] = is_horizontal
       ? [`ArrowLeft`, `ArrowRight`]
       : [`ArrowUp`, `ArrowDown`]

--- a/src/lib/structure/StructureCarousel.svelte
+++ b/src/lib/structure/StructureCarousel.svelte
@@ -360,6 +360,7 @@
       ? [`ArrowDown`, `ArrowUp`]
       : [`ArrowRight`, `ArrowLeft`]
     if (event.key !== grow && event.key !== shrink) return
+    if (is_modifier_chord(event)) return // Cmd/Ctrl+Arrow scrolls the page
     event.preventDefault()
     const step = event.key === grow ? keyboard_resize_step_px : -keyboard_resize_step_px
     if (is_horizontal) set_resized_size(`height`, effective_height + step)

--- a/src/lib/structure/StructureInfoPane.svelte
+++ b/src/lib/structure/StructureInfoPane.svelte
@@ -99,7 +99,7 @@
     } else if (event.key === `c` && plain_key) {
       event.preventDefault()
       copy(`${card.title}: ${site_summary(card)}`, `site-${card.idx}-summary`)
-    } else if ([`ArrowDown`, `ArrowUp`].includes(event.key)) {
+    } else if (plain_key && [`ArrowDown`, `ArrowUp`].includes(event.key)) {
       event.preventDefault()
       const current_card = event.currentTarget
       if (!(current_card instanceof HTMLElement)) return

--- a/src/lib/structure/StructureInfoPane.svelte
+++ b/src/lib/structure/StructureInfoPane.svelte
@@ -34,7 +34,7 @@
     ],
     [
       `Keyboard`,
-      `Press Ctrl/Cmd+f for fullscreen, Ctrl/Cmd+i to toggle this pane, r to reset the view`,
+      `Press f for fullscreen, i to toggle this pane, g for multi-view, r to reset the view`,
     ],
   ] as const
 

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -577,14 +577,12 @@
     if (player.handle_keydown(event)) return true
     const key = event.key.length === 1 ? event.key.toLowerCase() : event.key
     if (event.metaKey || event.ctrlKey) return false
-    if (key === `f` && fullscreen_toggle) {
-      if (!event.repeat) fullscreen = !fullscreen
-      return true
-    }
-    // 'i' is handled by the TrajectoryInfoPane's own toggle, Escape on panes by ViewerPane
+    // `f` is owned by FullscreenButton; panes dismiss themselves via ViewerPane. Escape
+    // leaves fullscreen to the browser, which exits on its own and lets the flag follow
+    // fullscreenchange — exiting here would steal it from a host that owns it (a slide
+    // deck embedding the viewer) and swallow the key.
     if (key !== `Escape`) return false
-    if (document.fullscreenElement) document.exitFullscreen()
-    else if (view_mode_dropdown_open) view_mode_dropdown_open = false
+    if (view_mode_dropdown_open) view_mode_dropdown_open = false
     else if (analysis_menu_open) analysis_menu_open = false
     else return false
     return true

--- a/src/lib/trajectory/Trajectory.svelte
+++ b/src/lib/trajectory/Trajectory.svelte
@@ -564,6 +564,10 @@
   // === keyboard ===
   // Returns true if the key was handled, so the caller can suppress the browser default
   function onkeydown(event: KeyboardEvent): boolean {
+    // Bound on the root and on the window: a click leaves the viewer focused *and*
+    // hovered, so both would run and a toggle would cancel itself out. The root fires
+    // first and prevents the default, which makes the window pass a no-op.
+    if (event.defaultPrevented) return false
     // Leave form fields alone; sequence controls handle their own navigation keys and let
     // the viewer shortcuts they do not use bubble here
     const target = event.target instanceof HTMLElement ? event.target : null

--- a/tests/playwright/phase-diagram/isobaric-binary.test.ts
+++ b/tests/playwright/phase-diagram/isobaric-binary.test.ts
@@ -385,20 +385,22 @@ test.describe(`IsobaricBinaryPhaseDiagram`, () => {
     await expect(tooltip).not.toHaveClass(/locked/)
   })
 
-  for (const modifier of [`Control`, `Meta`]) {
-    test(`${modifier}+Shift+E toggles export pane`, async ({ page }) => {
-      const { diagram } = get_diagram_elements(page)
-      const pane = diagram.locator(`.export-pane`)
+  test(`e toggles the export pane, its chords stay the browser's`, async ({ page }) => {
+    const { diagram } = get_diagram_elements(page)
+    const pane = diagram.locator(`.export-pane`)
+    await expect(pane).toBeHidden()
+    await diagram.hover() // the shortcut follows the pointer
 
-      await expect(pane).toBeHidden()
+    for (const chord of [`Control+Shift+E`, `Meta+Shift+E`, `Control+E`, `Meta+E`]) {
+      await page.keyboard.press(chord)
+      await expect(pane, chord).toBeHidden()
+    }
 
-      await page.keyboard.press(`${modifier}+Shift+E`)
-      await expect(pane).toBeVisible()
-
-      await page.keyboard.press(`${modifier}+Shift+E`)
-      await expect(pane).toBeHidden()
-    })
-  }
+    await page.keyboard.press(`e`)
+    await expect(pane).toBeVisible()
+    await page.keyboard.press(`e`)
+    await expect(pane).toBeHidden()
+  })
 
   test(`special points have labels and correct styling`, async ({ page }) => {
     const { svg } = get_diagram_elements(page)

--- a/tests/playwright/structure/structure.test.ts
+++ b/tests/playwright/structure/structure.test.ts
@@ -289,19 +289,21 @@ test.describe(`Structure Component Tests`, () => {
     )
   })
 
-  test(`keyboard shortcuts require modifier keys`, async ({ page }) => {
+  test(`claims plain-letter view toggles and leaves their chords to the browser`, async ({
+    page,
+  }) => {
     const structure_div = page.locator(`#test-structure`)
     await structure_div.click()
+    // a handled key is the one the viewer preventDefaults
+    const handles = (init: Parameters<typeof dispatch_cancelable_keydown>[1]) =>
+      dispatch_cancelable_keydown(structure_div, init).then((not_prevented) => !not_prevented)
 
-    // single keys don't trigger actions: not fullscreen after 'f'
-    await page.keyboard.press(`f`)
-    await page.keyboard.press(`i`)
-    expect(await page.evaluate(() => Boolean(document.fullscreenElement))).toBe(false)
-
-    for (const key of [`f`, `i`]) {
-      await expect(
-        dispatch_cancelable_keydown(structure_div, { key, [primary_modifier]: true }),
-      ).resolves.toBe(false)
+    // view toggles are plain letters; the same key as a chord is left to browser and host
+    for (const key of [`f`, `i`, `g`]) {
+      await expect(handles({ key }), `plain ${key}`).resolves.toBe(true)
+      await expect(handles({ key, [primary_modifier]: true }), `mod+${key}`).resolves.toBe(
+        false,
+      )
     }
 
     // The renderer remains mounted after the keyboard interactions. Do not assert on unrelated
@@ -1217,18 +1219,21 @@ test.describe(`Multi-side view (2x2 grid)`, () => {
     await expect(cell_select.locator(`.dropdown`)).toBeVisible()
   })
 
-  test(`Cmd/Ctrl+G toggles between grid and single view`, async ({ page }) => {
+  test(`g toggles between grid and single view`, async ({ page }) => {
     const structure_div = page.locator(`#test-structure`)
     const cells = structure_div.locator(`.viewport-cell`)
     await structure_div.focus() // viewer must be focused to receive the shortcut
     await expect(cells).toHaveCount(1)
 
-    const grid_shortcut = `${primary_modifier_key}+g`
-    await page.keyboard.press(grid_shortcut)
+    // the chord is the browser's; only the plain letter is ours
+    await page.keyboard.press(`${primary_modifier_key}+g`)
+    await expect(structure_div).not.toHaveClass(/multi-view/)
+
+    await page.keyboard.press(`g`)
     await expect(structure_div).toHaveClass(/multi-view/)
     await expect(cells).toHaveCount(4)
 
-    await page.keyboard.press(grid_shortcut)
+    await page.keyboard.press(`g`)
     await expect(structure_div).not.toHaveClass(/multi-view/)
     await expect(cells).toHaveCount(1)
   })

--- a/tests/playwright/structure/structure.test.ts
+++ b/tests/playwright/structure/structure.test.ts
@@ -308,7 +308,8 @@ test.describe(`Structure Component Tests`, () => {
 
     // The renderer remains mounted after the keyboard interactions. Do not assert on unrelated
     // page errors here: CI's SwiftShader adapter can report transient GPU allocation failures.
-    await expect(structure_div.locator(`canvas`)).toBeVisible()
+    // `g` left the viewer in the 2x2 grid, so there are four canvases by now.
+    await expect(structure_div.locator(`canvas`).first()).toBeVisible()
   })
 
   test(`dragging the canvas orbits the camera`, async ({ page }) => {
@@ -1217,6 +1218,15 @@ test.describe(`Multi-side view (2x2 grid)`, () => {
     expect(await receives_pointer_at_center(element_badge)).toBe(true)
     await cell_toggle.click()
     await expect(cell_select.locator(`.dropdown`)).toBeVisible()
+  })
+
+  // A real click leaves the viewer focused *and* hovered, so the root handler and the
+  // window forwarder both see the key. Clicking first would double-toggle without a guard.
+  test(`g toggles once from a clicked viewer`, async ({ page }) => {
+    const structure_div = page.locator(`#test-structure`)
+    await structure_div.click()
+    await page.keyboard.press(`g`)
+    await expect(structure_div).toHaveClass(/multi-view/)
   })
 
   test(`g toggles between grid and single view`, async ({ page }) => {

--- a/tests/vitest/brillouin/BrillouinZone.test.svelte.ts
+++ b/tests/vitest/brillouin/BrillouinZone.test.svelte.ts
@@ -5,7 +5,13 @@ import { reciprocal_lattice } from '$lib/math'
 import type * as symmetry from '$lib/symmetry'
 import { type ComponentProps, createRawSnippet, flushSync, mount, tick, unmount } from 'svelte'
 import { afterEach, expect, test, vi } from 'vitest'
-import { create_drop_event, cubic_matrix, make_crystal, type SimpleSite } from '../setup'
+import {
+  create_drop_event,
+  cubic_matrix,
+  doc_query,
+  make_crystal,
+  type SimpleSite,
+} from '../setup'
 
 // The IBZ needs moyo's point group; stand in for the WASM analysis so a test can make it fail
 const analyze_structure_symmetry = vi.hoisted(() => vi.fn())
@@ -363,4 +369,17 @@ test(`an IBZ failure keeps the zone rendered and clears once show_ibz is off`, a
 
   props.show_ibz = false
   await vi.waitFor(() => expect(viewer?.querySelector(`.status-message`)).toBeNull())
+})
+
+// Wiring check that a real viewer picks up the shared shortcut; the full key contract
+// (chords, repeats, nesting) is covered in layout/FullscreenButton.test
+test(`hovering the zone and pressing f fullscreens it`, async () => {
+  const props = $state({ structure: cubic, fullscreen: false })
+  mounted_component = mount(BrillouinZone, { target: document.body, props })
+  await tick()
+  const zone = doc_query(`.brillouin-zone`)
+  zone.dispatchEvent(new PointerEvent(`pointerenter`))
+  globalThis.dispatchEvent(new KeyboardEvent(`keydown`, { key: `f` }))
+  await tick()
+  expect(props.fullscreen).toBe(true)
 })

--- a/tests/vitest/convex-hull/ConvexHullSelection.test.ts
+++ b/tests/vitest/convex-hull/ConvexHullSelection.test.ts
@@ -491,6 +491,27 @@ describe(`convex hull replacement state`, () => {
     await let_frames_run()
     expect(clears.base).toBeGreaterThan(before)
   })
+
+  // Enter selects the hovered entry, but the chord belongs to the browser (Cmd+Enter is
+  // open-in-new-tab). The chord guard has to run before the Enter branch, not after it.
+  test.each([
+    [`Enter selects the hovered entry`, {}, `old-compound`],
+    [`Cmd+Enter is left to the browser`, { metaKey: true }, `none`],
+    [`Ctrl+Enter is left to the browser`, { ctrlKey: true }, `none`],
+  ])(`%s`, async (_name, modifiers, expected) => {
+    await mount_harness({ dim: `3d` })
+    const canvas = doc_query<HTMLCanvasElement>(`canvas`)
+    canvas.dispatchEvent(
+      new MouseEvent(`mousemove`, { bubbles: true, clientX: 100, clientY: 100 }),
+    )
+    flushSync()
+
+    canvas.dispatchEvent(
+      new KeyboardEvent(`keydown`, { key: `Enter`, bubbles: true, ...modifiers }),
+    )
+    await tick()
+    expect(doc_query(`[data-testid="selected-entry"]`).textContent).toBe(expected)
+  })
 })
 
 // End-to-end: magnetic_ordering -> pipeline marker assignment -> 2D SVG symbol rendering,

--- a/tests/vitest/heatmap-matrix/HeatmapMatrix.test.ts
+++ b/tests/vitest/heatmap-matrix/HeatmapMatrix.test.ts
@@ -1003,3 +1003,22 @@ describe(`virtualized keyboard navigation`, () => {
     expect(Number(focused?.dataset?.[fixed_axis])).toBe(fixed)
   })
 })
+
+// `e` downloads a file, so it must reach neither a chord nor a typed character
+test.each([
+  [`plain e exports`, { key: `e` }, undefined, 1],
+  [`Cmd+E is the browser's`, { key: `e`, metaKey: true }, undefined, 0],
+  [`Ctrl+E is the browser's`, { key: `e`, ctrlKey: true }, undefined, 0],
+  [`typing e in an input never exports`, { key: `e` }, `input`, 0],
+])(`%s`, async (_name, init, target_tag, calls) => {
+  const on_export = vi.fn()
+  mount_matrix({ on_export, export_formats: [`csv`] })
+  await tick()
+  const grid = doc_query(`.grid`)
+  const input = document.createElement(`input`)
+  if (target_tag) grid.append(input)
+  const target = target_tag ? input : grid
+  target.dispatchEvent(new KeyboardEvent(`keydown`, { ...init, bubbles: true }))
+  await tick()
+  expect(on_export).toHaveBeenCalledTimes(calls)
+})

--- a/tests/vitest/heatmap-matrix/HeatmapMatrix.test.ts
+++ b/tests/vitest/heatmap-matrix/HeatmapMatrix.test.ts
@@ -1022,3 +1022,24 @@ test.each([
   await tick()
   expect(on_export).toHaveBeenCalledTimes(calls)
 })
+
+// Cmd/Ctrl+Arrow is the browser's (scroll to end); only bare arrows walk cells
+test.each([
+  [`bare ArrowRight walks a cell`, {}, true],
+  [`Cmd+ArrowRight is the browser's`, { metaKey: true }, false],
+  [`Ctrl+ArrowRight is the browser's`, { ctrlKey: true }, false],
+])(`%s`, async (_name, modifiers, expect_handled) => {
+  mount_matrix()
+  await tick()
+  const cell = doc_query(`.grid [data-x="0"][data-y="0"]`)
+  cell.focus()
+  const event = new KeyboardEvent(`keydown`, {
+    key: `ArrowRight`,
+    bubbles: true,
+    cancelable: true,
+  })
+  Object.assign(event, modifiers)
+  doc_query(`.grid`).dispatchEvent(event)
+  await tick()
+  expect(event.defaultPrevented).toBe(expect_handled)
+})

--- a/tests/vitest/heatmap-matrix/HeatmapMatrix.test.ts
+++ b/tests/vitest/heatmap-matrix/HeatmapMatrix.test.ts
@@ -1010,6 +1010,7 @@ test.each([
   [`Cmd+E is the browser's`, { key: `e`, metaKey: true }, undefined, 0],
   [`Ctrl+E is the browser's`, { key: `e`, ctrlKey: true }, undefined, 0],
   [`typing e in an input never exports`, { key: `e` }, `input`, 0],
+  [`a held e does not re-download`, { key: `e`, repeat: true }, undefined, 0],
 ])(`%s`, async (_name, init, target_tag, calls) => {
   const on_export = vi.fn()
   mount_matrix({ on_export, export_formats: [`csv`] })

--- a/tests/vitest/layout/FullscreenButton.test.svelte.ts
+++ b/tests/vitest/layout/FullscreenButton.test.svelte.ts
@@ -1,24 +1,36 @@
 import FullscreenButton from '$lib/layout/FullscreenButton.svelte'
-import { flushSync, mount, tick } from 'svelte'
-import { describe, expect, test, vi } from 'vitest'
+import { flushSync, mount, tick, unmount } from 'svelte'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+// Buttons keep a window keydown listener for the `f` shortcut, so one left mounted would
+// answer a later test's keypress and fullscreen its own stale wrapper
+const mounted: ReturnType<typeof mount>[] = []
+afterEach(async () => {
+  for (const component of mounted.splice(0)) await unmount(component)
+  document.body.replaceChildren()
+  Object.defineProperty(document, `fullscreenElement`, { configurable: true, value: null })
+  vi.restoreAllMocks()
+})
 
 // Mount with a two-way bound `fullscreen` flag like every viewer does
 const mount_button = (wrapper?: HTMLElement) => {
   const state = $state({ fullscreen: false })
   const on_change = vi.fn<(fullscreen: boolean) => void>()
-  mount(FullscreenButton, {
-    target: document.body,
-    props: {
-      wrapper,
-      on_change,
-      get fullscreen() {
-        return state.fullscreen
+  mounted.push(
+    mount(FullscreenButton, {
+      target: document.body,
+      props: {
+        wrapper,
+        on_change,
+        get fullscreen() {
+          return state.fullscreen
+        },
+        set fullscreen(next: boolean) {
+          state.fullscreen = next
+        },
       },
-      set fullscreen(next: boolean) {
-        state.fullscreen = next
-      },
-    },
-  })
+    }),
+  )
   flushSync()
   const button = document.querySelector(`button.fullscreen-btn`)
   if (!(button instanceof HTMLButtonElement)) throw new Error(`fullscreen button missing`)
@@ -72,5 +84,67 @@ describe(`FullscreenButton`, () => {
     await tick()
     expect(state.fullscreen).toBe(false)
     expect(on_change.mock.calls).toEqual([[true], [false]])
+  })
+
+  // a host app (e.g. a slide deck) owning fullscreen around an embedded viewer
+  test(`fullscreen owned by another element is neither reported nor taken over`, async () => {
+    const host = document.createElement(`div`)
+    const wrapper = document.createElement(`div`)
+    host.append(wrapper)
+    document.body.append(host)
+    const exit_fullscreen = vi.spyOn(document, `exitFullscreen`)
+    const { state, on_change } = mount_button(wrapper)
+
+    // mounting inside an already-fullscreen host leaves it alone
+    await host.requestFullscreen()
+    await tick()
+    expect(document.fullscreenElement).toBe(host)
+    expect(state.fullscreen).toBe(false)
+    expect(on_change).not.toHaveBeenCalled()
+    expect(exit_fullscreen).not.toHaveBeenCalled()
+  })
+
+  // `f` is the one fullscreen shortcut across every viewer, claimed only while the pointer
+  // is over that viewer. Chords stay with the browser, notably Cmd/Ctrl+F for find-in-page.
+  test.each([
+    [`plain f toggles`, { key: `f` }, true],
+    [`Cmd+F stays find-in-page`, { key: `f`, metaKey: true }, false],
+    [`Ctrl+F stays find-in-page`, { key: `f`, ctrlKey: true }, false],
+    [`Alt+F is left alone`, { key: `f`, altKey: true }, false],
+    [`an autorepeat does not re-toggle`, { key: `f`, repeat: true }, false],
+    [`other keys are ignored`, { key: `g` }, false],
+  ])(`%s`, async (_name, init, toggles) => {
+    const wrapper = document.createElement(`div`)
+    document.body.append(wrapper)
+    const { state } = mount_button(wrapper)
+    wrapper.dispatchEvent(new PointerEvent(`pointerenter`))
+    globalThis.dispatchEvent(new KeyboardEvent(`keydown`, init))
+    await tick()
+    expect(state.fullscreen).toBe(toggles)
+  })
+
+  test(`f is ignored until the pointer is over the viewer`, async () => {
+    const wrapper = document.createElement(`div`)
+    document.body.append(wrapper)
+    const { state } = mount_button(wrapper)
+    globalThis.dispatchEvent(new KeyboardEvent(`keydown`, { key: `f` }))
+    await tick()
+    expect(state.fullscreen).toBe(false)
+  })
+
+  // A Structure inside a Trajectory is hovered at the same time as its host, so both would
+  // fullscreen their own root on one press. The inner viewer defers; its button still works.
+  test(`a viewer nested in another leaves f to the outer one`, async () => {
+    const outer = document.createElement(`div`)
+    const inner = document.createElement(`div`)
+    outer.append(inner)
+    document.body.append(outer)
+    const host = mount_button(outer)
+    const nested = mount_button(inner)
+
+    for (const node of [outer, inner]) node.dispatchEvent(new PointerEvent(`pointerenter`))
+    globalThis.dispatchEvent(new KeyboardEvent(`keydown`, { key: `f` }))
+    await tick()
+    expect([host.state.fullscreen, nested.state.fullscreen]).toEqual([true, false])
   })
 })

--- a/tests/vitest/phase-diagram/IsobaricBinaryPhaseDiagram.test.ts
+++ b/tests/vitest/phase-diagram/IsobaricBinaryPhaseDiagram.test.ts
@@ -211,7 +211,9 @@ describe(`IsobaricBinaryPhaseDiagram`, () => {
     await hover_at(wrapper, 0.5, 750)
     svg.dispatchEvent(new MouseEvent(`click`, { bubbles: true })) // re-lock
     await tick()
-    document.dispatchEvent(new KeyboardEvent(`keydown`, { key: `Escape` }))
+    // keys reach the diagram through the hover forwarder, not the whole document
+    wrapper.dispatchEvent(new PointerEvent(`pointerenter`))
+    globalThis.dispatchEvent(new KeyboardEvent(`keydown`, { key: `Escape` }))
     await tick()
     expect(wrapper.querySelector(`.tooltip-lock-indicator`)).toBeNull()
   })

--- a/tests/vitest/structure/Structure.test.svelte.ts
+++ b/tests/vitest/structure/Structure.test.svelte.ts
@@ -505,7 +505,7 @@ describe(`Structure`, () => {
 
     await assertHoverScopedShortcut({
       viewer: doc_query(`.structure`),
-      fire: () => press_window_key({ key: `i`, ctrlKey: true }),
+      fire: () => press_window_key({ key: `i` }),
       read_state: () => state.active_pane === `info`,
     })
   })
@@ -524,7 +524,7 @@ describe(`Structure`, () => {
     doc_query(`.structure`).dispatchEvent(new PointerEvent(`pointerenter`))
     await tick()
     // hovered (not focused) + edit mode → window forwarder ignores the key
-    press_window_key({ key: `i`, ctrlKey: true })
+    press_window_key({ key: `i` })
     expect(state.active_pane, `hover path ignored in edit mode`).toBeNull()
   })
 
@@ -1426,7 +1426,7 @@ describe(`Multi-side view`, () => {
     expect(doc_query(`.structure`).classList.contains(`multi-view`)).toBe(false)
 
     doc_query(`.structure`).dispatchEvent(
-      new KeyboardEvent(`keydown`, { key: `g`, ctrlKey: true, bubbles: true }),
+      new KeyboardEvent(`keydown`, { key: `g`, bubbles: true }),
     )
     await tick()
     expect(state.multi_view).toBe(false)

--- a/tests/vitest/structure/StructureInfoPane.test.ts
+++ b/tests/vitest/structure/StructureInfoPane.test.ts
@@ -130,11 +130,11 @@ describe(`StructureInfoPane`, () => {
     expect(document.querySelectorAll(`.site-card`)).toHaveLength(n_cards)
   })
 
-  // Tips stay in the DOM even when closed; must match Structure.svelte Ctrl/Cmd handlers.
-  test(`Keyboard tip documents Ctrl/Cmd for f/i and plain r`, () => {
+  // Tips stay in the DOM even when closed; must match Structure.svelte's plain-letter handlers.
+  test(`Keyboard tip documents the plain-letter shortcuts`, () => {
     mount_info_pane({ structure: get_dummy_structure(`H`, 1, true), pane_open: false })
     expect(document.body.textContent).toContain(
-      `Press Ctrl/Cmd+f for fullscreen, Ctrl/Cmd+i to toggle this pane, r to reset the view`,
+      `Press f for fullscreen, i to toggle this pane, g for multi-view, r to reset the view`,
     )
     expect(document.querySelector(`.structure-info-toggle path`)?.getAttribute(`d`)).toBe(
       info_pane_icon.d,

--- a/tests/vitest/trajectory/Trajectory.test.svelte.ts
+++ b/tests/vitest/trajectory/Trajectory.test.svelte.ts
@@ -602,6 +602,26 @@ describe(`events`, () => {
     expect(document.fullscreenElement).toBe(doc_query(`.trajectory`))
   })
 
+  test(`Escape closes the open menu and leaves parent-owned fullscreen alone`, async () => {
+    const target = mount_trajectory(default_props())
+    await tick()
+    // a host app (e.g. a slide deck) owns fullscreen while the viewer is embedded inside it
+    await target.requestFullscreen()
+    const exit_fullscreen = vi.spyOn(document, `exitFullscreen`)
+    const toggle = doc_query<HTMLButtonElement>(`${CONTROLS} .analysis-button`)
+    toggle.click()
+    await tick()
+    expect(toggle.getAttribute(`aria-expanded`)).toBe(`true`)
+
+    doc_query(`.trajectory`).dispatchEvent(
+      new KeyboardEvent(`keydown`, { key: `Escape`, bubbles: true }),
+    )
+    await tick()
+    expect(exit_fullscreen).not.toHaveBeenCalled()
+    expect(document.fullscreenElement).toBe(target)
+    expect(toggle.getAttribute(`aria-expanded`)).toBe(`false`)
+  })
+
   test(`on_controller hands out the controller and nulls it on unmount`, async () => {
     const on_controller = vi.fn<(controller: TrajectoryController | null) => void>()
     const target = document.createElement(`div`)


### PR DESCRIPTION
Two independent changes: a repo-wide keyboard-shortcut unification, and the VS Code webview theme fixes this branch started as.

## Keyboard shortcuts

Plain letters own view toggles and viewer actions; chords stay with the browser and the host. Every handler guards editable targets and consumes only the keys it acted on.

- `FullscreenButton`: owns `f` for all 8 fullscreen-capable viewers, replacing five divergent per-viewer handlers. A `data-mv-fullscreen-root` marker makes a viewer nested inside another defer the key to the outer one, since both are hovered at once; the nested viewer's own button still works. `NebViewer` and every plot gain the shortcut, which they never had.
- `Trajectory`: Escape no longer calls `document.exitFullscreen()`. It tested any truthy `fullscreenElement`, so Escape over a viewer embedded in a fullscreen host (a slide deck) exited the host's fullscreen and swallowed the key, leaving the open menu open. The browser exits on Escape by itself and the flag follows `fullscreenchange`.
- `FermiSurface`, `BrillouinZone`, `ChemPotDiagram3D`: toggled fullscreen on Cmd/Ctrl+F, shadowing find-in-page.
- `canvas-interactions`: convex hull had no chord guard, so Cmd+S/R/B/L/U fired hull actions alongside the browser's own.
- `HeatmapMatrix`: `e` downloads a file and had no editable-target guard.
- `canvas-interactions`, `IsobaricTernaryPhaseDiagram`: `stopPropagation`/`preventDefault` now fire only when the key was handled, so ignored keys reach the host.
- `IsobaricBinaryPhaseDiagram`: its listener moves off `<svelte:document>` onto the viewer's hover forwarder — being document-wide is what forced a chord there.

Undo/redo, duplicate, copy, the command palette, Cmd+Arrow seek and Alt+Arrow column moves stay chords as OS conventions.

### Breaking

| | before | after |
| --- | --- | --- |
| Structure info pane | Cmd/Ctrl+I | `i` |
| Structure multi-view | Cmd/Ctrl+G | `g` |
| Binary phase diagram export | Cmd/Ctrl+Shift+E | `e` |
| HeatmapMatrix export | Cmd/Ctrl+E | `e` |
| Fullscreen | Cmd+F, bare `f`, or nothing | `f` |

Stale UI hints advertising `Cmd/Ctrl+G` and `Ctrl/Cmd+f`/`i` are corrected.

## VS Code webview theming

In a dark VS Code theme the webview flashed white while loading, and the trajectory control bar rendered light over a dark viewer. Both happen before the app's JS applies the theme.

- `extension.ts`: `create_html` sets `color-scheme` and `background-color` as an inline `style` on `<html>`, before the CSS link. It has to be a style attribute, not a `<style>` rule, to outrank `main-*.css`'s same-specificity `:root, :host { color-scheme: light dark }`. The theme maps through `THEME_TYPE`, a `Record` over `ThemeName`, so a new theme is a type error rather than a silent light render.
- `vite.config.ts`: takes `cssTarget` from `make_config().build`, the shared config the root build already spreads. Vite's default target lacks `light-dark()`, so LightningCSS downleveled `app.css`'s tokens into an OS-preference polyfill that ignored the `color-scheme` the webview declares. Deriving the value rather than repeating it is what stops this build drifting from the root one again.

Measured on the built webview CSS: before, 0 native `light-dark()` calls and 1 `prefers-color-scheme` polyfill; after, 212 and 0.
