### PR TITLE
Add host prediction workflows with owned views and exports

### DIFF
--- a/extensions/jupyterlab/package.json
+++ b/extensions/jupyterlab/package.json
@@ -36,11 +36,11 @@
   },
   "devDependencies": {
     "@jupyterlab/builder": "^4.5.10",
-    "@spglib/moyo-wasm": "^0.16.0",
+    "@spglib/moyo-wasm": "^0.18.0",
     "@sveltejs/vite-plugin-svelte": "^7.3.0",
-    "@types/node": "^26.2.0",
+    "@types/node": "^26.4.1",
     "process": "^0.11.10",
-    "svelte": "^5.56.10",
+    "svelte": "^5.57.0",
     "typescript": "^6.0.3",
     "vite": "^8.2.2",
     "vitest": "5.0.0"

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -24,9 +24,9 @@
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^7.3.0",
-    "@types/node": "^26.2.0",
-    "@types/vscode": "~1.105.0",
-    "svelte": "^5.56.10",
+    "@types/node": "^26.4.1",
+    "@types/vscode": "~1.136.0",
+    "svelte": "^5.57.0",
     "typescript": "^6.0.3",
     "vite": "^8.2.2",
     "vitest": "5.0.0"

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^7.3.0",
     "@types/node": "^26.4.1",
-    "@types/vscode": "~1.136.0",
+    "@types/vscode": "~1.105.0",
     "svelte": "^5.57.0",
     "typescript": "^6.0.3",
     "vite": "^8.2.2",

--- a/package.json
+++ b/package.json
@@ -307,7 +307,7 @@
     "fflate": "^0.8.3",
     "h5wasm": "^0.10.3",
     "js-yaml": "^5.4.1",
-    "svelte-widgets": "github:janosh/svelte-widgets#main",
+    "svelte-widgets": "github:janosh/svelte-widgets#27e3bc06332e7ccdaa1709f03bd898c85d029b8d",
     "three": "^0.185.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -303,7 +303,7 @@
     "d3-scale-chromatic": "^3.1.0",
     "d3-shape": "^3.2.0",
     "d3-time-format": "^4.1.0",
-    "dompurify": "3.4.14",
+    "dompurify": "3.4.15",
     "fflate": "^0.8.3",
     "h5wasm": "^0.10.3",
     "js-yaml": "^5.4.1",
@@ -311,7 +311,7 @@
     "three": "^0.185.1"
   },
   "devDependencies": {
-    "@playwright/test": "^1.62.1",
+    "@playwright/test": "^1.63.0",
     "@sveltejs/adapter-static": "3.0.10",
     "@sveltejs/kit": "2.70.3",
     "@sveltejs/package": "^2.5.8",
@@ -331,7 +331,7 @@
     "@types/three": "^0.185.4",
     "@vitest/coverage-v8": "5.0.0",
     "@wooorm/starry-night": "^3.11.0",
-    "happy-dom": "^20.13.2",
+    "happy-dom": "^20.14.0",
     "knip": "^6.34.0",
     "pagefind": "^1.5.2",
     "publint": "^0.3.24",

--- a/package.json
+++ b/package.json
@@ -307,7 +307,7 @@
     "fflate": "^0.8.3",
     "h5wasm": "^0.10.3",
     "js-yaml": "^5.4.1",
-    "svelte-widgets": "github:janosh/svelte-widgets#27e3bc06332e7ccdaa1709f03bd898c85d029b8d",
+    "svelte-widgets": "github:janosh/svelte-widgets#main",
     "three": "^0.185.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -333,7 +333,6 @@
     "@wooorm/starry-night": "^3.11.0",
     "happy-dom": "^20.13.2",
     "knip": "^6.34.0",
-    "mdsvex": "^0.12.8",
     "pagefind": "^1.5.2",
     "publint": "^0.3.24",
     "svelte": "^5.57.0",

--- a/package.json
+++ b/package.json
@@ -357,7 +357,8 @@
           "src/site/**/*.{js,ts,svelte}",
           "src/scripts/capture-screenshots.mjs",
           "src/scripts/fetch-elem-images.mjs",
-          "src/lib/scene/three-compat.ts"
+          "src/lib/scene/three-compat.ts",
+          "src/routes/(demos)/structure/host-tool/prediction-worker.ts"
         ],
         "paths": {
           "$lib": [

--- a/readme.md
+++ b/readme.md
@@ -129,10 +129,10 @@ npm add -D matterviz
 
 This project would not have been possible as a one-person side project without many fine open-source projects. 🙏 To name just a few:
 
-|           3D graphics           |               2D graphics                |                     Docs                     |               Bundler               |               Testing                |
-| :-----------------------------: | :--------------------------------------: | :------------------------------------------: | :---------------------------------: | :----------------------------------: |
-| [three.js](https://threejs.org) |          [d3](https://d3js.org)          |         [mdsvex](https://mdsvex.com)         |     [vite](https://vitejs.dev)      | [playwright](https://playwright.dev) |
-| [threlte](https://threlte.xyz)  | [sharp](https://sharp.pixelplumbing.com) | [rehype](https://github.com/rehypejs/rehype) | [sveltekit](https://kit.svelte.dev) |     [vitest](https://vitest.dev)     |
+|           3D graphics           |               2D graphics                |                             Docs                             |               Bundler               |               Testing                |
+| :-----------------------------: | :--------------------------------------: | :----------------------------------------------------------: | :---------------------------------: | :----------------------------------: |
+| [three.js](https://threejs.org) |          [d3](https://d3js.org)          | [svelte-widgets](https://svelte-widgets.janosh.dev/markdown) |     [vite](https://vitejs.dev)      | [playwright](https://playwright.dev) |
+| [threlte](https://threlte.xyz)  | [sharp](https://sharp.pixelplumbing.com) |         [rehype](https://github.com/rehypejs/rehype)         | [sveltekit](https://kit.svelte.dev) |     [vitest](https://vitest.dev)     |
 
 ## How to cite `matterviz`
 

--- a/readme.md
+++ b/readme.md
@@ -86,7 +86,7 @@ npm add -D matterviz
 <Structure {data_url} style="width: 500px; aspect-ratio: 1" />
 ```
 
-`Structure` accepts `structure`, `data_url`, `structure_string`, and direct file drops. Convenience loading delegates to the same `open_material()` runtime available to non-component hosts, so fetching, decompression, format detection, workers, provenance, and disposal remain centralized. Selection, measurements, atom/bond editing with undo/redo and the supercell/image-atom pipeline live in a headless `StructureSession` (exported from `matterviz/structure`); `active_pane: 'controls' | 'info' | 'export' | null` identifies the open floating pane.
+`Structure` accepts `structure`, `data_url`, `structure_string`, and direct file drops. Convenience loading delegates to the same `open_material()` runtime available to non-component hosts, so fetching, decompression, format detection, workers, provenance, and disposal remain centralized. Prediction JSON files reopen with their input, properties, density and provenance; hosts can also pass `prediction_from_json(content)` as the `prediction` prop. Selection, measurements, atom/bond editing with undo/redo and the supercell/image-atom pipeline live in a headless `StructureSession` (exported from `matterviz/structure`); `active_pane: 'controls' | 'info' | 'export' | null` identifies the open floating pane.
 
 ### Composition
 

--- a/readme.md
+++ b/readme.md
@@ -129,10 +129,10 @@ npm add -D matterviz
 
 This project would not have been possible as a one-person side project without many fine open-source projects. 🙏 To name just a few:
 
-|           3D graphics           |               2D graphics                |                             Docs                             |               Bundler               |               Testing                |
-| :-----------------------------: | :--------------------------------------: | :----------------------------------------------------------: | :---------------------------------: | :----------------------------------: |
-| [three.js](https://threejs.org) |          [d3](https://d3js.org)          | [svelte-widgets](https://svelte-widgets.janosh.dev/markdown) |     [vite](https://vitejs.dev)      | [playwright](https://playwright.dev) |
-| [threlte](https://threlte.xyz)  | [sharp](https://sharp.pixelplumbing.com) |         [rehype](https://github.com/rehypejs/rehype)         | [sveltekit](https://kit.svelte.dev) |     [vitest](https://vitest.dev)     |
+|           3D graphics           |               2D graphics                |                         Docs                         |               Bundler               |               Testing                |
+| :-----------------------------: | :--------------------------------------: | :--------------------------------------------------: | :---------------------------------: | :----------------------------------: |
+| [three.js](https://threejs.org) |          [d3](https://d3js.org)          | [svelte-widgets](https://svelte-widgets.janosh.dev/) |     [vite](https://vitejs.dev)      | [playwright](https://playwright.dev) |
+| [threlte](https://threlte.xyz)  | [sharp](https://sharp.pixelplumbing.com) |     [rehype](https://github.com/rehypejs/rehype)     | [sveltekit](https://kit.svelte.dev) |     [vitest](https://vitest.dev)     |
 
 ## How to cite `matterviz`
 

--- a/src/lib/file-viewer/main.ts
+++ b/src/lib/file-viewer/main.ts
@@ -448,7 +448,10 @@ export const create_display = (
     log_message = `JSON browser opened: ${filename}`
   } else {
     // Single-viewer results share the dispatch table with JsonBrowser panels
-    app = mount_viewer(container, result.type, result.data, { defaults })
+    app = mount_viewer(container, result.type, result.data, {
+      defaults,
+      prediction: result.type === `structure` ? result.prediction : undefined,
+    })
     const detail =
       result.type === `convex_hull`
         ? ` (${result.data.length} entries)`

--- a/src/lib/file-viewer/mount-viewer.ts
+++ b/src/lib/file-viewer/mount-viewer.ts
@@ -16,6 +16,7 @@ import BandsAndDos from '$lib/spectral/BandsAndDos.svelte'
 import Dos from '$lib/spectral/Dos.svelte'
 import type { BaseBandStructure, DosInput } from '$lib/spectral/types'
 import type { AnyStructure } from '$lib/structure'
+import type { StructureToolPrediction } from '$lib/structure/prediction'
 import Structure from '$lib/structure/Structure.svelte'
 import type { XrdPattern } from '$lib/xrd'
 import XrdPlot from '$lib/xrd/XrdPlot.svelte'
@@ -27,6 +28,7 @@ import PlotPanel from './PlotPanel.svelte'
 export type ViewerMountType = Exclude<RenderableType, `volumetric`> | `isosurface`
 
 export interface MountViewerOptions {
+  prediction?: StructureToolPrediction
   defaults: DefaultSettings
   // Closes the hosting panel (JsonBrowser); viewers without a close affordance ignore it
   on_close?: () => void
@@ -44,7 +46,7 @@ export function mount_viewer(
   target: HTMLElement,
   type: ViewerMountType,
   data: unknown,
-  { defaults, on_close }: MountViewerOptions,
+  { defaults, on_close, prediction }: MountViewerOptions,
 ): ReturnType<typeof mount> {
   target.innerHTML = ``
   void target.offsetHeight // force layout so Three.js measures real dimensions
@@ -60,7 +62,7 @@ export function mount_viewer(
   if (type === `structure`) {
     return mount(Structure, {
       target,
-      props: { structure: data as AnyStructure, ...structure_props },
+      props: { structure: data as AnyStructure, prediction, ...structure_props },
     })
   }
   if (type === `isosurface`) {

--- a/src/lib/file-viewer/parse-worker.ts
+++ b/src/lib/file-viewer/parse-worker.ts
@@ -14,7 +14,16 @@ const prepare_parse_result = (
   id: number,
   result: ParseResult,
 ): { response: ParseWorkerResponse; transfer: Transferable[] } => {
-  if (result.type !== `trajectory`) return { response: { id, result }, transfer: [] }
+  if (result.type !== `trajectory`)
+    return {
+      response: { id, result },
+      transfer:
+        result.type === `structure`
+          ? (result.prediction?.volumes ?? []).map(
+              ({ values }) => values.buffer as ArrayBuffer,
+            )
+          : [],
+    }
   const run = result.data
   const run_port = serve_run_over_port(run)
   return {

--- a/src/lib/file-viewer/parse.ts
+++ b/src/lib/file-viewer/parse.ts
@@ -12,6 +12,7 @@ import {
 } from '$lib/io/decompress'
 import { parse_volumetric_file } from '$lib/isosurface/parse'
 import { is_vaspwave_filename, parse_vaspwave_charge } from '$lib/isosurface/parse-vaspwave'
+import { prediction_from_json, type StructureToolPrediction } from '$lib/structure/prediction'
 import { parse_structure_file } from '$lib/structure/parse'
 import { is_indexable_trajectory_filename } from '$lib/trajectory/format-detect'
 import { to_error } from '$lib/utils'
@@ -55,7 +56,7 @@ type Result<Type extends ViewType, Data> = { type: Type; data: Data; filename: s
 
 export type ParseResult =
   | Result<`trajectory`, TrajectoryRun>
-  | Result<`structure`, AnyStructure>
+  | (Result<`structure`, AnyStructure> & { prediction?: StructureToolPrediction })
   | Result<`fermi_surface`, BandGridData | FermiSurfaceData>
   | Result<`isosurface`, VolumetricFileData>
   | Result<`convex_hull`, PhaseData[]>
@@ -219,6 +220,16 @@ export const parse_file_content = async (
       throw new Error(`Invalid JSON in ${filename}: ${to_error(error).message}`, {
         cause: error,
       })
+    }
+    if (
+      parsed_json &&
+      typeof parsed_json === `object` &&
+      `schema` in parsed_json &&
+      typeof parsed_json.schema === `string` &&
+      parsed_json.schema.startsWith(`matterviz-prediction-`)
+    ) {
+      const prediction = prediction_from_json(parsed_json)
+      return { type: `structure`, data: prediction.input, prediction, filename }
     }
     const detected = detect_view_type(parsed_json)
     if (detected === `structure`) {

--- a/src/lib/layout/InfoTag.svelte
+++ b/src/lib/layout/InfoTag.svelte
@@ -37,6 +37,7 @@
 
   // one key, since a tag copies a single value; `copied` handles the timed reset
   const { copied, copy } = create_clipboard_feedback()
+  const has_action = $derived(Boolean(onclick) || (copy_value ?? value) !== undefined)
 
   function handle_click(event: MouseEvent): void {
     if (disabled) return
@@ -46,7 +47,12 @@
   }
 
   function handle_keydown(event: KeyboardEvent & { currentTarget: HTMLElement }): void {
-    if (disabled || (event.key !== `Enter` && event.key !== ` `)) return
+    if (
+      event.target !== event.currentTarget ||
+      disabled ||
+      (event.key !== `Enter` && event.key !== ` `)
+    )
+      return
     event.preventDefault()
     event.currentTarget.click()
   }
@@ -58,8 +64,7 @@
 </script>
 
 <span
-  role="button"
-  tabindex={disabled ? -1 : 0}
+  {...has_action ? { role: `button`, tabindex: disabled ? -1 : 0 } : {}}
   onclick={handle_click}
   onkeydown={handle_keydown}
   title={sanitize_html(title)}
@@ -77,7 +82,7 @@
       class="copy-checkmark"
     />
   {/if}
-  {#if removable && !disabled}
+  {#if removable && !disabled && on_remove}
     <button type="button" onclick={handle_remove} aria-label="Remove">
       <Icon icon={Close} style="width: 10px; height: 10px" />
     </button>
@@ -87,18 +92,20 @@
 
 <style>
   .info-tag {
-    cursor: pointer;
     position: relative;
     transition: all 0.12s;
     border: 1px solid;
     white-space: nowrap;
     border-color: color-mix(in srgb, var(--tag-color) 25%, transparent);
+    &[role='button'] {
+      cursor: pointer;
+    }
     em {
       font-style: normal;
       font-weight: 600;
       color: var(--tag-color);
     }
-    &:hover:not(.disabled) {
+    &[role='button']:hover:not(.disabled) {
       background: color-mix(in srgb, var(--tag-color) 18%, transparent);
       border-color: color-mix(in srgb, var(--tag-color) 40%, transparent);
     }
@@ -136,7 +143,7 @@
       opacity: 0.5;
       cursor: not-allowed;
     }
-    &:active:not(.disabled) {
+    &[role='button']:active:not(.disabled) {
       transform: scale(0.97);
     }
     :global(.copy-checkmark) {

--- a/src/lib/phase-diagram/PhaseDiagramEditorPane.svelte
+++ b/src/lib/phase-diagram/PhaseDiagramEditorPane.svelte
@@ -83,7 +83,7 @@
       {root_label}
       default_fold_level={2}
       download_filename="diagram-data.json"
-      editable
+      editable={Boolean(diagram_input || on_data)}
       on_change={handle_change}
     />
   {:else}

--- a/src/lib/scene/pan.ts
+++ b/src/lib/scene/pan.ts
@@ -34,6 +34,24 @@ export function clear_pan_offset(camera: Camera | undefined) {
   if (is_pannable(camera)) camera.clearViewOffset()
 }
 
+// Restore a cloned camera's view without overwriting the new viewport's projection bounds.
+export function restore_camera_view(
+  camera: Camera,
+  saved: Camera,
+  width: number,
+  height: number,
+) {
+  camera.position.copy(saved.position)
+  camera.quaternion.copy(saved.quaternion)
+  camera.up.copy(saved.up)
+  if (is_pannable(camera) && is_pannable(saved)) {
+    camera.zoom = saved.zoom
+    set_pan_offset(camera, read_pan_offset(saved), width, height)
+    camera.updateProjectionMatrix()
+  }
+  camera.updateMatrixWorld()
+}
+
 // Structural rather than the concrete OrbitControls class (see fly-to.ts): only the members the
 // gesture needs. Events are dispatched on the controls so every start/change/end listener —
 // Threlte's invalidate, hover suppression, StructureViewport's camera sync — treats a pan like

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -947,7 +947,7 @@
         {#if active_overlay && !session.shows_input_frame}
           <button onclick={() => (cell_type = `original`)}>Use original cell</button>
         {/if}
-        {#if active_overlay && session.has_supercell}
+        {#if active_overlay && session.has_supercell && (volumetric_data ?? []).some((volume) => owned_volume_set.has(volume) && !volume.periodic)}
           <button onclick={() => (supercell_scaling = `1x1x1`)}
             >Reset supercell to 1×1×1</button
           >

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -23,7 +23,6 @@
     DEFAULT_ISOSURFACE_SETTINGS,
     normalize_active_volume_idx,
     pin_layers,
-    remove_volume,
   } from '$lib/isosurface/types'
   import { ViewerChrome } from '$lib/layout'
   import { ToolbarMenu } from '$lib/overlays'
@@ -52,7 +51,7 @@
   import * as symmetry from '$lib/symmetry'
   import { OVERLAYS_INPUT_FRAME_NOTE } from './lattice-planes'
   import type { ComponentProps, Snippet } from 'svelte'
-  import { untrack } from 'svelte'
+  import { onDestroy, untrack } from 'svelte'
   import { forward_window_keydown, tooltip } from 'svelte-widgets/attachments'
   import type { HTMLAttributes } from 'svelte/elements'
   import { SvelteSet } from 'svelte/reactivity'
@@ -73,9 +72,12 @@
   import type { TrajectoryLinesStats } from './trajectory-lines'
   import {
     structure_host_tool,
-    type StructureToolOverlay,
+    create_structure_tool_controller,
+    type StructureToolPrediction,
+    type StructureToolVolume,
     type StructureToolView,
   } from './host-tool.svelte'
+  import { replace_tool_volumes } from './host-tool-volumes'
   import { apply_structure_material } from './material'
 
   export type StructureControlName =
@@ -285,7 +287,9 @@
         { structure, volumetric_data, isosurface_settings, active_volume_idx },
         opened,
       )
-      ;({ structure, volumetric_data, isosurface_settings, active_volume_idx } = document)
+      // Avoid wrapping an unchanged plain input in a proxy during a same-cell volume import.
+      if (document.structure !== structure) structure = document.structure
+      ;({ volumetric_data, isosurface_settings, active_volume_idx } = document)
       if (notice) show_toast(notice)
       on_file_load?.({
         structure: document.structure,
@@ -335,14 +339,11 @@
     on_notice: show_toast,
   })
 
+  let tool_source = $state.raw<AnyStructure | undefined>()
   let tool_view = $state.raw<StructureToolView | null>(null)
-  const active_tool_view = $derived(
-    tool_view?.source === session.tool_input ? tool_view : null,
-  )
-  let tool_overlay = $state.raw<StructureToolOverlay | null>(null)
-  const active_overlay: StructureToolOverlay | null = $derived(
-    tool_overlay?.source === session.tool_input ? tool_overlay : null,
-  )
+  const active_tool_view = $derived(tool_source === session.tool_input ? tool_view : null)
+  let tool_overlay = $state.raw<StructureToolPrediction | null>(null)
+  const active_overlay = $derived(tool_source === session.tool_input ? tool_overlay : null)
   const tool_structure = $derived(
     session.tool_input && active_overlay?.site_properties
       ? {
@@ -356,12 +357,13 @@
   )
   // Generated fields join the active document registry so imports, exports and controls
   // share one index space. Ownership tracks the stored identities, including caller proxies.
-  let owned_volumes = $state.raw<VolumetricData[]>([])
+  let owned_volumes = $state.raw<StructureToolVolume[]>([])
+  const owned_volume_set = $derived(new Set<VolumetricData>(owned_volumes))
   let original_active_volume: VolumetricData | undefined
   const hidden_volume_indices = $derived(
     new Set(
       (volumetric_data ?? []).flatMap((volume, idx) =>
-        owned_volumes.includes(volume) &&
+        owned_volume_set.has(volume) &&
         (!active_overlay ||
           !session.shows_input_frame ||
           (session.has_supercell && !volume.periodic))
@@ -402,9 +404,8 @@
   $effect(() => {
     if (!active_overlay?.color_property) untrack(restore_tool_color)
   })
-  const apply_tool_overlay = (overlay: StructureToolOverlay | null): void => {
-    const color_property =
-      overlay?.source === session.tool_input ? overlay?.color_property : undefined
+  const apply_tool_overlay = (overlay: StructureToolPrediction | null): void => {
+    const color_property = overlay?.color_property
     if (color_property) {
       original_tool_color ??= atom_color_config
       if (color_property !== active_overlay?.color_property)
@@ -416,43 +417,82 @@
         }
     } else restore_tool_color()
     const same_volumes =
-      tool_overlay?.source === overlay?.source && tool_overlay?.volumes === overlay?.volumes
+      tool_source === session.tool_input && tool_overlay?.volumes === overlay?.volumes
     tool_overlay = overlay
+    tool_source = session.tool_input
     if (same_volumes) return
     const active_before = volumetric_data?.[active_volume_idx]
-    const restore_active = active_before !== undefined && owned_volumes.includes(active_before)
+    const restore_active = active_before !== undefined && owned_volume_set.has(active_before)
     if (!restore_active) original_active_volume = active_before
-    for (const volume of owned_volumes) {
-      const volume_idx = volumetric_data?.indexOf(volume) ?? -1
-      if (volume_idx < 0) continue
-      const result = remove_volume(
-        volumetric_data ?? [],
-        isosurface_settings.layers,
-        volume_idx,
-        active_volume_idx,
+    const incoming = overlay?.volumes ?? []
+    const result = replace_tool_volumes(
+      volumetric_data ?? [],
+      isosurface_settings.layers,
+      owned_volumes,
+      incoming,
+      active_volume_idx,
+    )
+    volumetric_data = result.volumes
+    isosurface_settings = { ...isosurface_settings, layers: result.layers }
+    owned_volumes = volumetric_data.slice(result.first_idx) as StructureToolVolume[]
+    if (incoming.length) {
+      active_volume_idx =
+        restore_active && result.active_idx !== undefined
+          ? result.active_idx
+          : result.first_idx
+    } else {
+      const restored_idx = original_active_volume
+        ? volumetric_data.indexOf(original_active_volume)
+        : -1
+      active_volume_idx = normalize_active_volume_idx(
+        restore_active && restored_idx >= 0
+          ? restored_idx
+          : (result.active_idx ?? active_volume_idx),
+        volumetric_data.length,
       )
-      volumetric_data = result.volumes
-      isosurface_settings = { ...isosurface_settings, layers: result.layers }
-      if (active_volume_idx > volume_idx) active_volume_idx -= 1
-      active_volume_idx = normalize_active_volume_idx(active_volume_idx, result.volumes.length)
     }
-    owned_volumes = []
-    if (restore_active && original_active_volume) {
-      const restored_idx = volumetric_data?.indexOf(original_active_volume) ?? -1
-      if (restored_idx >= 0) active_volume_idx = restored_idx
-    }
-    if (overlay?.source !== session.tool_input || !overlay?.volumes?.length) return
-    const first_idx = volumetric_data?.length ?? 0
+  }
+  // Cached until an input property changes; catches in-place edits without rescanning per callback.
+  const tool_input_revision = $derived(
+    show_host_tool && structure_host_tool.component ? JSON.stringify(session.tool_input) : ``,
+  )
+  const tool_controller = create_structure_tool_controller(
+    () => session.tool_input,
+    () => (show_host_tool ? structure_host_tool.component : null),
+    apply_tool_overlay,
+    (view) => {
+      tool_view = view
+      if (view) tool_source = session.tool_input
+    },
+    () => tool_input_revision,
+  )
+  $effect(() => {
+    // Subscribe only to ownership/input changes, not the output mutations in cleanup.
+    void [
+      tool_input_revision,
+      session.tool_input,
+      show_host_tool,
+      structure_host_tool.component,
+    ]
+    untrack(() => tool_controller.invalidate_if_changed())
+  })
+  onDestroy(() => tool_controller.dispose())
+  const reset_prediction_surfaces = (): void => {
+    const owned = new Set<VolumetricData>(owned_volumes)
     isosurface_settings = {
       ...isosurface_settings,
       layers: [
-        ...pin_layers(isosurface_settings.layers, active_volume_idx),
-        ...overlay.volumes.map((volume, idx) => auto_volume_layer(volume, first_idx + idx)),
+        ...pin_layers(isosurface_settings.layers, active_volume_idx).filter(
+          (layer) =>
+            !owned.has(
+              volumetric_data?.[layer.volume_idx ?? active_volume_idx] as VolumetricData,
+            ),
+        ),
+        ...(volumetric_data ?? []).flatMap((volume, idx) =>
+          owned.has(volume) ? [auto_volume_layer(volume, idx)] : [],
+        ),
       ],
     }
-    volumetric_data = [...(volumetric_data ?? []), ...overlay.volumes]
-    owned_volumes = volumetric_data.slice(first_idx)
-    active_volume_idx = first_idx
   }
 
   // === inputs: mirror caller props into the local models ===
@@ -886,8 +926,7 @@
     <div style:display={active_tool_view ? `none` : `contents`}>
       <structure_host_tool.component
         structure={session.tool_input}
-        on_overlay={apply_tool_overlay}
-        on_view={(view) => (tool_view = view)}
+        start_run={tool_controller.start_run}
       />
     </div>
   {/if}
@@ -905,6 +944,15 @@
         style="position: absolute; bottom: 1rem; left: 1rem; right: 1rem; z-index: 2; background: var(--pane-bg, #222); padding: 0.6rem; border-radius: 0.4rem"
       >
         {tool_volume_notice}
+        {#if active_overlay && !session.shows_input_frame}
+          <button onclick={() => (cell_type = `original`)}>Use original cell</button>
+        {/if}
+        {#if active_overlay && session.has_supercell}
+          <button onclick={() => (supercell_scaling = `1x1x1`)}
+            >Reset supercell to 1×1×1</button
+          >
+        {/if}
+        <button onclick={tool_controller.clear}>Clear prediction</button>
       </p>{/if}
     {#if loading}
       <Spinner
@@ -985,6 +1033,9 @@
 
         {#if controls_config.visible(`export-pane`)}
           <StructureExportPane
+            prediction={active_overlay ?? undefined}
+            on_clear_prediction={tool_controller.clear}
+            on_reset_prediction_surfaces={reset_prediction_surfaces}
             bind:export_pane_open={
               () => is_pane_open(`export`), (open) => set_pane_open(`export`, open)
             }

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -478,18 +478,17 @@
   })
   onDestroy(() => tool_controller.dispose())
   const reset_prediction_surfaces = (): void => {
-    const owned = new Set<VolumetricData>(owned_volumes)
     isosurface_settings = {
       ...isosurface_settings,
       layers: [
         ...pin_layers(isosurface_settings.layers, active_volume_idx).filter(
           (layer) =>
-            !owned.has(
+            !owned_volume_set.has(
               volumetric_data?.[layer.volume_idx ?? active_volume_idx] as VolumetricData,
             ),
         ),
         ...(volumetric_data ?? []).flatMap((volume, idx) =>
-          owned.has(volume) ? [auto_volume_layer(volume, idx)] : [],
+          owned_volume_set.has(volume) ? [auto_volume_layer(volume, idx)] : [],
         ),
       ],
     }

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -359,6 +359,7 @@
   // share one index space. Ownership tracks the stored identities, including caller proxies.
   let owned_volumes = $state.raw<StructureToolVolume[]>([])
   const owned_volume_set = $derived(new Set<VolumetricData>(owned_volumes))
+  const removed_tool_fields = new Set<string>()
   let original_active_volume: VolumetricData | undefined
   const hidden_volume_indices = $derived(
     new Set(
@@ -416,15 +417,21 @@
           scale_type: `continuous`,
         }
     } else restore_tool_color()
-    const same_volumes =
-      tool_source === session.tool_input && tool_overlay?.volumes === overlay?.volumes
+    // A publication is a fresh snapshot; remember user removals by field ID within this run.
+    if (tool_overlay?.run_id !== overlay?.run_id) removed_tool_fields.clear()
+    else {
+      const present = new Set(volumetric_data)
+      for (const volume of owned_volumes)
+        if (!present.has(volume)) removed_tool_fields.add(volume.field_id)
+    }
     tool_overlay = overlay
     tool_source = session.tool_input
-    if (same_volumes) return
     const active_before = volumetric_data?.[active_volume_idx]
     const restore_active = active_before !== undefined && owned_volume_set.has(active_before)
     if (!restore_active) original_active_volume = active_before
-    const incoming = overlay?.volumes ?? []
+    const incoming = (overlay?.volumes ?? []).filter(
+      ({ field_id }) => !removed_tool_fields.has(field_id),
+    )
     const result = replace_tool_volumes(
       volumetric_data ?? [],
       isosurface_settings.layers,
@@ -697,7 +704,16 @@
       controls_config.visible(`reset-camera`),
   )
   // Inputs shared by every StructureViewport; camera bindings and chrome differ per pane
+  const viewport_states: NonNullable<
+    ComponentProps<typeof StructureViewport>[`view_state`]
+  >[] = []
   const pane_props = (pane_idx: number) => ({
+    view_state: (viewport_states[pane_idx] ??= {
+      get_pose_key: () =>
+        pane_idx === 0
+          ? JSON.stringify([scene_props.camera_position, scene_props.camera_target])
+          : ``,
+    }),
     in_grid: is_multi_view_active,
     active: is_multi_view_active && session.active_pane_idx === pane_idx,
     interactive: !is_multi_view_active || session.active_pane_idx === pane_idx,

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -23,6 +23,7 @@
     DEFAULT_ISOSURFACE_SETTINGS,
     normalize_active_volume_idx,
     pin_layers,
+    remove_volume,
   } from '$lib/isosurface/types'
   import { ViewerChrome } from '$lib/layout'
   import { ToolbarMenu } from '$lib/overlays'
@@ -70,7 +71,11 @@
   import type StructureScene from './StructureScene.svelte'
   import StructureViewport from './StructureViewport.svelte'
   import type { TrajectoryLinesStats } from './trajectory-lines'
-  import { structure_host_tool, type StructureToolOverlay } from './host-tool.svelte'
+  import {
+    structure_host_tool,
+    type StructureToolOverlay,
+    type StructureToolView,
+  } from './host-tool.svelte'
   import { apply_structure_material } from './material'
 
   export type StructureControlName =
@@ -104,6 +109,7 @@
   let {
     structure = $bindable(),
     structure_series_key = undefined,
+    show_host_tool = true,
     reference_structure = undefined,
     displacement_rmsd = $bindable(undefined),
     bonds = $bindable(),
@@ -159,7 +165,9 @@
     sym_data = $bindable(null),
     symmetry_settings = $bindable(symmetry.default_sym_settings),
     volumetric_data = $bindable<VolumetricData[] | undefined>(),
-    isosurface_settings = $bindable<IsosurfaceSettings>({ ...DEFAULT_ISOSURFACE_SETTINGS }),
+    isosurface_settings = $bindable<IsosurfaceSettings>({
+      ...DEFAULT_ISOSURFACE_SETTINGS,
+    }),
     slice_settings = $bindable<Partial<VolumeSliceSettings>>({}),
     display_mode = $bindable<StructureDisplayMode>(`structure`),
     active_volume_idx = $bindable(0),
@@ -175,6 +183,8 @@
     // Stable identity for coordinate-only updates (trajectory playback): camera and selection
     // persist while it is unchanged and the topology is the same
     structure_series_key?: unknown
+    // Disable nested host tools in a host-owned preview.
+    show_host_tool?: boolean
     // Comparison overlay: per-atom displacement arrows from this geometry to `structure`
     // (same atom count and order)
     reference_structure?: AnyStructure
@@ -289,59 +299,13 @@
     },
   })
 
-  let tool_overlay = $state.raw<StructureToolOverlay | null>(null)
-  const active_overlay = $derived(tool_overlay?.source === structure ? tool_overlay : null)
-  const tool_structure = $derived(
-    structure && active_overlay?.site_properties
-      ? {
-          ...structure,
-          sites: structure.sites.map((site, idx) => ({
-            ...site,
-            properties: { ...site.properties, ...active_overlay.site_properties?.[idx] },
-          })),
-        }
-      : structure,
-  )
-  let display_volumes = $derived(
-    active_overlay?.volumes?.length
-      ? [...(volumetric_data ?? []), ...active_overlay.volumes]
-      : volumetric_data,
-  )
-  let original_volume_idx = 0
-  const apply_tool_overlay = (overlay: StructureToolOverlay | null): void => {
-    const had_volumes = Boolean(tool_overlay?.volumes?.length)
-    const has_volumes = overlay?.source === structure && Boolean(overlay?.volumes?.length)
-    tool_overlay = overlay
-    if (!had_volumes && !has_volumes) return
-    if (!had_volumes) original_volume_idx = active_volume_idx
-    const base_count = volumetric_data?.length ?? 0
-    isosurface_settings = {
-      ...isosurface_settings,
-      layers: pin_layers(isosurface_settings.layers, active_volume_idx).filter(
-        (layer) => (layer.volume_idx ?? 0) < base_count,
-      ),
-    }
-    if (!has_volumes) active_volume_idx = original_volume_idx
-    if (overlay && overlay.source === structure && overlay.volumes?.length) {
-      active_volume_idx = base_count
-      isosurface_settings = {
-        ...isosurface_settings,
-        layers: [
-          ...isosurface_settings.layers,
-          ...overlay.volumes.map((volume, idx) => ({
-            ...auto_volume_layer(volume, 0),
-            volume_idx: base_count + idx,
-          })),
-        ],
-      }
-    }
-  }
-
   // === session: display pipeline, selection, editing, cameras ===
   // Coordinate-only updates (trajectory frames) share one key; otherwise every structure is new
   let series_key = $derived(structure_series_key ?? structure)
-  const session = new StructureSession({
+  const session: StructureSession = new StructureSession({
     structure: () => structure,
+    site_properties: (): Record<string, unknown>[] | undefined =>
+      active_overlay?.site_properties,
     set_structure: (value) => (structure = value),
     bonds: () => bonds,
     set_bonds: (value) => (bonds = value),
@@ -370,6 +334,120 @@
     bonding_strategy: () => scene_props.bonding_strategy,
     on_notice: show_toast,
   })
+
+  let tool_view = $state.raw<StructureToolView | null>(null)
+  const active_tool_view = $derived(
+    tool_view?.source === session.tool_input ? tool_view : null,
+  )
+  let tool_overlay = $state.raw<StructureToolOverlay | null>(null)
+  const active_overlay: StructureToolOverlay | null = $derived(
+    tool_overlay?.source === session.tool_input ? tool_overlay : null,
+  )
+  const tool_structure = $derived(
+    session.tool_input && active_overlay?.site_properties
+      ? {
+          ...session.tool_input,
+          sites: session.tool_input.sites.map((site, idx) => ({
+            ...site,
+            properties: { ...site.properties, ...active_overlay.site_properties?.[idx] },
+          })),
+        }
+      : session.tool_input,
+  )
+  // Generated fields join the active document registry so imports, exports and controls
+  // share one index space. Ownership tracks the stored identities, including caller proxies.
+  let owned_volumes = $state.raw<VolumetricData[]>([])
+  let original_active_volume: VolumetricData | undefined
+  const hidden_volume_indices = $derived(
+    new Set(
+      (volumetric_data ?? []).flatMap((volume, idx) =>
+        owned_volumes.includes(volume) &&
+        (!active_overlay ||
+          !session.shows_input_frame ||
+          (session.has_supercell && !volume.periodic))
+          ? [idx]
+          : [],
+      ),
+    ),
+  )
+  const tool_volume_notice = $derived(
+    hidden_volume_indices.size > 0
+      ? !active_overlay
+        ? `Prediction density belongs to a previous input. Run a new prediction.`
+        : !session.shows_input_frame
+          ? `Prediction density is hidden in standardized cells. Select the original cell to align it with the atoms.`
+          : `Finite and partially periodic prediction density is shown only in the input cell. Set supercell scaling to 1x1x1.`
+      : ``,
+  )
+  const display_isosurface_settings = $derived(
+    hidden_volume_indices.size > 0
+      ? {
+          ...isosurface_settings,
+          layers: isosurface_settings.layers.filter(
+            (layer) =>
+              !hidden_volume_indices.has(layer.volume_idx ?? active_volume_idx) &&
+              (layer.color_volume_idx === undefined ||
+                !hidden_volume_indices.has(layer.color_volume_idx)),
+          ),
+        }
+      : isosurface_settings,
+  )
+  let original_tool_color: AtomColorConfig | null = null
+  const apply_tool_overlay = (overlay: StructureToolOverlay | null): void => {
+    const color_property =
+      overlay?.source === session.tool_input ? overlay?.color_property : undefined
+    if (color_property) {
+      original_tool_color ??= atom_color_config
+      if (color_property !== active_overlay?.color_property)
+        atom_color_config = {
+          mode: `property`,
+          property_key: color_property,
+          scale: `interpolateRdBu`,
+          scale_type: `continuous`,
+        }
+    } else if (original_tool_color) {
+      atom_color_config = original_tool_color
+      original_tool_color = null
+    }
+    const same_volumes =
+      tool_overlay?.source === overlay?.source && tool_overlay?.volumes === overlay?.volumes
+    tool_overlay = overlay
+    if (same_volumes) return
+    const active_before = volumetric_data?.[active_volume_idx]
+    const restore_active = active_before !== undefined && owned_volumes.includes(active_before)
+    if (!restore_active) original_active_volume = active_before
+    for (const volume of owned_volumes) {
+      const volume_idx = volumetric_data?.indexOf(volume) ?? -1
+      if (volume_idx < 0) continue
+      const result = remove_volume(
+        volumetric_data ?? [],
+        isosurface_settings.layers,
+        volume_idx,
+        active_volume_idx,
+      )
+      volumetric_data = result.volumes
+      isosurface_settings = { ...isosurface_settings, layers: result.layers }
+      if (active_volume_idx > volume_idx) active_volume_idx -= 1
+      active_volume_idx = normalize_active_volume_idx(active_volume_idx, result.volumes.length)
+    }
+    owned_volumes = []
+    if (restore_active && original_active_volume) {
+      const restored_idx = volumetric_data?.indexOf(original_active_volume) ?? -1
+      if (restored_idx >= 0) active_volume_idx = restored_idx
+    }
+    if (overlay?.source !== session.tool_input || !overlay?.volumes?.length) return
+    const first_idx = volumetric_data?.length ?? 0
+    isosurface_settings = {
+      ...isosurface_settings,
+      layers: [
+        ...pin_layers(isosurface_settings.layers, active_volume_idx),
+        ...overlay.volumes.map((volume, idx) => auto_volume_layer(volume, first_idx + idx)),
+      ],
+    }
+    volumetric_data = [...(volumetric_data ?? []), ...overlay.volumes]
+    owned_volumes = volumetric_data.slice(first_idx)
+    active_volume_idx = first_idx
+  }
 
   // === inputs: mirror caller props into the local models ===
   // JavaScript callers can bypass the TypeScript union with partial JSON; normalize before the
@@ -501,14 +579,14 @@
     display_mode === `structure` && multi_view && multi_view_available,
   )
   let slice_layout_available = $derived(
-    Boolean(display_volumes?.length || display_mode === `slice`) &&
+    Boolean(volumetric_data?.length || display_mode === `slice`) &&
       controls_config.visible(`view-mode`),
   )
   let multi_layout_available = $derived(
     multi_view_available && controls_config.visible(`multi-view`),
   )
   let layout_control_visible = $derived(
-    (display_mode === `slice` && !display_volumes?.length) ||
+    (display_mode === `slice` && !volumetric_data?.length) ||
       slice_layout_available ||
       (display_mode === `structure` && multi_layout_available),
   )
@@ -585,7 +663,6 @@
   let shared_viewport_props = $derived({
     session,
     view_reset_key: series_key,
-    site_properties: active_overlay?.site_properties,
     reference_structure,
     scene_props: {
       ...scene_props,
@@ -593,9 +670,9 @@
       sphere_segments: effective_sphere_segments,
     },
     gizmo: scene_gizmo_props,
-    volumetric_data: display_volumes,
+    volumetric_data,
     active_volume_idx,
-    isosurface_settings,
+    isosurface_settings: display_isosurface_settings,
     property_colors: session.property_colors,
     active_sites: active_scene_sites,
   })
@@ -616,7 +693,7 @@
   $effect(() => {
     const clamped_idx = normalize_active_volume_idx(
       active_volume_idx,
-      display_volumes?.length ?? 0,
+      volumetric_data?.length ?? 0,
     )
     if (clamped_idx !== active_volume_idx) active_volume_idx = clamped_idx
   })
@@ -661,6 +738,7 @@
   // === keyboard ===
   // Returns true when the key was handled so the caller can suppress the browser default
   function handle_keydown(event: KeyboardEvent): boolean {
+    if (active_tool_view) return false
     // Bound on the root and on the window: a click leaves the viewer focused *and*
     // hovered, so both would run and a toggle would cancel itself out. The root fires
     // first and prevents the default, which makes the window pass a no-op.
@@ -798,258 +876,282 @@
   {@attach forward_window_keydown({ handle: handle_hover_keydown })}
 >
   {@render children?.({ structure, fullscreen })}
-  {#if structure_host_tool.component && structure?.sites.length}
-    <structure_host_tool.component {structure} on_overlay={apply_tool_overlay} />
+  {#if show_host_tool && structure_host_tool.component && session.tool_input?.sites.length}
+    <div style:display={active_tool_view ? `none` : `contents`}>
+      <structure_host_tool.component
+        structure={session.tool_input}
+        on_overlay={apply_tool_overlay}
+        on_view={(view) => (tool_view = view)}
+      />
+    </div>
   {/if}
-  {#if loading}
-    <Spinner
-      text="Loading structure..."
-      style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%)"
-    />
-  {:else if error_msg}
-    <StatusMessage bind:message={error_msg} type="error" dismissible />
-  {:else if (structure?.sites?.length ?? 0) > 0 || (volumetric_data?.length ?? 0) > 0}
-    <ViewerChrome
-      {controls_config}
-      bind:fullscreen
-      {fullscreen_toggle}
-      {wrapper}
-      fullscreen_bg_css_var="--struct-bg-fullscreen"
-      on_fullscreen_change={(value) =>
-        on_fullscreen_change?.({ structure, fullscreen: value })}
-      style="--viewer-buttons-gap: 4pt; --viewer-buttons-btn-padding: 1px 2px; --viewer-buttons-align: stretch; --viewer-buttons-hover-bg: transparent; --viewer-buttons-hover-color: light-dark(#000, #fff)"
-    >
-      {#if layout_control_visible}
-        <ToolbarMenu
-          bind:open={view_layout_menu_open}
-          label="View layout: {current_layout.label}"
-          class="view-layout-dropdown"
-        >
-          {#snippet button()}<Icon icon={current_layout.icon} />{/snippet}
-          {#each Object.values(STRUCTURE_LAYOUTS) as { mode, icon, label } (mode)}
-            {#if mode === `single` || (mode === `multi` && multi_layout_available) || (mode === `slice` && slice_layout_available)}
+  {#if active_tool_view}
+    <div class="host-view">
+      {@render active_tool_view.content({
+        scene_props,
+        supercell_scaling,
+        show_image_atoms,
+      })}
+    </div>
+  {:else}
+    {#if tool_volume_notice}<p
+        role="status"
+        style="position: absolute; bottom: 1rem; left: 1rem; right: 1rem; z-index: 2; background: var(--pane-bg, #222); padding: 0.6rem; border-radius: 0.4rem"
+      >
+        {tool_volume_notice}
+      </p>{/if}
+    {#if loading}
+      <Spinner
+        text="Loading structure..."
+        style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%)"
+      />
+    {:else if error_msg}
+      <StatusMessage bind:message={error_msg} type="error" dismissible />
+    {:else if (structure?.sites?.length ?? 0) > 0 || (volumetric_data?.length ?? 0) > 0}
+      <ViewerChrome
+        {controls_config}
+        bind:fullscreen
+        {fullscreen_toggle}
+        {wrapper}
+        fullscreen_bg_css_var="--struct-bg-fullscreen"
+        on_fullscreen_change={(value) =>
+          on_fullscreen_change?.({ structure, fullscreen: value })}
+        style="--viewer-buttons-gap: 4pt; --viewer-buttons-btn-padding: 1px 2px; --viewer-buttons-align: stretch; --viewer-buttons-hover-bg: transparent; --viewer-buttons-hover-color: light-dark(#000, #fff)"
+      >
+        {#if layout_control_visible}
+          <ToolbarMenu
+            bind:open={view_layout_menu_open}
+            label="View layout: {current_layout.label}"
+            class="view-layout-dropdown"
+          >
+            {#snippet button()}<Icon icon={current_layout.icon} />{/snippet}
+            {#each Object.values(STRUCTURE_LAYOUTS) as { mode, icon, label } (mode)}
+              {#if mode === `single` || (mode === `multi` && multi_layout_available) || (mode === `slice` && slice_layout_available)}
+                <button
+                  type="button"
+                  class={['view-mode-option', { selected: current_layout.mode === mode }]}
+                  title={mode === `multi` ? `${label} (G)` : label}
+                  aria-keyshortcuts={mode === `multi` ? `G` : undefined}
+                  aria-pressed={current_layout.mode === mode}
+                  onclick={() => select_structure_layout(mode)}
+                >
+                  <Icon {icon} />
+                  <span>{label}</span>
+                </button>
+              {/if}
+            {/each}
+            {#if reset_camera_available}
               <button
                 type="button"
-                class={['view-mode-option', { selected: current_layout.mode === mode }]}
-                title={mode === `multi` ? `${label} (G)` : label}
-                aria-keyshortcuts={mode === `multi` ? `G` : undefined}
-                aria-pressed={current_layout.mode === mode}
-                onclick={() => select_structure_layout(mode)}
+                class="view-mode-option reset-camera"
+                title={RESET_VIEW_TITLE}
+                aria-keyshortcuts="r"
+                onclick={() => {
+                  session.reset_all_cameras()
+                  view_layout_menu_open = false
+                }}
               >
-                <Icon {icon} />
-                <span>{label}</span>
+                <Icon icon={Reset} />
+                <span>Reset view <kbd>r</kbd></span>
               </button>
             {/if}
-          {/each}
-          {#if reset_camera_available}
-            <button
-              type="button"
-              class="view-mode-option reset-camera"
-              title={RESET_VIEW_TITLE}
-              aria-keyshortcuts="r"
-              onclick={() => {
-                session.reset_all_cameras()
-                view_layout_menu_open = false
-              }}
-            >
-              <Icon icon={Reset} />
-              <span>Reset view <kbd>r</kbd></span>
-            </button>
-          {/if}
-        </ToolbarMenu>
-      {/if}
+          </ToolbarMenu>
+        {/if}
 
-      {#if display_mode === `structure` && enable_measure_mode && controls_config.visible(`measure-mode`)}
-        <StructureEditToolbar {session} />
-      {/if}
+        {#if display_mode === `structure` && enable_measure_mode && controls_config.visible(`measure-mode`)}
+          <StructureEditToolbar {session} />
+        {/if}
 
-      {#if display_mode === `structure` && enable_info_pane && session.base_structure && session.displayed_structure && controls_config.visible(`info-pane`)}
-        <StructureInfoPane
-          structure={session.base_structure}
-          displayed_structure={session.displayed_structure}
-          bonding_strategy={scene_props.bonding_strategy}
-          bind:pane_open={() => is_pane_open(`info`), (open) => set_pane_open(`info`, open)}
-          bind:highlighted_sites
-          bind:hovered_site_idx
-          bind:selected_sites
-          {sym_data}
-          wyckoff_positions={session.wyckoff_rows}
-          {@attach tooltip({ content: `Structure info pane` })}
-        />
-      {/if}
+        {#if display_mode === `structure` && enable_info_pane && session.base_structure && session.displayed_structure && controls_config.visible(`info-pane`)}
+          <StructureInfoPane
+            structure={session.base_structure}
+            displayed_structure={session.displayed_structure}
+            bonding_strategy={scene_props.bonding_strategy}
+            bind:pane_open={() => is_pane_open(`info`), (open) => set_pane_open(`info`, open)}
+            bind:highlighted_sites
+            bind:hovered_site_idx
+            bind:selected_sites
+            {sym_data}
+            wyckoff_positions={session.wyckoff_rows}
+            {@attach tooltip({ content: `Structure info pane` })}
+          />
+        {/if}
 
-      {#if controls_config.visible(`export-pane`)}
-        <StructureExportPane
-          bind:export_pane_open={
-            () => is_pane_open(`export`), (open) => set_pane_open(`export`, open)
-          }
-          structure={session.normalized_structure}
-          {wrapper}
-          {scene}
-          {camera}
-          image_canvas={display_mode === `slice` ? slice_canvas : undefined}
-          image_filename={display_mode === `slice`
-            ? `${display_volumes?.[active_volume_idx]?.label ?? `volume`}-slice`
-            : undefined}
-          enable_3d_export={display_mode === `structure`}
-          bind:png_dpi
-          pane_props={{ style: `--pane-max-height: calc(${height}px - 50px)` }}
-        />
-      {/if}
+        {#if controls_config.visible(`export-pane`)}
+          <StructureExportPane
+            bind:export_pane_open={
+              () => is_pane_open(`export`), (open) => set_pane_open(`export`, open)
+            }
+            structure={session.normalized_structure}
+            {wrapper}
+            {scene}
+            {camera}
+            image_canvas={display_mode === `slice` ? slice_canvas : undefined}
+            image_filename={display_mode === `slice`
+              ? `${volumetric_data?.[active_volume_idx]?.label ?? `volume`}-slice`
+              : undefined}
+            enable_3d_export={display_mode === `structure`}
+            bind:png_dpi
+            pane_props={{ style: `--pane-max-height: calc(${height}px - 50px)` }}
+          />
+        {/if}
 
-      {#if controls_config.visible(`controls`)}
-        <StructureControls
-          bind:controls_open={
-            () => is_pane_open(`controls`), (open) => set_pane_open(`controls`, open)
-          }
-          bind:scene_props
-          bind:show_trajectory_lines
-          bind:show_image_atoms
-          bind:supercell_scaling
-          bind:background_color
-          bind:background_opacity
-          bind:color_scheme
+        {#if controls_config.visible(`controls`)}
+          <StructureControls
+            bind:controls_open={
+              () => is_pane_open(`controls`), (open) => set_pane_open(`controls`, open)
+            }
+            bind:scene_props
+            bind:show_trajectory_lines
+            bind:show_image_atoms
+            bind:supercell_scaling
+            bind:background_color
+            bind:background_opacity
+            bind:color_scheme
+            bind:atom_color_config
+            bind:cell_type
+            bind:volumetric_data
+            bind:isosurface_settings
+            bind:slice_settings
+            bind:active_volume_idx
+            {display_mode}
+            bind:multi_view
+            multi_view_control_visible={controls_config.visible(`multi-view`)}
+            {multi_view_unavailable_reason}
+            structure={tool_structure}
+            supercell_loading={session.supercell_loading}
+            {sym_data}
+            {polyhedra_rendered_elements}
+            {displacement_summary}
+            {trajectory_lines_result}
+            on_reset_camera={reset_camera_available ? session.reset_all_cameras : undefined}
+            bind:fly_to_request={session.fly_to_request}
+            {persist_settings}
+          />
+        {/if}
+
+        {@render top_right_controls?.()}
+      </ViewerChrome>
+
+      {#if display_mode === `structure` && structure?.sites?.length}
+        <AtomLegend
           bind:atom_color_config
-          bind:cell_type
-          bind:volumetric_data={display_volumes}
-          bind:isosurface_settings
-          bind:slice_settings
-          bind:active_volume_idx
-          {display_mode}
-          bind:multi_view
-          multi_view_control_visible={controls_config.visible(`multi-view`)}
-          {multi_view_unavailable_reason}
-          {structure}
-          supercell_loading={session.supercell_loading}
+          property_colors={session.property_colors}
+          elements={get_element_counts(session.supercell_structure ?? structure)}
+          bind:hidden_elements
+          bind:hidden_prop_vals={session.hidden_prop_vals}
+          bind:element_mapping={session.element_mapping}
+          bind:element_radius_overrides={session.element_radius_overrides}
+          bind:site_radius_overrides={session.site_radius_overrides}
+          selected_sites={measure_mode === `edit-atoms` ? session.selected_sites : []}
+          structure={session.render_structure}
+          show_mode_toggle={viewer_active}
           {sym_data}
-          {polyhedra_rendered_elements}
-          {displacement_summary}
-          {trajectory_lines_result}
-          on_reset_camera={reset_camera_available ? session.reset_all_cameras : undefined}
-          bind:fly_to_request={session.fly_to_request}
-          {persist_settings}
-        />
-      {/if}
-
-      {@render top_right_controls?.()}
-    </ViewerChrome>
-
-    {#if display_mode === `structure` && structure?.sites?.length}
-      <AtomLegend
-        bind:atom_color_config
-        property_colors={session.property_colors}
-        elements={get_element_counts(session.supercell_structure ?? structure)}
-        bind:hidden_elements
-        bind:hidden_prop_vals={session.hidden_prop_vals}
-        bind:element_mapping={session.element_mapping}
-        bind:element_radius_overrides={session.element_radius_overrides}
-        bind:site_radius_overrides={session.site_radius_overrides}
-        selected_sites={measure_mode === `edit-atoms` ? session.selected_sites : []}
-        structure={session.displayed_structure}
-        show_mode_toggle={viewer_active}
-        {sym_data}
-      >
-        {#snippet children({ mode_menu_open })}
-          <!-- A lattice is enough: repeating a cell is well defined whatever its pbc flags say
+        >
+          {#snippet children({ mode_menu_open })}
+            <!-- A lattice is enough: repeating a cell is well defined whatever its pbc flags say
             (the phonon explorer tiles a deliberately aperiodic cell), while the primitive and
             conventional buttons inside gate themselves on sym_data -->
-          {#if is_crystal(structure)}
-            <CellSelect
-              bind:supercell_scaling
-              bind:cell_type
-              {sym_data}
-              loading={session.supercell_loading}
-              direction="up"
-              suppress_hover={mode_menu_open}
-            />
-          {/if}
-        {/snippet}
-      </AtomLegend>
-    {/if}
+            {#if is_crystal(structure)}
+              <CellSelect
+                bind:supercell_scaling
+                bind:cell_type
+                {sym_data}
+                loading={session.supercell_loading}
+                direction="up"
+                suppress_hover={mode_menu_open}
+              />
+            {/if}
+          {/snippet}
+        </AtomLegend>
+      {/if}
 
-    <!-- One StructureViewport renders the single view; four render the 2x2 grid. The primary
+      <!-- One StructureViewport renders the single view; four render the 2x2 grid. The primary
       pane (index 0) carries the external camera API: scene/camera are bound out for export,
       camera_position/target persist into scene_props, and it emits on_camera_move/reset. -->
-    {#snippet primary_viewport(view: StructureView)}
-      <StructureViewport
-        {...pane_props(0)}
-        {on_camera_move}
-        {on_camera_reset}
-        {...shared_viewport_props}
-        camera_direction={view.direction}
-        camera_projection={view.projection ?? scene_props.camera_projection}
-        bind:camera_position={scene_props.camera_position}
-        bind:camera_target={scene_props.camera_target}
-        bind:fly_to_request={session.fly_to_request}
-        bind:displacement_summary
-        bind:scene
-        bind:camera
-        {hidden_elements}
-        bind:polyhedra_rendered_elements
-        bind:trajectory_lines_result
-      />
-    {/snippet}
+      {#snippet primary_viewport(view: StructureView)}
+        <StructureViewport
+          {...pane_props(0)}
+          {on_camera_move}
+          {on_camera_reset}
+          {...shared_viewport_props}
+          camera_direction={view.direction}
+          camera_projection={view.projection ?? scene_props.camera_projection}
+          bind:camera_position={scene_props.camera_position}
+          bind:camera_target={scene_props.camera_target}
+          bind:fly_to_request={session.fly_to_request}
+          bind:displacement_summary
+          bind:scene
+          bind:camera
+          {hidden_elements}
+          bind:polyhedra_rendered_elements
+          bind:trajectory_lines_result
+        />
+      {/snippet}
 
-    {#snippet extra_viewport(view: StructureView, pane_idx: number)}
-      <StructureViewport
-        {...pane_props(pane_idx)}
-        label={view.label}
-        {...shared_viewport_props}
-        camera_direction={view.direction}
-        camera_projection={view.projection ?? scene_props.camera_projection}
-        {hidden_elements}
-      />
-    {/snippet}
+      {#snippet extra_viewport(view: StructureView, pane_idx: number)}
+        <StructureViewport
+          {...pane_props(pane_idx)}
+          label={view.label}
+          {...shared_viewport_props}
+          camera_direction={view.direction}
+          camera_projection={view.projection ?? scene_props.camera_projection}
+          {hidden_elements}
+        />
+      {/snippet}
 
-    {#if display_mode === `slice`}
-      <VolumeSliceView
-        volume={display_volumes?.[active_volume_idx]}
-        bind:settings={slice_settings}
-        bind:canvas={slice_canvas}
+      {#if display_mode === `slice`}
+        <VolumeSliceView
+          volume={hidden_volume_indices.has(active_volume_idx)
+            ? undefined
+            : volumetric_data?.[active_volume_idx]}
+          bind:settings={slice_settings}
+          bind:canvas={slice_canvas}
+        />
+        <!-- no GPU adapter in SSR and the vitest runner -->
+      {:else if webgpu_available()}
+        <div class:multi={is_multi_view_active} class="viewport-stage">
+          {@render primary_viewport(is_multi_view_active ? (views[0] ?? {}) : {})}
+          {#if is_multi_view_active}
+            {#each views.slice(1) as view, idx (idx)}
+              {@render extra_viewport(view, idx + 1)}
+            {/each}
+          {/if}
+        </div>
+      {/if}
+
+      <Toast
+        store={toast_store}
+        position="bottom-center"
+        dismissible={false}
+        pause_on_hover={false}
+        focus_hotkey={null}
+        class="edit-toast"
       />
-      <!-- no GPU adapter in SSR and the vitest runner -->
-    {:else if webgpu_available()}
-      <div class:multi={is_multi_view_active} class="viewport-stage">
-        {@render primary_viewport(is_multi_view_active ? (views[0] ?? {}) : {})}
-        {#if is_multi_view_active}
-          {#each views.slice(1) as view, idx (idx)}
-            {@render extra_viewport(view, idx + 1)}
-          {/each}
-        {/if}
-      </div>
+
+      {#if analyze_symmetry && symmetry_error}
+        <StatusMessage
+          bind:message={symmetry_error}
+          type="warning"
+          dismissible
+          class="symmetry-error"
+          style="position: absolute; bottom: 0.5rem; right: 0.5rem; max-width: min(90%, 400px); font-size: 0.75rem; padding: 0.3rem 0.6rem; z-index: var(--z-index-viewer-tooltip, 1000)"
+        />
+      {/if}
+      {#if isosurface_error}
+        <StatusMessage
+          bind:message={isosurface_error}
+          type="warning"
+          dismissible
+          class="isosurface-error"
+          style="position: absolute; top: 0.5rem; left: 50%; transform: translateX(-50%); max-width: 90%; font-size: 0.75rem; padding: 0.3rem 0.6rem; z-index: var(--z-index-viewer-tooltip, 1000)"
+        />
+      {/if}
+    {:else if structure}
+      <p class="warn">No sites found in structure</p>
+    {:else}
+      <p class="warn">No structure provided</p>
     {/if}
-
-    <Toast
-      store={toast_store}
-      position="bottom-center"
-      dismissible={false}
-      pause_on_hover={false}
-      focus_hotkey={null}
-      class="edit-toast"
-    />
-
-    {#if analyze_symmetry && symmetry_error}
-      <StatusMessage
-        bind:message={symmetry_error}
-        type="warning"
-        dismissible
-        class="symmetry-error"
-        style="position: absolute; bottom: 0.5rem; right: 0.5rem; max-width: min(90%, 400px); font-size: 0.75rem; padding: 0.3rem 0.6rem; z-index: var(--z-index-viewer-tooltip, 1000)"
-      />
-    {/if}
-    {#if isosurface_error}
-      <StatusMessage
-        bind:message={isosurface_error}
-        type="warning"
-        dismissible
-        class="isosurface-error"
-        style="position: absolute; top: 0.5rem; left: 50%; transform: translateX(-50%); max-width: 90%; font-size: 0.75rem; padding: 0.3rem 0.6rem; z-index: var(--z-index-viewer-tooltip, 1000)"
-      />
-    {/if}
-  {:else if structure}
-    <p class="warn">No sites found in structure</p>
-  {:else}
-    <p class="warn">No structure provided</p>
   {/if}
 </div>
 
@@ -1084,6 +1186,12 @@
   .structure.dragover {
     background: var(--struct-dragover-bg, var(--dragover-bg));
     border: var(--struct-dragover-border, var(--dragover-border));
+  }
+  .host-view {
+    width: 100%;
+    height: 100%;
+    min-width: 0;
+    min-height: 0;
   }
   .viewport-stage {
     height: 100%;

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -393,6 +393,15 @@
       : isosurface_settings,
   )
   let original_tool_color: AtomColorConfig | null = null
+  const restore_tool_color = (): void => {
+    if (!original_tool_color) return
+    atom_color_config = original_tool_color
+    original_tool_color = null
+  }
+  // Input changes invalidate overlays without requiring another host callback.
+  $effect(() => {
+    if (!active_overlay?.color_property) untrack(restore_tool_color)
+  })
   const apply_tool_overlay = (overlay: StructureToolOverlay | null): void => {
     const color_property =
       overlay?.source === session.tool_input ? overlay?.color_property : undefined
@@ -405,10 +414,7 @@
           scale: `interpolateRdBu`,
           scale_type: `continuous`,
         }
-    } else if (original_tool_color) {
-      atom_color_config = original_tool_color
-      original_tool_color = null
-    }
+    } else restore_tool_color()
     const same_volumes =
       tool_overlay?.source === overlay?.source && tool_overlay?.volumes === overlay?.volumes
     tool_overlay = overlay

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -418,7 +418,8 @@
         }
     } else restore_tool_color()
     // A publication is a fresh snapshot; remember user removals by field ID within this run.
-    if (tool_overlay?.run_id !== overlay?.run_id) removed_tool_fields.clear()
+    const same_run = tool_overlay?.run_id === overlay?.run_id
+    if (!same_run) removed_tool_fields.clear()
     else {
       const present = new Set(volumetric_data)
       for (const volume of owned_volumes)
@@ -428,6 +429,7 @@
     tool_source = session.tool_input
     const active_before = volumetric_data?.[active_volume_idx]
     const restore_active = active_before !== undefined && owned_volume_set.has(active_before)
+    const preserve_active = restore_active || (same_run && owned_volumes.length > 0)
     if (!restore_active) original_active_volume = active_before
     const incoming = (overlay?.volumes ?? []).filter(
       ({ field_id }) => !removed_tool_fields.has(field_id),
@@ -444,7 +446,7 @@
     owned_volumes = volumetric_data.slice(result.first_idx) as StructureToolVolume[]
     if (incoming.length) {
       active_volume_idx =
-        restore_active && result.active_idx !== undefined
+        preserve_active && result.active_idx !== undefined
           ? result.active_idx
           : result.first_idx
     } else {

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -74,9 +74,11 @@
     structure_host_tool,
     create_structure_tool_controller,
     type StructureToolPrediction,
+    type StructureToolProvenance,
     type StructureToolVolume,
     type StructureToolView,
   } from './host-tool.svelte'
+  import { copy_prediction } from './prediction'
   import { replace_tool_volumes } from './host-tool-volumes'
   import { apply_structure_material } from './material'
 
@@ -143,6 +145,7 @@
     allow_file_drop = true,
     data_url,
     structure_string,
+    prediction,
     on_file_drop,
     on_file_load,
     on_error,
@@ -220,6 +223,7 @@
     atom_color_config?: AtomColorConfig
     allow_file_drop?: boolean
     data_url?: string // fetched and parsed when no structure is supplied
+    prediction?: StructureToolPrediction
     structure_string?: string // parsed when neither structure nor data_url is supplied
     // Host takes over dropped/fetched content (and owns `structure`) instead of the parser
     on_file_drop?: FileLoadCallback
@@ -283,6 +287,15 @@
     set_error: (message) => (error_msg = message),
     set_dragover: (over) => (dragover = over),
     commit: (opened) => {
+      if (opened.type === `structure` && opened.prediction) {
+        load_prediction(opened.prediction)
+        on_file_load?.({
+          structure,
+          ...opened.provenance,
+          total_atoms: structure?.sites.length ?? 0,
+        })
+        return
+      }
       const { document, notice } = apply_structure_material(
         { structure, volumetric_data, isosurface_settings, active_volume_idx },
         opened,
@@ -340,6 +353,7 @@
   })
 
   let tool_source = $state.raw<AnyStructure | undefined>()
+  let tool_source_revision = ``
   let tool_view = $state.raw<StructureToolView | null>(null)
   const active_tool_view = $derived(tool_source === session.tool_input ? tool_view : null)
   let tool_overlay = $state.raw<StructureToolPrediction | null>(null)
@@ -427,6 +441,7 @@
     }
     tool_overlay = overlay
     tool_source = session.tool_input
+    tool_source_revision = overlay ? JSON.stringify(tool_source) : ``
     const active_before = volumetric_data?.[active_volume_idx]
     const restore_active = active_before !== undefined && owned_volume_set.has(active_before)
     const preserve_active = restore_active || (same_run && owned_volumes.length > 0)
@@ -463,7 +478,9 @@
   }
   // Cached until an input property changes; catches in-place edits without rescanning per callback.
   const tool_input_revision = $derived(
-    show_host_tool && structure_host_tool.component ? JSON.stringify(session.tool_input) : ``,
+    (show_host_tool && structure_host_tool.component) || tool_overlay
+      ? JSON.stringify(session.tool_input)
+      : ``,
   )
   const tool_controller = create_structure_tool_controller(
     () => session.tool_input,
@@ -483,9 +500,40 @@
       show_host_tool,
       structure_host_tool.component,
     ]
-    untrack(() => tool_controller.invalidate_if_changed())
+    untrack(() => {
+      tool_controller.invalidate_if_changed()
+      clear_stale_prediction()
+    })
   })
+  // Imported output has no running computation. Clearing it must not abort a newer run.
+  function clear_stale_prediction(): void {
+    if (
+      tool_overlay &&
+      (tool_source !== session.tool_input || tool_source_revision !== tool_input_revision)
+    )
+      apply_tool_overlay(null)
+  }
+  function start_tool_run(provenance: StructureToolProvenance) {
+    clear_stale_prediction()
+    return tool_controller.start_run(provenance)
+  }
   onDestroy(() => tool_controller.dispose())
+  function load_prediction(source: StructureToolPrediction): void {
+    const snapshot = copy_prediction(source)
+    structure = snapshot.input
+    session.element_mapping = undefined
+    cell_type = `original`
+    supercell_scaling = `1x1x1`
+    // Abort listeners may restart synchronously; they must capture the imported input.
+    tool_controller.clear()
+    volumetric_data = []
+    isosurface_settings = { ...isosurface_settings, layers: [] }
+    active_volume_idx = 0
+    apply_tool_overlay(snapshot)
+  }
+  $effect(() => {
+    if (prediction) untrack(() => load_prediction(prediction))
+  })
   const reset_prediction_surfaces = (): void => {
     isosurface_settings = {
       ...isosurface_settings,
@@ -943,7 +991,7 @@
     <div style:display={active_tool_view ? `none` : `contents`}>
       <structure_host_tool.component
         structure={session.tool_input}
-        start_run={tool_controller.start_run}
+        start_run={start_tool_run}
       />
     </div>
   {/if}

--- a/src/lib/structure/Structure.svelte
+++ b/src/lib/structure/Structure.svelte
@@ -441,7 +441,7 @@
     }
     tool_overlay = overlay
     tool_source = session.tool_input
-    tool_source_revision = overlay ? JSON.stringify(tool_source) : ``
+    tool_source_revision = overlay ? tool_input_revision : ``
     const active_before = volumetric_data?.[active_volume_idx]
     const restore_active = active_before !== undefined && owned_volume_set.has(active_before)
     const preserve_active = restore_active || (same_run && owned_volumes.length > 0)

--- a/src/lib/structure/StructureControls.svelte
+++ b/src/lib/structure/StructureControls.svelte
@@ -22,7 +22,7 @@
   import type { ZoneAxisMode } from '$lib/scene'
   import { is_valid_zone_axis, ZONE_AXIS_MODE_LABELS, zone_axis_direction } from '$lib/scene'
   import { ColorScaleSelect } from '$lib/plot'
-  import type { AtomColorMode, VectorLayerConfig } from '$lib/settings'
+  import type { AtomColorMode, SettingType, VectorLayerConfig } from '$lib/settings'
   import { DEFAULTS, SETTINGS_CONFIG } from '$lib/settings'
   import type { StructurePaneSize, StructureViewState } from '$lib/settings/viewer-state'
   import {
@@ -305,6 +305,12 @@
     label,
     step,
   })
+  const number_range_props = (schema: SettingType, step = schema.multipleOf ?? `any`) => {
+    const { minimum: min, maximum: max, description: title } = schema
+    if (min === undefined || max === undefined)
+      throw new Error(`Missing range bounds for "${title}": min=${min}, max=${max}`)
+    return { min, max, step, title }
+  }
   // A getter, not a const: the parent may rebind scene_props to a fresh object
   const scene_record = () => scene_props as Record<string, unknown>
   const row_value = (current: Row): unknown =>
@@ -795,8 +801,7 @@
       {#if typeof schema.value === `number`}
         <NumberRangeInput
           setting={key}
-          schema={SETTINGS_CONFIG.structure}
-          {step}
+          {...number_range_props(schema, step)}
           bind:value={() => row_value(current) as number | undefined, set}
           >{label}</NumberRangeInput
         >
@@ -1377,8 +1382,7 @@
         </label>
         <NumberRangeInput
           setting="background_opacity"
-          schema={{ background_opacity: SETTINGS_CONFIG.background_opacity }}
-          step={0.02}
+          {...number_range_props(SETTINGS_CONFIG.background_opacity, 0.02)}
           bind:value={background_opacity}>Opacity</NumberRangeInput
         >
       </SettingsSection>
@@ -1447,7 +1451,7 @@
               {/if}
               <NumberRangeInput
                 setting="trajectory_line_trail_frames"
-                schema={SETTINGS_CONFIG.structure}
+                {...number_range_props(SETTINGS_CONFIG.structure.trajectory_line_trail_frames)}
                 max={Math.max(1, scene_props.trajectory_position_stream.n_frames)}
                 bind:value={scene_props.trajectory_line_trail_frames}
                 >Trail length <small>(0 = all)</small></NumberRangeInput

--- a/src/lib/structure/StructureExportPane.svelte
+++ b/src/lib/structure/StructureExportPane.svelte
@@ -122,6 +122,17 @@
     }
   }
 
+  let prediction_error = $state(``)
+  function prediction_text(): string | null {
+    prediction_error = ``
+    try {
+      return prediction ? prediction_to_json(prediction) : null
+    } catch (error) {
+      prediction_error = `Export failed: ${String(error)}. Correct the prediction metadata and retry.`
+      return null
+    }
+  }
+
   const sections = $derived<ExportSection[]>([
     ...(prediction
       ? [
@@ -132,14 +143,15 @@
                 label: `Export prediction`,
                 hint: `JSON with input structure, site properties, density grids, model/version, units and calculation settings`,
                 on_download: () => {
-                  if (prediction)
+                  const content = prediction_text()
+                  if (prediction && content)
                     download(
-                      prediction_to_json(prediction),
+                      content,
                       `prediction-${prediction.run_id}.json`,
                       `application/json`,
                     )
                 },
-                copy_text: () => (prediction ? prediction_to_json(prediction) : null),
+                copy_text: prediction_text,
               },
             ],
           },
@@ -204,6 +216,8 @@
       : []),
   ])
 </script>
+
+{#if prediction_error}<p role="alert">{prediction_error}</p>{/if}
 
 <ExportPane
   bind:export_pane_open

--- a/src/lib/structure/StructureExportPane.svelte
+++ b/src/lib/structure/StructureExportPane.svelte
@@ -217,10 +217,14 @@
   }}
   {...rest}
 >
-  {#if prediction}
+  {#if prediction && (on_reset_prediction_surfaces || on_clear_prediction)}
     <div style="display: flex; gap: 0.5rem; flex-wrap: wrap">
-      <button onclick={on_reset_prediction_surfaces}>Reset prediction surfaces</button>
-      <button onclick={on_clear_prediction}>Clear prediction</button>
+      {#if on_reset_prediction_surfaces}
+        <button onclick={on_reset_prediction_surfaces}>Reset prediction surfaces</button>
+      {/if}
+      {#if on_clear_prediction}
+        <button onclick={on_clear_prediction}>Clear prediction</button>
+      {/if}
     </div>
   {/if}
 </ExportPane>

--- a/src/lib/structure/StructureExportPane.svelte
+++ b/src/lib/structure/StructureExportPane.svelte
@@ -8,12 +8,17 @@
   import type { AnyStructure } from '$lib/structure'
   import * as exports from '$lib/structure/export'
   import type { StructTextFormat } from '$lib/structure/export'
+  import { download } from '$lib/io/fetch'
+  import { prediction_to_json, type StructureToolPrediction } from './host-tool.svelte'
   import type { ComponentProps } from 'svelte'
   import type { Camera, Scene } from 'three/webgpu'
 
   let {
     export_pane_open = $bindable(false),
     structure = undefined,
+    prediction,
+    on_clear_prediction,
+    on_reset_prediction_surfaces,
     wrapper = undefined,
     scene = undefined,
     camera = undefined,
@@ -27,6 +32,9 @@
   }: {
     export_pane_open?: boolean
     structure?: AnyStructure
+    prediction?: StructureToolPrediction
+    on_clear_prediction?: () => void
+    on_reset_prediction_surfaces?: () => void
     wrapper?: HTMLDivElement
     scene?: Scene
     camera?: Camera
@@ -115,6 +123,28 @@
   }
 
   const sections = $derived<ExportSection[]>([
+    ...(prediction
+      ? [
+          {
+            title: `Prediction`,
+            items: [
+              {
+                label: `Export prediction`,
+                hint: `JSON with input structure, site properties, density grids, model/version, units and calculation settings`,
+                on_download: () => {
+                  if (prediction)
+                    download(
+                      prediction_to_json(prediction),
+                      `prediction-${prediction.run_id}.json`,
+                      `application/json`,
+                    )
+                },
+                copy_text: () => (prediction ? prediction_to_json(prediction) : null),
+              },
+            ],
+          },
+        ]
+      : []),
     {
       title: `Export as text`,
       items: text_export_formats.map(({ label, format, hint }) => {
@@ -186,4 +216,11 @@
     class: [`structure-export-toggle`, toggle_props?.class],
   }}
   {...rest}
-/>
+>
+  {#if prediction}
+    <div style="display: flex; gap: 0.5rem; flex-wrap: wrap">
+      <button onclick={on_reset_prediction_surfaces}>Reset prediction surfaces</button>
+      <button onclick={on_clear_prediction}>Clear prediction</button>
+    </div>
+  {/if}
+</ExportPane>

--- a/src/lib/structure/StructureViewport.svelte
+++ b/src/lib/structure/StructureViewport.svelte
@@ -29,7 +29,6 @@
   import type { AtomPropertyColors } from './atom-properties'
   import type { StructureSession } from './session.svelte'
   import StructureScene from './StructureScene.svelte'
-  import { get_orig_site_idx } from './site'
 
   // Self-heal a lost GPU device (driver reset, resource pressure): unlike WebGL there is no
   // "restored" event, so recovery means remounting the <Canvas> for a fresh renderer.
@@ -91,7 +90,6 @@
     session,
     view_reset_key = undefined,
     reference_structure = undefined,
-    site_properties = undefined,
     scene_props = {},
     gizmo = false,
     volumetric_data = undefined,
@@ -127,7 +125,6 @@
     on_camera_reset?: (data: StructureHandlerData) => void
     session: StructureSession
     view_reset_key?: unknown
-    site_properties?: Record<string, unknown>[]
     reference_structure?: AnyStructure // comparison geometry for displacement arrows
     scene_props?: ComponentProps<typeof StructureScene>
     gizmo?: boolean | ComponentProps<typeof StructureScene>[`gizmo`]
@@ -149,17 +146,7 @@
     trajectory_lines_result?: TrajectoryLinesStats | null
   } = $props()
 
-  let structure = $derived.by(() => {
-    const displayed = session.displayed_structure
-    if (!displayed || !site_properties || !session.shows_input_frame) return displayed
-    return {
-      ...displayed,
-      sites: displayed.sites.map((site, idx) => ({
-        ...site,
-        properties: { ...site.properties, ...site_properties[get_orig_site_idx(site, idx)] },
-      })),
-    }
-  })
+  let structure = $derived(session.render_structure)
 
   // Cell-local dimensions (each pane is responsible for its own zoom sizing) and cursor
   let width = $state(0)

--- a/src/lib/structure/StructureViewport.svelte
+++ b/src/lib/structure/StructureViewport.svelte
@@ -17,12 +17,13 @@
   import type { TrajectoryLinesStats } from '$lib/structure/trajectory-lines'
   import { Canvas } from '@threlte/core'
   import type { ComponentProps } from 'svelte'
-  import { untrack } from 'svelte'
+  import { onDestroy, tick, untrack } from 'svelte'
   import { SvelteSet } from 'svelte/reactivity'
   import {
     clear_pan_offset,
     create_renderer,
     read_pan_offset,
+    restore_camera_view,
     responsive_gizmo_size,
   } from '$lib/scene'
   import { type Camera, OrthographicCamera, type Scene } from 'three/webgpu'
@@ -82,6 +83,7 @@
     interactive = true,
     on_activate = undefined,
     report_moved = undefined,
+    view_state,
     on_camera_move = undefined,
     on_camera_reset = undefined,
 
@@ -121,6 +123,16 @@
     interactive?: boolean
     on_activate?: () => void
     report_moved?: (moved: boolean) => void
+    // Parent-owned storage survives a host view replacing this viewport.
+    view_state?: {
+      get_pose_key: () => string
+      pose_key?: string
+      camera?: Camera
+      target?: Vec3
+      key?: unknown
+      reset_token?: number
+      direction?: Vec3
+    }
     on_camera_move?: (data: StructureHandlerData) => void
     on_camera_reset?: (data: StructureHandlerData) => void
     session: StructureSession
@@ -275,6 +287,48 @@
       pan: read_pan(),
     }
   }
+  onDestroy(() => {
+    if (!view_state || !camera) return
+    Object.assign(view_state, {
+      camera: camera.clone(),
+      target: read_orbit_target(),
+      key: view_reset_key,
+      reset_token,
+      direction: camera_direction && [...camera_direction],
+      pose_key: view_state.get_pose_key(),
+    })
+  })
+  $effect(() => {
+    const live_camera = camera
+    const controls = orbit_controls
+    if (!live_camera || !controls || !width || !height || initial_computed_zoom === undefined)
+      return
+    // Let the new scene finish applying its initial auto-fit before restoring user zoom.
+    let cancelled = false
+    void tick().then(() => {
+      if (cancelled) return
+      const saved = view_state?.camera
+      if (!saved || !view_state) return
+      delete view_state.camera
+      if (
+        view_state.key !== view_reset_key ||
+        view_state.reset_token !== reset_token ||
+        view_state.pose_key !== view_state.get_pose_key() ||
+        saved.type !== live_camera.type ||
+        !same_pose(view_state.direction, camera_direction)
+      )
+        return
+      restore_camera_view(live_camera, saved, width, height)
+      if (view_state.target) controls.target.set(...view_state.target)
+      controls.update()
+      camera_position = read_camera_position()
+      camera_target = read_orbit_target()
+      remember_current_view()
+    })
+    return () => {
+      cancelled = true
+    }
+  })
   // Only a fresh gesture may cancel a pending settle. Rebaselining alone must not: the push
   // effect below also rebaselines, and cancelling there drops the sync that reports a drag.
   // OrbitControls dispatches `end` on every pointer release, also for presses it never turned

--- a/src/lib/structure/StructureViewport.svelte
+++ b/src/lib/structure/StructureViewport.svelte
@@ -287,17 +287,29 @@
       pan: read_pan(),
     }
   }
-  onDestroy(() => {
-    if (!view_state || !camera) return
-    Object.assign(view_state, {
-      camera: camera.clone(),
-      target: read_orbit_target(),
+  // Capture parent props while mounted: evaluating their derived getters during destruction
+  // can disconnect the layout dependencies that are removing this pane.
+  let save_view: (() => void) | undefined
+  $effect(() => {
+    const owner = view_state
+    const live_camera = camera
+    const controls = orbit_controls
+    const context = {
       key: view_reset_key,
       reset_token,
       direction: camera_direction && [...camera_direction],
-      pose_key: view_state.get_pose_key(),
-    })
+      pose_key: owner?.get_pose_key(),
+    }
+    save_view = () => {
+      if (!owner || !live_camera) return
+      Object.assign(owner, {
+        ...context,
+        camera: live_camera.clone(),
+        target: controls?.target.toArray(),
+      })
+    }
   })
+  onDestroy(() => save_view?.())
   $effect(() => {
     const live_camera = camera
     const controls = orbit_controls

--- a/src/lib/structure/host-tool-volumes.ts
+++ b/src/lib/structure/host-tool-volumes.ts
@@ -1,0 +1,57 @@
+import { auto_volume_layer } from '$lib/isosurface/types'
+import type { IsosurfaceLayer, VolumetricData } from '$lib/isosurface/types'
+import type { StructureToolVolume } from './host-tool.svelte'
+
+// Rebuild one index map for both geometry and color sources. Surviving field IDs retain
+// every layer (including zero layers); only genuinely new fields receive defaults.
+export function replace_tool_volumes(
+  volumes: VolumetricData[],
+  layers: IsosurfaceLayer[],
+  owned: StructureToolVolume[],
+  incoming: StructureToolVolume[],
+  active_volume_idx: number,
+) {
+  const owned_set = new Set<VolumetricData>(owned)
+  const retained = volumes.filter((volume) => !owned_set.has(volume))
+  const next_volumes = [...retained, ...incoming]
+  const next_indices = new Map<VolumetricData, number>(
+    next_volumes.map((volume, idx) => [volume, idx]),
+  )
+  const field_indices = new Map(
+    incoming.map(({ field_id }, idx) => [field_id, retained.length + idx]),
+  )
+  const old_fields = new Map<VolumetricData, string>(
+    owned.map((volume) => [volume, volume.field_id]),
+  )
+  const remap = volumes.map((volume) => {
+    const field_id = old_fields.get(volume)
+    return field_id === undefined ? next_indices.get(volume) : field_indices.get(field_id)
+  })
+  const next_layers: IsosurfaceLayer[] = layers.flatMap((layer) => {
+    const volume_idx = remap[layer.volume_idx ?? active_volume_idx]
+    return volume_idx === undefined
+      ? []
+      : [
+          {
+            ...layer,
+            volume_idx,
+            color_volume_idx:
+              layer.color_volume_idx === undefined ? undefined : remap[layer.color_volume_idx],
+          },
+        ]
+  })
+  const present_volumes = new Set(volumes)
+  const previous_ids = new Set(
+    owned.filter((volume) => present_volumes.has(volume)).map(({ field_id }) => field_id),
+  )
+  for (const [idx, volume] of incoming.entries()) {
+    if (!previous_ids.has(volume.field_id))
+      next_layers.push(auto_volume_layer(volume, retained.length + idx))
+  }
+  return {
+    volumes: next_volumes,
+    layers: next_layers,
+    first_idx: retained.length,
+    active_idx: remap[active_volume_idx],
+  }
+}

--- a/src/lib/structure/host-tool-volumes.ts
+++ b/src/lib/structure/host-tool-volumes.ts
@@ -11,22 +11,17 @@ export function replace_tool_volumes(
   incoming: StructureToolVolume[],
   active_volume_idx: number,
 ) {
-  const owned_set = new Set<VolumetricData>(owned)
-  const retained = volumes.filter((volume) => !owned_set.has(volume))
-  const next_volumes = [...retained, ...incoming]
-  const next_indices = new Map<VolumetricData, number>(
-    next_volumes.map((volume, idx) => [volume, idx]),
-  )
-  const field_indices = new Map(
-    incoming.map(({ field_id }, idx) => [field_id, retained.length + idx]),
-  )
   const old_fields = new Map<VolumetricData, string>(
     owned.map((volume) => [volume, volume.field_id]),
   )
-  const remap = volumes.map((volume) => {
-    const field_id = old_fields.get(volume)
-    return field_id === undefined ? next_indices.get(volume) : field_indices.get(field_id)
-  })
+  const retained = volumes.filter((volume) => !old_fields.has(volume))
+  const next_volumes = [...retained, ...incoming]
+  // Retained volumes use object identity; replaced tool fields use their stable IDs.
+  const next_indices = new Map<VolumetricData | string, number>(
+    next_volumes.map((volume, idx) => [volume, idx]),
+  )
+  incoming.forEach(({ field_id }, idx) => next_indices.set(field_id, retained.length + idx))
+  const remap = volumes.map((volume) => next_indices.get(old_fields.get(volume) ?? volume))
   const next_layers: IsosurfaceLayer[] = layers.flatMap((layer) => {
     const volume_idx = remap[layer.volume_idx ?? active_volume_idx]
     return volume_idx === undefined
@@ -40,10 +35,7 @@ export function replace_tool_volumes(
           },
         ]
   })
-  const present_volumes = new Set(volumes)
-  const previous_ids = new Set(
-    owned.filter((volume) => present_volumes.has(volume)).map(({ field_id }) => field_id),
-  )
+  const previous_ids = new Set(volumes.map((volume) => old_fields.get(volume)))
   for (const [idx, volume] of incoming.entries()) {
     if (!previous_ids.has(volume.field_id))
       next_layers.push(auto_volume_layer(volume, retained.length + idx))

--- a/src/lib/structure/host-tool.svelte.ts
+++ b/src/lib/structure/host-tool.svelte.ts
@@ -8,7 +8,7 @@ import type { AnyStructure } from './index'
 export type StructureToolVolume = VolumetricData & { field_id: string }
 export interface StructureToolOverlay {
   // Publication copies these values. Hosts may reuse or mutate buffers after on_overlay returns.
-  // Shared buffers are supported for density values, but not inside site properties.
+  // Shared buffers are supported for density values, but not inside metadata.
   site_properties?: Record<string, unknown>[]
   volumes?: StructureToolVolume[]
   color_property?: string
@@ -56,7 +56,7 @@ function reject_shared_buffers(value: unknown, seen = new WeakSet<object>()): vo
   const buffer = ArrayBuffer.isView(value) ? value.buffer : value
   if (typeof SharedArrayBuffer !== `undefined` && buffer instanceof SharedArrayBuffer)
     throw new Error(
-      `Prediction properties cannot contain shared buffers; copy them before publishing`,
+      `Prediction metadata cannot contain shared buffers; copy them before publishing`,
     )
   if (ArrayBuffer.isView(value)) return
   const children =
@@ -66,6 +66,12 @@ function reject_shared_buffers(value: unknown, seen = new WeakSet<object>()): vo
         ? [...value]
         : Object.values(value)
   for (const child of children) reject_shared_buffers(child, seen)
+}
+
+function copy_metadata<T>(value: T) {
+  const copied = structuredClone($state.snapshot(value))
+  reject_shared_buffers(copied)
+  return copied
 }
 
 // Each mounted viewer owns its controller. Guards also run synchronously on callbacks, so
@@ -99,8 +105,8 @@ export function create_structure_tool_controller(
         throw new Error(`Cannot start a host run without a mounted, enabled structure viewer`)
       if (!provenance.model.trim() || !provenance.version.trim())
         throw new Error(`Prediction model and version must be nonempty`)
-      const input = structuredClone($state.snapshot(structure))
-      const captured_provenance = structuredClone($state.snapshot(provenance))
+      const input = copy_metadata(structure)
+      const captured_provenance = copy_metadata(provenance)
       const previous = current
       const stale_output = previous && !previous.is_current()
       const abort = new AbortController()
@@ -144,13 +150,11 @@ export function create_structure_tool_controller(
           }
           if (!overlay) return on_prediction(null)
           const { volumes, ...properties } = overlay
-          const copied_properties = structuredClone($state.snapshot(properties))
-          reject_shared_buffers(copied_properties)
           on_prediction({
-            ...copied_properties,
+            ...copy_metadata(properties),
             // Keep large density buffers out of $state.snapshot so each is copied only once.
             volumes: volumes?.map(({ values, ...metadata }) => ({
-              ...structuredClone($state.snapshot(metadata)),
+              ...copy_metadata(metadata),
               values: new Float64Array(values),
             })),
             input,

--- a/src/lib/structure/host-tool.svelte.ts
+++ b/src/lib/structure/host-tool.svelte.ts
@@ -7,6 +7,8 @@ import type { AnyStructure } from './index'
 // when those semantics change; array order, labels and grid resolution do not affect identity.
 export type StructureToolVolume = VolumetricData & { field_id: string }
 export interface StructureToolOverlay {
+  // Publication copies these values. Hosts may reuse or mutate buffers after on_overlay returns.
+  // Shared buffers are supported for density values, but not inside site properties.
   site_properties?: Record<string, unknown>[]
   volumes?: StructureToolVolume[]
   color_property?: string
@@ -45,6 +47,25 @@ export interface StructureToolRun {
 export interface StructureToolProps {
   structure: AnyStructure
   start_run: (provenance: StructureToolProvenance) => StructureToolRun
+}
+
+// structuredClone keeps shared storage shared; reject it in arbitrary property metadata.
+function reject_shared_buffers(value: unknown, seen = new WeakSet<object>()): void {
+  if (!value || typeof value !== `object` || seen.has(value)) return
+  seen.add(value)
+  const buffer = ArrayBuffer.isView(value) ? value.buffer : value
+  if (typeof SharedArrayBuffer !== `undefined` && buffer instanceof SharedArrayBuffer)
+    throw new Error(
+      `Prediction properties cannot contain shared buffers; copy them before publishing`,
+    )
+  if (ArrayBuffer.isView(value)) return
+  const children =
+    value instanceof Map
+      ? [...value.keys(), ...value.values()]
+      : value instanceof Set
+        ? [...value]
+        : Object.values(value)
+  for (const child of children) reject_shared_buffers(child, seen)
 }
 
 // Each mounted viewer owns its controller. Guards also run synchronously on callbacks, so
@@ -121,11 +142,21 @@ export function create_structure_tool_controller(
               )
             field_ids.add(field_id)
           }
-          on_prediction(
-            overlay
-              ? { ...overlay, input, run_id: id, provenance: captured_provenance }
-              : null,
-          )
+          if (!overlay) return on_prediction(null)
+          const { volumes, ...properties } = overlay
+          const copied_properties = structuredClone($state.snapshot(properties))
+          reject_shared_buffers(copied_properties)
+          on_prediction({
+            ...copied_properties,
+            // Keep large density buffers out of $state.snapshot so each is copied only once.
+            volumes: volumes?.map(({ values, ...metadata }) => ({
+              ...structuredClone($state.snapshot(metadata)),
+              values: new Float64Array(values),
+            })),
+            input,
+            run_id: id,
+            provenance: captured_provenance,
+          })
         },
         on_view(view) {
           if (is_current()) on_view(view)

--- a/src/lib/structure/host-tool.svelte.ts
+++ b/src/lib/structure/host-tool.svelte.ts
@@ -1,4 +1,5 @@
-import type { Component } from 'svelte'
+import type { Component, ComponentProps, Snippet } from 'svelte'
+import type StructureScene from './StructureScene.svelte'
 import type { VolumetricData } from '$lib/isosurface'
 import type { AnyStructure } from './index'
 
@@ -8,11 +9,25 @@ export interface StructureToolOverlay {
   source: AnyStructure
   site_properties?: Record<string, unknown>[]
   volumes?: VolumetricData[]
+  color_property?: string
+}
+
+// A host can lend a full-size view (for example a growing trajectory) without replacing
+// the source structure or unmounting the tool that owns the computation.
+export interface StructureToolViewProps {
+  scene_props: ComponentProps<typeof StructureScene>
+  supercell_scaling: string
+  show_image_atoms: boolean
+}
+export interface StructureToolView {
+  source: AnyStructure
+  content: Snippet<[StructureToolViewProps]>
 }
 
 export interface StructureToolProps {
   structure: AnyStructure
   on_overlay: (overlay: StructureToolOverlay | null) => void
+  on_view: (view: StructureToolView | null) => void
 }
 
 // A host registers once before mounting; this also reaches independently mounted file viewers.

--- a/src/lib/structure/host-tool.svelte.ts
+++ b/src/lib/structure/host-tool.svelte.ts
@@ -56,21 +56,18 @@ export function create_structure_tool_controller(
   on_view: (view: StructureToolView | null) => void,
   get_revision: () => string,
 ) {
-  let current: StructureToolRun | undefined
-  let abort: AbortController | undefined
+  let current: { abort: AbortController; is_current: () => boolean } | undefined
   let next_id = 0
   let disposed = false
-  let is_current_run = (): boolean => false
   const clear = (): void => {
     on_prediction(null)
     on_view(null)
   }
   const invalidate = (): void => {
-    const previous_abort = abort
-    abort = undefined
+    const previous = current
     current = undefined
     clear()
-    previous_abort?.abort()
+    previous?.abort.abort()
   }
   return {
     start_run(provenance: StructureToolProvenance): StructureToolRun {
@@ -83,19 +80,27 @@ export function create_structure_tool_controller(
         throw new Error(`Prediction model and version must be nonempty`)
       const input = structuredClone($state.snapshot(structure))
       const captured_provenance = structuredClone($state.snapshot(provenance))
-      const stale_output = current && !is_current_run()
-      const previous_abort = abort
-      abort = new AbortController()
+      const previous = current
+      const stale_output = previous && !previous.is_current()
+      const abort = new AbortController()
       const id = ++next_id
       const signal = abort.signal
       const is_current = (): boolean =>
         !disposed &&
         !signal.aborted &&
-        current?.id === id &&
+        current?.abort === abort &&
         get_owner() === owner &&
         get_structure() === structure &&
         get_revision() === revision
-      const run: StructureToolRun = {
+      current = { abort, is_current }
+      // A same-turn input/tool change may precede the invalidation effect. Only retain
+      // previous output (and its appearance) when it still belongs to this input and tool.
+      if (stale_output) on_prediction(null)
+      // A previous view may close over its aborted run. Return before starting new work.
+      on_view(null)
+      // Abort listeners can synchronously start another run; it must retain ownership.
+      previous?.abort.abort()
+      return {
         id,
         structure: structuredClone(input),
         signal,
@@ -132,19 +137,9 @@ export function create_structure_tool_controller(
           if (is_current()) invalidate()
         },
       }
-      current = run
-      is_current_run = is_current
-      // A same-turn input/tool change may precede the invalidation effect. Only retain
-      // previous output (and its appearance) when it still belongs to this input and tool.
-      if (stale_output) on_prediction(null)
-      // A previous view may close over its aborted run. Return before starting new work.
-      on_view(null)
-      // Abort listeners can synchronously start another run; it must retain ownership.
-      previous_abort?.abort()
-      return run
     },
     invalidate_if_changed(): void {
-      if (current && !is_current_run()) invalidate()
+      if (current && !current.is_current()) invalidate()
     },
     clear: invalidate,
     dispose(): void {

--- a/src/lib/structure/host-tool.svelte.ts
+++ b/src/lib/structure/host-tool.svelte.ts
@@ -83,6 +83,7 @@ export function create_structure_tool_controller(
         throw new Error(`Prediction model and version must be nonempty`)
       const input = structuredClone($state.snapshot(structure))
       const captured_provenance = structuredClone($state.snapshot(provenance))
+      const stale_output = current && !is_current_run()
       const previous_abort = abort
       abort = new AbortController()
       const id = ++next_id
@@ -133,6 +134,9 @@ export function create_structure_tool_controller(
       }
       current = run
       is_current_run = is_current
+      // A same-turn input/tool change may precede the invalidation effect. Only retain
+      // previous output (and its appearance) when it still belongs to this input and tool.
+      if (stale_output) on_prediction(null)
       // A previous view may close over its aborted run. Return before starting new work.
       on_view(null)
       // Abort listeners can synchronously start another run; it must retain ownership.

--- a/src/lib/structure/host-tool.svelte.ts
+++ b/src/lib/structure/host-tool.svelte.ts
@@ -3,7 +3,8 @@ import type StructureScene from './StructureScene.svelte'
 import type { VolumetricData } from '$lib/isosurface'
 import type { AnyStructure } from './index'
 
-// Field IDs describe a physical quantity, independently of array order, labels or grid size.
+// Reuse a field ID only for the same physical quantity, units and normalization. Change it
+// when those semantics change; array order, labels and grid resolution do not affect identity.
 export type StructureToolVolume = VolumetricData & { field_id: string }
 export interface StructureToolOverlay {
   site_properties?: Record<string, unknown>[]

--- a/src/lib/structure/host-tool.svelte.ts
+++ b/src/lib/structure/host-tool.svelte.ts
@@ -1,29 +1,24 @@
 import type { Component, ComponentProps, Snippet } from 'svelte'
 import type StructureScene from './StructureScene.svelte'
-import type { VolumetricData } from '$lib/isosurface'
 import type { AnyStructure } from './index'
+import {
+  copy_prediction_input,
+  copy_prediction_overlay,
+  copy_prediction_provenance,
+} from './prediction'
+import type {
+  StructureToolOverlay,
+  StructureToolPrediction,
+  StructureToolProvenance,
+} from './prediction'
 
-// Reuse a field ID only for the same physical quantity, units and normalization. Change it
-// when those semantics change; array order, labels and grid resolution do not affect identity.
-export type StructureToolVolume = VolumetricData & { field_id: string }
-export interface StructureToolOverlay {
-  // Publication copies these values. Hosts may reuse or mutate buffers after on_overlay returns.
-  // Shared buffers are supported for density values, but not inside metadata.
-  site_properties?: Record<string, unknown>[]
-  volumes?: StructureToolVolume[]
-  color_property?: string
-}
-export interface StructureToolProvenance {
-  model: string
-  version: string
-  units: Record<string, string>
-  settings: Record<string, unknown>
-}
-export interface StructureToolPrediction extends StructureToolOverlay {
-  input: AnyStructure
-  run_id: number
-  provenance: StructureToolProvenance
-}
+export { prediction_to_json, prediction_from_json } from './prediction'
+export type {
+  StructureToolVolume,
+  StructureToolOverlay,
+  StructureToolPrediction,
+  StructureToolProvenance,
+} from './prediction'
 
 // The host lends a full-size view without unmounting the tool that owns the computation.
 export interface StructureToolViewProps {
@@ -47,31 +42,6 @@ export interface StructureToolRun {
 export interface StructureToolProps {
   structure: AnyStructure
   start_run: (provenance: StructureToolProvenance) => StructureToolRun
-}
-
-// structuredClone keeps shared storage shared; reject it in arbitrary property metadata.
-function reject_shared_buffers(value: unknown, seen = new WeakSet<object>()): void {
-  if (!value || typeof value !== `object` || seen.has(value)) return
-  seen.add(value)
-  const buffer = ArrayBuffer.isView(value) ? value.buffer : value
-  if (typeof SharedArrayBuffer !== `undefined` && buffer instanceof SharedArrayBuffer)
-    throw new Error(
-      `Prediction metadata cannot contain shared buffers; copy them before publishing`,
-    )
-  if (ArrayBuffer.isView(value)) return
-  const children =
-    value instanceof Map
-      ? [...value.keys(), ...value.values()]
-      : value instanceof Set
-        ? [...value]
-        : Object.values(value)
-  for (const child of children) reject_shared_buffers(child, seen)
-}
-
-function copy_metadata<T>(value: T) {
-  const copied = structuredClone($state.snapshot(value))
-  reject_shared_buffers(copied)
-  return copied
 }
 
 // Each mounted viewer owns its controller. Guards also run synchronously on callbacks, so
@@ -103,10 +73,8 @@ export function create_structure_tool_controller(
       const revision = get_revision()
       if (disposed || !owner || !structure)
         throw new Error(`Cannot start a host run without a mounted, enabled structure viewer`)
-      if (!provenance.model.trim() || !provenance.version.trim())
-        throw new Error(`Prediction model and version must be nonempty`)
-      const input = copy_metadata(structure)
-      const captured_provenance = copy_metadata(provenance)
+      const input = copy_prediction_input(structure)
+      const captured_provenance = copy_prediction_provenance(provenance)
       const previous = current
       const stale_output = previous && !previous.is_current()
       const abort = new AbortController()
@@ -133,30 +101,9 @@ export function create_structure_tool_controller(
         signal,
         on_overlay(overlay) {
           if (!is_current()) return
-          if (
-            overlay?.site_properties &&
-            overlay.site_properties.length !== input.sites.length
-          )
-            throw new Error(
-              `Run ${id}: received ${overlay.site_properties.length} property rows for ${input.sites.length} sites`,
-            )
-          const field_ids = new Set<string>()
-          for (const { field_id } of overlay?.volumes ?? []) {
-            if (!field_id?.trim() || field_ids.has(field_id))
-              throw new Error(
-                `Run ${id}: density field ID must be nonempty and unique, got ${field_id}`,
-              )
-            field_ids.add(field_id)
-          }
-          if (!overlay) return on_prediction(null)
-          const { volumes, ...properties } = overlay
+          if (overlay === null) return on_prediction(null)
           on_prediction({
-            ...copy_metadata(properties),
-            // Keep large density buffers out of $state.snapshot so each is copied only once.
-            volumes: volumes?.map(({ values, ...metadata }) => ({
-              ...copy_metadata(metadata),
-              values: new Float64Array(values),
-            })),
+            ...copy_prediction_overlay(overlay, input.sites.length),
             input,
             run_id: id,
             provenance: captured_provenance,
@@ -183,22 +130,6 @@ export function create_structure_tool_controller(
     },
   }
 }
-
-// JSON preserves the full input and transient outputs, including flat density arrays with
-// their lattice, origin, dimensions, ordering and boundary conditions.
-export const prediction_to_json = (prediction: StructureToolPrediction): string =>
-  JSON.stringify(
-    {
-      schema: `matterviz-prediction-v1`,
-      ...prediction,
-      volumes: prediction.volumes?.map(({ values, ...volume }) => ({
-        ...volume,
-        values: Array.from(values),
-      })),
-    },
-    null,
-    2,
-  )
 
 // Register before mounting; this also reaches independently mounted file viewers.
 export const structure_host_tool = $state<{

--- a/src/lib/structure/host-tool.svelte.ts
+++ b/src/lib/structure/host-tool.svelte.ts
@@ -3,36 +3,169 @@ import type StructureScene from './StructureScene.svelte'
 import type { VolumetricData } from '$lib/isosurface'
 import type { AnyStructure } from './index'
 
-// Host tools operate on the input cell. Their overlays are transient and never edit the
-// caller's structure, including when a trajectory lends its current frame to the viewer.
+// Field IDs describe a physical quantity, independently of array order, labels or grid size.
+export type StructureToolVolume = VolumetricData & { field_id: string }
 export interface StructureToolOverlay {
-  source: AnyStructure
   site_properties?: Record<string, unknown>[]
-  volumes?: VolumetricData[]
+  volumes?: StructureToolVolume[]
   color_property?: string
 }
+export interface StructureToolProvenance {
+  model: string
+  version: string
+  units: Record<string, string>
+  settings: Record<string, unknown>
+}
+export interface StructureToolPrediction extends StructureToolOverlay {
+  input: AnyStructure
+  run_id: number
+  provenance: StructureToolProvenance
+}
 
-// A host can lend a full-size view (for example a growing trajectory) without replacing
-// the source structure or unmounting the tool that owns the computation.
+// The host lends a full-size view without unmounting the tool that owns the computation.
 export interface StructureToolViewProps {
   scene_props: ComponentProps<typeof StructureScene>
   supercell_scaling: string
   show_image_atoms: boolean
 }
 export interface StructureToolView {
-  source: AnyStructure
   content: Snippet<[StructureToolViewProps]>
 }
-
-export interface StructureToolProps {
+export interface StructureToolRun {
+  id: number
   structure: AnyStructure
+  signal: AbortSignal
   on_overlay: (overlay: StructureToolOverlay | null) => void
   on_view: (view: StructureToolView | null) => void
+  // Clear just the result/view, or cancel the computation and clear both.
+  clear: () => void
+  cancel: () => void
+}
+export interface StructureToolProps {
+  structure: AnyStructure
+  start_run: (provenance: StructureToolProvenance) => StructureToolRun
 }
 
-// A host registers once before mounting; this also reaches independently mounted file viewers.
+// Each mounted viewer owns its controller. Guards also run synchronously on callbacks, so
+// an input change cannot race the effect that aborts the old computation.
+export function create_structure_tool_controller(
+  get_structure: () => AnyStructure | null | undefined,
+  get_owner: () => unknown,
+  on_prediction: (prediction: StructureToolPrediction | null) => void,
+  on_view: (view: StructureToolView | null) => void,
+  get_revision: () => string,
+) {
+  let current: StructureToolRun | undefined
+  let abort: AbortController | undefined
+  let next_id = 0
+  let disposed = false
+  let is_current_run = (): boolean => false
+  const clear = (): void => {
+    on_prediction(null)
+    on_view(null)
+  }
+  const invalidate = (): void => {
+    const previous_abort = abort
+    abort = undefined
+    current = undefined
+    clear()
+    previous_abort?.abort()
+  }
+  return {
+    start_run(provenance: StructureToolProvenance): StructureToolRun {
+      const structure = get_structure()
+      const owner = get_owner()
+      const revision = get_revision()
+      if (disposed || !owner || !structure)
+        throw new Error(`Cannot start a host run without a mounted, enabled structure viewer`)
+      if (!provenance.model.trim() || !provenance.version.trim())
+        throw new Error(`Prediction model and version must be nonempty`)
+      const input = structuredClone($state.snapshot(structure))
+      const captured_provenance = structuredClone($state.snapshot(provenance))
+      const previous_abort = abort
+      abort = new AbortController()
+      const id = ++next_id
+      const signal = abort.signal
+      const is_current = (): boolean =>
+        !disposed &&
+        !signal.aborted &&
+        current?.id === id &&
+        get_owner() === owner &&
+        get_structure() === structure &&
+        get_revision() === revision
+      const run: StructureToolRun = {
+        id,
+        structure: structuredClone(input),
+        signal,
+        on_overlay(overlay) {
+          if (!is_current()) return
+          if (
+            overlay?.site_properties &&
+            overlay.site_properties.length !== input.sites.length
+          )
+            throw new Error(
+              `Run ${id}: received ${overlay.site_properties.length} property rows for ${input.sites.length} sites`,
+            )
+          const field_ids = new Set<string>()
+          for (const { field_id } of overlay?.volumes ?? []) {
+            if (!field_id?.trim() || field_ids.has(field_id))
+              throw new Error(
+                `Run ${id}: density field ID must be nonempty and unique, got ${field_id}`,
+              )
+            field_ids.add(field_id)
+          }
+          on_prediction(
+            overlay
+              ? { ...overlay, input, run_id: id, provenance: captured_provenance }
+              : null,
+          )
+        },
+        on_view(view) {
+          if (is_current()) on_view(view)
+        },
+        clear() {
+          if (is_current()) clear()
+        },
+        cancel() {
+          if (is_current()) invalidate()
+        },
+      }
+      current = run
+      is_current_run = is_current
+      // A previous view may close over its aborted run. Return before starting new work.
+      on_view(null)
+      // Abort listeners can synchronously start another run; it must retain ownership.
+      previous_abort?.abort()
+      return run
+    },
+    invalidate_if_changed(): void {
+      if (current && !is_current_run()) invalidate()
+    },
+    clear: invalidate,
+    dispose(): void {
+      disposed = true
+      invalidate()
+    },
+  }
+}
+
+// JSON preserves the full input and transient outputs, including flat density arrays with
+// their lattice, origin, dimensions, ordering and boundary conditions.
+export const prediction_to_json = (prediction: StructureToolPrediction): string =>
+  JSON.stringify(
+    {
+      schema: `matterviz-prediction-v1`,
+      ...prediction,
+      volumes: prediction.volumes?.map(({ values, ...volume }) => ({
+        ...volume,
+        values: Array.from(values),
+      })),
+    },
+    null,
+    2,
+  )
+
+// Register before mounting; this also reaches independently mounted file viewers.
 export const structure_host_tool = $state<{
   component: Component<StructureToolProps> | null
-}>({
-  component: null,
-})
+}>({ component: null })

--- a/src/lib/structure/index.ts
+++ b/src/lib/structure/index.ts
@@ -17,6 +17,17 @@ export * from './lattice-planes'
 export { default as LatticePlanes } from './LatticePlanes.svelte'
 export * from './camera-fit'
 export * from './density'
+export { structure_host_tool, prediction_to_json } from './host-tool.svelte'
+export type {
+  StructureToolProps,
+  StructureToolRun,
+  StructureToolOverlay,
+  StructureToolVolume,
+  StructureToolProvenance,
+  StructureToolPrediction,
+  StructureToolView,
+  StructureToolViewProps,
+} from './host-tool.svelte'
 export * from './measure'
 export * from './material'
 export { StructureSession, type StructureSessionInputs } from './session.svelte'

--- a/src/lib/structure/index.ts
+++ b/src/lib/structure/index.ts
@@ -17,7 +17,11 @@ export * from './lattice-planes'
 export { default as LatticePlanes } from './LatticePlanes.svelte'
 export * from './camera-fit'
 export * from './density'
-export { structure_host_tool, prediction_to_json } from './host-tool.svelte'
+export {
+  structure_host_tool,
+  prediction_to_json,
+  prediction_from_json,
+} from './host-tool.svelte'
 export type {
   StructureToolProps,
   StructureToolRun,

--- a/src/lib/structure/index.ts
+++ b/src/lib/structure/index.ts
@@ -165,6 +165,7 @@ const VECTOR_KEY_PREFIXES = [
   `velocity`,
   `velocities`,
   `phonon`,
+  `dipole`,
 ] as const
 
 // Memoised: the scan below asks this for every property key of every site on every

--- a/src/lib/structure/parse.ts
+++ b/src/lib/structure/parse.ts
@@ -925,7 +925,11 @@ function find_structure_in_json(obj: unknown, visited = new WeakSet()): Structur
 // species plus abc and/or xyz; the lattice, when present, is authoritative only in its
 // matrix (default pymatgen verbosity writes matrix + pbc and no scalar params)
 type StructureLike = Omit<AnyStructure, `sites` | `lattice`> & {
-  sites: (Omit<Site, `abc` | `xyz`> & { abc?: Vec3; xyz?: Vec3 })[]
+  sites: (Omit<Site, `abc` | `xyz` | `properties`> & {
+    abc?: Vec3
+    xyz?: Vec3
+    properties?: Site[`properties`]
+  })[]
   lattice?: { matrix: math.Matrix3x3; pbc?: unknown }
 }
 
@@ -962,7 +966,12 @@ export function structure_from_json(
       if (!site.xyz) {
         throw new Error(`JSON site ${idx} has no xyz and the structure has no lattice`)
       }
-      return { ...site, xyz: site.xyz, abc: site.abc ?? ([0, 0, 0] as Vec3) }
+      return {
+        ...site,
+        properties: site.properties ?? {},
+        xyz: site.xyz,
+        abc: site.abc ?? ([0, 0, 0] as Vec3),
+      }
     })
     return { ...rest, sites }
   }
@@ -970,7 +979,8 @@ export function structure_from_json(
   const lattice = make_lattice(matrix, is_pbc(raw_lattice.pbc) ? raw_lattice.pbc : undefined)
   const frac_to_cart = math.create_frac_to_cart(matrix)
   const cart_to_frac = cart_to_frac_with_fallback(matrix, { context: `JSON lattice` }).convert
-  const sites = raw_sites.map((site, idx) => {
+  const sites = raw_sites.map((raw_site, idx) => {
+    const site = { ...raw_site, properties: raw_site.properties ?? {} }
     if (site.abc && site.xyz) return { ...site, abc: site.abc, xyz: site.xyz }
     if (site.abc) return { ...site, abc: site.abc, xyz: frac_to_cart(site.abc) }
     if (site.xyz) return { ...site, xyz: site.xyz, abc: cart_to_frac(site.xyz) }

--- a/src/lib/structure/prediction.ts
+++ b/src/lib/structure/prediction.ts
@@ -1,0 +1,239 @@
+// Prediction interchange and publication validation. No Svelte/DOM imports: file workers use
+// the same contract as live tools. Undefined object fields are omitted; array holes are errors.
+import { grid_data_range, type VolumetricData } from '$lib/isosurface/types'
+import { grid_dimensions } from '$lib/isosurface/grid'
+import { det_3x3 } from '$lib/math'
+import { is_elem_symbol } from '$lib/element/helpers'
+import type { AnyStructure } from './index'
+
+// Reuse IDs only for the same physical quantity, units and normalization.
+export type StructureToolVolume = VolumetricData & { field_id: string }
+export interface StructureToolOverlay {
+  site_properties?: Record<string, unknown>[]
+  volumes?: StructureToolVolume[]
+  color_property?: string
+}
+export interface StructureToolProvenance {
+  model: string
+  version: string
+  units: Record<string, string>
+  settings: Record<string, unknown>
+}
+export interface StructureToolPrediction extends StructureToolOverlay {
+  input: AnyStructure
+  run_id: number
+  provenance: StructureToolProvenance
+}
+
+const invalid = (path: string, reason: string): never => {
+  throw new TypeError(`${path}: ${reason}`)
+}
+const record = (value: unknown, path: string): Record<string, unknown> => {
+  if (!value || typeof value !== `object` || Array.isArray(value))
+    return invalid(path, `expected an object`)
+  if (
+    Object.getPrototypeOf(value) !== Object.prototype &&
+    Object.getPrototypeOf(value) !== null
+  )
+    return invalid(
+      path,
+      `expected plain JSON metadata; copy shared buffers and convert special objects first`,
+    )
+  return value as Record<string, unknown>
+}
+const nonempty = (value: unknown, path: string): void => {
+  if (typeof value !== `string` || !value.trim()) invalid(path, `must be a nonempty string`)
+}
+
+// Copy while validating, so Maps, typed arrays, cycles and non-finite numbers cannot be
+// silently changed by JSON.stringify. Repeated references are fine; ancestor cycles aren't.
+function copy_prediction_metadata<T>(source: T, root_path: string): T {
+  const ancestors = new WeakSet<object>()
+  function copy(value: unknown, path: string): unknown {
+    if (value === null || typeof value === `string` || typeof value === `boolean`) return value
+    if (typeof value === `number` && Number.isFinite(value)) return value
+    if (!value || typeof value !== `object`)
+      return invalid(path, `expected a finite JSON value`)
+    if (ancestors.has(value)) return invalid(path, `cyclic metadata is not supported`)
+    if (!Array.isArray(value)) record(value, path)
+    if (Object.getOwnPropertySymbols(value).length) invalid(path, `symbol keys are not JSON`)
+    ancestors.add(value)
+    const copied = Array.isArray(value)
+      ? Array.from(value, (entry, idx) => copy(entry, `${path}[${idx}]`))
+      : Object.fromEntries(
+          Object.entries(value)
+            .filter(([, entry]) => entry !== undefined)
+            .map(([key, entry]) => [key, copy(entry, `${path}.${key}`)]),
+        )
+    ancestors.delete(value)
+    return copied
+  }
+  return copy(source, root_path) as T
+}
+
+const vec3 = (value: unknown): boolean =>
+  Array.isArray(value) && value.length === 3 && value.every(Number.isFinite)
+const matrix = (value: unknown, path: string): void => {
+  if (!Array.isArray(value) || value.length !== 3 || !value.every(vec3))
+    invalid(path, `expected a finite 3x3 lattice`)
+  // Only cast after checking every row; a singular lattice cannot locate a density grid.
+  const determinant = det_3x3(value as VolumetricData[`lattice`])
+  if (!Number.isFinite(determinant) || determinant === 0)
+    invalid(path, `lattice must be invertible`)
+}
+
+export function copy_prediction_input(value: unknown): AnyStructure {
+  const input = record(copy_prediction_metadata(value, `input`), `input`)
+  if (!Array.isArray(input.sites) || !input.sites.length)
+    invalid(`input.sites`, `expected sites`)
+  for (const [idx, raw] of (input.sites as unknown[]).entries()) {
+    const site = record(raw, `input.sites[${idx}]`)
+    if (!vec3(site.xyz) || !vec3(site.abc))
+      invalid(`input.sites[${idx}]`, `expected xyz and abc vectors`)
+    if (typeof site.label !== `string`)
+      invalid(`input.sites[${idx}].label`, `expected a string`)
+    record(site.properties, `input.sites[${idx}].properties`)
+    if (!Array.isArray(site.species) || !site.species.length)
+      invalid(`input.sites[${idx}].species`, `expected species`)
+    for (const species of site.species as unknown[]) {
+      const entry = record(species, `input.sites[${idx}].species`)
+      if (typeof entry.element !== `string` || !is_elem_symbol(entry.element))
+        invalid(`input.sites[${idx}].species.element`, `unknown element: ${entry.element}`)
+      if (typeof entry.occu !== `number` || entry.occu < 0)
+        invalid(`input.sites[${idx}].species.occu`, `expected nonnegative occupancy`)
+    }
+  }
+  if (input.lattice !== undefined) {
+    const lattice = record(input.lattice, `input.lattice`)
+    matrix(lattice.matrix, `input.lattice.matrix`)
+    if (
+      !Array.isArray(lattice.pbc) ||
+      lattice.pbc.length !== 3 ||
+      !lattice.pbc.every((flag) => typeof flag === `boolean`)
+    )
+      invalid(`input.lattice.pbc`, `expected three booleans`)
+    for (const key of [`a`, `b`, `c`, `alpha`, `beta`, `gamma`, `volume`])
+      if (typeof lattice[key] !== `number` || lattice[key] <= 0)
+        invalid(`input.lattice.${key}`, `expected a positive finite number`)
+  }
+  return input as unknown as AnyStructure
+}
+
+export function copy_prediction_provenance(value: unknown): StructureToolProvenance {
+  const provenance = record(copy_prediction_metadata(value, `provenance`), `provenance`)
+  nonempty(provenance.model, `provenance.model`)
+  nonempty(provenance.version, `provenance.version`)
+  record(provenance.settings, `provenance.settings`)
+  for (const [key, unit] of Object.entries(record(provenance.units, `provenance.units`)))
+    nonempty(unit, `provenance.units.${key}`)
+  return provenance as unknown as StructureToolProvenance
+}
+
+export function copy_prediction_overlay(
+  value: unknown,
+  n_sites: number,
+  from_json = false,
+): StructureToolOverlay {
+  const { volumes, ...rest } = record(value, `prediction`)
+  const properties = copy_prediction_metadata(rest, `prediction`)
+  if (
+    properties.site_properties !== undefined &&
+    (!Array.isArray(properties.site_properties) ||
+      properties.site_properties.length !== n_sites)
+  )
+    invalid(`prediction.site_properties`, `expected ${n_sites} property rows`)
+  if (Array.isArray(properties.site_properties))
+    properties.site_properties.forEach((row, idx) =>
+      record(row, `prediction.site_properties[${idx}]`),
+    )
+  if (properties.color_property !== undefined)
+    nonempty(properties.color_property, `prediction.color_property`)
+  if (volumes === undefined) return { ...properties }
+  if (!Array.isArray(volumes)) invalid(`prediction.volumes`, `expected an array`)
+  const field_ids = new Set<string>()
+  const copied_volumes = Array.from(volumes as unknown[], (raw, idx) => {
+    const path = `prediction.volumes[${idx}]`
+    const { values: raw_values, ...metadata_fields } = record(raw, path)
+    const metadata = copy_prediction_metadata(metadata_fields, path)
+    nonempty(metadata.field_id, `${path}.field_id`)
+    const field_id = metadata.field_id as string
+    if (field_ids.has(field_id)) invalid(`${path}.field_id`, `must be unique: ${field_id}`)
+    field_ids.add(field_id)
+    if (
+      !(raw_values instanceof Float64Array) &&
+      !(
+        from_json &&
+        Array.isArray(raw_values) &&
+        raw_values.every((entry) => typeof entry === `number`)
+      )
+    )
+      invalid(`${path}.values`, `expected ${from_json ? `a number array` : `Float64Array`}`)
+    const values = new Float64Array(raw_values as Float64Array)
+    if (!values.every(Number.isFinite)) invalid(`${path}.values`, `density must be finite`)
+    const volume = { ...metadata, values } as StructureToolVolume
+    try {
+      grid_dimensions(volume)
+    } catch (error) {
+      invalid(path, String(error))
+    }
+    if (volume.order !== `z_fastest` || volume.dims.some((size) => size < 1))
+      invalid(path, `expected positive dimensions and z_fastest ordering`)
+    matrix(volume.lattice, `${path}.lattice`)
+    if (!vec3(volume.origin)) invalid(`${path}.origin`, `expected a finite Vec3`)
+    if (typeof volume.periodic !== `boolean`) invalid(`${path}.periodic`, `expected a boolean`)
+    // Cached host statistics may be stale after a reused buffer was updated.
+    volume.data_range = grid_data_range(values)
+    if (!Object.values(volume.data_range).every(Number.isFinite))
+      invalid(
+        `${path}.data_range`,
+        `density statistics overflowed; rescale the field and update its units`,
+      )
+    return volume
+  })
+  return {
+    ...properties,
+    volumes: copied_volumes,
+  }
+}
+
+export const copy_prediction = (
+  value: unknown,
+  from_json = false,
+): StructureToolPrediction => {
+  const {
+    input: raw_input,
+    provenance,
+    run_id,
+    schema: _schema,
+    ...overlay
+  } = record(value, `prediction`)
+  const input = copy_prediction_input(raw_input)
+  if (!Number.isSafeInteger(run_id) || (run_id as number) < 1)
+    invalid(`run_id`, `expected a positive safe integer`)
+  return {
+    ...copy_prediction_overlay(overlay, input.sites.length, from_json),
+    input,
+    run_id: run_id as number,
+    provenance: copy_prediction_provenance(provenance),
+  }
+}
+
+export function prediction_to_json(prediction: StructureToolPrediction): string {
+  const snapshot = copy_prediction(prediction)
+  return JSON.stringify({
+    schema: `matterviz-prediction-v1`,
+    ...snapshot,
+    volumes: snapshot.volumes?.map(({ values, ...metadata }) => ({
+      ...metadata,
+      values: Array.from(values),
+    })),
+  })
+}
+
+// Accept JSON text or an already parsed document so file loading does not parse large grids twice.
+export function prediction_from_json(content: unknown): StructureToolPrediction {
+  const raw: unknown = typeof content === `string` ? JSON.parse(content) : content
+  if (record(raw, `prediction`).schema !== `matterviz-prediction-v1`)
+    invalid(`schema`, `expected matterviz-prediction-v1`)
+  return copy_prediction(raw, true)
+}

--- a/src/lib/structure/session.svelte.ts
+++ b/src/lib/structure/session.svelte.ts
@@ -40,6 +40,7 @@ import { make_supercell, parse_supercell_scaling } from './supercell'
 // a caller-bound prop and the session never hold two copies
 export interface StructureSessionInputs {
   structure: () => AnyStructure | undefined
+  site_properties?: () => Record<string, unknown>[] | undefined
   set_structure: (value: AnyStructure | undefined) => void
   bonds: () => StructureBond[] | undefined
   set_bonds: (value: StructureBond[] | undefined) => void
@@ -263,24 +264,27 @@ export class StructureSession {
   // Remap element symbols for display (LAMMPS type placeholders → real elements)
   element_mapping = $state<Partial<Record<ElementSymbol, ElementSymbol>> | undefined>()
   dragging_atoms = $state(false)
-  // Element-mapped + PBC image atoms. Images are skipped during drags (doubled site count
-  // drops frames) and return on release.
-  displayed_structure = $derived.by((): AnyStructure | undefined => {
-    let struct = this.supercell_structure
+  // Host computations see mapped elements in the borrowed input cell, without display
+  // tiling, images or cell standardization. Mapping changes therefore change input identity.
+  tool_input = $derived.by(() => this.map_elements(this.inputs.structure()))
+  private map_elements(struct: AnyStructure | undefined): AnyStructure | undefined {
     const mapping = this.element_mapping
-    if (struct && mapping && Object.keys(mapping).length > 0) {
-      struct = {
-        ...struct,
-        sites: struct.sites.map((site) => ({
-          ...site,
-          species: site.species.map((species) => ({
-            ...species,
-            element: mapping[species.element] ?? species.element,
-          })),
-          label: mapping[site.label as ElementSymbol] ?? site.label,
+    if (!struct || !mapping || Object.keys(mapping).length === 0) return struct
+    return {
+      ...struct,
+      sites: struct.sites.map((site) => ({
+        ...site,
+        species: site.species.map((species) => ({
+          ...species,
+          element: mapping[species.element] ?? species.element,
         })),
-      }
+        label: mapping[site.label as ElementSymbol] ?? site.label,
+      })),
     }
+  }
+  // Element-mapped + PBC image atoms. Images are skipped during drags.
+  displayed_structure = $derived.by((): AnyStructure | undefined => {
+    const struct = this.map_elements(this.supercell_structure)
     return !this.dragging_atoms &&
       this.inputs.show_image_atoms() &&
       struct &&
@@ -293,6 +297,20 @@ export class StructureSession {
   // primitive transform applies. Overlays expressed in the input frame (symmetry elements) are
   // only placed correctly then; a supercell of the input cell still qualifies.
   shows_input_frame = $derived(this.base_structure === this.structure_with_bonds)
+  // Transient host properties follow this session's own tiling/image provenance and never
+  // enter editable snapshots or cell transforms. Scene, colors and legend share this view.
+  render_structure = $derived.by(() => {
+    const displayed = this.displayed_structure
+    const properties = this.inputs.site_properties?.()
+    if (!displayed || !properties || !this.shows_input_frame) return displayed
+    return {
+      ...displayed,
+      sites: displayed.sites.map((site, idx) => ({
+        ...site,
+        properties: { ...site.properties, ...properties[this.to_base_site_idx(site, idx)] },
+      })),
+    }
+  })
   // Wyckoff rows of the analyzed cell with site_indices re-expressed onto the displayed
   // structure (conventional/primitive cell, supercell, image atoms), so the table and the
   // Wyckoff coloring address the atoms actually on screen rather than the analyzed cell's
@@ -312,7 +330,7 @@ export class StructureSession {
   property_colors = $derived.by((): AtomPropertyColors | null => {
     const config = this.inputs.atom_color_config()
     if (config.mode === `element`) return null
-    return get_property_colors(this.displayed_structure, config, {
+    return get_property_colors(this.render_structure, config, {
       base: this.base_structure,
       to_base_idx: this.to_base_site_idx,
       bonding_strategy: this.inputs.bonding_strategy(),

--- a/src/lib/trajectory/TrajectoryDataInspectorPane.svelte
+++ b/src/lib/trajectory/TrajectoryDataInspectorPane.svelte
@@ -33,6 +33,14 @@
   // Per-frame scalars vs per-atom rows
   let active_tab = $state<`frames` | `atoms`>(`frames`)
 
+  const row_click_handler = (callback: ((idx: number) => void) | undefined, key: string) =>
+    callback
+      ? (_event: MouseEvent | KeyboardEvent, row: RowData) => {
+          const idx = row[key]
+          if (typeof idx === `number`) callback(idx)
+        }
+      : undefined
+
   const VEC3_AXES = [`x`, `y`, `z`] as const
   const FRAC_AXES = [`a`, `b`, `c`] as const
 
@@ -249,9 +257,7 @@
             search={{ placeholder: `Filter frames`, fuzzy: true }}
             export_data={{ formats: [`csv`, `json`], filename: `trajectory-frames` }}
             initial_sort={{ column: `frame_idx` }}
-            on_row_click={(_event, row) => {
-              if (typeof row.frame_idx === `number`) on_step_change?.(row.frame_idx)
-            }}
+            on_row_click={row_click_handler(on_step_change, `frame_idx`)}
             {...table_props}
           />
         {:else if selected && item.value === `atoms`}
@@ -264,9 +270,7 @@
               search={{ placeholder: `Filter atoms`, fuzzy: true }}
               export_data={{ formats: [`csv`, `json`], filename: `frame-atoms` }}
               initial_sort={{ column: `site_idx` }}
-              on_row_click={(_event, row) => {
-                if (typeof row.site_idx === `number`) on_site_select?.(row.site_idx)
-              }}
+              on_row_click={row_click_handler(on_site_select, `site_idx`)}
               {...table_props}
             />
           {/if}

--- a/src/lib/trajectory/TrajectoryExportPane.svelte
+++ b/src/lib/trajectory/TrajectoryExportPane.svelte
@@ -91,9 +91,12 @@
       : undefined,
   )
 
-  let canvas = $derived(wrapper?.querySelector<HTMLCanvasElement>(`canvas`) ?? null)
-  let has_canvas = $state(false)
-  $effect(() => observe_canvas_presence(wrapper, (val) => (has_canvas = val)))
+  let canvas = $state.raw<HTMLCanvasElement | null>(null)
+  $effect(() =>
+    observe_canvas_presence(wrapper, () => {
+      canvas = wrapper?.querySelector<HTMLCanvasElement>(`canvas`) ?? null
+    }),
+  )
   let is_video_supported = $derived(
     typeof MediaRecorder !== `undefined` &&
       MediaRecorder.isTypeSupported(`video/webm;codecs=vp9`),
@@ -160,9 +163,11 @@
     if (!run || !on_step_change || !canvas || export_frame_count === 0) {
       export_error = !run
         ? `No trajectory`
-        : !canvas
-          ? `Canvas not ready`
-          : `Invalid frame range`
+        : !on_step_change
+          ? `Frame navigation unavailable`
+          : !canvas
+            ? `Canvas not ready`
+            : `Invalid frame range`
       return
     }
     await run_export(format.toUpperCase(), async () => {
@@ -334,7 +339,7 @@
           <button
             type="button"
             onclick={() => export_video(format)}
-            disabled={running !== null || !run || !has_canvas}
+            disabled={data_export_disabled || !on_step_change || !canvas}
             aria-label="Download {label}"
             {@attach tooltip({ content: hint })}
           >
@@ -353,7 +358,7 @@
       {/if}
     </div>
 
-    {#if run && !has_canvas}
+    {#if run && !canvas}
       <div class="warning">Waiting for canvas...</div>
     {/if}
   {/if}

--- a/src/md.d.ts
+++ b/src/md.d.ts
@@ -1,4 +1,4 @@
-// mdsvex compiles .md to Svelte components, so .svelte pages can import markdown partials and
+// Widgets compiles .md to Svelte components, so .svelte pages can import markdown partials and
 // get build-time starry-night highlighting. Keep this file free of top-level imports: inside a
 // module the wildcard would be a module augmentation and never match (hence not in app.d.ts).
 declare module '*.md' {

--- a/src/routes/(demos)/structure/+page.md
+++ b/src/routes/(demos)/structure/+page.md
@@ -360,3 +360,7 @@ Load structures from text with `structure_string` (CIF, POSCAR, XYZ, JSON, …).
 
 <Structure structure_string={selected_file.content} bind:structure={parsed_structure} />
 ```
+
+## Host prediction tools
+
+The [runnable host-tool example](/structure/host-tool) demonstrates transient scalar colors, dipole arrows, density, a host-owned trajectory, scoped asynchronous runs and prediction export through the public package API.

--- a/src/routes/(demos)/structure/host-tool/+page.svelte
+++ b/src/routes/(demos)/structure/host-tool/+page.svelte
@@ -79,7 +79,9 @@ run.on_overlay({
 <p>
   Use the export pane to download the prediction JSON, including the captured input,
   properties, density grids and provenance, or export the original structure in the usual
-  formats. Field IDs preserve surface appearance across reruns and reordering; <strong
+  formats. Reuse a field ID only while its physical quantity, units and normalization stay
+  compatible; change the ID when those semantics change. Labels, order and grid resolution can
+  change without losing surface appearance, including extra or deliberately removed layers. <strong
     >Reset prediction surfaces</strong
   > restores defaults. Hidden-density notices offer direct cell and supercell recovery actions.
 </p>

--- a/src/routes/(demos)/structure/host-tool/+page.svelte
+++ b/src/routes/(demos)/structure/host-tool/+page.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+  import { Structure, make_site, structure_host_tool, type Crystal } from '$lib/structure'
+  import {
+    calc_lattice_params,
+    create_frac_to_cart,
+    type Matrix3x3,
+    type Vec3,
+  } from '$lib/math'
+  import { onMount } from 'svelte'
+  import DemoHostTool from './DemoHostTool.svelte'
+
+  const matrix: Matrix3x3 = [
+    [0, 1.805, 1.805],
+    [1.805, 0, 1.805],
+    [1.805, 1.805, 0],
+  ]
+  const to_cart = create_frac_to_cart(matrix)
+  const positions: Vec3[] = [
+    [0.13, 0.27, 0.41],
+    [0.63, 0.77, 0.91],
+  ]
+  const structure: Crystal = {
+    lattice: { matrix, pbc: [true, true, true], ...calc_lattice_params(matrix) },
+    sites: positions.map((abc) => make_site(`Cu`, abc, to_cart(abc), `Cu`)),
+  }
+  let ready = $state(false)
+  onMount(() => {
+    const previous = structure_host_tool.component
+    structure_host_tool.component = DemoHostTool
+    ready = true
+    return () => {
+      structure_host_tool.component = previous
+    }
+  })
+</script>
+
+<svelte:head><title>Host prediction tools | MatterViz</title></svelte:head>
+<h1>Host prediction tools</h1>
+<p>
+  This runnable example adds deterministic charges, dipole arrows, density and a six-frame
+  trajectory to an unchanged input crystal. No model download or server is needed.
+</p>
+{#if ready}
+  <Structure
+    {structure}
+    show_controls="always"
+    scene_props={{ camera_position: [7, 5, 6], camera_target: [1.5, 1.5, 1.5] }}
+    style="height: 650px"
+  />
+{/if}
+<h2>Integrate a host tool</h2>
+<p>
+  Import <code>structure_host_tool</code> and <code>StructureToolProps</code> from
+  <code>matterviz/structure</code>
+  (also exported from <code>matterviz</code>). Register your Svelte component before mounting
+  viewers, and restore the registration when your host unmounts.
+</p>
+<pre><code
+    >{`const run = start_run({
+  model: 'my-model', version: '1.0',
+  units: { charge: 'e', density: 'e/A^3' },
+  settings: { seed: 0 },
+})
+const result = await predict(run.structure, { signal: run.signal })
+run.on_overlay({
+  site_properties: result.site_properties,
+  volumes: result.volumes, // each field needs a stable, unique field_id
+  color_property: 'charge',
+})`}</code
+  ></pre>
+<p>
+  Each run receives a snapshot of its input; treat it as read-only. Each new run aborts the
+  previous run. Its callbacks cannot change or clear newer results, and input changes or viewer
+  unmounting invalidate it. Use <code>run.cancel()</code> to abort and clear,
+  <code>run.clear()</code>
+  to clear its outputs, and <code>run.on_view(null)</code> to return from a host view. Supply
+  <code>show_host_tool: false</code> to nested structure viewers.
+</p>
+<p>
+  Use the export pane to download the prediction JSON, including the captured input,
+  properties, density grids and provenance, or export the original structure in the usual
+  formats. Field IDs preserve surface appearance across reruns and reordering; <strong
+    >Reset prediction surfaces</strong
+  > restores defaults. Hidden-density notices offer direct cell and supercell recovery actions.
+</p>

--- a/src/routes/(demos)/structure/host-tool/+page.svelte
+++ b/src/routes/(demos)/structure/host-tool/+page.svelte
@@ -38,7 +38,9 @@
 <h1>Host prediction tools</h1>
 <p>
   This runnable example adds deterministic charges, dipole arrows, density and a six-frame
-  trajectory to an unchanged input crystal. No model download or server is needed.
+  trajectory to an unchanged input crystal in a Web Worker. Set a delay to try cancelling or
+  restarting work, or enable failure to verify that the previous result remains available. No
+  model download or server is needed.
 </p>
 {#if ready}
   <Structure
@@ -84,4 +86,23 @@ run.on_overlay({
   change without losing surface appearance, including extra or deliberately removed layers. <strong
     >Reset prediction surfaces</strong
   > restores defaults. Hidden-density notices offer direct cell and supercell recovery actions.
+</p>
+
+<p>
+  Prediction metadata must contain plain JSON objects, arrays, strings, booleans, finite
+  numbers or null. Undefined object fields are omitted. Convert Maps, Sets, Dates and typed
+  arrays explicitly; unsupported values report their field path. Density values use
+  Float64Array, are copied on publication, and must not be written concurrently while copying
+  shared storage. Grid geometry is validated and cached statistics are recomputed.
+</p>
+<p>
+  Drop an exported prediction JSON onto any Structure viewer to reopen its input, properties,
+  density and provenance. Hosts can also import <code>prediction_from_json</code> from
+  <code>matterviz/structure</code> and pass its result as the viewer's <code>prediction</code>
+  prop. Import accepts version 1 only and restores the original cell and 1×1×1 scaling.
+</p>
+<p>
+  To measure larger grids locally, open <code>/test/isosurface-performance?size=128</code> and
+  click <strong>Benchmark prediction</strong>. The page records three publication timings,
+  export time and bytes, alongside the existing geometry/render timings and heap sampling.
 </p>

--- a/src/routes/(demos)/structure/host-tool/DemoHostTool.svelte
+++ b/src/routes/(demos)/structure/host-tool/DemoHostTool.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   import { Trajectory } from '$lib/trajectory'
   import type {
+    StructureToolOverlay,
     StructureToolProps,
     StructureToolRun,
     StructureToolViewProps,
   } from '$lib/structure'
-  import { make_volume } from '$lib/isosurface'
   import { onDestroy } from 'svelte'
   import { make_demo_trajectory } from './demo'
 
@@ -15,40 +15,68 @@
   let current_step_idx = $state(0)
   const trajectory = $derived(make_demo_trajectory(structure))
 
+  let delay_ms = $state(100)
+  let fail = $state(false)
+  let running = $state(false)
   function predict(): void {
-    run = start_run({
+    const current = start_run({
       model: `Deterministic host example`,
       version: `1`,
       units: { charge: `e`, dipole: `e A`, density: `e/A^3` },
       settings: { grid_size: 12, seed: 0 },
     })
-    const lattice = `lattice` in structure ? structure.lattice.matrix : undefined
-    if (!lattice) throw new Error(`The demo requires a crystal`)
-    const values = Float64Array.from({ length: 12 ** 3 }, (_, idx) => {
-      const x_idx = Math.floor(idx / 144)
-      const y_idx = Math.floor(idx / 12) % 12
-      const z_idx = idx % 12
-      return Math.exp(-((x_idx - 6) ** 2 + (y_idx - 6) ** 2 + (z_idx - 6) ** 2) / 10)
+    run = current
+    running = true
+    status = `Prediction ${current.id} running`
+    let worker: Worker
+    try {
+      worker = new Worker(new URL(`prediction-worker.ts`, import.meta.url), {
+        type: `module`,
+      })
+    } catch (error) {
+      status = String(error)
+      running = false
+      return
+    }
+    const stop = () => {
+      worker.terminate()
+      current.signal.removeEventListener(`abort`, stop)
+      if (run === current) {
+        running = false
+        if (current.signal.aborted) status = `Prediction ${current.id} cancelled`
+      }
+    }
+    const finish = (error?: string) => {
+      if (run === current && !current.signal.aborted)
+        status = error ?? `Prediction ${current.id} ready: charges, dipoles and density`
+      stop()
+    }
+    worker.addEventListener(
+      `message`,
+      ({ data }: MessageEvent<{ result?: StructureToolOverlay; error?: string }>) => {
+        try {
+          if (data.result) current.on_overlay(data.result)
+          finish(data.error)
+        } catch (error) {
+          finish(String(error))
+        }
+      },
+    )
+    worker.addEventListener(`error`, (event) => {
+      event.preventDefault()
+      finish(event.message)
     })
-    run.on_overlay({
-      site_properties: structure.sites.map((_, idx) => ({
-        charge: idx % 2 ? -0.4 : 0.4,
-        dipole: [0.4, 0.2, 0.1],
-      })),
-      color_property: `charge`,
-      volumes: [
-        {
-          ...make_volume(values, [12, 12, 12], {
-            lattice,
-            origin: [0, 0, 0],
-            periodic: false,
-            label: `Predicted density`,
-          }),
-          field_id: `density`,
-        },
-      ],
-    })
-    status = `Prediction ${run.id} ready: charges, dipoles and density`
+    current.signal.addEventListener(`abort`, stop, { once: true })
+    if (current.signal.aborted) stop()
+    else {
+      try {
+        // Worker messages have no Window targetOrigin.
+        // oxlint-disable-next-line eslint-plugin-unicorn/require-post-message-target-origin
+        worker.postMessage({ structure: current.structure, delay_ms, fail })
+      } catch (error) {
+        finish(String(error))
+      }
+    }
   }
   function show_trajectory(): void {
     if (!run || run.signal.aborted) predict()
@@ -60,6 +88,9 @@
 
 <div class="demo-tool" data-testid="host-tool-controls">
   <button onclick={predict}>Run prediction</button>
+  <button onclick={() => run?.cancel()} disabled={!running}>Cancel prediction</button>
+  <label>Delay (ms) <input type="number" min="0" max="10000" bind:value={delay_ms} /></label>
+  <label><input type="checkbox" bind:checked={fail} /> Fail prediction</label>
   <button onclick={show_trajectory}>Show predicted trajectory</button>
   <span role="status">{status}</span>
 </div>
@@ -95,6 +126,9 @@
     max-width: 75%;
     background: var(--pane-bg, white);
     padding: 0.5rem;
+  }
+  .demo-tool input[type='number'] {
+    width: 5rem;
   }
   .trajectory-view {
     display: grid;

--- a/src/routes/(demos)/structure/host-tool/DemoHostTool.svelte
+++ b/src/routes/(demos)/structure/host-tool/DemoHostTool.svelte
@@ -1,0 +1,104 @@
+<script lang="ts">
+  import { Trajectory } from '$lib/trajectory'
+  import type {
+    StructureToolProps,
+    StructureToolRun,
+    StructureToolViewProps,
+  } from '$lib/structure'
+  import { make_volume } from '$lib/isosurface'
+  import { onDestroy } from 'svelte'
+  import { make_demo_trajectory } from './demo'
+
+  let { structure, start_run }: StructureToolProps = $props()
+  let run = $state.raw<StructureToolRun>()
+  let status = $state(`Ready`)
+  let current_step_idx = $state(0)
+  const trajectory = $derived(make_demo_trajectory(structure))
+
+  function predict(): void {
+    run = start_run({
+      model: `Deterministic host example`,
+      version: `1`,
+      units: { charge: `e`, dipole: `e A`, density: `e/A^3` },
+      settings: { grid_size: 12, seed: 0 },
+    })
+    const lattice = `lattice` in structure ? structure.lattice.matrix : undefined
+    if (!lattice) throw new Error(`The demo requires a crystal`)
+    const values = Float64Array.from({ length: 12 ** 3 }, (_, idx) => {
+      const x_idx = Math.floor(idx / 144)
+      const y_idx = Math.floor(idx / 12) % 12
+      const z_idx = idx % 12
+      return Math.exp(-((x_idx - 6) ** 2 + (y_idx - 6) ** 2 + (z_idx - 6) ** 2) / 10)
+    })
+    run.on_overlay({
+      site_properties: structure.sites.map((_, idx) => ({
+        charge: idx % 2 ? -0.4 : 0.4,
+        dipole: [0.4, 0.2, 0.1],
+      })),
+      color_property: `charge`,
+      volumes: [
+        {
+          ...make_volume(values, [12, 12, 12], {
+            lattice,
+            origin: [0, 0, 0],
+            periodic: false,
+            label: `Predicted density`,
+          }),
+          field_id: `density`,
+        },
+      ],
+    })
+    status = `Prediction ${run.id} ready: charges, dipoles and density`
+  }
+  function show_trajectory(): void {
+    if (!run || run.signal.aborted) predict()
+    current_step_idx = 0
+    run?.on_view({ content: trajectory_view })
+  }
+  onDestroy(() => run?.cancel())
+</script>
+
+<div class="demo-tool" data-testid="host-tool-controls">
+  <button onclick={predict}>Run prediction</button>
+  <button onclick={show_trajectory}>Show predicted trajectory</button>
+  <span role="status">{status}</span>
+</div>
+
+{#snippet trajectory_view(view: StructureToolViewProps)}
+  <div class="trajectory-view" data-testid="predicted-trajectory">
+    <div style="display: flex; align-items: center; gap: 1rem">
+      <button onclick={() => run?.on_view(null)}>Return to structure</button>
+      <output aria-label="Trajectory frame">Frame {current_step_idx + 1}</output>
+    </div>
+    <Trajectory
+      {trajectory}
+      bind:current_step_idx
+      auto_play={false}
+      display_mode="structure"
+      show_controls="always"
+      structure_props={{ ...view, show_host_tool: false, show_controls: `always` }}
+      style="height: 100%; min-height: 0"
+    />
+  </div>
+{/snippet}
+
+<style>
+  .demo-tool {
+    position: absolute;
+    top: 0.5rem;
+    left: 0.5rem;
+    z-index: 2;
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    flex-wrap: wrap;
+    max-width: 75%;
+    background: var(--pane-bg, white);
+    padding: 0.5rem;
+  }
+  .trajectory-view {
+    display: grid;
+    grid-template-rows: auto minmax(0, 1fr);
+    height: 100%;
+  }
+</style>

--- a/src/routes/(demos)/structure/host-tool/demo.ts
+++ b/src/routes/(demos)/structure/host-tool/demo.ts
@@ -1,0 +1,20 @@
+import { trajectory_from_frames } from '$lib/trajectory'
+import type { AnyStructure } from '$lib/structure'
+import { create_frac_to_cart, type Vec3 } from '$lib/math'
+
+export function make_demo_trajectory(structure: AnyStructure) {
+  if (!(`lattice` in structure)) throw new Error(`The demo requires a crystal`)
+  const to_cart = create_frac_to_cart(structure.lattice.matrix)
+  return trajectory_from_frames(
+    Array.from({ length: 6 }, (_, frame_idx) => ({
+      step: frame_idx,
+      structure: {
+        ...structure,
+        sites: structure.sites.map((site) => {
+          const abc: Vec3 = [site.abc[0] + frame_idx * 0.015, site.abc[1], site.abc[2]]
+          return { ...site, abc, xyz: to_cart(abc) }
+        }),
+      },
+    })),
+  )
+}

--- a/src/routes/(demos)/structure/host-tool/demo.ts
+++ b/src/routes/(demos)/structure/host-tool/demo.ts
@@ -1,4 +1,5 @@
-import { trajectory_from_frames } from '$lib/trajectory'
+import { make_volume } from '$lib/isosurface/types'
+import { trajectory_from_frames } from '$lib/trajectory/runs/memory'
 import type { AnyStructure } from '$lib/structure'
 import { create_frac_to_cart, type Vec3 } from '$lib/math'
 
@@ -17,4 +18,33 @@ export function make_demo_trajectory(structure: AnyStructure) {
       },
     })),
   )
+}
+
+export function predict_demo(structure: AnyStructure) {
+  const lattice = `lattice` in structure ? structure.lattice.matrix : undefined
+  if (!lattice) throw new Error(`The demo requires a crystal`)
+  const values = Float64Array.from({ length: 12 ** 3 }, (_, idx) => {
+    const x_idx = Math.floor(idx / 144)
+    const y_idx = Math.floor(idx / 12) % 12
+    const z_idx = idx % 12
+    return Math.exp(-((x_idx - 6) ** 2 + (y_idx - 6) ** 2 + (z_idx - 6) ** 2) / 10)
+  })
+  return {
+    site_properties: structure.sites.map((_, idx) => ({
+      charge: idx % 2 ? -0.4 : 0.4,
+      dipole: [0.4, 0.2, 0.1],
+    })),
+    color_property: `charge`,
+    volumes: [
+      {
+        ...make_volume(values, [12, 12, 12], {
+          lattice,
+          origin: [0, 0, 0],
+          periodic: false,
+          label: `Predicted density`,
+        }),
+        field_id: `density`,
+      },
+    ],
+  }
 }

--- a/src/routes/(demos)/structure/host-tool/prediction-worker.ts
+++ b/src/routes/(demos)/structure/host-tool/prediction-worker.ts
@@ -1,0 +1,22 @@
+// Worker postMessage has no Window targetOrigin.
+// oxlint-disable eslint-plugin-unicorn/require-post-message-target-origin
+import { predict_demo } from './demo'
+import type { AnyStructure } from '$lib/structure'
+
+self.addEventListener(
+  `message`,
+  ({ data }: MessageEvent<{ structure: AnyStructure; delay_ms: number; fail: boolean }>) => {
+    setTimeout(() => {
+      try {
+        if (data.fail) throw new Error(`Simulated model failure; retry with failure disabled`)
+        const result = predict_demo(data.structure)
+        self.postMessage(
+          { result },
+          { transfer: result.volumes.map(({ values }) => values.buffer) },
+        )
+      } catch (error) {
+        self.postMessage({ error: String(error) })
+      }
+    }, data.delay_ms)
+  },
+)

--- a/src/routes/acknowledgements/+page.md
+++ b/src/routes/acknowledgements/+page.md
@@ -13,10 +13,10 @@
 
 This project would not have been possible as a one-person side project without many fine open-source projects. 🙏 To name just a few:
 
-|           3D graphics           |               2D graphics                |                             Docs                             |               Bundler               |               Testing                |
-| :-----------------------------: | :--------------------------------------: | :----------------------------------------------------------: | :---------------------------------: | :----------------------------------: |
-| [three.js](https://threejs.org) |          [d3](https://d3js.org)          | [svelte-widgets](https://svelte-widgets.janosh.dev/markdown) |     [vite](https://vitejs.dev)      | [playwright](https://playwright.dev) |
-| [threlte](https://threlte.xyz)  | [sharp](https://sharp.pixelplumbing.com) |         [rehype](https://github.com/rehypejs/rehype)         | [sveltekit](https://kit.svelte.dev) |     [vitest](https://vitest.dev)     |
+|           3D graphics           |               2D graphics                |                         Docs                         |               Bundler               |               Testing                |
+| :-----------------------------: | :--------------------------------------: | :--------------------------------------------------: | :---------------------------------: | :----------------------------------: |
+| [three.js](https://threejs.org) |          [d3](https://d3js.org)          | [svelte-widgets](https://svelte-widgets.janosh.dev/) |     [vite](https://vitejs.dev)      | [playwright](https://playwright.dev) |
+| [threlte](https://threlte.xyz)  | [sharp](https://sharp.pixelplumbing.com) |     [rehype](https://github.com/rehypejs/rehype)     | [sveltekit](https://kit.svelte.dev) |     [vitest](https://vitest.dev)     |
 
 Note that the last two cells are empty because there were only 8 items in the list. In markdown tables, if you have less items in a row than there are columns, the remaining cells will just be empty.
 

--- a/src/routes/acknowledgements/+page.md
+++ b/src/routes/acknowledgements/+page.md
@@ -18,8 +18,6 @@ This project would not have been possible as a one-person side project without m
 | [three.js](https://threejs.org) |          [d3](https://d3js.org)          | [svelte-widgets](https://svelte-widgets.janosh.dev/) |     [vite](https://vitejs.dev)      | [playwright](https://playwright.dev) |
 | [threlte](https://threlte.xyz)  | [sharp](https://sharp.pixelplumbing.com) |     [rehype](https://github.com/rehypejs/rehype)     | [sveltekit](https://kit.svelte.dev) |     [vitest](https://vitest.dev)     |
 
-Note that the last two cells are empty because there were only 8 items in the list. In markdown tables, if you have less items in a row than there are columns, the remaining cells will just be empty.
-
 ## Element Images
 
 Big thanks to the element image providers listed below. Each image caption links back to the source website. See [`fetch-elem-images.mjs`](https://github.com/janosh/matterviz/blob/main/src/scripts/fetch-elem-images.mjs) for details.

--- a/src/routes/acknowledgements/+page.md
+++ b/src/routes/acknowledgements/+page.md
@@ -13,10 +13,10 @@
 
 This project would not have been possible as a one-person side project without many fine open-source projects. 🙏 To name just a few:
 
-|           3D graphics           |               2D graphics                |                     Docs                     |               Bundler               |               Testing                |
-| :-----------------------------: | :--------------------------------------: | :------------------------------------------: | :---------------------------------: | :----------------------------------: |
-| [three.js](https://threejs.org) |          [d3](https://d3js.org)          |         [mdsvex](https://mdsvex.com)         |     [vite](https://vitejs.dev)      | [playwright](https://playwright.dev) |
-| [threlte](https://threlte.xyz)  | [sharp](https://sharp.pixelplumbing.com) | [rehype](https://github.com/rehypejs/rehype) | [sveltekit](https://kit.svelte.dev) |     [vitest](https://vitest.dev)     |
+|           3D graphics           |               2D graphics                |                             Docs                             |               Bundler               |               Testing                |
+| :-----------------------------: | :--------------------------------------: | :----------------------------------------------------------: | :---------------------------------: | :----------------------------------: |
+| [three.js](https://threejs.org) |          [d3](https://d3js.org)          | [svelte-widgets](https://svelte-widgets.janosh.dev/markdown) |     [vite](https://vitejs.dev)      | [playwright](https://playwright.dev) |
+| [threlte](https://threlte.xyz)  | [sharp](https://sharp.pixelplumbing.com) |         [rehype](https://github.com/rehypejs/rehype)         | [sveltekit](https://kit.svelte.dev) |     [vitest](https://vitest.dev)     |
 
 Note that the last two cells are empty because there were only 8 items in the list. In markdown tables, if you have less items in a row than there are columns, the remaining cells will just be empty.
 

--- a/src/routes/test/isosurface-performance/+page.svelte
+++ b/src/routes/test/isosurface-performance/+page.svelte
@@ -12,6 +12,9 @@
   import { create_renderer } from '$lib/scene'
   import { Canvas, T } from '@threlte/core'
   import { onMount } from 'svelte'
+  import { make_site } from '$lib/structure/site'
+  import { create_structure_tool_controller } from '$lib/structure/host-tool.svelte'
+  import { prediction_to_json, type StructureToolPrediction } from '$lib/structure/prediction'
 
   const lattice: Matrix3x3 = [
     [4, 0, 0],
@@ -127,6 +130,52 @@
     }
   }
 
+  let prediction_metrics = $state<Record<string, number | number[]>>()
+  function benchmark_prediction(): void {
+    const input = { sites: [make_site(`H`, [0, 0, 0], [0, 0, 0], `H`)] }
+    let prediction: StructureToolPrediction | null = null
+    const controller = create_structure_tool_controller(
+      () => input,
+      () => true,
+      (value) => {
+        prediction = value
+      },
+      () => {},
+      () => `benchmark`,
+    )
+    const run = controller.start_run({
+      model: `benchmark`,
+      version: `1`,
+      units: { density: `e/A^3`, color: `eV` },
+      settings: { grid_size },
+    })
+    const payload = {
+      volumes: volumes.map((volume, idx) => ({ ...volume, field_id: `field-${idx}` })),
+    }
+    const publication_ms = [0, 1, 2].map(() => {
+      const start = performance.now()
+      run.on_overlay(payload)
+      return performance.now() - start
+    })
+    if (!prediction) throw new Error(`Benchmark did not publish a prediction`)
+    const start = performance.now()
+    const json = prediction_to_json(prediction)
+    const export_ms = performance.now() - start
+    prediction_metrics = {
+      grid_size,
+      publication_ms,
+      export_ms,
+      density_bytes: payload.volumes.reduce(
+        (total, volume) => total + volume.values.byteLength,
+        0,
+      ),
+      export_bytes: new Blob([json]).size,
+    }
+    // Feed the last accepted buffers to the existing renderer profiling harness.
+    volumes = (prediction as StructureToolPrediction).volumes ?? []
+    controller.dispose()
+  }
+
   function change_isovalue(): void {
     const { layers } = settings
     if (!layers[0]) return
@@ -184,6 +233,10 @@
   })
 </script>
 
+<button onclick={benchmark_prediction}>Benchmark prediction</button>
+<output data-testid="prediction-metrics"
+  >{prediction_metrics ? JSON.stringify(prediction_metrics) : `Not measured`}</output
+>
 <button data-testid="change-isovalue" onclick={change_isovalue}>Change isovalue</button>
 <button data-testid="recolor" onclick={recolor}>Recolor only</button>
 <button data-testid="measure-fps" onclick={measure_fps}>Measure FPS</button>

--- a/svelte.config.ts
+++ b/svelte.config.ts
@@ -8,25 +8,28 @@ import { common } from '@wooorm/starry-night'
 import svelte_grammar from '@wooorm/starry-night/source.svelte'
 import tsx_grammar from '@wooorm/starry-night/source.tsx'
 import vue_grammar from '@wooorm/starry-night/text.html.vue'
-import { mdsvex } from 'mdsvex'
 import type { PreprocessorGroup } from 'svelte/compiler'
 import { heading_ids } from 'svelte-widgets/heading-anchors'
-import { mdsvex_transform } from 'svelte-widgets/live-examples'
-import {
-  create_highlighter,
-  render_block,
-} from 'svelte-widgets/live-examples/create-highlighter'
+import { create_markdown } from 'svelte-widgets/markdown'
+import { markdown_vite } from 'svelte-widgets/markdown/vite'
+import { create_highlighter } from 'svelte-widgets/highlight'
 
 const defaults = {
-  Wrapper: [`svelte-widgets`, `CodeExample`],
-  hideStyle: true,
+  hide_style: true,
   collapsible: true,
 }
 
 // svelte-widgets' default highlighter only knows starry-night's `common` bundle plus
 // Svelte, which would leave the tsx/vue fences in the framework-interop docs unstyled
 const grammars = [...common, svelte_grammar, tsx_grammar, vue_grammar]
-const starry_night = await create_highlighter(grammars).ready()
+const highlighter = create_highlighter(grammars)
+export const docs = markdown_vite(
+  create_markdown({
+    examples: defaults,
+    highlight: highlighter.highlight,
+    typography: true,
+  }),
+)
 
 // Heading anchors are a docs-site feature, but preprocessors run over src/lib too, where
 // the injected ids end up in the published package: nothing references them, and a heading
@@ -48,12 +51,8 @@ export default {
   extensions: [`.svelte`, `.svx`, `.md`],
 
   preprocess: [
-    mdsvex({
-      remarkPlugins: [[mdsvex_transform, { defaults }]],
-      extensions: [`.svx`, `.md`],
-      highlight: { highlighter: (code, lang) => render_block(starry_night, code, lang) },
-    }),
-    site_heading_ids, // runs after mdsvex converts markdown to HTML
+    docs.preprocess,
+    site_heading_ids, // anchors for native Svelte pages
   ],
 
   kit: {

--- a/tests/playwright/isosurface-performance.test.ts
+++ b/tests/playwright/isosurface-performance.test.ts
@@ -53,5 +53,22 @@ test.describe(`Isosurface performance harness`, () => {
     expect(marching.every((event) => event.meta.worker === true)).toBe(true)
     expect(marching.every((event) => Number(event.meta.vertices) > 0)).toBe(true)
     expect(events.some((event) => event.meta.worker_fallback === true)).toBe(false)
+    const rebuild_count = events.filter((event) => event.stage === `rebuild_total`).length
+    await page.getByRole(`button`, { name: `Benchmark prediction` }).click()
+    await expect
+      .poll(
+        async () =>
+          (await read_events(page)).filter((event) => event.stage === `rebuild_total`).length,
+        { timeout: 30_000 },
+      )
+      .toBeGreaterThan(rebuild_count)
+    const metrics = JSON.parse(
+      (await page.getByTestId(`prediction-metrics`).textContent()) ?? `null`,
+    )
+    expect(metrics.publication_ms).toHaveLength(3)
+    expect(metrics.publication_ms.every((duration: number) => duration > 0)).toBe(true)
+    expect(metrics.export_ms).toBeGreaterThan(0)
+    expect(metrics.density_bytes).toBe((64 ** 3 + 53 ** 3) * 8)
+    expect(metrics.export_bytes).toBeGreaterThan(metrics.density_bytes)
   })
 })

--- a/tests/playwright/plot/spacegroup-bar-plot.test.ts
+++ b/tests/playwright/plot/spacegroup-bar-plot.test.ts
@@ -4,7 +4,7 @@ import { expect_bottom_within, get_chart_svg, is_present } from '../helpers'
 test.describe(`SpacegroupBarPlot Component Tests`, () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(`/plot/spacegroup-bar-plot`, { waitUntil: `networkidle` })
-    // Wait for first bar-plot to render (mdsvex examples may take time)
+    // Wait for the first bar-plot example to render.
     await page.waitForSelector(`.bar-plot`, { timeout: 15000 })
   })
 

--- a/tests/playwright/structure/host-tool.test.ts
+++ b/tests/playwright/structure/host-tool.test.ts
@@ -1,0 +1,149 @@
+import { expect, type Download, type Page } from '@playwright/test'
+import { drag_canvas, test_without_errors as test } from '../helpers'
+
+const scene_state = (page: Page) =>
+  page.evaluate(async () => {
+    const module_path = `/src/lib/io/export.ts`
+    const { scene_registry, renderer_registry } = await import(/* @vite-ignore */ module_path)
+    const canvas = document.querySelector(`.structure canvas`)
+    const entry = canvas && scene_registry.get(canvas)
+    const renderer = canvas && renderer_registry.get(canvas)
+    let arrows = 0
+    let density_vertices = 0
+    const atom_colors: number[] = []
+    entry?.scene.traverse(
+      (node: {
+        isMesh?: boolean
+        isInstancedMesh?: boolean
+        count?: number
+        geometry?: {
+          type: string
+          getAttribute: (name: string) => { count: number } | undefined
+        }
+        material?: { metalness?: number; roughness?: number }
+        instanceColor?: { array: ArrayLike<number> }
+      }) => {
+        if (node.isInstancedMesh && node.geometry?.type === `ConeGeometry`)
+          arrows += node.count ?? 0
+        if (
+          node.isInstancedMesh &&
+          node.geometry?.type === `SphereGeometry` &&
+          node.instanceColor
+        )
+          atom_colors.push(
+            ...Array.from(node.instanceColor.array).slice(0, (node.count ?? 0) * 3),
+          )
+        if (
+          node.isMesh &&
+          !node.isInstancedMesh &&
+          node.geometry?.type === `BufferGeometry` &&
+          node.material?.metalness === 0.1 &&
+          node.material?.roughness === 0.6
+        )
+          density_vertices += node.geometry.getAttribute(`position`)?.count ?? 0
+      },
+    )
+    return {
+      arrows,
+      density_vertices,
+      atom_colors,
+      webgpu: Boolean(renderer?.backend?.isWebGPUBackend),
+      camera: entry
+        ? [...entry.camera.position.toArray(), ...entry.camera.quaternion.toArray()]
+        : undefined,
+      rendered: (renderer?.info.render.calls ?? 0) > 0,
+    }
+  })
+
+test(`prediction tools render with WebGPU and hand keyboard/camera ownership to a nested trajectory`, async ({
+  page,
+}) => {
+  await page.goto(`/structure/host-tool`)
+  await expect.poll(() => scene_state(page)).toMatchObject({ webgpu: true, rendered: true })
+  const outer = page.locator(`.structure`).first()
+  const original_colors = (await scene_state(page)).atom_colors
+  await page.getByRole(`button`, { name: `Run prediction`, exact: true }).click()
+  await expect(
+    page.getByRole(`status`).filter({ hasText: `charges, dipoles and density` }),
+  ).toBeVisible()
+  await expect.poll(async () => (await scene_state(page)).arrows).toBeGreaterThan(0)
+  await expect.poll(async () => (await scene_state(page)).density_vertices).toBeGreaterThan(0)
+  expect((await scene_state(page)).atom_colors).not.toEqual(original_colors)
+  await page.locator(`button.structure-controls-toggle`).click()
+  await expect(
+    page.getByRole(`button`, { name: `Add surface for Predicted density`, exact: true }),
+  ).toBeVisible()
+  await page.locator(`button.structure-controls-toggle`).click()
+  await drag_canvas(outer.locator(`canvas`).first(), { dx: 65, dy: 35 })
+  const before = (await scene_state(page)).camera
+  expect(before).toHaveLength(7)
+  await page.getByRole(`button`, { name: `Show predicted trajectory` }).click()
+  await expect(page.getByTestId(`predicted-trajectory`)).toBeVisible()
+  // The outer tool remains mounted but hidden; the nested Structure must not register one.
+  await expect(page.getByTestId(`host-tool-controls`)).toHaveCount(1)
+  await expect(page.getByTestId(`host-tool-controls`)).toBeHidden()
+  await expect.poll(() => scene_state(page)).toMatchObject({ webgpu: true, rendered: true })
+  const nested = page.getByTestId(`predicted-trajectory`)
+  await nested.locator(`canvas`).first().hover()
+  await page.keyboard.press(`ArrowRight`)
+  await expect(page.getByLabel(`Trajectory frame`)).toHaveText(`Frame 2`)
+  await page.keyboard.press(`i`)
+  await expect(nested.locator(`.structure-info-pane`)).toBeVisible()
+  await page.getByRole(`button`, { name: `Return to structure` }).click()
+  await expect(nested).toHaveCount(0)
+  await expect(outer.locator(`.structure-info-pane`)).toBeHidden()
+  await expect(page.getByTestId(`host-tool-controls`)).toBeVisible()
+  await expect.poll(() => scene_state(page)).toMatchObject({ webgpu: true, rendered: true })
+  await expect
+    .poll(async () => {
+      const after = (await scene_state(page)).camera
+      return after && before
+        ? Math.max(...after.map((coord: number, idx: number) => Math.abs(coord - before[idx])))
+        : Infinity
+    })
+    .toBeLessThan(1e-10)
+})
+
+const read_download = async (download: Download) => {
+  const stream = await download.createReadStream()
+  if (!stream) throw new Error(`Download has no stream`)
+  const chunks: Buffer[] = []
+  for await (const chunk of stream) chunks.push(Buffer.from(chunk))
+  return JSON.parse(Buffer.concat(chunks).toString())
+}
+
+test(`exports reproducible predictions separately from the original structure`, async ({
+  page,
+}) => {
+  await page.goto(`/structure/host-tool`)
+  await page.getByRole(`button`, { name: `Run prediction`, exact: true }).click()
+  await page.locator(`button.structure-export-toggle`).click()
+  const prediction_download = page.waitForEvent(`download`)
+  await page.getByTitle(`Download Export prediction`, { exact: true }).click()
+  const download = await prediction_download
+  expect(download.suggestedFilename()).toMatch(/^prediction-\d+\.json$/)
+  const data = await read_download(download)
+  expect(data.provenance).toMatchObject({
+    model: `Deterministic host example`,
+    version: `1`,
+    units: { density: `e/A^3` },
+    settings: { seed: 0 },
+  })
+  expect(data.site_properties).toHaveLength(data.input.sites.length)
+  expect(data.site_properties[0]).toMatchObject({ charge: 0.4, dipole: [0.4, 0.2, 0.1] })
+  expect(data.input.sites[0].properties.charge).toBeUndefined()
+  expect(data.volumes[0]).toMatchObject({ field_id: `density`, dims: [12, 12, 12] })
+  expect(data.volumes[0].values).toHaveLength(12 ** 3)
+  const original_download = page.waitForEvent(`download`)
+  await page.getByTitle(`Download JSON`, { exact: true }).click()
+  const original = await read_download(await original_download)
+  expect(original.sites).toEqual(data.input.sites)
+  expect(original.lattice).toEqual(data.input.lattice)
+  expect(original.volumes).toBeUndefined()
+  await page.getByRole(`button`, { name: `Reset prediction surfaces` }).click()
+  await page.getByRole(`button`, { name: `Clear prediction`, exact: true }).click()
+  await expect(page.getByTitle(`Download Export prediction`, { exact: true })).toHaveCount(0)
+  await expect(
+    page.getByRole(`button`, { name: `Add surface for Predicted density`, exact: true }),
+  ).toHaveCount(0)
+})

--- a/tests/playwright/structure/host-tool.test.ts
+++ b/tests/playwright/structure/host-tool.test.ts
@@ -140,10 +140,15 @@ test(`exports reproducible predictions separately from the original structure`, 
   expect(original.sites).toEqual(data.input.sites)
   expect(original.lattice).toEqual(data.input.lattice)
   expect(original.volumes).toBeUndefined()
+  // Closed panes retain controls, so include hidden buttons when checking their removal.
+  const density_surface = page.getByRole(`button`, {
+    name: `Add surface for Predicted density`,
+    exact: true,
+    includeHidden: true,
+  })
+  await expect(density_surface).toHaveCount(1)
   await page.getByRole(`button`, { name: `Reset prediction surfaces` }).click()
   await page.getByRole(`button`, { name: `Clear prediction`, exact: true }).click()
   await expect(page.getByTitle(`Download Export prediction`, { exact: true })).toHaveCount(0)
-  await expect(
-    page.getByRole(`button`, { name: `Add surface for Predicted density`, exact: true }),
-  ).toHaveCount(0)
+  await expect(density_surface).toHaveCount(0)
 })

--- a/tests/playwright/structure/host-tool.test.ts
+++ b/tests/playwright/structure/host-tool.test.ts
@@ -62,6 +62,18 @@ const scene_state = (page: Page) =>
     }
   })
 
+const drop_prediction = async (page: Page, prediction: unknown): Promise<void> => {
+  const transfer = await page.evaluateHandle((payload) => {
+    const drop_data = new DataTransfer()
+    drop_data.items.add(
+      new File([JSON.stringify(payload)], `prediction.json`, { type: `application/json` }),
+    )
+    return drop_data
+  }, prediction)
+  await page.locator(`.structure`).first().dispatchEvent(`drop`, { dataTransfer: transfer })
+  await transfer.dispose()
+}
+
 test(`prediction tools render with WebGPU and hand keyboard/camera ownership to a nested trajectory`, async ({
   page,
 }) => {
@@ -202,4 +214,90 @@ test(`exports reproducible predictions separately from the original structure`, 
   await page.getByRole(`button`, { name: `Clear prediction`, exact: true }).click()
   await expect(page.getByTitle(`Download Export prediction`, { exact: true })).toHaveCount(0)
   await expect(density_surface).toHaveCount(0)
+  await drop_prediction(page, data)
+  await expect(density_surface).toHaveCount(1)
+  const reopened_download = page.waitForEvent(`download`)
+  await page.getByTitle(`Download Export prediction`, { exact: true }).click()
+  expect(await read_download(await reopened_download)).toEqual(data)
+})
+
+test(`worker predictions guard reversed completion, failure and cancellation`, async ({
+  page,
+}) => {
+  // Model a computation that ignores cancellation. Its late message must still be harmless.
+  await page.addInitScript(() => {
+    globalThis.Worker = class extends Worker {
+      prediction_worker = false
+      constructor(...args: ConstructorParameters<typeof Worker>) {
+        const prediction_worker = String(args[0]).includes(`prediction-worker`)
+        if (prediction_worker && document.documentElement.dataset.failWorkerSetup)
+          throw new Error(`Worker setup failed`)
+        super(...args)
+        this.prediction_worker = prediction_worker
+        if (!prediction_worker) return
+        this.addEventListener(`message`, () => {
+          const root = document.documentElement
+          root.dataset.workerReplies = String(Number(root.dataset.workerReplies ?? 0) + 1)
+        })
+      }
+      terminate() {
+        if (!this.prediction_worker) return super.terminate()
+        const root = document.documentElement
+        root.dataset.workerStops = String(Number(root.dataset.workerStops ?? 0) + 1)
+      }
+    }
+  })
+  await page.goto(`/structure/host-tool`)
+  const delay = page.getByRole(`spinbutton`, { name: `Delay (ms)` })
+  const predict = page.getByRole(`button`, { name: `Run prediction`, exact: true })
+  const status = page.locator(`[data-testid="host-tool-controls"] [role="status"]`)
+  await delay.fill(`1000`)
+  await predict.click()
+  await expect(status).toContainText(`Prediction 1 running`)
+  await delay.fill(`0`)
+  await predict.click()
+  await expect(status).toContainText(`Prediction 2 ready`)
+  await expect(page.locator(`html`)).toHaveAttribute(`data-worker-replies`, `2`)
+  await expect(status).toContainText(`Prediction 2 ready`)
+  const exporting = page.getByTitle(`Download Export prediction`, { exact: true })
+  await page.getByRole(`checkbox`, { name: `Fail prediction` }).check()
+  await predict.click()
+  await expect(status).toContainText(`Simulated model failure`)
+  await page.locator(`button.structure-export-toggle`).click()
+  await expect(exporting).toBeVisible()
+  const saved = page.waitForEvent(`download`)
+  await exporting.click()
+  const retained = await read_download(await saved)
+  expect(retained.run_id).toBe(2)
+  await page.getByRole(`checkbox`, { name: `Fail prediction` }).uncheck()
+  await delay.fill(`500`)
+  await predict.click()
+  await page.getByRole(`button`, { name: `Cancel prediction`, exact: true }).click()
+  await expect(status).toContainText(`cancelled`)
+  await expect(page.locator(`html`)).toHaveAttribute(`data-worker-replies`, `4`)
+  await expect(exporting).toHaveCount(0)
+  await expect(status).toContainText(`cancelled`)
+  await predict.click()
+  retained.input.sites[0].species[0].element = `Zn`
+  await drop_prediction(page, retained)
+  await expect(page.locator(`html`)).toHaveAttribute(`data-worker-replies`, `5`)
+  await page.locator(`button.structure-export-toggle`).click()
+  const imported = page.waitForEvent(`download`)
+  await exporting.click()
+  expect(await read_download(await imported)).toEqual(retained)
+  await page.evaluate(() => {
+    document.documentElement.dataset.failWorkerSetup = `true`
+  })
+  await predict.click()
+  await expect(status).toContainText(`Worker setup failed`)
+  await expect(
+    page.getByRole(`button`, { name: `Cancel prediction`, exact: true }),
+  ).toBeDisabled()
+  await page.evaluate(() => {
+    delete document.documentElement.dataset.failWorkerSetup
+  })
+  await predict.click()
+  const stopped = Number(await page.locator(`html`).getAttribute(`data-worker-stops`))
+  await page.locator(`a[href="/"]`).first().click()
+  await expect(page.locator(`html`)).toHaveAttribute(`data-worker-stops`, String(stopped + 1))
 })

--- a/tests/playwright/structure/host-tool.test.ts
+++ b/tests/playwright/structure/host-tool.test.ts
@@ -5,6 +5,8 @@ const scene_state = (page: Page) =>
   page.evaluate(async () => {
     const module_path = `/src/lib/io/export.ts`
     const { scene_registry, renderer_registry } = await import(/* @vite-ignore */ module_path)
+    const pan_module = `/src/lib/scene/pan.ts`
+    const { read_pan_offset } = await import(/* @vite-ignore */ pan_module)
     const canvas = document.querySelector(`.structure canvas`)
     const entry = canvas && scene_registry.get(canvas)
     const renderer = canvas && renderer_registry.get(canvas)
@@ -49,7 +51,12 @@ const scene_state = (page: Page) =>
       atom_colors,
       webgpu: Boolean(renderer?.backend?.isWebGPUBackend),
       camera: entry
-        ? [...entry.camera.position.toArray(), ...entry.camera.quaternion.toArray()]
+        ? [
+            ...entry.camera.position.toArray(),
+            ...entry.camera.quaternion.toArray(),
+            entry.camera.zoom,
+            ...read_pan_offset(entry.camera),
+          ]
         : undefined,
       rendered: (renderer?.info.render.calls ?? 0) > 0,
     }
@@ -58,6 +65,7 @@ const scene_state = (page: Page) =>
 test(`prediction tools render with WebGPU and hand keyboard/camera ownership to a nested trajectory`, async ({
   page,
 }) => {
+  await page.setViewportSize({ width: 1280, height: 1100 })
   await page.goto(`/structure/host-tool`)
   await expect.poll(() => scene_state(page)).toMatchObject({ webgpu: true, rendered: true })
   const outer = page.locator(`.structure`).first()
@@ -74,9 +82,25 @@ test(`prediction tools render with WebGPU and hand keyboard/camera ownership to 
     page.getByRole(`button`, { name: `Add surface for Predicted density`, exact: true }),
   ).toBeVisible()
   await page.locator(`button.structure-controls-toggle`).click()
+  await outer.locator(`canvas`).first().hover()
   await drag_canvas(outer.locator(`canvas`).first(), { dx: 65, dy: 35 })
+  // Seed the live camera directly: this tests remount persistence independently of gestures.
+  await page.evaluate(async () => {
+    const export_module = `/src/lib/io/export.ts`
+    const pan_module = `/src/lib/scene/pan.ts`
+    const { scene_registry } = await import(/* @vite-ignore */ export_module)
+    const { set_pan_offset } = await import(/* @vite-ignore */ pan_module)
+    const canvas = document.querySelector(`.structure canvas`)
+    const camera = canvas && scene_registry.get(canvas)?.camera
+    if (!canvas || !camera) throw new Error(`Missing structure camera`)
+    camera.zoom = 68.5797
+    camera.updateProjectionMatrix()
+    const { width, height } = canvas.getBoundingClientRect()
+    set_pan_offset(camera, [30, 15], width, height)
+  })
   const before = (await scene_state(page)).camera
-  expect(before).toHaveLength(7)
+  expect(before).toHaveLength(10)
+  expect(before?.slice(8)).toEqual([30, 15])
   await page.getByRole(`button`, { name: `Show predicted trajectory` }).click()
   await expect(page.getByTestId(`predicted-trajectory`)).toBeVisible()
   // The outer tool remains mounted but hidden; the nested Structure must not register one.
@@ -102,6 +126,35 @@ test(`prediction tools render with WebGPU and hand keyboard/camera ownership to 
         : Infinity
     })
     .toBeLessThan(1e-10)
+  expect((await scene_state(page)).camera?.slice(7)).toEqual(before?.slice(7))
+})
+
+test(`caller camera updates during a host view take precedence over its saved view`, async ({
+  page,
+}) => {
+  await page.goto(`/test/structure`)
+  await page.evaluate(async () => {
+    const host_module = `/src/lib/structure/index.ts`
+    const demo_module = `/src/routes/(demos)/structure/host-tool/DemoHostTool.svelte`
+    const { structure_host_tool } = await import(/* @vite-ignore */ host_module)
+    const { default: component } = await import(/* @vite-ignore */ demo_module)
+    structure_host_tool.component = component
+  })
+  await expect.poll(() => scene_state(page)).toMatchObject({ webgpu: true, rendered: true })
+  await page.getByRole(`button`, { name: `Show predicted trajectory` }).click()
+  await expect(page.getByTestId(`predicted-trajectory`)).toBeVisible()
+  await page.evaluate(() =>
+    window.dispatchEvent(
+      new CustomEvent(`set-scene-props`, {
+        detail: { camera_position: [12, 9, 7], camera_target: [0, 0, 0] },
+      }),
+    ),
+  )
+  await page.getByRole(`button`, { name: `Return to structure` }).click()
+  await expect(page.getByTestId(`predicted-trajectory`)).toHaveCount(0)
+  await expect
+    .poll(async () => (await scene_state(page)).camera?.slice(0, 3))
+    .toEqual([12, 9, 7])
 })
 
 const read_download = async (download: Download) => {

--- a/tests/playwright/structure/host-tool.test.ts
+++ b/tests/playwright/structure/host-tool.test.ts
@@ -1,5 +1,5 @@
 import { expect, type Download, type Page } from '@playwright/test'
-import { drag_canvas, test_without_errors as test } from '../helpers'
+import { test_without_errors as test } from '../helpers'
 
 const scene_state = (page: Page) =>
   page.evaluate(async () => {
@@ -82,9 +82,7 @@ test(`prediction tools render with WebGPU and hand keyboard/camera ownership to 
     page.getByRole(`button`, { name: `Add surface for Predicted density`, exact: true }),
   ).toBeVisible()
   await page.locator(`button.structure-controls-toggle`).click()
-  await outer.locator(`canvas`).first().hover()
-  await drag_canvas(outer.locator(`canvas`).first(), { dx: 65, dy: 35 })
-  // Seed the live camera directly: this tests remount persistence independently of gestures.
+  // Seed the live camera directly: a damped drag keeps changing the pose until suspension.
   await page.evaluate(async () => {
     const export_module = `/src/lib/io/export.ts`
     const pan_module = `/src/lib/scene/pan.ts`

--- a/tests/vitest/file-viewer/parse-entry.test.ts
+++ b/tests/vitest/file-viewer/parse-entry.test.ts
@@ -11,6 +11,7 @@ test(`worker-safe file-viewer entry graphs stay free of Svelte`, () => {
       `src/lib/file-viewer/host-transfer.ts`,
       // These load inside a Worker, where `document` does not exist.
       `src/lib/file-viewer/parse-worker.ts`,
+      `src/routes/(demos)/structure/host-tool/prediction-worker.ts`,
       `src/lib/file-viewer/parse-worker-protocol.ts`,
     ],
     10,

--- a/tests/vitest/file-viewer/parse-in-worker.test.ts
+++ b/tests/vitest/file-viewer/parse-in-worker.test.ts
@@ -11,6 +11,8 @@ import {
   parse_trajectory_in_worker,
 } from '$lib/file-viewer/parse-in-worker'
 import { handle_parse_worker_request } from '$lib/file-viewer/parse-worker'
+import { prediction_to_json } from '$lib/structure/prediction'
+import { make_grid, make_volume } from '../setup'
 import type { Hdf5GroupSelectionRequiredError, TrajectoryFrame } from '$lib/trajectory'
 import { summarize_run, trajectory_from_frames } from '$lib/trajectory'
 import { serve_run_over_port } from '$lib/trajectory/runs/worker'
@@ -323,6 +325,36 @@ describe(`parse_trajectory_in_worker`, () => {
 })
 
 describe(`parse worker handler`, () => {
+  it.each([0, 2])(`transfers all %i imported density buffers`, async (count) => {
+    const volumes = Array.from({ length: count }, (_, idx) => ({
+      ...make_volume(make_grid(2, 2, 2, () => idx + 1)),
+      field_id: `density-${idx}`,
+    }))
+    const { response, transfer } = await handle_parse_worker_request({
+      kind: `file`,
+      id: 8,
+      filename: `prediction.json`,
+      is_base64: false,
+      content: prediction_to_json({
+        input: frame.structure,
+        run_id: 1,
+        provenance: { model: `test`, version: `1`, units: {}, settings: {} },
+        volumes,
+      }),
+    })
+    if (response.result?.type !== `structure`) throw new Error(`Expected structure result`)
+    const buffers = response.result.prediction?.volumes?.map(({ values }) => values.buffer)
+    expect(transfer).toEqual(buffers)
+    expect(transfer).toHaveLength(count)
+    const received = structuredClone(response, { transfer })
+    expect(buffers?.every((buffer) => buffer.byteLength === 0)).toBe(true)
+    if (received.result?.type !== `structure`)
+      throw new Error(`Expected transferred structure`)
+    expect(received.result.prediction?.volumes?.map(({ values }) => values)).toEqual(
+      volumes.map(({ values }) => values),
+    )
+  })
+
   it(`keeps a parsed trajectory behind a transferred run port`, async () => {
     const { response, transfer } = await handle_parse_worker_request({
       kind: `trajectory`,

--- a/tests/vitest/layout/InfoTag.test.ts
+++ b/tests/vitest/layout/InfoTag.test.ts
@@ -119,6 +119,8 @@ describe(`InfoTag`, () => {
   ])(
     `remove button visible=$expected when removable=$removable, disabled=$disabled, callback=$callback`,
     ({ removable, disabled, callback, expected }) => {
+      const onclick = vi.fn()
+      const on_remove = vi.fn()
       mount(InfoTag, {
         target: document.body,
         props: {
@@ -126,29 +128,22 @@ describe(`InfoTag`, () => {
           value: 1,
           removable,
           disabled,
-          on_remove: callback ? vi.fn() : undefined,
+          onclick,
+          on_remove: callback ? on_remove : undefined,
         },
       })
-      expect(Boolean(document.querySelector(`[aria-label="Remove"]`))).toBe(expected)
+      const remove = document.querySelector<HTMLButtonElement>(`[aria-label="Remove"]`)
+      expect(Boolean(remove)).toBe(expected)
+      if (!remove) return
+      for (const key of [`Enter`, ` `])
+        remove.dispatchEvent(new KeyboardEvent(`keydown`, { key, bubbles: true }))
+      expect(onclick).not.toHaveBeenCalled()
+      remove.click()
+      flushSync()
+      expect(on_remove).toHaveBeenCalledExactlyOnceWith()
+      expect(onclick).not.toHaveBeenCalled()
     },
   )
-
-  test(`on_remove fires without triggering tag onclick`, () => {
-    const onclick = vi.fn()
-    const on_remove = vi.fn()
-    mount(InfoTag, {
-      target: document.body,
-      props: { label: `Test`, value: 1, removable: true, onclick, on_remove },
-    })
-    const remove = doc_query<HTMLButtonElement>(`[aria-label="Remove"]`)
-    for (const key of [`Enter`, ` `])
-      remove.dispatchEvent(new KeyboardEvent(`keydown`, { key, bubbles: true }))
-    expect(onclick).not.toHaveBeenCalled()
-    remove.click()
-    flushSync()
-    expect(on_remove).toHaveBeenCalledExactlyOnceWith()
-    expect(onclick).not.toHaveBeenCalled()
-  })
 
   test.each([
     { value: undefined, expected: `` },

--- a/tests/vitest/layout/InfoTag.test.ts
+++ b/tests/vitest/layout/InfoTag.test.ts
@@ -46,6 +46,7 @@ describe(`InfoTag`, () => {
   test.each([
     { value: `abc123`, copy_value: undefined, expected: `abc123` },
     { value: `abc123`, copy_value: `full-id-abc123`, expected: `full-id-abc123` },
+    { value: undefined, copy_value: `full-id-abc123`, expected: `full-id-abc123` },
   ])(
     `copies $expected to clipboard (copy_value=$copy_value)`,
     ({ value, copy_value, expected }) => {
@@ -54,6 +55,7 @@ describe(`InfoTag`, () => {
         target: document.body,
         props: { label: `ID:`, value, copy_value },
       })
+      expect(get_tag().getAttribute(`role`)).toBe(`button`)
       get_tag().click()
       flushSync()
       expect(write_text_spy).toHaveBeenCalledWith(expected)
@@ -79,7 +81,11 @@ describe(`InfoTag`, () => {
 
     // Custom onclick overrides copy
     const onclick = vi.fn()
-    mount(InfoTag, { target: document.body, props: { label: `Test`, value: 1, onclick } })
+    mount(InfoTag, {
+      target: document.body,
+      props: { label: `Test`, value: undefined, onclick },
+    })
+    expect(get_tag().getAttribute(`role`)).toBe(`button`)
     get_tag().click()
     flushSync()
     expect(onclick).toHaveBeenCalled()
@@ -106,17 +112,24 @@ describe(`InfoTag`, () => {
   })
 
   test.each([
-    { removable: true, disabled: false, expected: true },
-    { removable: false, disabled: false, expected: false },
-    { removable: true, disabled: true, expected: false },
+    { removable: true, disabled: false, callback: true, expected: true },
+    { removable: false, disabled: false, callback: true, expected: false },
+    { removable: true, disabled: true, callback: true, expected: false },
+    { removable: true, disabled: false, callback: false, expected: false },
   ])(
-    `remove button visible=$expected when removable=$removable, disabled=$disabled`,
-    (params) => {
+    `remove button visible=$expected when removable=$removable, disabled=$disabled, callback=$callback`,
+    ({ removable, disabled, callback, expected }) => {
       mount(InfoTag, {
         target: document.body,
-        props: { label: `Test`, value: 1, ...params },
+        props: {
+          label: `Test`,
+          value: 1,
+          removable,
+          disabled,
+          on_remove: callback ? vi.fn() : undefined,
+        },
       })
-      expect(Boolean(document.querySelector(`[aria-label="Remove"]`))).toBe(params.expected)
+      expect(Boolean(document.querySelector(`[aria-label="Remove"]`))).toBe(expected)
     },
   )
 
@@ -127,9 +140,13 @@ describe(`InfoTag`, () => {
       target: document.body,
       props: { label: `Test`, value: 1, removable: true, onclick, on_remove },
     })
-    doc_query<HTMLButtonElement>(`[aria-label="Remove"]`).click()
+    const remove = doc_query<HTMLButtonElement>(`[aria-label="Remove"]`)
+    for (const key of [`Enter`, ` `])
+      remove.dispatchEvent(new KeyboardEvent(`keydown`, { key, bubbles: true }))
+    expect(onclick).not.toHaveBeenCalled()
+    remove.click()
     flushSync()
-    expect(on_remove).toHaveBeenCalled()
+    expect(on_remove).toHaveBeenCalledExactlyOnceWith()
     expect(onclick).not.toHaveBeenCalled()
   })
 
@@ -140,6 +157,8 @@ describe(`InfoTag`, () => {
   ])(`displays value $value as "$expected"`, ({ value, expected }) => {
     mount(InfoTag, { target: document.body, props: { label: `Test:`, value } })
     expect(doc_query(`em`).textContent).toBe(expected)
+    expect(get_tag().getAttribute(`role`)).toBe(value === undefined ? null : `button`)
+    expect(get_tag().getAttribute(`tabindex`)).toBe(value === undefined ? null : `0`)
   })
 
   test(`spreads additional attributes`, () => {

--- a/tests/vitest/package-exports.test.ts
+++ b/tests/vitest/package-exports.test.ts
@@ -121,6 +121,7 @@ describe(`package.json exports`, () => {
   test(`root barrel exposes the host prediction API`, () => {
     expect(lib.structure_host_tool).toHaveProperty(`component`)
     expect(lib.prediction_to_json).toBeTypeOf(`function`)
+    expect(lib.prediction_from_json).toBeTypeOf(`function`)
     expectTypeOf<lib.StructureToolRun>().toHaveProperty(`signal`)
     expectTypeOf<lib.StructureToolProps>().toHaveProperty(`start_run`)
   })
@@ -130,9 +131,12 @@ describe(`package.json exports`, () => {
     { timeout: 60_000 },
     async (entry) => {
       expect(import.meta.resolve(entry)).toContain(`/dist/`)
-      const { structure_host_tool, prediction_to_json } = await import(entry)
+      const { structure_host_tool, prediction_to_json, prediction_from_json } = await import(
+        entry
+      )
       expect(structure_host_tool).toHaveProperty(`component`, null)
       expect(prediction_to_json).toBeTypeOf(`function`)
+      expect(prediction_from_json).toBeTypeOf(`function`)
       expectTypeOf<StructureToolRun>().toHaveProperty(`signal`)
       expectTypeOf<StructureToolProps>().toHaveProperty(`start_run`)
     },

--- a/tests/vitest/package-exports.test.ts
+++ b/tests/vitest/package-exports.test.ts
@@ -25,6 +25,8 @@ import {
 } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
+import type { StructureToolRun } from 'matterviz'
+import type { StructureToolProps } from 'matterviz/structure'
 import { afterAll, describe, expect, expectTypeOf, test } from 'vitest'
 import svelte_config from '../../svelte.config'
 
@@ -122,6 +124,19 @@ describe(`package.json exports`, () => {
     expectTypeOf<lib.StructureToolRun>().toHaveProperty(`signal`)
     expectTypeOf<lib.StructureToolProps>().toHaveProperty(`start_run`)
   })
+
+  test.skipIf(!has_dist).each([`matterviz`, `matterviz/structure`])(
+    `built %s entry exposes the host prediction API`,
+    { timeout: 60_000 },
+    async (entry) => {
+      expect(import.meta.resolve(entry)).toContain(`/dist/`)
+      const { structure_host_tool, prediction_to_json } = await import(entry)
+      expect(structure_host_tool).toHaveProperty(`component`, null)
+      expect(prediction_to_json).toBeTypeOf(`function`)
+      expectTypeOf<StructureToolRun>().toHaveProperty(`signal`)
+      expectTypeOf<StructureToolProps>().toHaveProperty(`start_run`)
+    },
+  )
 
   test(`plot keeps its selected public title and decoration exports`, () => {
     expectTypeOf<DecorationSide>().toEqualTypeOf<`top` | `right` | `bottom` | `left`>()

--- a/tests/vitest/package-exports.test.ts
+++ b/tests/vitest/package-exports.test.ts
@@ -116,6 +116,13 @@ describe(`package.json exports`, () => {
     ])
   })
 
+  test(`root barrel exposes the host prediction API`, () => {
+    expect(lib.structure_host_tool).toHaveProperty(`component`)
+    expect(lib.prediction_to_json).toBeTypeOf(`function`)
+    expectTypeOf<lib.StructureToolRun>().toHaveProperty(`signal`)
+    expectTypeOf<lib.StructureToolProps>().toHaveProperty(`start_run`)
+  })
+
   test(`plot keeps its selected public title and decoration exports`, () => {
     expectTypeOf<DecorationSide>().toEqualTypeOf<`top` | `right` | `bottom` | `left`>()
     expectTypeOf<FreeAnnotationDecorationItem[`kind`]>().toEqualTypeOf<`free-annotation`>()

--- a/tests/vitest/phase-diagram/PhaseDiagramEditorPane.test.ts
+++ b/tests/vitest/phase-diagram/PhaseDiagramEditorPane.test.ts
@@ -4,14 +4,14 @@ import { flushSync, mount, tick, unmount } from 'svelte'
 import { expect, onTestFinished, test, vi } from 'vitest'
 import al_cu_data from './fixtures/al-cu-sample.json' with { type: 'json' }
 
-test.each([false, true])(
-  `editor handles a leaf edit whose path becomes stale=%s`,
-  async (stale) => {
+test.each([`edit`, `stale edit`, `read-only`])(
+  `editor handles %s with callback availability and stale-path protection`,
+  async (mode) => {
     const data = structuredClone(al_cu_data) as unknown as PhaseDiagramData
     const on_data = vi.fn()
     const component = mount(PhaseDiagramEditorPane, {
       target: document.body,
-      props: { data, editor_open: true, on_data },
+      props: { data, editor_open: true, on_data: mode === `read-only` ? undefined : on_data },
     })
     onTestFinished(() => unmount(component))
     flushSync()
@@ -20,14 +20,19 @@ test.each([false, true])(
     leaf.dispatchEvent(new MouseEvent(`dblclick`, { bubbles: true }))
     await tick()
     const input = document.querySelector<HTMLInputElement>(`.edit-input`)
+    if (mode === `read-only`) {
+      expect(input).toBeNull()
+      expect(on_data).not.toHaveBeenCalled()
+      return
+    }
     if (!input) throw new Error(`Missing edit input`)
     input.value = `edited-unit`
     input.dispatchEvent(new Event(`input`, { bubbles: true }))
     // The source can change while a leaf editor is open.
-    if (stale) Reflect.deleteProperty(data, `temperature_unit`)
+    if (mode === `stale edit`) Reflect.deleteProperty(data, `temperature_unit`)
     input.dispatchEvent(new KeyboardEvent(`keydown`, { key: `Enter`, bubbles: true }))
     await tick()
-    if (stale) {
+    if (mode === `stale edit`) {
       expect(on_data).not.toHaveBeenCalled()
       expect(document.querySelector(`.rejection-flash`)?.textContent).toContain(
         `Cannot edit missing path`,

--- a/tests/vitest/scene/pan.test.ts
+++ b/tests/vitest/scene/pan.test.ts
@@ -3,6 +3,7 @@ import {
   attach_pan_gesture,
   clear_pan_offset,
   read_pan_offset,
+  restore_camera_view,
   set_pan_offset,
 } from '$lib/scene/pan'
 import { Camera, OrthographicCamera, PerspectiveCamera } from 'three/webgpu'
@@ -30,6 +31,20 @@ describe(`pan offset on the camera view`, () => {
       height: 600,
     })
     expect(read_pan_offset(camera)).toEqual([30, -12])
+    camera.position.set(3, 4, 5)
+    camera.lookAt(1, 2, 3)
+    camera.zoom = 68.5797
+    const saved = camera.clone()
+    const replacement = camera.clone()
+    replacement.position.set(0, 0, 0)
+    replacement.zoom = 53.0657
+    clear_pan_offset(replacement)
+    restore_camera_view(replacement, saved, 400, 300)
+    expect(replacement.position.toArray()).toEqual(camera.position.toArray())
+    expect(replacement.quaternion.toArray()).toEqual(camera.quaternion.toArray())
+    expect(replacement.zoom).toBe(68.5797)
+    expect(read_pan_offset(replacement)).toEqual([30, -12])
+    expect(replacement.view).toMatchObject({ fullWidth: 400, fullHeight: 300 })
     // re-applying at a new size keeps the CSS-px shift
     set_pan_offset(camera, read_pan_offset(camera), 400, 300)
     expect(camera.view).toMatchObject({ fullWidth: 400, fullHeight: 300, offsetX: -30 })

--- a/tests/vitest/structure/Structure.test.svelte.ts
+++ b/tests/vitest/structure/Structure.test.svelte.ts
@@ -423,14 +423,22 @@ test.each([`clear`, `replace input`])(
   },
 )
 
-test.each([`mutate input`, `replace tool`, `unmount`])(
-  `invalidates a mounted host run on %s`,
-  async (cause) => {
+test.each([
+  [`mutate input`, false],
+  [`replace tool`, false],
+  [`unmount`, false],
+  [`mutate input`, true],
+  [`replace input`, true],
+  [`replace tool`, true],
+] as const)(
+  `invalidates a mounted host run on %s with immediate restart=%s`,
+  async (cause, restart) => {
     const state = $state<ComponentProps<typeof Structure>>({
       structure: make_crystal(1, [{ element: `H`, abc: [0, 0, 0] }]),
       volumetric_data: [],
     })
     const run = await mount_host_structure(bind_props({}, state))
+    let next_run: StructureToolRun | undefined
     flushSync(() => run.on_overlay({ volumes: volumetric_data }))
     if (cause === `unmount`) {
       const component = mounted.pop()
@@ -439,9 +447,14 @@ test.each([`mutate input`, `replace tool`, `unmount`])(
     } else {
       flushSync(() => {
         if (cause === `replace tool`) structure_host_tool.component = () => ({})
+        else if (cause === `replace input` && state.structure)
+          state.structure = { ...state.structure }
         else if (state.structure) state.structure.sites[0].xyz[0] = 9
         // Run guards must reject same-turn stale completions before effects clean up.
         run.on_overlay({ volumes: volumetric_data })
+        if (restart) {
+          next_run = run.start_run({ model: `test`, version: `2`, units: {}, settings: {} })
+        }
       })
     }
     expect(run.signal.aborted).toBe(true)
@@ -449,6 +462,11 @@ test.each([`mutate input`, `replace tool`, `unmount`])(
     expect(state.volumetric_data).toEqual([])
     flushSync(() => run.on_overlay({ volumes: volumetric_data }))
     expect(state.volumetric_data).toEqual([])
+    if (next_run) {
+      expect(next_run.signal.aborted).toBe(false)
+      flushSync(() => next_run?.on_overlay({ volumes: volumetric_data }))
+      expect(state.volumetric_data).toHaveLength(1)
+    }
   },
 )
 

--- a/tests/vitest/structure/Structure.test.svelte.ts
+++ b/tests/vitest/structure/Structure.test.svelte.ts
@@ -2205,3 +2205,100 @@ describe(`data_url acquisition`, () => {
     expect(props.structure?.sites[0]?.species[0]?.element).toBe(`He`)
   })
 })
+
+test.each([`replace`, `mutate`, `restart`] as const)(
+  `imported prediction ownership after %s`,
+  async (action) => {
+    let host: StructureToolProps | undefined
+    if (action === `restart`)
+      structure_host_tool.component = (_anchor, props) => {
+        host = props
+        return {}
+      }
+    const input = make_crystal(1, [{ element: `Cu`, abc: [0.1, 0.2, 0.3] }])
+    const saved_volume = { ...make_volume(make_grid(2, 2, 2, () => 1)), field_id: `density` }
+    const state = $state({
+      structure: undefined as AnyStructure | undefined,
+      volumetric_data: [] as VolumetricData[],
+      cell_type: `primitive` as const,
+      supercell_scaling: `2x2x2`,
+    })
+    mount_structure(
+      bind_props(
+        {
+          show_host_tool: action === `restart`,
+          show_controls: `always` as const,
+          prediction: {
+            input,
+            run_id: 7,
+            provenance: {
+              model: `saved model`,
+              version: `1`,
+              units: { charge: `e` },
+              settings: {},
+            },
+            site_properties: [{ charge: 1 }],
+            color_property: `charge`,
+            volumes: [saved_volume],
+          },
+        },
+        state,
+      ),
+    )
+    await tick()
+    expect(state.structure).toEqual(input)
+    expect(state.structure).not.toBe(input)
+    expect(state.volumetric_data).toHaveLength(1)
+    expect(state.cell_type).toBe(`original`)
+    expect(state.supercell_scaling).toBe(`1x1x1`)
+    expect(document.querySelector(`[title="Download Export prediction"]`)).not.toBeNull()
+    if (action === `mutate` && state.structure)
+      state.structure.sites[0].species[0].element = `H`
+    else state.structure = make_crystal(2, [{ element: `H`, abc: [0, 0, 0] }])
+    const run = host?.start_run({ model: `new`, version: `1`, units: {}, settings: {} })
+    if (run) expect(state.volumetric_data).toEqual([])
+    await tick()
+    expect(state.volumetric_data).toEqual([])
+    expect(document.querySelector(`[title="Download Export prediction"]`)).toBeNull()
+    if (run) {
+      expect(run.signal.aborted).toBe(false)
+      run.on_overlay({ site_properties: [{ charge: 2 }] })
+      await tick()
+      expect(document.querySelector(`[title="Download Export prediction"]`)).not.toBeNull()
+    }
+  },
+)
+
+test(`import survives a synchronous restart from the previous run's abort listener`, async () => {
+  const props = $state<ComponentProps<typeof Structure>>({
+    structure: make_crystal(1, [{ element: `Cu`, abc: [0, 0, 0] }]),
+    show_controls: `always`,
+    volumetric_data: [],
+  })
+  const run = await mount_host_structure(props)
+  let restarted: StructureToolRun | undefined
+  run.signal.addEventListener(
+    `abort`,
+    () => {
+      restarted = run.start_run({ model: `restart`, version: `1`, units: {}, settings: {} })
+    },
+    { once: true },
+  )
+  const input = make_crystal(2, [{ element: `H`, abc: [0, 0, 0] }])
+  props.prediction = {
+    input,
+    run_id: 7,
+    provenance: { model: `saved`, version: `1`, units: {}, settings: {} },
+    volumes: [{ ...make_volume(make_grid(2, 2, 2, () => 1)), field_id: `density` }],
+  }
+  await tick()
+  expect(props.volumetric_data).toHaveLength(1)
+  expect(document.querySelector(`[title="Download Export prediction"]`)).not.toBeNull()
+  if (!restarted) throw new Error(`Abort listener did not restart`)
+  expect(restarted.structure).toEqual(input)
+  expect(restarted.signal.aborted).toBe(false)
+  restarted.on_overlay({ site_properties: [{ charge: 2 }] })
+  await tick()
+  expect(props.volumetric_data).toEqual([])
+  expect(document.querySelector(`[title="Download Export prediction"]`)).not.toBeNull()
+})

--- a/tests/vitest/structure/Structure.test.svelte.ts
+++ b/tests/vitest/structure/Structure.test.svelte.ts
@@ -25,6 +25,7 @@ import { make_supercell } from '$lib/structure/supercell'
 import { structures } from '$site/structures'
 import { type ComponentProps, createRawSnippet, flushSync, mount, tick, unmount } from 'svelte'
 import { afterEach, describe, expect, test, vi } from 'vitest'
+import { OrthographicCamera } from 'three/webgpu'
 import {
   assertHoverScopedShortcut,
   bind_props,
@@ -44,6 +45,19 @@ import {
   press_window_key,
   trigger_resize_observer,
 } from '../setup'
+
+// Exercise viewport lifecycle without creating a renderer in happy-dom.
+vi.mock(`@threlte/core`, async (import_original) => ({
+  ...(await import_original<Record<string, unknown>>()),
+  Canvas: (anchor: Node, props: { children: (anchor: Node) => void }) =>
+    props.children(anchor),
+}))
+vi.mock(`$lib/structure/StructureScene.svelte`, () => ({
+  default: (_anchor: Node, props: { camera: OrthographicCamera }) => {
+    props.camera = new OrthographicCamera()
+    return {}
+  },
+}))
 
 // Passthrough spy so individual tests can make make_supercell throw
 vi.mock(`$lib/structure/supercell`, async (import_original) => {
@@ -600,14 +614,18 @@ test.each([false, true])(
       expect(state.volumetric_data.map(({ label }) => label)).toContain(`added.CHGCAR`),
     )
     flushSync(() => tool_props.on_overlay({ ...overlay, site_properties: [{ charge: 1 }] }))
+    expect(state.volumetric_data[state.active_volume_idx]?.label).toBe(`added.CHGCAR`)
     const predicted_layer = state.isosurface_settings.layers.find(
       ({ isovalue }) => isovalue === 0.321,
     )
     expect(state.volumetric_data[predicted_layer?.volume_idx ?? -1]?.label).toBe(`Prediction`)
-    // A newly selected prediction field should return to the imported volume on clear.
-    flushSync(() =>
-      tool_props.on_overlay({ ...overlay, volumes: [{ ...overlay.volumes[0] }] }),
-    )
+    // A selected prediction field should return to the imported volume on clear.
+    flushSync(() => {
+      tool_props.on_overlay({ ...overlay, volumes: [{ ...overlay.volumes[0] }] })
+      state.active_volume_idx = state.volumetric_data.findIndex(
+        ({ label }) => label === `Prediction`,
+      )
+    })
     flushSync(() => tool_props.on_overlay(null))
     expect(state.volumetric_data.map(({ label }) => label)).toEqual(
       with_base ? [`Original`, `added.CHGCAR`] : [`added.CHGCAR`],
@@ -1867,10 +1885,7 @@ describe(`atom label controls`, () => {
   })
 })
 
-// Multi-side view (2x2 grid). The canvas grid itself is gated behind a
-// `typeof WebGLRenderingContext !== 'undefined'` guard so it doesn't render in
-// happy-dom; these cover the toggle button + wrapper class. The 4-canvas render
-// and independent rotation are exercised by the playwright suite.
+// Grid layout and viewport lifecycle; rendered camera interactions are covered by Playwright.
 describe(`Multi-side view`, () => {
   const mock_viewer_size = (client_width: number, client_height: number): void => {
     vi.spyOn(HTMLElement.prototype, `clientWidth`, `get`).mockReturnValue(client_width)
@@ -1878,7 +1893,12 @@ describe(`Multi-side view`, () => {
   }
   afterEach(() => vi.restoreAllMocks())
 
-  test(`layout dropdown is layered and switches multi_view`, async () => {
+  test(`layout dropdown survives repeated grid toggles and resizing`, async () => {
+    vi.stubGlobal(`navigator`, {
+      gpu: {},
+      userAgent: navigator.userAgent,
+      platform: navigator.platform,
+    })
     const props = $state<ComponentProps<typeof Structure>>({
       structure,
       show_controls: `always`,
@@ -1891,14 +1911,26 @@ describe(`Multi-side view`, () => {
     expect(document.querySelector(`.view-mode-caret`)).toBeNull()
     expect(doc_query(`.structure`).classList.contains(`multi-view`)).toBe(false)
 
-    await select_structure_layout(`3D 2×2 grid`)
-    expect(props.multi_view).toBe(true)
-    expect(doc_query(`.structure`).classList.contains(`multi-view`)).toBe(true)
-    expect(document.querySelector(`.view-mode-dropdown`)).toBeNull()
+    for (const _iteration of [0, 1]) {
+      await select_structure_layout(`3D 2×2 grid`)
+      expect(props.multi_view).toBe(true)
+      expect(doc_query(`.structure`).classList.contains(`multi-view`)).toBe(true)
+      expect(document.querySelector(`.view-mode-dropdown`)).toBeNull()
 
-    await select_structure_layout(`3D single view`)
-    expect(props.multi_view).toBe(false)
-    expect(doc_query(`.structure`).classList.contains(`multi-view`)).toBe(false)
+      for (const [width, height, active] of [
+        [599, 399, false],
+        [800, 600, true],
+      ] as const) {
+        mock_viewer_size(width, height)
+        trigger_resize_observer(doc_query(`.structure`))
+        await tick()
+        expect(doc_query(`.structure`).classList.contains(`multi-view`)).toBe(active)
+      }
+
+      await select_structure_layout(`3D single view`)
+      expect(props.multi_view).toBe(false)
+      expect(doc_query(`.structure`).classList.contains(`multi-view`)).toBe(false)
+    }
   })
 
   test(`toggle button is hidden when 'multi-view' control is in hidden list`, async () => {

--- a/tests/vitest/structure/Structure.test.svelte.ts
+++ b/tests/vitest/structure/Structure.test.svelte.ts
@@ -18,6 +18,7 @@ import {
 import {
   structure_host_tool,
   type StructureToolProps,
+  type StructureToolRun,
   type StructureToolViewProps,
 } from '$lib/structure/host-tool.svelte'
 import { make_supercell } from '$lib/structure/supercell'
@@ -284,24 +285,27 @@ test(`multi-file drops continue after failures and report one batch error`, asyn
 })
 
 const volumetric_data = [
-  make_volume(
-    make_grid(2, 2, 2, (x_idx, y_idx, z_idx) => 4 * x_idx + 2 * y_idx + z_idx),
-    {
-      lattice: [
-        [1, 0, 0],
-        [0, 1, 0],
-        [0, 0, 1],
-      ],
-      data_range: { min: 0, max: 7, abs_max: 7, mean: 3.5 },
-      label: `Charge density`,
-    },
-  ),
+  {
+    field_id: `density`,
+    ...make_volume(
+      make_grid(2, 2, 2, (x_idx, y_idx, z_idx) => 4 * x_idx + 2 * y_idx + z_idx),
+      {
+        lattice: [
+          [1, 0, 0],
+          [0, 1, 0],
+          [0, 0, 1],
+        ],
+        data_range: { min: 0, max: 7, abs_max: 7, mean: 3.5 },
+        label: `Charge density`,
+      },
+    ),
+  },
 ]
 
 // Capture the registered host API while mounting; the shared cleanup restores registration.
 const mount_host_structure = async (
   props: ComponentProps<typeof Structure>,
-): Promise<StructureToolProps> => {
+): Promise<StructureToolRun & Pick<StructureToolProps, `start_run`>> => {
   let tool_props: StructureToolProps | undefined
   structure_host_tool.component = (_anchor, host_props) => {
     tool_props = host_props
@@ -310,7 +314,15 @@ const mount_host_structure = async (
   mount_structure(props)
   await tick()
   if (!tool_props) throw new Error(`Host tool did not mount`)
-  return tool_props
+  return {
+    ...tool_props.start_run({
+      model: `test`,
+      version: `1`,
+      units: { density: `e/A^3`, charge: `e` },
+      settings: {},
+    }),
+    start_run: tool_props.start_run,
+  }
 }
 
 test(`host views fill the main viewer, inherit its camera and cell, and reject stale sources`, async () => {
@@ -326,7 +338,7 @@ test(`host views fill the main viewer, inherit its camera and cell, and reject s
     scene_props: { camera_position: [3, 4, 5], camera_target: [1, 2, 3] },
   })
   const original_input = tool_props.structure
-  tool_props.on_view({ source: original_input, content })
+  tool_props.on_view({ content })
   await tick()
   expect(
     document.querySelector(`.structure > .host-view > [data-testid="live-host-view"]`),
@@ -336,10 +348,7 @@ test(`host views fill the main viewer, inherit its camera and cell, and reject s
   expect(received?.scene_props.camera_position).toEqual([3, 4, 5])
   expect(received?.scene_props.camera_target).toEqual([1, 2, 3])
   expect(tool_props.structure).toBe(original_input)
-  tool_props.on_view({ source: { ...original_input }, content })
-  await tick()
-  expect(document.querySelector(`.host-view`)).toBeNull()
-  tool_props.on_view({ source: original_input, content })
+  tool_props.on_view({ content })
   await tick()
   tool_props.on_view(null)
   await tick()
@@ -366,7 +375,6 @@ test.each([`clear`, `replace input`])(
     })
     const tool_props = await mount_host_structure(bind_props({}, state))
     const overlay = {
-      source: tool_props.structure,
       site_properties: tool_props.structure.sites.map((_, idx) => ({
         charge: idx,
         magmom: -idx,
@@ -415,6 +423,87 @@ test.each([`clear`, `replace input`])(
   },
 )
 
+test.each([`mutate input`, `replace tool`, `unmount`])(
+  `invalidates a mounted host run on %s`,
+  async (cause) => {
+    const state = $state<ComponentProps<typeof Structure>>({
+      structure: make_crystal(1, [{ element: `H`, abc: [0, 0, 0] }]),
+      volumetric_data: [],
+    })
+    const run = await mount_host_structure(bind_props({}, state))
+    flushSync(() => run.on_overlay({ volumes: volumetric_data }))
+    if (cause === `unmount`) {
+      const component = mounted.pop()
+      if (!component) throw new Error(`Missing mounted viewer`)
+      await unmount(component)
+    } else {
+      flushSync(() => {
+        if (cause === `replace tool`) structure_host_tool.component = () => ({})
+        else if (state.structure) state.structure.sites[0].xyz[0] = 9
+        // Run guards must reject same-turn stale completions before effects clean up.
+        run.on_overlay({ volumes: volumetric_data })
+      })
+    }
+    expect(run.signal.aborted).toBe(true)
+    expect(run.structure.sites[0].xyz[0]).toBe(0)
+    expect(state.volumetric_data).toEqual([])
+    flushSync(() => run.on_overlay({ volumes: volumetric_data }))
+    expect(state.volumetric_data).toEqual([])
+  },
+)
+
+test(`reruns preserve surface appearance by field ID and explicit reset restores defaults`, async () => {
+  const state = $state<ComponentProps<typeof Structure>>({
+    structure,
+    volumetric_data: [],
+    isosurface_settings: { ...DEFAULT_ISOSURFACE_SETTINGS, layers: [] },
+    active_pane: `export`,
+  })
+  const first = await mount_host_structure(bind_props({}, state))
+  const fields = [
+    { ...volumetric_data[0], field_id: `density`, label: `Density` },
+    { ...volumetric_data[0], field_id: `potential`, label: `Potential` },
+  ]
+  flushSync(() => first.on_overlay({ volumes: fields }))
+  flushSync(() => {
+    const layers = state.isosurface_settings?.layers
+    if (!layers) throw new Error(`Missing surfaces`)
+    Object.assign(layers[0], {
+      color: `#123456`,
+      isovalue: 0.321,
+      opacity: 0.4,
+      color_volume_idx: 1,
+    })
+  })
+  const next = first.start_run({ model: `test`, version: `2`, units: {}, settings: {} })
+  const reordered = fields.toReversed().map((field) => ({ ...field }))
+  flushSync(() => next.on_overlay({ volumes: reordered }))
+  expect(first.signal.aborted).toBe(true)
+  expect(state.isosurface_settings?.layers[0]).toMatchObject({
+    volume_idx: 1,
+    color_volume_idx: 0,
+    color: `#123456`,
+    isovalue: 0.321,
+    opacity: 0.4,
+  })
+  flushSync(() => first.clear())
+  expect(state.volumetric_data).toHaveLength(2)
+  const click_button = (name: string) => {
+    const button = [...document.querySelectorAll(`button`)].find(
+      (candidate) => candidate.textContent === name,
+    )
+    if (!button) throw new Error(`Missing button: ${name}`)
+    flushSync(() => button.click())
+  }
+  click_button(`Reset prediction surfaces`)
+  expect(state.isosurface_settings?.layers).toEqual(
+    reordered.map((volume, idx) => auto_volume_layer(volume, idx)),
+  )
+  click_button(`Clear prediction`)
+  expect(state.volumetric_data).toEqual([])
+  expect(next.signal.aborted).toBe(true)
+})
+
 test.each([`Original`, `Prediction`])(
   `removing %s volumes updates their owner across later tool callbacks`,
   async (removed_label) => {
@@ -428,7 +517,7 @@ test.each([`Original`, `Prediction`])(
       isosurface_settings: { ...DEFAULT_ISOSURFACE_SETTINGS, layers: [] },
     })
     const tool_props = await mount_host_structure(bind_props({ structure }, state))
-    const overlay = { source: tool_props.structure, volumes: [prediction_volume] }
+    const overlay = { volumes: [prediction_volume] }
     flushSync(() => tool_props.on_overlay(overlay))
     const remove = doc_query<HTMLButtonElement>(
       `button[aria-label="Remove volume ${removed_label}"]`,
@@ -471,7 +560,6 @@ test.each([false, true])(
     })
     const tool_props = await mount_host_structure(bind_props({ structure: source }, state))
     const overlay = {
-      source: tool_props.structure,
       volumes: [{ ...volumetric_data[0], label: `Prediction` }],
     }
     flushSync(() => tool_props.on_overlay(overlay))
@@ -521,7 +609,6 @@ test.each([false, true])(
     state.sym_data = await symmetry.analyze_structure_symmetry(crystal)
     flushSync()
     const overlay = {
-      source: tool_props.structure,
       volumes: [{ ...volumetric_data[0], label: `Prediction`, periodic: true }],
     }
     flushSync(() => tool_props.on_overlay(overlay))
@@ -536,7 +623,11 @@ test.each([false, true])(
     })
     expect(document.body.textContent).toContain(`No volumetric data available`)
     flushSync(() => {
-      state.cell_type = `original`
+      const recovery = [...document.querySelectorAll(`button`)].find(
+        (button) => button.textContent === `Use original cell`,
+      )
+      if (!recovery) throw new Error(`Missing cell recovery action`)
+      recovery.click()
       state.display_mode = `structure`
     })
     expect(
@@ -562,7 +653,11 @@ test.each([false, true])(
         ...overlay,
         volumes: [
           { ...overlay.volumes[0], periodic: false },
-          { ...overlay.volumes[0], label: `Periodic prediction` },
+          {
+            ...overlay.volumes[0],
+            label: `Periodic prediction`,
+            field_id: `periodic-density`,
+          },
         ],
       }),
     )
@@ -583,6 +678,19 @@ test.each([false, true])(
     expect(
       document.querySelector(`input[aria-label="Slice position on canvas"]`),
     ).not.toBeNull()
+    if (!remove_finite) {
+      flushSync(() => {
+        const reset = [...document.querySelectorAll(`button`)].find(
+          (button) => button.textContent === `Reset supercell to 1×1×1`,
+        )
+        if (!reset) throw new Error(`Missing supercell recovery`)
+        reset.click()
+      })
+      expect(state.supercell_scaling).toBe(`1x1x1`)
+      expect(document.body.textContent).not.toContain(
+        `partially periodic prediction density is shown only`,
+      )
+    }
   },
 )
 

--- a/tests/vitest/structure/Structure.test.svelte.ts
+++ b/tests/vitest/structure/Structure.test.svelte.ts
@@ -500,6 +500,7 @@ test(`reruns preserve surface appearance by field ID and explicit reset restores
     reordered.map((volume, idx) => auto_volume_layer(volume, idx)),
   )
   click_button(`Clear prediction`)
+  flushSync(() => next.on_overlay({ volumes: reordered }))
   expect(state.volumetric_data).toEqual([])
   expect(next.signal.aborted).toBe(true)
 })
@@ -592,6 +593,13 @@ test.each([false, true])(
 test.each([false, true])(
   `host density respects each field's coordinate frame with finite volume removed=%s`,
   async (remove_finite) => {
+    const click_recovery = (label: string) => {
+      const button = [...document.querySelectorAll(`button`)].find(
+        (candidate) => candidate.textContent === label,
+      )
+      if (!button) throw new Error(`Missing recovery action: ${label}`)
+      flushSync(() => button.click())
+    }
     await init_moyo_for_tests()
     const crystal = make_crystal(fcc_primitive_matrix(3.61), [
       { element: `Cu`, abc: [0.13, 0.27, 0.41] },
@@ -614,20 +622,18 @@ test.each([false, true])(
     flushSync(() => tool_props.on_overlay(overlay))
     flushSync(() => {
       state.cell_type = `conventional`
+      state.supercell_scaling = `2x1x1`
     })
     expect(document.body.textContent).toContain(
       `Prediction density is hidden in standardized cells`,
     )
+    expect(document.body.textContent).not.toContain(`Reset supercell to 1×1×1`)
     flushSync(() => {
       state.display_mode = `slice`
     })
     expect(document.body.textContent).toContain(`No volumetric data available`)
+    click_recovery(`Use original cell`)
     flushSync(() => {
-      const recovery = [...document.querySelectorAll(`button`)].find(
-        (button) => button.textContent === `Use original cell`,
-      )
-      if (!recovery) throw new Error(`Missing cell recovery action`)
-      recovery.click()
       state.display_mode = `structure`
     })
     expect(
@@ -641,7 +647,11 @@ test.each([false, true])(
     )
     flushSync(() => {
       state.supercell_scaling = `2x1x1`
+      state.cell_type = `conventional`
     })
+    expect(document.body.textContent).toContain(`Reset supercell to 1×1×1`)
+    click_recovery(`Use original cell`)
+    expect(state.supercell_scaling).toBe(`2x1x1`)
     expect(document.body.textContent).toContain(
       `partially periodic prediction density is shown only in the input cell`,
     )
@@ -679,13 +689,7 @@ test.each([false, true])(
       document.querySelector(`input[aria-label="Slice position on canvas"]`),
     ).not.toBeNull()
     if (!remove_finite) {
-      flushSync(() => {
-        const reset = [...document.querySelectorAll(`button`)].find(
-          (button) => button.textContent === `Reset supercell to 1×1×1`,
-        )
-        if (!reset) throw new Error(`Missing supercell recovery`)
-        reset.click()
-      })
+      click_recovery(`Reset supercell to 1×1×1`)
       expect(state.supercell_scaling).toBe(`1x1x1`)
       expect(document.body.textContent).not.toContain(
         `partially periodic prediction density is shown only`,

--- a/tests/vitest/structure/Structure.test.svelte.ts
+++ b/tests/vitest/structure/Structure.test.svelte.ts
@@ -513,6 +513,7 @@ test.each([false, true])(
       cell_type: `original`,
       display_mode: `structure`,
       active_volume_idx: 0,
+      slice_settings: { resolution: 2 },
       supercell_scaling: `1x1x1`,
       sym_data: null,
     })

--- a/tests/vitest/structure/Structure.test.svelte.ts
+++ b/tests/vitest/structure/Structure.test.svelte.ts
@@ -347,54 +347,73 @@ test(`host views fill the main viewer, inherit its camera and cell, and reject s
   expect(tool_props.structure).toBe(original_input)
 })
 
-test(`host overlays restore atom colors and preserve adjusted surfaces when only properties change`, async () => {
-  const state = $state<{
-    atom_color_config: AtomColorConfig
-    isosurface_settings: IsosurfaceSettings
-  }>({
-    atom_color_config: { ...DEFAULT_ATOM_COLOR_CONFIG },
-    isosurface_settings: { ...DEFAULT_ISOSURFACE_SETTINGS, layers: [] },
-  })
-  const tool_props = await mount_host_structure(bind_props({ structure }, state))
-  const overlay = {
-    source: tool_props.structure,
-    site_properties: tool_props.structure.sites.map((_, idx) => ({
-      charge: idx,
-      magmom: -idx,
-    })),
-    volumes: volumetric_data,
-    color_property: `charge`,
-  }
-  flushSync(() => tool_props.on_overlay(overlay))
-  expect(state.atom_color_config).toMatchObject({
-    mode: `property`,
-    property_key: `charge`,
-  })
-  expect(state.isosurface_settings.layers).toHaveLength(1)
-  flushSync(() => {
-    state.isosurface_settings.layers[0].isovalue = 0.123
-    state.atom_color_config = {
-      ...state.atom_color_config,
+test.each([`clear`, `replace input`])(
+  `host overlays restore atom colors on %s and preserve adjusted surfaces when only properties change`,
+  async (reset) => {
+    const original_color: AtomColorConfig = {
+      mode: `element`,
       scale: `interpolateViridis`,
+      scale_type: `categorical`,
     }
-  })
-  flushSync(() =>
-    tool_props.on_overlay({
-      ...overlay,
-      site_properties: [...overlay.site_properties],
-    }),
-  )
-  expect(state.atom_color_config.scale).toBe(`interpolateViridis`)
-  flushSync(() => tool_props.on_overlay({ ...overlay, color_property: `magmom` }))
-  expect(state.atom_color_config).toMatchObject({
-    mode: `property`,
-    property_key: `magmom`,
-  })
-  expect(state.isosurface_settings.layers[0].isovalue).toBe(0.123)
-  flushSync(() => tool_props.on_overlay(null))
-  expect(state.atom_color_config).toEqual(DEFAULT_ATOM_COLOR_CONFIG)
-  expect(state.isosurface_settings.layers).toEqual([])
-})
+    const state = $state<{
+      structure: AnyStructure
+      atom_color_config: AtomColorConfig
+      isosurface_settings: IsosurfaceSettings
+    }>({
+      structure,
+      atom_color_config: { ...original_color },
+      isosurface_settings: { ...DEFAULT_ISOSURFACE_SETTINGS, layers: [] },
+    })
+    const tool_props = await mount_host_structure(bind_props({}, state))
+    const overlay = {
+      source: tool_props.structure,
+      site_properties: tool_props.structure.sites.map((_, idx) => ({
+        charge: idx,
+        magmom: -idx,
+      })),
+      volumes: volumetric_data,
+      color_property: `charge`,
+    }
+    flushSync(() => tool_props.on_overlay(overlay))
+    expect(state.atom_color_config).toMatchObject({
+      mode: `property`,
+      property_key: `charge`,
+    })
+    expect(state.isosurface_settings.layers).toHaveLength(1)
+    flushSync(() => {
+      state.isosurface_settings.layers[0].isovalue = 0.123
+      state.atom_color_config = {
+        ...state.atom_color_config,
+        scale: `interpolateViridis`,
+      }
+    })
+    flushSync(() =>
+      tool_props.on_overlay({
+        ...overlay,
+        site_properties: [...overlay.site_properties],
+      }),
+    )
+    expect(state.atom_color_config.scale).toBe(`interpolateViridis`)
+    flushSync(() => tool_props.on_overlay({ ...overlay, color_property: `magmom` }))
+    expect(state.atom_color_config).toMatchObject({
+      mode: `property`,
+      property_key: `magmom`,
+    })
+    expect(state.isosurface_settings.layers[0].isovalue).toBe(0.123)
+    flushSync(() => {
+      if (reset === `clear`) tool_props.on_overlay(null)
+      else state.structure = { ...state.structure }
+    })
+    expect(state.atom_color_config).toEqual(original_color)
+    // A later tool cleanup must not restore the saved configuration a second time.
+    flushSync(() => {
+      state.atom_color_config = { ...DEFAULT_ATOM_COLOR_CONFIG }
+    })
+    flushSync(() => tool_props.on_overlay(null))
+    expect(state.atom_color_config).toEqual(DEFAULT_ATOM_COLOR_CONFIG)
+    expect(state.isosurface_settings.layers).toEqual([])
+  },
+)
 
 test.each([`Original`, `Prediction`])(
   `removing %s volumes updates their owner across later tool callbacks`,

--- a/tests/vitest/structure/Structure.test.svelte.ts
+++ b/tests/vitest/structure/Structure.test.svelte.ts
@@ -368,10 +368,12 @@ test.each([`clear`, `replace input`])(
       structure: AnyStructure
       atom_color_config: AtomColorConfig
       isosurface_settings: IsosurfaceSettings
+      volumetric_data: VolumetricData[]
     }>({
       structure,
       atom_color_config: { ...original_color },
       isosurface_settings: { ...DEFAULT_ISOSURFACE_SETTINGS, layers: [] },
+      volumetric_data: [],
     })
     const tool_props = await mount_host_structure(bind_props({}, state))
     const overlay = {
@@ -379,7 +381,7 @@ test.each([`clear`, `replace input`])(
         charge: idx,
         magmom: -idx,
       })),
-      volumes: volumetric_data,
+      volumes: [...volumetric_data],
       color_property: `charge`,
     }
     flushSync(() => tool_props.on_overlay(overlay))
@@ -407,6 +409,11 @@ test.each([`clear`, `replace input`])(
       mode: `property`,
       property_key: `magmom`,
     })
+    expect(state.isosurface_settings.layers[0].isovalue).toBe(0.123)
+    // Reusing the array must still publish its changed contents and preserve appearance.
+    overlay.volumes[0] = { ...overlay.volumes[0], label: `Updated prediction` }
+    flushSync(() => tool_props.on_overlay(overlay))
+    expect(state.volumetric_data[0].label).toBe(`Updated prediction`)
     expect(state.isosurface_settings.layers[0].isovalue).toBe(0.123)
     flushSync(() => {
       if (reset === `clear`) tool_props.on_overlay(null)
@@ -542,12 +549,13 @@ test.each([`Original`, `Prediction`])(
       `button[aria-label="Remove volume ${removed_label}"]`,
     )
     flushSync(() => remove.click())
-    flushSync(() =>
-      tool_props.on_overlay({
-        ...overlay,
-        site_properties: structure.sites.map(() => ({ charge: 1 })),
-      }),
-    )
+    for (const charge of [1, 2])
+      flushSync(() =>
+        tool_props.on_overlay({
+          ...overlay,
+          site_properties: structure.sites.map(() => ({ charge })),
+        }),
+      )
     expect(
       document.querySelector(`button[aria-label="Remove volume ${removed_label}"]`),
     ).toBeNull()

--- a/tests/vitest/structure/Structure.test.svelte.ts
+++ b/tests/vitest/structure/Structure.test.svelte.ts
@@ -11,9 +11,18 @@ import * as symmetry from '$lib/symmetry'
 import type { StructureBond, StructureHandlerData, StructurePane } from '$lib/structure'
 import { get_element_counts, OVERLAYS_INPUT_FRAME_NOTE } from '$lib/structure'
 import type { Pbc } from '$lib/structure/pbc'
+import {
+  DEFAULT_ATOM_COLOR_CONFIG,
+  type AtomColorConfig,
+} from '$lib/structure/atom-properties'
+import {
+  structure_host_tool,
+  type StructureToolProps,
+  type StructureToolViewProps,
+} from '$lib/structure/host-tool.svelte'
 import { make_supercell } from '$lib/structure/supercell'
 import { structures } from '$site/structures'
-import { type ComponentProps, flushSync, mount, tick, unmount } from 'svelte'
+import { type ComponentProps, createRawSnippet, flushSync, mount, tick, unmount } from 'svelte'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import {
   assertHoverScopedShortcut,
@@ -50,11 +59,13 @@ const structure = structures[0]
 // mount is unmounted after its test so component cleanup runs before happy-dom tears down:
 // the edit toast's dismiss timer would otherwise fire into a vanished `document`.
 const mounted: Record<string, unknown>[] = []
+const original_host_component = structure_host_tool.component
 const mount_structure = (props: ComponentProps<typeof Structure>): void => {
   mounted.push(mount(Structure, { target: document.body, props }))
 }
 afterEach(() => {
   for (const component of mounted.splice(0)) void unmount(component)
+  structure_host_tool.component = original_host_component
   vi.restoreAllMocks()
   vi.unstubAllGlobals()
 })
@@ -137,7 +148,10 @@ test(`loads strings, URLs and dropped files through the component API`, async ()
       expect.objectContaining({ filename: `string`, total_atoms: 5 }),
     )
     expect(url_load).toHaveBeenCalledWith(
-      expect.objectContaining({ filename: `loaded.poscar`, source_url: `/loaded.poscar` }),
+      expect.objectContaining({
+        filename: `loaded.poscar`,
+        source_url: `/loaded.poscar`,
+      }),
     )
     expect(drop_load).toHaveBeenCalledWith(
       expect.objectContaining({ filename: `dropped.poscar`, total_atoms: 5 }),
@@ -283,6 +297,274 @@ const volumetric_data = [
     },
   ),
 ]
+
+// Capture the registered host API while mounting; the shared cleanup restores registration.
+const mount_host_structure = async (
+  props: ComponentProps<typeof Structure>,
+): Promise<StructureToolProps> => {
+  let tool_props: StructureToolProps | undefined
+  structure_host_tool.component = (_anchor, host_props) => {
+    tool_props = host_props
+    return {}
+  }
+  mount_structure(props)
+  await tick()
+  if (!tool_props) throw new Error(`Host tool did not mount`)
+  return tool_props
+}
+
+test(`host views fill the main viewer, inherit its camera and cell, and reject stale sources`, async () => {
+  let received: StructureToolViewProps | undefined
+  const content = createRawSnippet<[StructureToolViewProps]>((get_props) => {
+    received = get_props()
+    return { render: () => `<div data-testid="live-host-view">Live trajectory</div>` }
+  })
+  const tool_props = await mount_host_structure({
+    structure,
+    supercell_scaling: `2x1x1`,
+    show_image_atoms: false,
+    scene_props: { camera_position: [3, 4, 5], camera_target: [1, 2, 3] },
+  })
+  const original_input = tool_props.structure
+  tool_props.on_view({ source: original_input, content })
+  await tick()
+  expect(
+    document.querySelector(`.structure > .host-view > [data-testid="live-host-view"]`),
+  ).not.toBeNull()
+  expect(received?.supercell_scaling).toBe(`2x1x1`)
+  expect(received?.show_image_atoms).toBe(false)
+  expect(received?.scene_props.camera_position).toEqual([3, 4, 5])
+  expect(received?.scene_props.camera_target).toEqual([1, 2, 3])
+  expect(tool_props.structure).toBe(original_input)
+  tool_props.on_view({ source: { ...original_input }, content })
+  await tick()
+  expect(document.querySelector(`.host-view`)).toBeNull()
+  tool_props.on_view({ source: original_input, content })
+  await tick()
+  tool_props.on_view(null)
+  await tick()
+  expect(document.querySelector(`.host-view`)).toBeNull()
+  expect(tool_props.structure).toBe(original_input)
+})
+
+test(`host overlays restore atom colors and preserve adjusted surfaces when only properties change`, async () => {
+  const state = $state<{
+    atom_color_config: AtomColorConfig
+    isosurface_settings: IsosurfaceSettings
+  }>({
+    atom_color_config: { ...DEFAULT_ATOM_COLOR_CONFIG },
+    isosurface_settings: { ...DEFAULT_ISOSURFACE_SETTINGS, layers: [] },
+  })
+  const tool_props = await mount_host_structure(bind_props({ structure }, state))
+  const overlay = {
+    source: tool_props.structure,
+    site_properties: tool_props.structure.sites.map((_, idx) => ({
+      charge: idx,
+      magmom: -idx,
+    })),
+    volumes: volumetric_data,
+    color_property: `charge`,
+  }
+  flushSync(() => tool_props.on_overlay(overlay))
+  expect(state.atom_color_config).toMatchObject({
+    mode: `property`,
+    property_key: `charge`,
+  })
+  expect(state.isosurface_settings.layers).toHaveLength(1)
+  flushSync(() => {
+    state.isosurface_settings.layers[0].isovalue = 0.123
+    state.atom_color_config = {
+      ...state.atom_color_config,
+      scale: `interpolateViridis`,
+    }
+  })
+  flushSync(() =>
+    tool_props.on_overlay({
+      ...overlay,
+      site_properties: [...overlay.site_properties],
+    }),
+  )
+  expect(state.atom_color_config.scale).toBe(`interpolateViridis`)
+  flushSync(() => tool_props.on_overlay({ ...overlay, color_property: `magmom` }))
+  expect(state.atom_color_config).toMatchObject({
+    mode: `property`,
+    property_key: `magmom`,
+  })
+  expect(state.isosurface_settings.layers[0].isovalue).toBe(0.123)
+  flushSync(() => tool_props.on_overlay(null))
+  expect(state.atom_color_config).toEqual(DEFAULT_ATOM_COLOR_CONFIG)
+  expect(state.isosurface_settings.layers).toEqual([])
+})
+
+test.each([`Original`, `Prediction`])(
+  `removing %s volumes updates their owner across later tool callbacks`,
+  async (removed_label) => {
+    const base_volume = { ...volumetric_data[0], label: `Original` }
+    const prediction_volume = { ...volumetric_data[0], label: `Prediction` }
+    const state = $state<{
+      volumetric_data: VolumetricData[]
+      isosurface_settings: IsosurfaceSettings
+    }>({
+      volumetric_data: [base_volume],
+      isosurface_settings: { ...DEFAULT_ISOSURFACE_SETTINGS, layers: [] },
+    })
+    const tool_props = await mount_host_structure(bind_props({ structure }, state))
+    const overlay = { source: tool_props.structure, volumes: [prediction_volume] }
+    flushSync(() => tool_props.on_overlay(overlay))
+    const remove = doc_query<HTMLButtonElement>(
+      `button[aria-label="Remove volume ${removed_label}"]`,
+    )
+    flushSync(() => remove.click())
+    flushSync(() =>
+      tool_props.on_overlay({
+        ...overlay,
+        site_properties: structure.sites.map(() => ({ charge: 1 })),
+      }),
+    )
+    expect(
+      document.querySelector(`button[aria-label="Remove volume ${removed_label}"]`),
+    ).toBeNull()
+    const retained_label = removed_label === `Original` ? `Prediction` : `Original`
+    expect(
+      document.querySelector(`button[aria-label="Add surface for ${retained_label}"]`),
+    ).not.toBeNull()
+    expect(state.volumetric_data.map(({ label }) => label)).toEqual([retained_label])
+    if (removed_label === `Original`)
+      expect(state.isosurface_settings.layers).toEqual([
+        expect.objectContaining({ volume_idx: 0 }),
+      ])
+    else expect(state.isosurface_settings.layers).toEqual([])
+  },
+)
+
+test.each([false, true])(
+  `same-cell imports preserve prediction layers with existing base=%s`,
+  async (with_base) => {
+    const source = make_crystal(1, [{ element: `H`, abc: [0, 0, 0] }])
+    const state = $state<{
+      volumetric_data: VolumetricData[]
+      isosurface_settings: IsosurfaceSettings
+      active_volume_idx: number
+    }>({
+      volumetric_data: with_base ? [{ ...volumetric_data[0], label: `Original` }] : [],
+      isosurface_settings: { ...DEFAULT_ISOSURFACE_SETTINGS, layers: [] },
+      active_volume_idx: 0,
+    })
+    const tool_props = await mount_host_structure(bind_props({ structure: source }, state))
+    const overlay = {
+      source: tool_props.structure,
+      volumes: [{ ...volumetric_data[0], label: `Prediction` }],
+    }
+    flushSync(() => tool_props.on_overlay(overlay))
+    flushSync(() => {
+      state.isosurface_settings.layers[0].isovalue = 0.321
+    })
+    doc_query(`.structure`).dispatchEvent(
+      create_drop_event(new File([SAMPLE_CHGCAR_CONTENT], `added.CHGCAR`)),
+    )
+    await vi.waitFor(() =>
+      expect(state.volumetric_data.map(({ label }) => label)).toContain(`added.CHGCAR`),
+    )
+    flushSync(() => tool_props.on_overlay({ ...overlay, site_properties: [{ charge: 1 }] }))
+    const predicted_layer = state.isosurface_settings.layers.find(
+      ({ isovalue }) => isovalue === 0.321,
+    )
+    expect(state.volumetric_data[predicted_layer?.volume_idx ?? -1]?.label).toBe(`Prediction`)
+    // A newly selected prediction field should return to the imported volume on clear.
+    flushSync(() =>
+      tool_props.on_overlay({ ...overlay, volumes: [{ ...overlay.volumes[0] }] }),
+    )
+    flushSync(() => tool_props.on_overlay(null))
+    expect(state.volumetric_data.map(({ label }) => label)).toEqual(
+      with_base ? [`Original`, `added.CHGCAR`] : [`added.CHGCAR`],
+    )
+    expect(state.volumetric_data[state.active_volume_idx]?.label).toBe(`added.CHGCAR`)
+  },
+)
+
+test.each([false, true])(
+  `host density respects each field's coordinate frame with finite volume removed=%s`,
+  async (remove_finite) => {
+    await init_moyo_for_tests()
+    const crystal = make_crystal(fcc_primitive_matrix(3.61), [
+      { element: `Cu`, abc: [0.13, 0.27, 0.41] },
+    ])
+    const state = $state<ComponentProps<typeof Structure>>({
+      structure: crystal,
+      cell_type: `original`,
+      display_mode: `structure`,
+      active_volume_idx: 0,
+      supercell_scaling: `1x1x1`,
+      sym_data: null,
+    })
+    const tool_props = await mount_host_structure(bind_props({}, state))
+    state.sym_data = await symmetry.analyze_structure_symmetry(crystal)
+    flushSync()
+    const overlay = {
+      source: tool_props.structure,
+      volumes: [{ ...volumetric_data[0], label: `Prediction`, periodic: true }],
+    }
+    flushSync(() => tool_props.on_overlay(overlay))
+    flushSync(() => {
+      state.cell_type = `conventional`
+    })
+    expect(document.body.textContent).toContain(
+      `Prediction density is hidden in standardized cells`,
+    )
+    flushSync(() => {
+      state.display_mode = `slice`
+    })
+    expect(document.body.textContent).toContain(`No volumetric data available`)
+    flushSync(() => {
+      state.cell_type = `original`
+      state.display_mode = `structure`
+    })
+    expect(
+      document.querySelector(`button[aria-label="Add surface for Prediction"]`),
+    ).not.toBeNull()
+    flushSync(() =>
+      tool_props.on_overlay({
+        ...overlay,
+        volumes: [{ ...overlay.volumes[0], periodic: false }],
+      }),
+    )
+    flushSync(() => {
+      state.supercell_scaling = `2x1x1`
+    })
+    expect(document.body.textContent).toContain(
+      `partially periodic prediction density is shown only in the input cell`,
+    )
+    expect(
+      document.querySelector(`button[aria-label="Add surface for Prediction"]`),
+    ).not.toBeNull()
+    flushSync(() =>
+      tool_props.on_overlay({
+        ...overlay,
+        volumes: [
+          { ...overlay.volumes[0], periodic: false },
+          { ...overlay.volumes[0], label: `Periodic prediction` },
+        ],
+      }),
+    )
+    if (remove_finite) {
+      flushSync(() =>
+        doc_query<HTMLButtonElement>(`button[aria-label="Remove volume Prediction"]`).click(),
+      )
+    }
+    flushSync(() => {
+      state.active_volume_idx = remove_finite ? 0 : 1
+      state.display_mode = `slice`
+    })
+    expect(
+      document.body.textContent?.includes(
+        `partially periodic prediction density is shown only in the input cell`,
+      ),
+    ).toBe(!remove_finite)
+    expect(
+      document.querySelector(`input[aria-label="Slice position on canvas"]`),
+    ).not.toBeNull()
+  },
+)
 
 const mount_volumetric = (
   overrides: Partial<ComponentProps<typeof Structure>> = {},
@@ -567,7 +849,11 @@ describe(`Structure`, () => {
 
     // dispatch on the viewer (focused/element path) — handle_and_prevent should run
     const press = (init: KeyboardEventInit) => {
-      const event = new KeyboardEvent(`keydown`, { cancelable: true, bubbles: true, ...init })
+      const event = new KeyboardEvent(`keydown`, {
+        cancelable: true,
+        bubbles: true,
+        ...init,
+      })
       doc_query(`.structure`).dispatchEvent(event)
       return event
     }
@@ -1073,7 +1359,10 @@ describe(`Structure`, () => {
 
     await set_fullscreen_element(null)
     expect(fullscreen_button.getAttribute(`aria-pressed`)).toBe(`false`)
-    expect(on_fullscreen_change).toHaveBeenLastCalledWith({ structure, fullscreen: false })
+    expect(on_fullscreen_change).toHaveBeenLastCalledWith({
+      structure,
+      fullscreen: false,
+    })
     expect(on_fullscreen_change).toHaveBeenCalledTimes(2)
   })
 
@@ -1272,7 +1561,12 @@ describe(`Structure empty states`, () => {
 
 test(`camera projection and auto-rotate controls reflect scene_props`, async () => {
   const scene_props = { camera_projection: `perspective` as const, auto_rotate: 0.5 }
-  mount_structure({ structure, active_pane: `controls`, show_controls: true, scene_props })
+  mount_structure({
+    structure,
+    active_pane: `controls`,
+    show_controls: true,
+    scene_props,
+  })
   await tick()
 
   const projection_label = [...document.querySelectorAll(`label`)].find((label) =>
@@ -1619,7 +1913,10 @@ describe(`data_url acquisition`, () => {
   // Mount with `/a.json` as a pending (deferred) fetch and wait for the request to be issued
   const mount_pending_url = async (extra: ComponentProps<typeof Structure> = {}) => {
     const responses = deferred_fetch_responses()
-    const props = $state<ComponentProps<typeof Structure>>({ data_url: `/a.json`, ...extra })
+    const props = $state<ComponentProps<typeof Structure>>({
+      data_url: `/a.json`,
+      ...extra,
+    })
     mount_structure(props)
     await vi.waitFor(() => expect(responses.has(`/a.json`)).toBe(true))
     return { responses, props }

--- a/tests/vitest/structure/StructureControls.test.svelte.ts
+++ b/tests/vitest/structure/StructureControls.test.svelte.ts
@@ -601,6 +601,13 @@ describe(`StructureControls layout`, () => {
       }
       expect(inputs[1].getAttribute(`aria-label`)).toBe(config.description)
     }
+    const opacity_inputs = target.querySelectorAll<HTMLInputElement>(
+      `[data-key="background_opacity"] input`,
+    )
+    expect(opacity_inputs).toHaveLength(2)
+    for (const input of opacity_inputs) {
+      expect([input.min, input.max, input.step]).toEqual([`0`, `1`, `0.02`])
+    }
   })
 })
 

--- a/tests/vitest/structure/StructureExportPane.test.ts
+++ b/tests/vitest/structure/StructureExportPane.test.ts
@@ -439,3 +439,17 @@ describe(`StructureExportPane`, () => {
     })
   })
 })
+
+test(`prediction export reports invalid metadata in the pane`, async () => {
+  mount_pane({
+    prediction: {
+      input: simple_structure,
+      run_id: 1,
+      provenance: { model: `test`, version: `1`, units: {}, settings: { invalid: new Map() } },
+    },
+  })
+  doc_query<HTMLButtonElement>(`button[title="Download Export prediction"]`).click()
+  await tick()
+  expect(doc_query(`[role="alert"]`).textContent).toContain(`provenance.settings.invalid`)
+  expect(doc_query(`[role="alert"]`).textContent).toContain(`retry`)
+})

--- a/tests/vitest/structure/StructureExportPane.test.ts
+++ b/tests/vitest/structure/StructureExportPane.test.ts
@@ -83,6 +83,37 @@ describe(`StructureExportPane`, () => {
   })
 
   test.each([
+    [false, false],
+    [true, false],
+    [false, true],
+    [true, true],
+  ])(`prediction actions require their callbacks (clear=%s, reset=%s)`, (clear, reset) => {
+    const on_clear_prediction = vi.fn()
+    const on_reset_prediction_surfaces = vi.fn()
+    mount_pane({
+      prediction: {
+        input: simple_structure,
+        run_id: 1,
+        provenance: { model: `test`, version: `1`, units: {}, settings: {} },
+      },
+      on_clear_prediction: clear ? on_clear_prediction : undefined,
+      on_reset_prediction_surfaces: reset ? on_reset_prediction_surfaces : undefined,
+    })
+    expect(get_button(`Download Export prediction`).disabled).toBe(false)
+    for (const [label, enabled, callback] of [
+      [`Clear prediction`, clear, on_clear_prediction],
+      [`Reset prediction surfaces`, reset, on_reset_prediction_surfaces],
+    ] as const) {
+      const button = [...document.querySelectorAll(`button`)].find(
+        (candidate) => candidate.textContent === label,
+      )
+      expect(Boolean(button), label).toBe(enabled)
+      button?.click()
+      expect(callback).toHaveBeenCalledTimes(enabled ? 1 : 0)
+    }
+  })
+
+  test.each([
     { format: `json`, label: `JSON` },
     { format: `xyz`, label: `XYZ` },
     { format: `cif`, label: `CIF` },

--- a/tests/vitest/structure/host-tool.test.ts
+++ b/tests/vitest/structure/host-tool.test.ts
@@ -173,6 +173,14 @@ describe(`host prediction ownership`, () => {
         site_properties: [{ nested: new Map([[`shared`, shared_property]]) }],
       }),
     ).toThrow(`shared buffers`)
+    const shared_volume = { ...volume(`density`), extra: { shared_property } }
+    expect(() => latest.on_overlay({ volumes: [shared_volume] })).toThrow(`shared buffers`)
+    expect(() =>
+      controller.start_run({
+        ...provenance,
+        settings: { shared_property },
+      }),
+    ).toThrow(`shared buffers`)
   })
 })
 

--- a/tests/vitest/structure/host-tool.test.ts
+++ b/tests/vitest/structure/host-tool.test.ts
@@ -108,7 +108,7 @@ describe(`host prediction ownership`, () => {
     },
   )
 
-  test(`exports a captured input and provenance with typed density values`, () => {
+  test.each([false, true])(`exports an owned snapshot with shared density=%s`, (shared) => {
     const structure = make_crystal(1, [{ element: `H`, abc: [0, 0, 0] }])
     const settings = { seed: 0 }
     let prediction: StructureToolPrediction | null = null
@@ -123,11 +123,23 @@ describe(`host prediction ownership`, () => {
     )
     const run = controller.start_run({ ...provenance, settings })
     settings.seed = 9
-    run.on_overlay({
+    const overlay = {
       site_properties: [{ charge: 0.5, dipole: [1, 2, 3] }],
       volumes: [volume(`density`)],
-    })
+    }
+    if (shared) {
+      overlay.volumes[0].values = new Float64Array(
+        new SharedArrayBuffer(8 * Float64Array.BYTES_PER_ELEMENT),
+      )
+      overlay.volumes[0].values.fill(1)
+    }
+    run.on_overlay(overlay)
     if (!prediction) throw new Error(`Missing prediction`)
+    // Published buffers belong to the viewer, even after this run loses ownership.
+    controller.start_run(provenance)
+    overlay.site_properties[0].dipole[0] = 99
+    overlay.volumes[0].values[0] = 99
+    overlay.volumes[0].lattice[0][0] = 99
     run.structure.sites[0].xyz[0] = 8
     const exported = JSON.parse(prediction_to_json(prediction))
     expect(exported.input.sites[0].xyz[0]).toBe(0)
@@ -142,13 +154,25 @@ describe(`host prediction ownership`, () => {
       field_id: `density`,
       dims: [2, 2, 2],
       values: Array(8).fill(1),
+      lattice: [
+        [5, 0, 0],
+        [0, 5, 0],
+        [0, 0, 5],
+      ],
     })
     expect(structure.sites[0].properties?.charge).toBeUndefined()
-    expect(() => run.on_overlay({ site_properties: [] })).toThrow(`property rows`)
-    expect(() => run.on_overlay({ volumes: [volume(`same`), volume(`same`)] })).toThrow(
+    const latest = controller.start_run(provenance)
+    expect(() => latest.on_overlay({ site_properties: [] })).toThrow(`property rows`)
+    expect(() => latest.on_overlay({ volumes: [volume(`same`), volume(`same`)] })).toThrow(
       `unique`,
     )
-    expect(() => run.on_overlay({ volumes: [volume(``)] })).toThrow(`nonempty`)
+    expect(() => latest.on_overlay({ volumes: [volume(``)] })).toThrow(`nonempty`)
+    const shared_property = new Float64Array(new SharedArrayBuffer(8))
+    expect(() =>
+      latest.on_overlay({
+        site_properties: [{ nested: new Map([[`shared`, shared_property]]) }],
+      }),
+    ).toThrow(`shared buffers`)
   })
 })
 

--- a/tests/vitest/structure/host-tool.test.ts
+++ b/tests/vitest/structure/host-tool.test.ts
@@ -29,6 +29,38 @@ const volume = (field_id: string) => ({
 })
 
 describe(`host prediction ownership`, () => {
+  test.each([`molecule`, `xyz`, `abc`, `both`] as const)(
+    `starts predictions from %s JSON with omitted site properties`,
+    async (coordinates) => {
+      const source = make_crystal(2, [
+        { element: `H`, abc: [0, 0, 0] },
+        { element: `He`, abc: [0.5, 0.5, 0.5] },
+      ])
+      Reflect.deleteProperty(source.sites[0], `properties`)
+      source.sites[1].properties = { charge: 0.5 }
+      if (coordinates === `molecule`) Reflect.deleteProperty(source, `lattice`)
+      for (const site of source.sites) {
+        if (coordinates === `abc`) Reflect.deleteProperty(site, `xyz`)
+        else if (coordinates !== `both`) Reflect.deleteProperty(site, `abc`)
+      }
+      const parsed = await parse_file_content(JSON.stringify(source), `input.json`)
+      if (parsed.type !== `structure`) throw new Error(`Expected parsed structure`)
+      const controller = create_structure_tool_controller(
+        () => parsed.data,
+        () => true,
+        () => {},
+        () => {},
+        () => `input`,
+      )
+      const run = controller.start_run(provenance)
+      expect(run.structure.sites.map(({ properties }) => properties)).toEqual([
+        {},
+        { charge: 0.5 },
+      ])
+      controller.dispose()
+    },
+  )
+
   test.each([
     `new run`,
     `input change`,

--- a/tests/vitest/structure/host-tool.test.ts
+++ b/tests/vitest/structure/host-tool.test.ts
@@ -1,11 +1,15 @@
+import { parse_file_content } from '$lib/file-viewer/parse'
 import {
   create_structure_tool_controller,
   prediction_to_json,
+  prediction_from_json,
 } from '$lib/structure/host-tool.svelte'
 import type {
   StructureToolPrediction,
+  StructureToolOverlay,
   StructureToolProvenance,
   StructureToolRun,
+  StructureToolVolume,
 } from '$lib/structure/host-tool.svelte'
 import { replace_tool_volumes } from '$lib/structure/host-tool-volumes'
 import { auto_volume_layer } from '$lib/isosurface'
@@ -250,4 +254,154 @@ test(`demo trajectory keeps fractional and Cartesian coordinates consistent`, as
     expect(xyz).toEqual(expected)
   }
   expect(crystal.sites[0].abc).toEqual([0.13, 0.27, 0.41])
+})
+
+const publication_fixture = () => {
+  const input = make_crystal(1, [{ element: `H`, abc: [0, 0, 0] }])
+  const accepted = vi.fn()
+  const controller = create_structure_tool_controller(
+    () => input,
+    () => true,
+    accepted,
+    () => {},
+    () => ``,
+  )
+  const run = controller.start_run(provenance)
+  return { input, accepted, controller, run }
+}
+
+test.each([
+  [`Map`, (): unknown => new Map([[`key`, 1]])],
+  [`Set`, (): unknown => new Set([1])],
+  [`Date`, (): unknown => new Date(0)],
+  [`BigInt`, (): unknown => 1n],
+  [`NaN`, (): unknown => NaN],
+  [`Infinity`, (): unknown => Infinity],
+  [`typed array`, (): unknown => new Uint8Array([1])],
+  [`array hole`, (): unknown => Array(1)],
+  [
+    `cycle`,
+    (): unknown => {
+      const value: { self?: unknown } = {}
+      value.self = value
+      return value
+    },
+  ],
+] as const)(
+  `rejects %s metadata with a field path without replacing accepted output`,
+  (_name, make_bad) => {
+    const { input, accepted, controller, run } = publication_fixture()
+    run.on_overlay({ site_properties: [{ charge: 1 }] })
+    const bad = make_bad()
+    expect(() => run.on_overlay(bad as StructureToolOverlay)).toThrow(`prediction`)
+    expect(() => run.on_overlay({ site_properties: [{ bad }] })).toThrow(
+      `prediction.site_properties[0].bad`,
+    )
+    expect(() => controller.start_run({ ...provenance, settings: { bad } })).toThrow(
+      `provenance.settings.bad`,
+    )
+    expect(() =>
+      prediction_to_json({
+        input,
+        run_id: 1,
+        provenance: { ...provenance, settings: { bad } },
+      }),
+    ).toThrow(`provenance.settings.bad`)
+    expect(accepted).toHaveBeenCalledTimes(1)
+    expect(run.signal.aborted).toBe(false)
+  },
+)
+
+test.each([
+  { dims: [2, 2, 3] },
+  { dims: [-2, -2, 2] },
+  { dims: [1.5, 2, 2] },
+  { dims: [0, 2, 2], values: new Float64Array() },
+  { order: `x_fastest` },
+  { origin: [NaN, 0, 0] },
+  { periodic: `yes` },
+  {
+    lattice: [
+      [0, 0, 0],
+      [0, 0, 0],
+      [0, 0, 0],
+    ],
+  },
+  { values: new Float64Array(8).fill(Infinity) },
+  { values: new Float64Array(8).fill(1e308) },
+  {
+    lattice: [
+      [1e308, 1e308, 0],
+      [1e308, 1e308, 0],
+      [0, 0, 1],
+    ],
+  },
+  { values: new Float32Array(8) },
+])(`rejects malformed density atomically: %j`, (overrides) => {
+  const { accepted, run } = publication_fixture()
+  run.on_overlay({ volumes: [volume(`valid`)] })
+  const previous = accepted.mock.lastCall?.[0]
+  expect(() => run.on_overlay({ volumes: Array(1) })).toThrow(`prediction.volumes[0]`)
+  expect(() =>
+    run.on_overlay({
+      volumes: [volume(`valid`), { ...volume(`bad`), ...overrides } as StructureToolVolume],
+    }),
+  ).toThrow(`prediction.volumes[1]`)
+  expect(accepted).toHaveBeenCalledTimes(1)
+  expect(accepted.mock.lastCall?.[0]).toBe(previous)
+})
+
+test(`prediction import preserves input, fields and provenance, recomputes ranges, and rejects unsupported schemas`, async () => {
+  const input = make_crystal(1, [{ element: `Cu`, abc: [0.1, 0.2, 0.3] }])
+  const density = volume(`density`)
+  density.values[0] = 5 // Deliberately leave the host's cached statistics stale.
+  const prediction = {
+    input,
+    run_id: 3,
+    provenance,
+    volumes: [density],
+    site_properties: [{ charge: 0.5 }],
+    color_property: `charge`,
+  }
+  const text = prediction_to_json(prediction)
+  const restored = prediction_from_json(text)
+  expect(restored).toMatchObject({
+    input,
+    run_id: 3,
+    provenance,
+    site_properties: prediction.site_properties,
+  })
+  expect(restored.volumes?.[0].values).toEqual(density.values)
+  expect(restored.volumes?.[0].data_range).toEqual({ min: 1, max: 5, abs_max: 5, mean: 1.5 })
+  expect(prediction_to_json(restored)).toBe(text)
+  expect(prediction_from_json(JSON.parse(text))).toEqual(restored)
+  for (const [key, value] of [
+    [`label`, {}],
+    [`properties`, null],
+    [`properties`, []],
+  ] as const) {
+    const malformed = JSON.parse(text)
+    malformed.input.sites[0][key] = value
+    expect(() => prediction_from_json(malformed)).toThrow(`input.sites[0].${key}`)
+  }
+  expect(() => prediction_from_json(text.replace(`"Cu"`, `"DefinitelyNotAnElement"`))).toThrow(
+    `input.sites[0].species.element`,
+  )
+  for (const key of [`pbc`, `a`, `volume`]) {
+    const malformed = JSON.parse(text)
+    Reflect.deleteProperty(malformed.input.lattice, key)
+    expect(() => prediction_from_json(malformed)).toThrow(`input.lattice.${key}`)
+  }
+  const parsed = await parse_file_content(text, `prediction.json`)
+  expect(parsed).toMatchObject({ type: `structure`, data: input, prediction: restored })
+  await expect(
+    parse_file_content(text.replace(`prediction-v1`, `prediction-v2`), `prediction.json`),
+  ).rejects.toThrow(`schema`)
+  expect(() => prediction_from_json(text.replace(`"run_id":3`, `"run_id":0`))).toThrow(
+    `run_id`,
+  )
+  expect(() => prediction_from_json(text.replace(`"occu":1`, `"occu":-1`))).toThrow(`occu`)
+  expect(() =>
+    prediction_from_json(text.replace(`"xyz":[`, `"xyz":null,"old_xyz":[`)),
+  ).toThrow(`xyz`)
 })

--- a/tests/vitest/structure/host-tool.test.ts
+++ b/tests/vitest/structure/host-tool.test.ts
@@ -1,0 +1,217 @@
+import {
+  create_structure_tool_controller,
+  prediction_to_json,
+} from '$lib/structure/host-tool.svelte'
+import type {
+  StructureToolPrediction,
+  StructureToolProvenance,
+  StructureToolRun,
+} from '$lib/structure/host-tool.svelte'
+import { replace_tool_volumes } from '$lib/structure/host-tool-volumes'
+import { auto_volume_layer } from '$lib/isosurface'
+import { make_demo_trajectory } from '../../../src/routes/(demos)/structure/host-tool/demo'
+import { describe, expect, test, vi } from 'vitest'
+import { fcc_primitive_matrix, make_crystal, make_grid, make_volume } from '../setup'
+
+const provenance: StructureToolProvenance = {
+  model: `example`,
+  version: `1.2`,
+  units: { charge: `e`, density: `e/A^3` },
+  settings: { seed: 0 },
+}
+const volume = (field_id: string) => ({
+  ...make_volume(make_grid(2, 2, 2, () => 1)),
+  field_id,
+})
+
+describe(`host prediction ownership`, () => {
+  test.each([
+    `new run`,
+    `input change`,
+    `disabled`,
+    `unmount`,
+    `cancel`,
+    `mutated input`,
+    `owner change`,
+  ] as const)(`rejects stale updates and cleanup after %s`, (cause) => {
+    let structure = make_crystal(1, [{ element: `H`, abc: [0, 0, 0] }])
+    let owner: object | null = {}
+    const on_prediction = vi.fn()
+    const on_view = vi.fn()
+    const controller = create_structure_tool_controller(
+      () => structure,
+      () => owner,
+      on_prediction,
+      on_view,
+      () => JSON.stringify(structure),
+    )
+    const old_run = controller.start_run(provenance)
+    old_run.on_overlay({ site_properties: [{ charge: 1 }] })
+    if (cause === `new run`) {
+      const latest = controller.start_run(provenance)
+      expect(latest.id).toBeGreaterThan(old_run.id)
+      latest.on_overlay({ site_properties: [{ charge: 2 }] })
+    } else if (cause === `input change`) structure = { ...structure }
+    else if (cause === `disabled`) owner = null
+    else if (cause === `owner change`) owner = {}
+    else if (cause === `mutated input`) {
+      structure.sites[0].xyz[0] = 9
+      expect(old_run.structure.sites[0].xyz[0]).toBe(0)
+    } else if (cause === `unmount`) controller.dispose()
+    else old_run.cancel()
+    const prediction_calls = on_prediction.mock.calls.length
+    const view_calls = on_view.mock.calls.length
+    // Same-turn callbacks before invalidation effects run are stale too.
+    old_run.on_overlay({ site_properties: [{ charge: -1 }] })
+    old_run.on_view(null)
+    old_run.clear()
+    old_run.cancel()
+    expect(on_prediction).toHaveBeenCalledTimes(prediction_calls)
+    expect(on_view).toHaveBeenCalledTimes(view_calls)
+    controller.invalidate_if_changed()
+    expect(old_run.signal.aborted).toBe(true)
+    if (cause === `new run`)
+      expect(on_prediction.mock.lastCall?.[0].site_properties).toEqual([{ charge: 2 }])
+    else expect(on_prediction).toHaveBeenLastCalledWith(null)
+    if (cause === `unmount`) expect(() => controller.start_run(provenance)).toThrow(`mounted`)
+  })
+  test.each([`cancel`, `replace`] as const)(
+    `abort handlers can start a newer run during %s`,
+    (action) => {
+      const structure = make_crystal(1, [{ element: `H`, abc: [0, 0, 0] }])
+      const on_prediction = vi.fn()
+      const on_view = vi.fn()
+      const controller = create_structure_tool_controller(
+        () => structure,
+        () => true,
+        on_prediction,
+        on_view,
+        () => JSON.stringify(structure),
+      )
+      const old_run = controller.start_run(provenance)
+      let replacement: StructureToolRun | undefined
+      old_run.signal.addEventListener(`abort`, () => {
+        replacement = controller.start_run(provenance)
+        replacement.on_overlay({ site_properties: [{ charge: 3 }] })
+      })
+      if (action === `cancel`) old_run.cancel()
+      else {
+        const superseded = controller.start_run(provenance)
+        expect(superseded.signal.aborted).toBe(true)
+      }
+      if (!replacement) throw new Error(`Abort did not start replacement`)
+      expect(replacement.signal.aborted).toBe(false)
+      expect(on_prediction.mock.lastCall?.[0].site_properties).toEqual([{ charge: 3 }])
+      replacement.on_overlay({ site_properties: [{ charge: 4 }] })
+      expect(on_prediction.mock.lastCall?.[0].site_properties).toEqual([{ charge: 4 }])
+      expect(on_view).toHaveBeenLastCalledWith(null)
+    },
+  )
+
+  test(`exports a captured input and provenance with typed density values`, () => {
+    const structure = make_crystal(1, [{ element: `H`, abc: [0, 0, 0] }])
+    const settings = { seed: 0 }
+    let prediction: StructureToolPrediction | null = null
+    const controller = create_structure_tool_controller(
+      () => structure,
+      () => true,
+      (value) => {
+        prediction = value
+      },
+      () => {},
+      () => JSON.stringify(structure),
+    )
+    const run = controller.start_run({ ...provenance, settings })
+    settings.seed = 9
+    run.on_overlay({
+      site_properties: [{ charge: 0.5, dipole: [1, 2, 3] }],
+      volumes: [volume(`density`)],
+    })
+    if (!prediction) throw new Error(`Missing prediction`)
+    run.structure.sites[0].xyz[0] = 8
+    const exported = JSON.parse(prediction_to_json(prediction))
+    expect(exported.input.sites[0].xyz[0]).toBe(0)
+    expect(exported).toMatchObject({
+      schema: `matterviz-prediction-v1`,
+      run_id: run.id,
+      provenance: { ...provenance, settings: { seed: 0 } },
+      input: structure,
+      site_properties: [{ charge: 0.5, dipole: [1, 2, 3] }],
+    })
+    expect(exported.volumes[0]).toMatchObject({
+      field_id: `density`,
+      dims: [2, 2, 2],
+      values: Array(8).fill(1),
+    })
+    expect(structure.sites[0].properties?.charge).toBeUndefined()
+    expect(() => run.on_overlay({ site_properties: [] })).toThrow(`property rows`)
+    expect(() => run.on_overlay({ volumes: [volume(`same`), volume(`same`)] })).toThrow(
+      `unique`,
+    )
+    expect(() => run.on_overlay({ volumes: [volume(``)] })).toThrow(`nonempty`)
+  })
+})
+
+test(`field IDs preserve layers and both index references across replacement, reorder and removal`, () => {
+  const base = volume(`base`)
+  const density = volume(`density`)
+  const potential = volume(`potential`)
+  const layers = [
+    { ...auto_volume_layer(base, 0), color_volume_idx: 1 },
+    {
+      ...auto_volume_layer(density, 1),
+      isovalue: 0.123,
+      opacity: 0.4,
+      color: `red`,
+      color_volume_idx: 2,
+    },
+    { ...auto_volume_layer(density, 1), isovalue: -0.2, visible: false },
+  ]
+  const incoming = [volume(`potential`), volume(`density`), volume(`new`)]
+  const result = replace_tool_volumes(
+    [base, density, potential],
+    layers,
+    [density, potential],
+    incoming,
+    1,
+  )
+  expect(result.active_idx).toBe(2)
+  expect(result.layers).toEqual([
+    { ...layers[0], color_volume_idx: 2 },
+    { ...layers[1], volume_idx: 2, color_volume_idx: 1 },
+    { ...layers[2], volume_idx: 2 },
+    auto_volume_layer(incoming[2], 3),
+  ])
+  // No auto-layer is resurrected for a field whose surfaces the user removed.
+  expect(result.layers.filter(({ volume_idx }) => volume_idx === 1)).toEqual([])
+  const removed = replace_tool_volumes(
+    result.volumes,
+    result.layers,
+    incoming,
+    [volume(`density`)],
+    2,
+  )
+  expect(removed.layers).toEqual([
+    { ...layers[0], color_volume_idx: 1 },
+    { ...layers[1], color_volume_idx: undefined },
+    layers[2],
+  ])
+})
+
+test(`demo trajectory keeps fractional and Cartesian coordinates consistent`, async () => {
+  const crystal = make_crystal(fcc_primitive_matrix(3.61), [
+    { element: `Cu`, abc: [0.13, 0.27, 0.41] },
+  ])
+  const trajectory = make_demo_trajectory(crystal)
+  for (const frame_idx of [0, 1, 5]) {
+    const frame = await trajectory.read_frame(frame_idx)
+    const { abc, xyz } = frame.structure.sites[0]
+    const expected = [
+      1.805 * abc[1] + 1.805 * abc[2],
+      1.805 * abc[0] + 1.805 * abc[2],
+      1.805 * abc[0] + 1.805 * abc[1],
+    ]
+    expect(xyz).toEqual(expected)
+  }
+  expect(crystal.sites[0].abc).toEqual([0.13, 0.27, 0.41])
+})

--- a/tests/vitest/structure/host-tool.test.ts
+++ b/tests/vitest/structure/host-tool.test.ts
@@ -167,7 +167,11 @@ test(`field IDs preserve layers and both index references across replacement, re
     },
     { ...auto_volume_layer(density, 1), isovalue: -0.2, visible: false },
   ]
-  const incoming = [volume(`potential`), volume(`density`), volume(`new`)]
+  const incoming = [
+    volume(`potential`),
+    { ...make_volume(make_grid(3, 3, 3, () => 2)), field_id: `density`, label: `Renamed` },
+    volume(`new`),
+  ]
   const result = replace_tool_volumes(
     [base, density, potential],
     layers,

--- a/tests/vitest/structure/index.test.ts
+++ b/tests/vitest/structure/index.test.ts
@@ -358,6 +358,8 @@ describe(`is_vector_key`, () => {
     [`magmoms`, true],
     [`velocity`, true],
     [`force_DFT`, true],
+    [`dipole_charge`, true],
+    [`dipole_spin`, true],
     [`spins_down`, true],
     [`force_`, true],
     [`charge`, false],

--- a/tests/vitest/structure/session.test.svelte.ts
+++ b/tests/vitest/structure/session.test.svelte.ts
@@ -42,6 +42,7 @@ type Host = {
   cell_type: CellType
   sym_data: SymmetryDataset | null
   atom_color_config: AtomColorConfig
+  site_properties?: Record<string, unknown>[]
 }
 
 const crystal = (atoms = 3): AnyStructure => get_dummy_structure(`H`, atoms, true)
@@ -71,6 +72,7 @@ function make_session(initial: Partial<Host> = {}) {
   const destroy = $effect.root(() => {
     session = new StructureSession({
       structure: () => host.structure,
+      site_properties: () => host.site_properties,
       set_structure: (value) => (host.structure = value),
       bonds: () => host.bonds,
       set_bonds: (value) => (host.bonds = value),
@@ -130,11 +132,26 @@ describe(`display pipeline`, () => {
     expect(session.scaled_cell_displayed).toBe(true)
     expect(session.supercell_tiling).toEqual([2, 1, 1])
     expect(session.bond_edits_enabled).toBe(false)
+    const original_input = session.tool_input
     session.element_mapping = { H: `Na` }
     flushSync()
     expect(
       session.displayed_structure?.sites.every((site) => site.species[0].element === `Na`),
     ).toBe(true)
+    expect(session.tool_input?.sites).toHaveLength(3)
+    expect(session.tool_input?.sites.map((site) => site.species[0].element)).toEqual([
+      `Na`,
+      `Na`,
+      `Na`,
+    ])
+    expect(session.tool_input?.sites.map((site) => site.xyz)).toEqual(
+      host.structure?.sites.map((site) => site.xyz),
+    )
+    expect(session.tool_input).not.toBe(original_input)
+    expect(host.structure?.sites[0].species[0].element).toBe(`H`)
+    session.element_mapping = undefined
+    flushSync()
+    expect(session.tool_input).toBe(original_input)
     destroy()
   })
 
@@ -188,6 +205,17 @@ describe(`display pipeline`, () => {
     expect(values.slice(0, 4)).toEqual(Array(4).fill(values[0]))
     expect(values[image_idx]).toBe(values[2])
 
+    host.site_properties = [10, 20, 30, 40].map((charge) => ({ charge }))
+    host.atom_color_config = {
+      ...DEFAULT_ATOM_COLOR_CONFIG,
+      mode: `property`,
+      property_key: `charge`,
+    }
+    flushSync()
+    expect(session.property_colors?.values.slice(0, 4)).toEqual([10, 20, 30, 40])
+    expect(session.property_colors?.values[image_idx]).toBe(30)
+    expect(foreign.sites[2].properties).not.toHaveProperty(`charge`)
+
     // once the session tiles a supercell itself, its orig_unit_cell_idx is followed
     host.supercell_scaling = `1x2x1`
     flushSync()
@@ -196,6 +224,7 @@ describe(`display pipeline`, () => {
       (site) => site.properties.orig_unit_cell_idx === 3 && !is_image_site(site),
     )
     expect([...session.scene_to_structure_indices([site_idx ?? -1])]).toEqual([3])
+    expect(session.property_colors?.values[site_idx ?? -1]).toBe(40)
     destroy()
   })
 

--- a/tests/vitest/trajectory/TrajectoryDataInspectorPane.test.ts
+++ b/tests/vitest/trajectory/TrajectoryDataInspectorPane.test.ts
@@ -156,21 +156,25 @@ test(`atoms tab virtualizes a large frame`, async () => {
   expect(document.body.textContent).toContain(`Atoms (100)`)
 })
 
-test(`row clicks report frame and site indices`, async () => {
+test.each([false, true])(`row navigation requires callbacks=%s`, async (can_navigate) => {
   const on_step_change = vi.fn()
   const on_site_select = vi.fn()
   const run = make_run(5)
   await mount_pane({
     run,
     current_frame: run.preview,
-    on_step_change,
-    on_site_select,
+    on_step_change: can_navigate ? on_step_change : undefined,
+    on_site_select: can_navigate ? on_site_select : undefined,
   })
+  expect(body_rows()[2].getAttribute(`tabindex`)).toBe(can_navigate ? `0` : null)
   body_rows()[2].click()
-  expect(on_step_change).toHaveBeenCalledExactlyOnceWith(2)
+  if (can_navigate) expect(on_step_change).toHaveBeenCalledExactlyOnceWith(2)
+  else expect(on_step_change).not.toHaveBeenCalled()
   await open_atoms()
+  expect(body_rows()[1].getAttribute(`tabindex`)).toBe(can_navigate ? `0` : null)
   body_rows()[1].click()
-  expect(on_site_select).toHaveBeenCalledExactlyOnceWith(1)
+  if (can_navigate) expect(on_site_select).toHaveBeenCalledExactlyOnceWith(1)
+  else expect(on_site_select).not.toHaveBeenCalled()
 })
 
 test(`closed pane builds no table`, async () => {

--- a/tests/vitest/trajectory/file-export.test.ts
+++ b/tests/vitest/trajectory/file-export.test.ts
@@ -2,6 +2,7 @@ import type { Crystal } from '$lib/structure'
 import type { Vec3 } from '$lib/math'
 import { parse_poscar, parse_xyz } from '$lib/structure/parse'
 import { download } from '$lib/io/fetch'
+import * as io_export from '$lib/io/export'
 import type { TrajectoryFrame, TrajectoryMetadata } from '$lib/trajectory'
 import { trajectory_from_frames, TrajectoryExportPane } from '$lib/trajectory'
 import type { TrajectoryPropertyTable } from '$lib/trajectory/file-export'
@@ -25,6 +26,10 @@ import { doc_query, make_crystal, with_property_rows } from '../setup'
 vi.mock(`$lib/io/fetch`, async (import_original) => ({
   ...(await import_original<Record<string, unknown>>()),
   download: vi.fn(),
+}))
+vi.mock(`$lib/io/export`, async (import_original) => ({
+  ...(await import_original<typeof io_export>()),
+  export_trajectory_video: vi.fn().mockResolvedValue(undefined),
 }))
 
 // Si + O in a 5 A cube at the given Cartesian positions
@@ -396,6 +401,7 @@ describe(`TrajectoryExportPane property export`, () => {
   afterEach(() => {
     document.body.replaceChildren()
     vi.mocked(download).mockClear()
+    vi.mocked(io_export.export_trajectory_video).mockClear()
     vi.mocked(navigator.clipboard.writeText).mockClear()
     vi.unstubAllGlobals()
   })
@@ -485,13 +491,53 @@ describe(`TrajectoryExportPane property export`, () => {
     expect(exported.map(({ step }) => step)).toEqual([5, 9])
   })
 
-  test(`names every download action`, () => {
-    vi.stubGlobal(`MediaRecorder`, { isTypeSupported: () => true })
-    open_pane({ run: trajectory })
-    for (const label of [`extXYZ`, `POSCAR ZIP`, `CSV`, `JSON`, `WebM`, `MP4`]) {
-      expect(document.querySelector(`button[aria-label="Download ${label}"]`)).not.toBeNull()
-    }
-  })
+  test.each([false, true])(
+    `video export requires frame navigation=%s`,
+    async (can_navigate) => {
+      vi.stubGlobal(`MediaRecorder`, { isTypeSupported: () => true })
+      const wrapper = document.createElement(`div`)
+      open_pane({
+        run: trajectory,
+        wrapper,
+        on_step_change: can_navigate ? vi.fn() : undefined,
+      })
+      await tick()
+      expect(doc_query<HTMLButtonElement>(`button[aria-label="Download WebM"]`).disabled).toBe(
+        true,
+      )
+      const canvas = document.createElement(`canvas`)
+      wrapper.append(canvas)
+      await vi.waitFor(() => expect(doc_query(`.export-info`).textContent).toContain(`KB`))
+      for (const label of [`extXYZ`, `POSCAR ZIP`, `CSV`, `JSON`, `WebM`, `MP4`]) {
+        const button = doc_query<HTMLButtonElement>(`button[aria-label="Download ${label}"]`)
+        expect(button.disabled, label).toBe(!can_navigate && [`WebM`, `MP4`].includes(label))
+      }
+      if (can_navigate) {
+        const initial_info = doc_query(`.export-info`).textContent
+        const replacement = document.createElement(`canvas`)
+        replacement.width = 1000
+        replacement.height = 1000
+        canvas.replaceWith(replacement)
+        await vi.waitFor(() =>
+          expect(doc_query(`.export-info`).textContent).not.toBe(initial_info),
+        )
+        await click(`Download WebM`)
+        await vi.waitFor(() =>
+          expect(io_export.export_trajectory_video).toHaveBeenCalledExactlyOnceWith(
+            replacement,
+            `run.extxyz.webm`,
+            expect.objectContaining({ total_frames: 3 }),
+          ),
+        )
+        replacement.remove()
+        await vi.waitFor(() =>
+          expect(
+            doc_query<HTMLButtonElement>(`button[aria-label="Download WebM"]`).disabled,
+          ).toBe(true),
+        )
+      }
+    },
+  )
 
   test(`downloads the whole frame range as CSV`, async () => {
     open_pane({ run: trajectory })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,13 +3,16 @@ import { sveltekit } from '@sveltejs/kit/vite'
 import { readFileSync } from 'node:fs'
 import process from 'node:process'
 import { gunzipSync } from 'node:zlib'
-import { vite_plugin as live_examples } from 'svelte-widgets/live-examples'
+// @ts-expect-error Node ESM config load needs the .ts extension here
+import svelte_config, { docs } from './svelte.config.ts'
 import source_links from 'svelte-widgets/source-links/vite-plugin'
 import type { Plugin } from 'vite'
 import { defineConfig, type PluginOption } from 'vite-plus'
 import { configDefaults } from 'vitest/config'
 // @ts-expect-error Node ESM config load needs the .ts extension here
 import * as shared from './src/vite-plugins.ts'
+
+const { kit, ...compiler_config } = svelte_config
 
 // Extensions raw_text_plugin below claims and hands back as a plain string. Covers exactly
 // the structure/trajectory/phonon fixtures this repo imports (from src/site and tests), not
@@ -74,7 +77,7 @@ const raw_text_plugin: Plugin = {
   },
 }
 
-// sveltekit()/live-examples ship their own copy of vite's Plugin type; inferring this
+// sveltekit()/markdown ship their own copy of vite's Plugin type; inferring this
 // array's element type deep-compares them and exceeds TS's instantiation depth (TS2321).
 // Typing as `unknown[]` skips that comparison; vite ignores the falsy (null) entry.
 const plugins = [
@@ -82,8 +85,8 @@ const plugins = [
   raw_text_plugin as unknown,
   starry_night_theme_plugin as unknown,
   source_links() as unknown,
-  sveltekit() as unknown,
-  live_examples() as unknown,
+  sveltekit({ ...compiler_config, ...kit }) as unknown,
+  docs.plugin as unknown,
 ] as PluginOption[]
 
 const config = make_config()


### PR DESCRIPTION
- Export the host-tool API from `matterviz` and `matterviz/structure`, with a runnable demo of scalar colors, dipole arrows, density, and a host-owned trajectory covered by WebGPU browser tests.
- Scope asynchronous results to run IDs, captured input snapshots, and registered tool ownership. New runs abort older work; stale updates and cleanup cannot replace or clear newer results, including during input changes and unmounting.
- Add prediction JSON export containing the original input, transient site properties, density grids, model/version, units, and calculation settings. Keep the existing original-structure exports available.
- Preserve surface appearance by stable field IDs across reruns and reordering, including geometry and color-field references. Provide an explicit reset to default prediction surfaces.
- Add original-cell, supercell-reset, and clear-prediction recovery controls. Restore prior atom colors and active volumes when prediction output clears.
- Let host views inherit camera and cell settings while owning keyboard interaction; nested previews can disable host tools.
- Replace mdsvex and the separate live-example plugin with the shared svelte-widgets Markdown pipeline. Track the latest svelte-widgets main branch, which supplies the required Markdown exports. Refresh supporting dependencies while retaining TypeScript 6 for Svelte tooling compatibility.

API migration: host tools call `start_run(provenance)` and publish through the returned run's `on_overlay` and `on_view` callbacks; generated volumes require a stable `field_id`. Pass transient site properties through the `StructureSessionInputs.site_properties` getter instead of the removed `StructureViewport.site_properties` prop.
